### PR TITLE
Fix CI bootstrap: invoke immutable installs as builtins, not a script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - beta
-      - new-foundation
   workflow_dispatch:
 
 permissions:
@@ -28,8 +27,16 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
+      # Invoke the immutable installs as yarn builtins, not via the
+      # install:all:immutable script: on a fresh checkout Yarn cannot run
+      # package.json scripts before an install has created its state file
+      # ("Couldn't find the node_modules state file"), so the script form
+      # fails on every CI runner.
       - name: Install dependencies from lockfiles
-        run: yarn install:all:immutable
+        run: |
+          yarn install --immutable
+          yarn --cwd server install --immutable
+          yarn --cwd client install --immutable
 
       - name: Run server typecheck
         run: npx tsc --noEmit -p server/tsconfig.json

--- a/scripts/security-preflight.test.mjs
+++ b/scripts/security-preflight.test.mjs
@@ -624,8 +624,13 @@ test('production dependency audit covers root, server, and client workspaces', (
 
 test('CI runs immutable installs and the same deploy security preflight used locally', () => {
   assert.match(ciWorkflow, /name:\s*Install dependencies from lockfiles/);
-  assert.match(ciWorkflow, /run:\s*yarn install:all:immutable/);
-  assert.doesNotMatch(ciWorkflow, /run:\s*yarn install:all(?:\s|$)/);
+  // Installs are invoked as yarn builtins (a fresh runner cannot execute
+  // package.json scripts before an install exists); all three workspaces
+  // must stay immutable and no mutable install may sneak in.
+  assert.match(ciWorkflow, /yarn install --immutable/);
+  assert.match(ciWorkflow, /yarn --cwd server install --immutable/);
+  assert.match(ciWorkflow, /yarn --cwd client install --immutable/);
+  assert.doesNotMatch(ciWorkflow, /run:\s*yarn install:all(?::immutable)?(?:\s|$)/);
   assert.match(ciWorkflow, /name:\s*Run deploy security preflight/);
   assert.match(ciWorkflow, /run:\s*yarn security:preflight/);
 });


### PR DESCRIPTION
## Summary

Fixes the last CI blocker. Every CI run — including the one on #99 — died at the **first step**: `yarn install:all:immutable` is a package.json *script*, and Yarn 4 refuses to run any script on a fresh checkout before an install has created its state file:

```
Usage Error: Couldn't find the node_modules state file - running an install might help (findPackageLocation)
```

So the install step failed on every runner since it was introduced, and no later step (typecheck, tests, preflight, audit, build) ever executed. The green pipeline from #99 was verified locally but could not be reached in CI because of this bootstrap bug.

**Fix:** invoke the three immutable installs directly as yarn builtins (builtins don't need the state file); also remove the deleted `new-foundation` branch from the PR trigger list.

## Verification

Reproduced CI's environment with a pristine clone (no `node_modules`, no build artifacts):
- `yarn install --immutable` + server + client — all exit 0 against the committed lockfiles
- `npx tsc --noEmit -p server/tsconfig.json` ✅
- `yarn security:preflight` ✅ (also exercises the new dist-conditional policy checks, since the fresh clone has no `client/dist`)
- `yarn npm audit --recursive --severity moderate` ✅

With the install step unblocked, the remaining steps run the suites that #99 made green (server 2477/2477, client 717/717). This PR's own CI run is the end-to-end proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
