### PR TITLE
Reduce security-layer overhead that degraded core UX flows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,14 +223,15 @@ The only other workflow is `keep-alive.yml`, which pings the Beta Render service
 
 ## Rate Limiting
 
-Two rate limiters in `app.ts`, both keyed by authenticated user's `netId` with IP fallback for unauthenticated requests:
+Three rate limiters in `app.ts`, all keyed by authenticated user's `netId` with IP fallback for unauthenticated requests:
 
 | Limiter | Scope | Limit |
 |---------|-------|-------|
-| `apiLimiter` | All `/api` routes | 200 req / 15 min |
-| `writeLimiter` | Non-GET API routes, including the legacy listing/fellowship CRUD routes | 50 req / 15 min |
+| `apiLimiter` | All `/api` routes except `/api/cas` (the CAS login callback is always unauthenticated → keys by IP; campus NAT could exhaust a shared budget and lock users out of login) and the public discovery mounts below (which get their own deliberately sized budget) | 200 req / 15 min |
+| `publicDiscoveryLimiter` | `/api/research` + `/api/opportunities` — the sole budget for the anonymous, IP-keyed browse surface (debounced search-as-you-type, filters, infinite scroll, detail views, possibly several users behind one NAT egress IP) | 300 req / 15 min |
+| `writeLimiter` | Non-GET API routes, including the legacy listing/fellowship CRUD routes — except read-shaped traffic that must not consume the write budget: `READ_ONLY_UNSAFE_METHOD_API_PATHS` (`POST /api/research/search`, a pure read whose body is too rich for a query string) and `READ_ONLY_UNSAFE_METHOD_API_PATH_PATTERNS` (the `PUT …/addView` view-telemetry routes fired on every detail-page open) | 50 req / 15 min |
 
-Both limiters are skipped in CI, development, and test environments.
+All limiters are skipped in CI, development, and test environments.
 
 ## Auth Middleware
 
@@ -302,8 +303,10 @@ User → Yale CAS SSO → passport.ts findOrCreateUser
      → Yalies API (student/grad detection)
      → Yale Directory (faculty detection)
      → Fallback: fname "NA", userType "unknown"
-     → Create/Update User → cookie-session (1 year, httpOnly, secure in production, sameSite lax)
+     → Create/Update User → cookie-session (30 days, httpOnly, secure in production, sameSite lax)
 ```
+
+The find-or-create cascade above runs at **login time only**. Per-request session restore (`deserializeUser`) is a plain `validateUser` read plus the admin-grant check (cached in-memory for 60s in `adminGrantService`, invalidated immediately on grant/revoke) — no user creation, no Yalies/Directory calls — so external API or DB blips on those sources cannot fail steady-state requests. A session whose user doc no longer exists deserializes to unauthenticated.
 
 ## Key Services
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -336,6 +336,10 @@ User → Yale CAS SSO → passport.ts findOrCreateUser
      → Create/Update User → cookie-session
 ```
 
+The find-or-create cascade runs at login time only. Per-request session restore (`deserializeUser`) is a plain user read plus the admin-grant check — no user creation and no Yalies/Directory calls — so a hiccup in those external sources can't fail already-authenticated requests. The CAS login callback (`/api/cas`) is also exempt from the general API rate limiter: it's always unauthenticated, so it keys by IP, and many users behind one campus NAT egress IP could otherwise exhaust the shared budget and be locked out of login.
+
+The public browse surfaces (`/api/research`, `/api/opportunities`) follow the same principle: they are exempt from both the general and the write limiter (`POST /api/research/search` is a pure read despite its method) and are governed solely by `publicDiscoveryLimiter` (300 req / 15 min), sized for anonymous IP-keyed traffic — debounced search-as-you-type, filters, infinite scroll, and detail views, potentially from several users behind one NAT egress IP. The `PUT …/addView` view-telemetry routes are likewise exempt from the write limiter so ordinary browsing can't 429 a user's real mutations. Sessions last 30 days; the per-request admin-grant check is cached in-memory for 60s (invalidated immediately on grant/revoke). Public detail endpoints (research entity by slug, opportunity by id) and `/api/config` allow brief HTTP caching instead of the global `/api` no-store.
+
 ### Auth Middleware (`server/src/middleware/auth.ts`)
 
 | Middleware | Check |

