### PR TITLE
Fix missing dotenv load in pathway Meilisearch rebuild

### DIFF
--- a/server/src/scripts/rebuildPathwaySearchIndex.ts
+++ b/server/src/scripts/rebuildPathwaySearchIndex.ts
@@ -1,3 +1,5 @@
+import dotenv from 'dotenv';
+dotenv.config();
 import mongoose from 'mongoose';
 import fs from 'fs';
 import path from 'path';


### PR DESCRIPTION
## Summary

- `rebuildPathwaySearchIndex.ts` was missing `dotenv.config()`, so `MEILISEARCH_API_KEY` was never loaded from `server/.env` when running `meili:rebuild-pathways` or `beta:seed-meili`
- `rebuildResearchEntitySearchIndex.ts` already had this call — this brings the pathway script to parity

## Test plan

- [ ] Run `yarn --cwd server beta:seed-meili` on Beta and confirm both indexes rebuild without an API key error

🤖 Generated with [Claude Code](https://claude.com/claude-code)