### PR TITLE
XML Parsing Error Fix

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,10 +1,12 @@
 import PrivateRoute from "./components/PrivateRoute";
+import UnprivateRoute from "./components/UnprivateRoute";
 import { BrowserRouter as Router, Routes, Route, } from 'react-router-dom'
 import Home from "./pages/home";
 import Login from "./pages/login";
 import About from "./pages/about";
 import Account from "./pages/account";
 import Unknown from "./pages/unknown";
+import LoginError from "./pages/loginError";
 import Navbar from "./components/Navbar";
 
 const App = () => {
@@ -16,6 +18,7 @@ const App = () => {
           <Route path="/about" element={<PrivateRoute Component={About} unknownBlocked={true}/>} />
           <Route path="/account" element={<PrivateRoute Component={Account} unknownBlocked={true}/>} />
           <Route path="/login" element={<Login />} />
+          <Route path="/login-error" element={<UnprivateRoute Component={LoginError} />} />
           <Route path="/unknown" element={<PrivateRoute Component={Unknown} knownBlocked={true}/>} />
       </Routes>
   </Router>

--- a/client/src/components/SignInButton.tsx
+++ b/client/src/components/SignInButton.tsx
@@ -8,7 +8,7 @@ const SignInButton = () => {
   return (
     <Button
       variant="contained"
-      href={backendBaseURL + `/cas?redirect=${window.location.origin}`}
+      href={backendBaseURL + `/cas?redirect=${window.location.origin}&error=${window.location.origin}/login-error`}
     >
       Sign in With Yale CAS
     </Button>

--- a/client/src/components/UnprivateRoute.tsx
+++ b/client/src/components/UnprivateRoute.tsx
@@ -1,0 +1,15 @@
+import { Navigate } from 'react-router-dom';
+import { useContext, FunctionComponent } from 'react';
+import UserContext from '../contexts/UserContext';
+
+interface UnprivateRouteProps {
+  Component: FunctionComponent;
+}
+
+const UnprivateRoute = ({ Component } : UnprivateRouteProps) => {
+ 
+  const { user } = useContext(UserContext);
+
+  return user ? <Navigate to='/' /> : <Component />;
+};
+export default UnprivateRoute;

--- a/client/src/pages/loginError.tsx
+++ b/client/src/pages/loginError.tsx
@@ -1,0 +1,27 @@
+import swal from 'sweetalert';
+import {useEffect, useState} from 'react';
+
+const LoginError = () => {
+    const [showError, setShowError] = useState(false);
+    
+    useEffect(() => {
+        const timeout = setTimeout(() => {
+            setShowError(true);
+        }, 500);
+    });
+
+    useEffect(() => {
+        if(showError) {
+            swal({
+                text: "We were unable to process your login. Please try again or contact support if the issue persists.",
+                icon: "warning",
+            }).then(() => {
+                window.location.href = '/login';
+            });
+        }
+    }, [showError]);
+    
+    return null;
+}
+
+export default LoginError;


### PR DESCRIPTION
Attempted fix to the XML parsing error some users get on first-time login:

- Error appears to originate in the passport-cas node module
- Only appearing more now because passport-cas both propagates the error and continues the regular authentication flow, causing two parallel authentication flows to be running
- Before, the authentication flow without the error would finish before the one with it, but now since we fetch Yalies in the non-error authentication flow, the authentication flow with the error occasionally finishes first
- Can't change the passport-cas module to fix the error, so instead changed to the CAS1.0 protocol in passport.ts, since CAS1.0 is supported by Yale and transfers data as raw text, rather than XML (to hopefully avoid the parsing error)
- If the error or others continue to occur, added a /login-error page to indicate a login error and redirect user to /login
- Prevented /login-error from being accessed when the user is logged in successfully (with "UnprivateRoute" in App.tsx)

Once merged to main, will test with many first-time users (professors and students) to see if login flow is improved