--- a/client/src/components/AdminRoute.tsx
+++ b/client/src/components/AdminRoute.tsx
@@ -5,6 +5,7 @@ import { Navigate } from 'react-router-dom';
 import { useContext, FunctionComponent, useEffect } from 'react';
 import UserContext from '../contexts/UserContext';
 import { buildApiUrl } from '../utils/apiBaseUrl';
+import LoadingSpinner from './shared/LoadingSpinner';
 
 const MAX_LOCAL_ADMIN_REDIRECT_URL_LENGTH = 2048;
 
@@ -54,7 +55,11 @@ const AdminRoute = ({ Component }: AdminRouteProps) => {
   }, [isAuthenticated, isLoading, localAdminDevLoginUrl, user]);
 
   if (isLoading) {
-    return null;
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center">
+        <LoadingSpinner size="lg" inline />
+      </div>
+    );
   }
 
   if (!isAuthenticated) {

--- a/client/src/components/PrivateRoute.tsx
+++ b/client/src/components/PrivateRoute.tsx
@@ -4,6 +4,7 @@
 import { Navigate, useLocation } from 'react-router-dom';
 import { useContext, FunctionComponent } from 'react';
 import UserContext from '../contexts/UserContext';
+import LoadingSpinner from './shared/LoadingSpinner';
 
 interface PrivateRouteProps {
   Component: FunctionComponent;
@@ -16,7 +17,11 @@ const PrivateRoute = ({ Component, unknownBlocked, knownBlocked }: PrivateRouteP
   const location = useLocation();
 
   if (isLoading) {
-    return null;
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center">
+        <LoadingSpinner size="lg" inline />
+      </div>
+    );
   }
 
   if (!isAuthenticated) {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -26,6 +26,19 @@ const SAFE_RATE_LIMIT_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
 // No GET routes currently need write-limiter treatment; logout is protected by
 // isTrustedLogoutRequest (Sec-Fetch-Site + Origin/Referer) inside its own handler.
 const WRITE_LIKE_SAFE_METHOD_API_PATHS = new Set<string>();
+// POST routes that are pure reads (search bodies too rich for a query string).
+// They stay behind the CSRF origin guard and their surface limiter, but must
+// not consume the write budget: research search is public and IP-keyed for
+// anonymous visitors, so 50/15min shared across a campus NAT egress IP would
+// throttle the main browse page.
+const READ_ONLY_UNSAFE_METHOD_API_PATHS = new Set<string>(['/research/search']);
+// View-telemetry PUTs fired on every detail-page open. Billing them as writes
+// lets ordinary browsing exhaust the 50/15min budget and 429 the user's real
+// mutations (favorites, tracking, profile edits). They remain under the
+// general per-user limiter.
+const READ_ONLY_UNSAFE_METHOD_API_PATH_PATTERNS = [
+  /^\/(?:programs|listings)\/[0-9a-fA-F]{24}\/addView$/,
+];
 
 dotenv.config();
 
@@ -85,6 +98,22 @@ const getRateLimitKey = (req: express.Request): string => {
   return `ip:${ipKeyGenerator(req.ip || '')}`;
 };
 
+// The CAS login callback is always unauthenticated, so it keys by IP —
+// and Yale campus NAT can put many users behind one egress IP, letting the
+// shared budget lock people out of login. CAS ticket validation already
+// gates the endpoint, so it is exempt from the general limiter.
+const isCasLoginCallback = (req: express.Request): boolean => req.path === '/cas';
+
+// Surfaces governed by publicDiscoveryLimiter below; exempt from the general
+// limiter so the discovery budget is the single, deliberately sized cap for
+// the anonymous (IP-keyed) browse experience. Both mounts hold only public
+// search/detail reads.
+const isPublicDiscoveryPath = (req: express.Request): boolean =>
+  req.path === '/research' ||
+  req.path.startsWith('/research/') ||
+  req.path === '/opportunities' ||
+  req.path.startsWith('/opportunities/');
+
 // General rate limiter: 200 requests per 15 minutes per user (falls back to IP for unauthenticated requests)
 const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
@@ -93,7 +122,7 @@ const apiLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: 'Too many requests, please try again later.' },
-  skip: () => bypassRuntimeSecurity,
+  skip: (req) => bypassRuntimeSecurity || isCasLoginCallback(req) || isPublicDiscoveryPath(req),
 });
 
 // Write limiter for API mutations
@@ -107,10 +136,15 @@ const writeLimiter = rateLimit({
   skip: () => bypassRuntimeSecurity,
 });
 
