### PR TITLE
Shared Listings

### DIFF
--- a/client/src/components/accounts/ListingForm/FormFields/ArrayInput.tsx
+++ b/client/src/components/accounts/ListingForm/FormFields/ArrayInput.tsx
@@ -13,6 +13,7 @@ interface ArrayInputProps {
     type?: string;
     permanentValue?: string;
     onValidate?: (newArray: string[]) => void;
+    infoText?: string;
 }
 
 const ArrayInput = ({
@@ -26,7 +27,8 @@ const ArrayInput = ({
     error,
     type = "text",
     permanentValue,
-    onValidate
+    onValidate,
+    infoText
 }: ArrayInputProps) => {
     const inputRef = useRef<HTMLInputElement>(null);
     const [showTooltip, setShowTooltip] = useState(false);
@@ -133,6 +135,11 @@ const ArrayInput = ({
             <label className="block text-gray-700 text-sm font-bold mb-2">
                 {label}
             </label>
+            {infoText && (
+                <div className="text-xs text-gray-500 mb-2">
+                    {infoText}
+                </div>
+            )}
             <div className="flex flex-wrap gap-2 mb-2 overflow-x-auto">
                 {renderItems()}
             </div>

--- a/client/src/components/accounts/ListingForm/FormFields/DepartmentInput.tsx
+++ b/client/src/components/accounts/ListingForm/FormFields/DepartmentInput.tsx
@@ -96,8 +96,19 @@ const DepartmentInput = ({
   return (
     <div className="mb-4" ref={deptDropdownRef}>
       <label className="block text-gray-700 text-sm font-bold mb-2">
-        Departments
+        ⭐ Departments
       </label>
+      <div className="text-xs text-gray-500 mb-2">
+        Don't see your department? Let us know{" "}
+        <a
+            href={"https://docs.google.com/forms/d/e/1FAIpQLSf2BE6MBulJHWXhDDp3y4Nixwe6EH0Oo9X1pTo976-KrJKv5g/viewform"}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-500"
+        >
+            here
+        </a>
+      </div>
       <div className="flex flex-wrap gap-2 mb-2 overflow-x-auto">
         {departments.map((department, index) => (
           <span 

--- a/client/src/components/accounts/ListingForm/FormFields/HiringStatus.tsx
+++ b/client/src/components/accounts/ListingForm/FormFields/HiringStatus.tsx
@@ -65,7 +65,7 @@ const HiringStatus = ({
     return (
         <div className="mb-4" ref={hiringRef}>
             <label className="block text-gray-700 text-sm font-bold mb-2">
-                Hiring Status
+                ⭐ Hiring Status
             </label>
 
             {/* Button/display */}

--- a/client/src/components/accounts/ListingForm/utils/validation.ts
+++ b/client/src/components/accounts/ListingForm/utils/validation.ts
@@ -64,3 +64,23 @@ export const validateWebsites = (websites: string[]): string | undefined => {
   
   return undefined;
 };
+
+export const validateProfessorIds = (professorIds: string[]): string | undefined => {
+  if (professorIds.length > 3) {
+    return "Maximum of 3 collaborators allowed"
+  }
+  
+  const uniqueIds = new Set(professorIds);
+  if (uniqueIds.size !== professorIds.length) {
+    return "Please remove duplicate collaborators";
+  }
+
+  //must be alphanumeric (no spaces, apostrophes, etc)
+  for (const id of professorIds) {
+    if (!/^[a-zA-Z0-9]+$/.test(id)) {
+      return `Invalid format for collaborator netid: ${id}`;
+    }
+  }
+
+  return undefined;
+};

--- a/client/src/utils/apiCleaner.ts
+++ b/client/src/utils/apiCleaner.ts
@@ -1,7 +1,7 @@
 //Cleans api response listing format to the listing type
 
 export const createListing = (listing: any) => {
-    const titleDefault = listing._id === "create" ? "New Listing" : "";
+    const titleDefault = listing._id === "create" ? "* Your Lab's Name (or Professor's Name) *" : "";
     const descriptionDefault = listing._id === "create" ? "This is your new listing! Please edit the details and click save to post it. If you click cancel, this listing will be deleted." : "";
     const currentDate = new Date();
 


### PR DESCRIPTION
Shared listings capabilities already in place on backend, so just added field to form (only for those who created the listing) to add/remove collaborators. Also:

- Added form validation for collaborators (alphanumeric, no more than 3)
- Added stars to important fields
- Re-ordered fields (hiring status higher up)
- Changed title default (more clear that professors should change it)
- Added info text for select fields (collaborators and departments)

To test the shared listing functionality, make sure you are running on the production MongoDB locally (set in the server .env, text me with questions), and add users as collaborators. If you save the listing locally and have someone log onto the deployed version, they should see and be able to update the listing that you shared (recipients of sharing will not have the ability to add collaborators anyways)