### PR TITLE
Fix /api/logout 403 under Referrer-Policy: no-referrer

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -23,7 +23,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const API_BODY_LIMIT = '64kb';
 const API_URLENCODED_PARAMETER_LIMIT = 100;
 const SAFE_RATE_LIMIT_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
-const WRITE_LIKE_SAFE_METHOD_API_PATHS = new Set(['/logout']);
+// No GET routes currently need write-limiter treatment; logout is protected by
+// isTrustedLogoutRequest (Sec-Fetch-Site + Origin/Referer) inside its own handler.
+const WRITE_LIKE_SAFE_METHOD_API_PATHS = new Set<string>();
 
 dotenv.config();
 

--- a/server/src/passport.ts
+++ b/server/src/passport.ts
@@ -136,6 +136,12 @@ function isLocalAuthBypassAllowed(env: NodeJS.ProcessEnv = process.env): boolean
 function isTrustedLogoutRequest(req: express.Request): boolean {
   if (!requiresDeployedRuntimeSecurity()) return true;
 
+  // Sec-Fetch-Site is set by the browser and cannot be forged by JavaScript.
+  // Referrer-Policy: no-referrer strips Referer on navigation, but Sec-Fetch-Site
+  // is always present for same-origin navigations (e.g. window.location.href).
+  const secFetchSite = req.get('sec-fetch-site');
+  if (secFetchSite === 'same-origin') return true;
+
   const allowedOrigin = originFromUrl(authConfig.serverBaseURL);
   if (!allowedOrigin) return false;
 


### PR DESCRIPTION
## Summary

- **Root cause**: The server sets `Referrer-Policy: no-referrer` globally. When a user clicks Sign Out (`window.location.href` navigation), the browser sends no `Origin` (navigations never do) and no `Referer` (stripped by the policy). The `csrfOriginGuard` middleware saw no identifying signal and returned 403 `{"error":"Cross-site request blocked"}`.
- **Fix 1** (`app.ts`): Remove `/logout` from `WRITE_LIKE_SAFE_METHOD_API_PATHS` — the global CSRF middleware no longer gates it. The logout handler already has its own dedicated CSRF check (`isTrustedLogoutRequest`), so the middleware check was redundant and actively breaking legitimate logout.
- **Fix 2** (`passport.ts`): Add `Sec-Fetch-Site: same-origin` as a trusted signal in `isTrustedLogoutRequest`. `Sec-Fetch-Site` is a browser-controlled header that JavaScript cannot forge — it's always `same-origin` for in-app navigations even when `Referrer-Policy: no-referrer` strips the `Referer`. Cross-site CSRF attempts carry `Sec-Fetch-Site: cross-site` and are still rejected.

## Test plan
- [ ] Deploy to Beta
- [ ] Click Sign Out from the Beta app — confirm redirect to Yale CAS logout (no 403)
- [ ] Verify the `Referer`/`Origin` fallback paths still work (existing behaviour for browsers that do send those headers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)