-// Public discovery endpoints perform search/detail fan-out and get a narrower budget than cheap API reads.
+// Public discovery endpoints (research/opportunity search + detail) are the
+// sole rate budget for the anonymous browse surface, which keys by IP — often
+// a shared campus NAT egress. The ceiling must absorb debounced
+// search-as-you-type, filter toggles, infinite scroll, and detail views from
+// several concurrent users on one IP; the fan-out behind it is Meilisearch,
+// which is cheap.
 const publicDiscoveryLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
-  max: 60,
+  max: 300,
   keyGenerator: getRateLimitKey,
   standardHeaders: true,
   legacyHeaders: false,
@@ -118,8 +152,13 @@ const publicDiscoveryLimiter = rateLimit({
   skip: () => bypassRuntimeSecurity,
 });
 
-const shouldApplyWriteLimiter = (req: express.Request): boolean =>
-  WRITE_LIKE_SAFE_METHOD_API_PATHS.has(req.path) || !SAFE_RATE_LIMIT_METHODS.has(req.method);
+const shouldApplyWriteLimiter = (req: express.Request): boolean => {
+  if (READ_ONLY_UNSAFE_METHOD_API_PATHS.has(req.path)) return false;
+  if (READ_ONLY_UNSAFE_METHOD_API_PATH_PATTERNS.some((pattern) => pattern.test(req.path))) {
+    return false;
+  }
+  return WRITE_LIKE_SAFE_METHOD_API_PATHS.has(req.path) || !SAFE_RATE_LIMIT_METHODS.has(req.method);
+};
 
 const deployedBrowserOrigins = new Set([
   'https://yalelabs.onrender.com',
@@ -217,7 +256,9 @@ const app = express()
     cookieSession({
       name: sessionCookieName(),
       keys: [sessionSecret],
-      maxAge: 72 * 60 * 60 * 1000,
+      // 30 days: long enough that students aren't silently logged out
+      // mid-semester workflows, short enough to bound stale sessions.
+      maxAge: 30 * 24 * 60 * 60 * 1000,
       httpOnly: true,
       secure: requiresSecureSessionCookie(),
       path: '/',

--- a/server/src/middleware/__tests__/securityHeaders.test.ts
+++ b/server/src/middleware/__tests__/securityHeaders.test.ts
@@ -118,7 +118,7 @@ describe('securityHeaders', () => {
       .find((directive) => directive.startsWith('img-src '));
 
     expect(imageDirective).toBe(
-      "img-src 'self' data: blob: https://yale.edu https://*.yale.edu https://ysm-res.cloudinary.com https://yalies.io https://www.google-analytics.com https://stats.g.doubleclick.net",
+      "img-src 'self' data: blob: https://yale.edu https://*.yale.edu https://ysm-res.cloudinary.com https://yalies.io https://*.yalies.io https://www.google-analytics.com https://stats.g.doubleclick.net",
     );
     expect(imageDirective).not.toMatch(/\shttps:(?:\s|$)/);
   });

--- a/server/src/middleware/securityHeaders.ts
+++ b/server/src/middleware/securityHeaders.ts
@@ -25,6 +25,7 @@ const IMG_SRC_ORIGINS = [
   'https://*.yale.edu',
   'https://ysm-res.cloudinary.com',
   'https://yalies.io',
+  'https://*.yalies.io',
   'https://www.google-analytics.com',
   'https://stats.g.doubleclick.net',
 ];

--- a/server/src/passport.ts
+++ b/server/src/passport.ts
@@ -463,6 +463,10 @@ passport.serializeUser(function (user: any, done) {
   done(null, safeNetId);
 });
 
+// Runs on every authenticated request, so it must stay a plain read:
+// the find-or-create cascade (user creation, Yalies/Directory refresh)
+// belongs at login time only. A missing user doc means the session
+// references someone we no longer know — treat as unauthenticated.
 passport.deserializeUser(async (netId: string, done) => {
   try {
     authDebug('Deserializing user');
@@ -471,7 +475,11 @@ passport.deserializeUser(async (netId: string, done) => {
       done(null, null);
       return;
     }
-    const user = await findOrCreateUser(safeNetId);
+    const user = await validateUser(safeNetId);
+    if (!user) {
+      done(null, null);
+      return;
+    }
     done(null, await buildAuthenticatedSessionUser(user, safeNetId));
   } catch (error) {
     console.log('Deserialize: Error');

--- a/server/src/routes/opportunities.ts
+++ b/server/src/routes/opportunities.ts
@@ -6,12 +6,27 @@
  * The route is intentionally backed by PostedOpportunity only. Durable
  * exploratory EntryPathway records belong on the Pathways surface.
  */
-import { Router } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import * as opportunityController from '../controllers/opportunityController';
 import { asyncHandler, validateObjectId } from '../middleware/index';
 
 const router = Router();
 
-router.get('/:id', validateObjectId('id'), asyncHandler(opportunityController.getOpportunityById));
+// Detail payloads are identical for every viewer, so allow brief caching
+// (same pattern as GET /api/config) instead of the global /api no-store.
+function setPublicDetailCacheHeaders(_req: Request, res: Response, next: NextFunction) {
+  res.set('Cache-Control', 'public, max-age=60');
+  res.removeHeader('Pragma');
+  res.removeHeader('Surrogate-Control');
+  res.vary('Origin');
+  next();
+}
+
+router.get(
+  '/:id',
+  setPublicDetailCacheHeaders,
+  validateObjectId('id'),
+  asyncHandler(opportunityController.getOpportunityById),
+);
 
 export default router;

--- a/server/src/routes/researchGroups.ts
+++ b/server/src/routes/researchGroups.ts
@@ -5,16 +5,30 @@
  * - GET  /:slug  → Full lab detail payload (group + members + papers + listings).
  *
  * Both endpoints are public so unauthenticated visitors can explore Yale labs;
- * the global `apiLimiter` in app.ts already provides per-IP rate limiting.
+ * `publicDiscoveryLimiter` in app.ts provides per-IP rate limiting.
  */
-import { Router } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import * as researchGroupController from '../controllers/researchGroupController';
 import { asyncHandler } from '../middleware/index';
 
 const router = Router();
 
+// Detail payloads are identical for every viewer, so allow brief caching
+// (same pattern as GET /api/config) instead of the global /api no-store.
+function setPublicDetailCacheHeaders(_req: Request, res: Response, next: NextFunction) {
+  res.set('Cache-Control', 'public, max-age=60');
+  res.removeHeader('Pragma');
+  res.removeHeader('Surrogate-Control');
+  res.vary('Origin');
+  next();
+}
+
 router.post('/search', asyncHandler(researchGroupController.searchResearchGroups));
 
-router.get('/:slug', asyncHandler(researchGroupController.getResearchGroupBySlug));
+router.get(
+  '/:slug',
+  setPublicDetailCacheHeaders,
+  asyncHandler(researchGroupController.getResearchGroupBySlug),
+);
 
 export default router;

--- a/server/src/scripts/profileImageQualityAuditCore.ts
+++ b/server/src/scripts/profileImageQualityAuditCore.ts
@@ -87,7 +87,9 @@ function isTrustedPublicProfileImageHost(value: unknown): boolean {
     const hostname = url.hostname.toLowerCase();
     if (url.protocol !== 'https:') return false;
     if (hostname === 'yale.edu' || hostname.endsWith('.yale.edu')) return true;
-    if (hostname === 'yalies.io') return true;
+    // Yalies serves photos from subdomains (e.g. images.yalies.io); an
+    // exact-host match would silently strip every Yalies-hosted photo.
+    if (hostname === 'yalies.io' || hostname.endsWith('.yalies.io')) return true;
     if (hostname === 'ysm-res.cloudinary.com') return true;
   } catch {
     return false;

--- a/server/src/services/adminGrantService.ts
+++ b/server/src/services/adminGrantService.ts
@@ -71,12 +71,33 @@ export const listAdminGrants = async (): Promise<AdminGrantResponse> => {
   };
 };
 
+// Session deserialization checks admin authority on every authenticated
+// request, so the grant lookup is cached briefly to keep it off the hot path.
+// Grant/revoke invalidate this instance immediately; the TTL bounds staleness
+// anywhere else.
+const ADMIN_GRANT_CACHE_TTL_MS = 60 * 1000;
+const ADMIN_GRANT_CACHE_MAX_ENTRIES = 10_000;
+const adminGrantCache = new Map<string, { value: boolean; expiresAt: number }>();
+
+export const clearAdminGrantCache = (): void => {
+  adminGrantCache.clear();
+};
+
 export const hasActiveAdminGrant = async (netid: unknown): Promise<boolean> => {
   const normalizedNetid = normalizeNetid(netid);
   if (!NETID_RE.test(normalizedNetid)) return false;
 
+  const cached = adminGrantCache.get(normalizedNetid);
+  if (cached && cached.expiresAt > Date.now()) return cached.value;
+
   const grant = await AdminGrant.exists({ netid: normalizedNetid, status: 'active' });
-  return Boolean(grant);
+  const value = Boolean(grant);
+  if (adminGrantCache.size >= ADMIN_GRANT_CACHE_MAX_ENTRIES) adminGrantCache.clear();
+  adminGrantCache.set(normalizedNetid, {
+    value,
+    expiresAt: Date.now() + ADMIN_GRANT_CACHE_TTL_MS,
+  });
+  return value;
 };
 
 export const grantAdminAccess = async ({
@@ -94,6 +115,7 @@ export const grantAdminAccess = async ({
   const normalizedActor = normalizeNetid(actorNetid);
   assertValidNetid(normalizedNetid);
   assertValidNetid(normalizedActor);
+  adminGrantCache.delete(normalizedNetid);
 
   return AdminGrant.findOneAndUpdate(
     { netid: normalizedNetid },
@@ -129,6 +151,7 @@ export const revokeAdminAccess = async ({
   const normalizedActor = normalizeNetid(actorNetid);
   assertValidNetid(normalizedNetid);
   assertValidNetid(normalizedActor);
+  adminGrantCache.delete(normalizedNetid);
 
   return AdminGrant.findOneAndUpdate(
     { netid: normalizedNetid, status: 'active' },


### PR DESCRIPTION
## Summary

Follow-up to the recent auth-stack incidents (#92–#95): several security layers were imposing real UX costs with little threat coverage. This PR removes the overhead without weakening the actual protections (CSRF origin guard, open-redirect validation, SSRF guards, and CSP all unchanged in substance).

### Rate limiting
- **`/api/cas` exempt from the general limiter** — the login callback is always unauthenticated so it keys by IP; many users behind one campus NAT egress IP could exhaust the shared 200/15min budget and be locked out of login. CAS ticket validation already gates the endpoint.
- **Read-shaped traffic no longer bills as writes** — `POST /api/research/search` (pure read, body too rich for a query string) and the `PUT …/addView` view-telemetry routes are exempt from the 50/15min write limiter, so ordinary browsing can no longer 429 a user's real mutations (favorites, tracking moves, profile edits).
- **One deliberate budget for the anonymous browse surface** — `/api/research` + `/api/opportunities` are exempt from the general limiter and governed solely by `publicDiscoveryLimiter`, raised 60 → 300 req/15min (previously three overlapping limiters made the effective cap ~50/15min shared per NAT IP).

### Auth hot path
- **`deserializeUser` is now a plain read** — no find-or-create cascade, no Yalies/Directory calls per request; external-source or DB blips can't fail steady-state authenticated requests (the root fragility behind the #92–#94 incident chain). A session whose user doc no longer exists deserializes to unauthenticated instead of resurrecting a placeholder user. The full cascade still runs at login.
- **`hasActiveAdminGrant` cached in-memory for 60s** (invalidated immediately on grant/revoke) — removes a Mongo query from every authenticated request and every `isAdmin` route.

### UX / caching
- `PrivateRoute`/`AdminRoute` render the shared `LoadingSpinner` instead of a blank white page while `/api/check` is in flight.
- Public detail endpoints (research by slug, opportunity by id) send `Cache-Control: public, max-age=60` instead of the global `/api` no-store — both controllers are viewer-independent (no `req.user` reads), matching the pattern `/api/config` already uses.
- Session `maxAge` 72h → 30 days (docs previously claimed 1 year; students were being silently logged out every 3 days).
- Profile-image trust filter and CSP `img-src` now accept `*.yalies.io` subdomains, so Yalies-hosted photos can't be silently stripped by an exact-host match.

CLAUDE.md and DEVELOPER_GUIDE.md updated in the same commit.

## Verification

- Server typecheck clean apart from the pre-existing corrupted `visibilityRepairQueueService.test.ts` (syntax errors on `beta` before this PR).
- Server suite run with and without this diff (stash-compared): **2274 passed / 125 failed — byte-identical to the beta baseline; zero new failures.**
- Client suite: **713 passed / 4 failed — same 4 pre-existing failures as baseline.**

⚠️ Note for reviewers: CI on this PR will be red for the pre-existing reasons above (corrupted test file + 125 failing server tests inherited from `beta`), not from this change. That cleanup should land separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
