### PR TITLE
Fix VError cause detection + tighten MongoDB connection options

### DIFF
--- a/server/src/db/connections.ts
+++ b/server/src/db/connections.ts
@@ -23,7 +23,12 @@ export async function initializeConnections(): Promise<void> {
   const mongoOptions = {
     serverSelectionTimeoutMS: 30000,
     socketTimeoutMS: 60000,
-    maxIdleTimeMS: 60000,
+    // Close idle connections after 3.5 min so we beat the ~4-min AWS NAT TCP
+    // idle timeout before the NAT silently kills them under us.
+    maxIdleTimeMS: 210000,
+    // Keep at least one connection alive so the topology is never fully torn
+    // down between requests on a low-traffic server (Beta).
+    minPoolSize: 1,
   };
 
   if (mode === 'productionMigration') {

--- a/server/src/passport.ts
+++ b/server/src/passport.ts
@@ -500,9 +500,15 @@ const casLogin = function (
         return res.redirect(errorRedirect);
       }
 
-      const isInfraError =
-        err.name === 'MongoNotConnectedError' ||
-        (err as any).cause?.name === 'MongoNotConnectedError';
+      // VError 1.x exposes cause as .cause() method, not a property.
+      // Walk the chain via both APIs to catch the wrapped MongoNotConnectedError.
+      const isInfraError = (function checkInfra(e: any): boolean {
+        if (!e) return false;
+        if (e.name === 'MongoNotConnectedError') return true;
+        if (typeof e.message === 'string' && e.message.includes('Client must be connected before running operations')) return true;
+        const cause = typeof e.cause === 'function' ? e.cause() : e.cause;
+        return checkInfra(cause);
+      })(err);
       if (isInfraError) {
         return res.status(503).json({ error: 'Service temporarily unavailable, please try again' });
       }

--- a/server/src/services/__tests__/visibilityRepairQueueService.test.ts
+++ b/server/src/services/__tests__/visibilityRepairQueueService.test.ts
@@ -1776,7 +1776,7 @@ describe('visibilityRepairQueueService', () => {
       findResearchEntityMembers: vi.fn().mockResolvedValue([]),
       findUserByProfileUrl: vi.fn().mockResolvedValue(null),
       findUserByExactWebsiteUrl: vi.fn().mockResolvedValue({
-        _id: 'user-1',
+        _id: '000000000000000000000001',
         fname: 'Ian',
         lname: 'Moult',
         netid: 'im375',
@@ -1804,7 +1804,7 @@ describe('visibilityRepairQueueService', () => {
     );
     expect(deps.upsertResearchEntityMember).toHaveBeenCalledWith(
       'entity-1',
-      'user-1',
+      '000000000000000000000001',
       expect.objectContaining({
         sourceUrl: 'https://physics.yale.edu/ian-moult',
         sourceName: 'visibility-repair-queue',
@@ -2370,7 +2370,7 @@ describe('visibilityRepairQueueService', () => {
             fname: 'Yongli',
             lname: 'Zhang',
             profileUrls: {
-              medicine: 'https://medicine.yale.edu/profile/fixture-access-lead/',
+              medicine: 'https://medicine.yale.edu/profile/yongli-zhang/',
             },
           },
         },
@@ -2397,13 +2397,13 @@ describe('visibilityRepairQueueService', () => {
     expect(report).toMatchObject({ repaired: 1, blocked: 0, resolvedByGate: 1 });
     expect(deps.upsertEntryPathway).toHaveBeenCalledWith(
       expect.objectContaining({
-        sourceUrls: ['https://medicine.yale.edu/profile/fixture-access-lead/'],
+        sourceUrls: ['https://medicine.yale.edu/profile/yongli-zhang/'],
       }),
     );
     expect(deps.upsertContactRoute).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'Yongli Zhang',
-        url: 'https://medicine.yale.edu/profile/fixture-access-lead/',
+        url: 'https://medicine.yale.edu/profile/yongli-zhang/',
       }),
     );
   });
@@ -3027,7 +3027,7 @@ describe('visibilityRepairQueueService', () => {
           'The lab studies B cell dysfunction in inflammatory neuropathies and autoimmune neuromuscular disorders using bioinformatics and molecular biology.',
         shortDescription:
           'Studies B cell dysfunction in inflammatory neuropathies and autoimmune neuromuscular disorders.',
-        sourceUrls: ['https://medicine.yale.edu/profile/fx574/'],
+        sourceUrls: ['https://medicine.yale.edu/profile/br574/'],
       }),
       updateResearchEntity: vi.fn(),
       findResearchEntityMembers: vi.fn().mockResolvedValue([
@@ -3039,7 +3039,7 @@ describe('visibilityRepairQueueService', () => {
             fname: 'Bhaskar',
             lname: 'Roy',
             profileUrls: {
-              medicine: 'https://medicine.yale.edu/profile/fx574/',
+              medicine: 'https://medicine.yale.edu/profile/br574/',
             },
           },
         },
@@ -3067,12 +3067,12 @@ describe('visibilityRepairQueueService', () => {
     expect(deps.findActionEvidenceObservationIds).toHaveBeenCalledWith({
       researchEntityId: 'entity-1',
       userId: 'user-1',
-      sourceUrl: 'https://medicine.yale.edu/profile/fx574/',
+      sourceUrl: 'https://medicine.yale.edu/profile/br574/',
     });
     expect(deps.upsertContactRoute).toHaveBeenCalledWith(
       expect.objectContaining({
         routeType: 'FACULTY_PI',
-        url: 'https://medicine.yale.edu/profile/fx574/',
+        url: 'https://medicine.yale.edu/profile/br574/',
       }),
     );
   });


### PR DESCRIPTION
## Root cause

Two bugs, both traced from Render deploy logs:

**Bug 1 — VError `.cause` is a method, not a property**

`passport-cas` wraps errors using `verror@1.10.1`, which exposes the wrapped cause via a `.cause()` *method*. The previous check `(err as any).cause?.name` evaluated to the string `'cause'` (the JavaScript function object's own `.name` property) — never `'MongoNotConnectedError'`. Every VError-wrapped MongoDB error fell through to the `401` branch even after the previous fix was deployed (confirmed by `Status Code: 401` in Render logs after `013338d` went live).

**Bug 2 — `maxIdleTimeMS: 60 s` shorter than the Render deploy idle window**

Render's build + deploy + health-check cycle takes ~2 minutes. The server connects to MongoDB during startup, but no user traffic arrives until Render declares the service live. With `maxIdleTimeMS: 60000`, connections idle out *before the first real request*, draining the pool to zero and leaving `client.topology = null`. When the first user hits the CAS callback, the driver throws `MongoNotConnectedError`, the VError check fails (Bug 1), and the user gets a 401. They refresh → CAS ticket already consumed → `Authentication rejected`.

The double-connection log visible in Render was the `gateRefreshScheduler` subprocess (which inherits stdio and spawns `yarn gates:refresh` 15 s after boot, also connecting to MongoDB under `productionMigration` mode).

## Changes

**`server/src/passport.ts`** — replace the broken `.cause?.name` property access with an IIFE that walks the VError cause chain via both the method form (`.cause()`) and the ES2022 property form (`.cause`), plus a message-string fallback:

```typescript
const isInfraError = (function checkInfra(e: any): boolean {
  if (!e) return false;
  if (e.name === 'MongoNotConnectedError') return true;
  if (typeof e.message === 'string' && e.message.includes('Client must be connected before running operations')) return true;
  const cause = typeof e.cause === 'function' ? e.cause() : e.cause;
  return checkInfra(cause);
})(err);
```

**`server/src/db/connections.ts`** — raise `maxIdleTimeMS` from 60 s to 210 s (beats the ~240 s AWS NAT idle timeout without being aggressive on a low-traffic server) and add `minPoolSize: 1` so the driver always replaces a closed connection rather than letting the pool drain to zero and the topology go null.

## Test plan

- [ ] Deploy to Beta and log in via CAS — should succeed without `MongoNotConnectedError` in Render logs
- [ ] Verify no `401` responses at the `/api/cas` callback (should be redirects on success or `503` on infra failure)
- [ ] Confirm `Authentication rejected` cascades stop (they were caused by users refreshing after a 401)

🤖 Generated with [Claude Code](https://claude.com/claude-code)