### PR TITLE
Fix MongoDB connection drop causing CAS auth failures

### DIFF
--- a/server/src/db/connections.ts
+++ b/server/src/db/connections.ts
@@ -20,6 +20,12 @@ export function getApiMode(): ApiMode {
 export async function initializeConnections(): Promise<void> {
   const mode = getApiMode();
 
+  const mongoOptions = {
+    serverSelectionTimeoutMS: 30000,
+    socketTimeoutMS: 60000,
+    maxIdleTimeMS: 60000,
+  };
+
   if (mode === 'productionMigration') {
     const primaryUrl = process.env.MONGODBURL;
     const migrationUrl = process.env.MONGODBURL_MIGRATION;
@@ -31,11 +37,11 @@ export async function initializeConnections(): Promise<void> {
       throw new Error('MONGODBURL_MIGRATION is required for ProductionMigration mode');
     }
 
-    await mongoose.connect(primaryUrl);
+    await mongoose.connect(primaryUrl, mongoOptions);
     productionConnection = mongoose.connection;
     console.log('Connected to primary database (default) 🚀');
 
-    migrationConnection = await mongoose.createConnection(migrationUrl).asPromise();
+    migrationConnection = await mongoose.createConnection(migrationUrl, mongoOptions).asPromise();
     console.log('Connected to migration database (listings) 🔄');
 
     MigrationListing = migrationConnection.model('Listing', listingSchema, 'listings');
@@ -44,7 +50,7 @@ export async function initializeConnections(): Promise<void> {
     if (!url) {
       throw new Error('MONGODBURL is required');
     }
-    await mongoose.connect(url);
+    await mongoose.connect(url, mongoOptions);
     console.log(`Connected to database 🚀`);
   }
 }

--- a/server/src/middleware/errorHandler.ts
+++ b/server/src/middleware/errorHandler.ts
@@ -74,6 +74,10 @@ export const errorHandler = (error: Error, req: Request, res: Response, next: Ne
     return res.status(409).json({ error: 'Duplicate key error' });
   }
 
+  if (error.name === 'MongoNotConnectedError') {
+    return res.status(503).json({ error: 'Service temporarily unavailable' });
+  }
+
   res.status(500).json({
     error: 'Internal server error',
     message: undefined,

--- a/server/src/passport.ts
+++ b/server/src/passport.ts
@@ -500,6 +500,13 @@ const casLogin = function (
         return res.redirect(errorRedirect);
       }
 
+      const isInfraError =
+        err.name === 'MongoNotConnectedError' ||
+        (err as any).cause?.name === 'MongoNotConnectedError';
+      if (isInfraError) {
+        return res.status(503).json({ error: 'Service temporarily unavailable, please try again' });
+      }
+
       return res.status(401).json({ error: 'Error in authentication' });
     }
 


### PR DESCRIPTION
## Summary
- Add `maxIdleTimeMS: 60000` (+ explicit `serverSelectionTimeoutMS` / `socketTimeoutMS`) to `mongoose.connect()` so the driver recycles idle connections before Atlas silently closes them — the root cause of the repeated CAS login failures on Beta
- Handle `MongoNotConnectedError` as **503** in the global error handler (was falling through to 500)
- Handle `MongoNotConnectedError` as **503** in the CAS login handler (was returning a misleading 401 "Error in authentication")

## Root cause
CAS ticket validation succeeds, but the verify callback (`findOrCreateUser`) runs a MongoDB query. When Atlas closes an idle connection and the driver fails to reconnect, that query throws `MongoNotConnectedError`, which passport-cas wraps as `VError: user-provided verify function failed` → `{"error":"Error in authentication"}` with 401. The CAS part was never broken.

## Test plan
- [ ] Merge to `beta` and confirm Render redeploys (fresh connection fixes the live broken state)
- [ ] Log in via CAS on Beta after deploy
- [ ] Confirm no `MongoNotConnectedError` in logs after the service has been idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)