### PR TITLE
feat: unlock public research discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Architecture
 
-Monorepo with a React client and Express server communicating over REST. MongoDB Atlas is the primary data store. Meilisearch handles search (semantic + keyword) with an OpenAI embedder configured server-side. Yale CAS provides SSO authentication.
+Monorepo with a React client and Express server communicating over REST. MongoDB Atlas is the primary data store. Meilisearch handles search (semantic + keyword) with an OpenAI embedder configured server-side. Yale CAS provides SSO authentication, while the public research discovery flow exposes redacted confirmed listings to logged-out visitors.
 
 ```
 React (Vite) → Express (Passport.js) → MongoDB Atlas + Meilisearch
@@ -87,13 +87,15 @@ MongoDB via Mongoose 8. All environments use `MONGODBURL` — the connection str
 
 Search has migrated from MongoDB Atlas Vector Search to **Meilisearch**. The old `embeddingService.ts` (OpenAI client-side embedding generation + in-memory LRU cache) has been removed.
 
-Current search flow:
+Current authenticated listing search flow:
 
 1. Client sends query + filters to `/api/listings/search`
 2. Controller builds Meilisearch filter strings from query params (`departments`, `researchAreas`, `archived`, `confirmed`)
-3. When a text query is present, hybrid search is enabled with `semanticRatio: 0.8` using the Meilisearch-configured OpenAI embedder
+3. When a multi-word text query is present, hybrid search is enabled with `semanticRatio: 0.8` using the Meilisearch-configured OpenAI embedder; single-word queries remain keyword-only to avoid semantic drift
 4. If hybrid search fails, the controller retries keyword-only Meilisearch; if Meilisearch is unavailable, it falls back to MongoDB filtering
 5. Results are returned with `totalCount` for pagination and a `degraded` boolean indicating whether fallback behavior was used
+
+Public research discovery uses the same degradation path through `/api/research`, but only returns confirmed, unarchived listings after redacting contact/private fields (`ownerEmail`, `emails`, owner/professor IDs, views, favorites, archived/confirmed/audit internals). Client routes `/research` and `/research/:slug` render the browse page without `PrivateRoute`; opening a card updates the URL to a shareable modal route. Authenticated users on those public routes additionally call `/api/research/:slug/contact` to retrieve the full listing with contact fields. Public research search uses a contact-redacted searchable field set and only accepts `createdAt` or `updatedAt` sort fields.
 
 The Meilisearch client (`server/src/utils/meiliClient.ts`) lazy-loads and caches the connection. Configuration: `MEILISEARCH_HOST` (defaults to `http://localhost:7700`), `MEILISEARCH_API_KEY`, and `MEILISEARCH_INDEX_PREFIX` (optional, for multi-environment isolation on a shared instance). The module exports `getMeiliIndex(name)` which resolves prefixed index names and `resolveIndexName(name)` for use in migration scripts.
 
@@ -205,14 +207,15 @@ The only other workflow is `keep-alive.yml`, which pings the Beta Render service
 
 ## Rate Limiting
 
-Two rate limiters in `app.ts`, both keyed by authenticated user's `netId` with IP fallback for unauthenticated requests:
+Three rate limiters in `app.ts`, all keyed by authenticated user's `netId` with IP fallback for unauthenticated requests:
 
 | Limiter        | Scope                                                      | Limit            |
 | -------------- | ---------------------------------------------------------- | ---------------- |
 | `apiLimiter`   | All `/api` routes                                          | 200 req / 15 min |
+| `publicDiscoveryLimiter` | `/api/research` public browse/detail traffic      | 120 req / 15 min |
 | `writeLimiter` | Non-GET requests to `/api/listings` and `/api/fellowships` | 50 req / 15 min  |
 
-Both limiters are skipped in CI, development, and test environments.
+All three limiters are skipped in CI, development, and test environments.
 
 ## Auth Middleware
 
@@ -227,7 +230,7 @@ Defined in `server/src/middleware/auth.ts`:
 | `isTrustworthy`    | `userConfirmed` + admin/professor/faculty             |
 | `isConfirmed`      | `userConfirmed === true`                              |
 
-Client-side route guards: `PrivateRoute` (auth required, redirects unknown users when `unknownBlocked=true`), `AdminRoute` (admin only), `UnprivateRoute` (no auth required, for error pages).
+Client-side route guards: `PrivateRoute` (auth required, redirects unknown users when `unknownBlocked=true`), `AdminRoute` (admin only), `UnprivateRoute` (no auth required, for error pages). Public `/research` routes intentionally bypass `PrivateRoute`; favorites, contact actions, and other authenticated actions preserve the return path and send logged-out users to `/login`.
 
 ## Validation Middleware
 
@@ -246,7 +249,8 @@ All routes mount under `/api` in `app.ts`. Route files in `server/src/routes/`:
 
 | Prefix            | File               | Auth                                           |
 | ----------------- | ------------------ | ---------------------------------------------- |
-| `/listings`       | `listings.ts`      | Varies (search public, mutations require auth) |
+| `/listings`       | `listings.ts`      | Varies (authenticated search, mutations require auth) |
+| `/research`       | `research.ts`      | Public browse/detail; contact detail requires auth |
 | `/fellowships`    | `fellowships.ts`   | Varies                                         |
 | `/users`          | `users.ts`         | Yes                                            |
 | `/profiles`       | `profiles.ts`      | Varies                                         |

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -6,7 +6,7 @@
 
 ## What Is This?
 
-Y/Labs is a **Yale research lab discovery platform**. Students find labs and fellowships, professors create and manage listings, admins oversee everything.
+Y/Labs is a **Yale research lab discovery platform**. Visitors can browse public research listings, students find labs and fellowships, professors create and manage listings, and admins oversee everything.
 
 ---
 
@@ -192,13 +192,21 @@ ylabs/
 
 ## Search
 
-Search uses **Meilisearch** with hybrid mode (80% semantic, 20% keyword).
+Search uses **Meilisearch** with keyword search and hybrid mode (80% semantic, 20% keyword) for multi-word queries.
 
 1. Client sends query + filters to `/api/listings/search`
 2. Controller builds Meilisearch filter strings from query params
-3. Hybrid search uses the Meilisearch-configured OpenAI embedder
+3. Multi-word queries use hybrid search with the Meilisearch-configured OpenAI embedder; single-word queries use keyword search to avoid semantic drift
 4. If hybrid search fails, the controller retries keyword-only Meilisearch; if Meilisearch is unavailable, it falls back to MongoDB filtering
 5. Results are returned with `totalCount` for pagination and a `degraded` boolean indicating whether fallback behavior was used
+
+Logged-out visitors use the public research discovery path instead:
+
+- Client routes `/research` and `/research/:slug` render the listings browse page without the `PrivateRoute` guard.
+- The client sends public browse requests to `/api/research` and public detail requests to `/api/research/:slug`.
+- Public responses include only confirmed, unarchived listings and redact contact/private fields such as owner email, additional emails, owner/professor IDs, view counts, favorites, and audit fields.
+- Authenticated users opening a public detail modal also request `/api/research/:slug/contact` to load the full listing, including contact fields.
+- Public research search only allows `createdAt` and `updatedAt` sort fields and searches a contact-redacted field set.
 
 Listing CRUD in `listingService.ts` automatically syncs to Meilisearch after MongoDB writes.
 
@@ -236,17 +244,18 @@ User → Yale CAS SSO → passport.ts findOrCreateUser
 
 All mount under `/api`.
 
-| Prefix            | Description                  | Auth             |
-| ----------------- | ---------------------------- | ---------------- |
-| `/listings`       | Listing CRUD and search      | Varies           |
-| `/fellowships`    | Fellowship CRUD and search   | Varies           |
-| `/users`          | User CRUD                    | Yes              |
-| `/profiles`       | Faculty profiles             | Varies           |
-| `/analytics`      | Analytics dashboards         | Admin            |
-| `/config`         | Departments + research areas | No               |
-| `/research-areas` | Research area CRUD           | Admin for writes |
-| `/admin`          | Admin operations             | Admin            |
-| `/seed`           | Dev seeding routes           | Dev mode only    |
+| Prefix            | Description                                             | Auth                                            |
+| ----------------- | ------------------------------------------------------- | ----------------------------------------------- |
+| `/listings`       | Listing CRUD and authenticated search                   | Varies                                          |
+| `/research`       | Public read-only listing discovery and shareable detail URLs | Public; `/research/:slug/contact` requires login |
+| `/fellowships`    | Fellowship CRUD and search                              | Varies                                          |
+| `/users`          | User CRUD                                               | Yes                                             |
+| `/profiles`       | Faculty profiles                                        | Varies                                          |
+| `/analytics`      | Analytics dashboards                                    | Admin                                           |
+| `/config`         | Departments + research areas                            | No                                              |
+| `/research-areas` | Research area CRUD                                      | Admin for writes                                |
+| `/admin`          | Admin operations                                        | Admin                                           |
+| `/seed`           | Dev seeding routes                                      | Dev mode only                                   |
 
 ---
 
@@ -304,6 +313,8 @@ The workflow also accepts `workflow_dispatch` so it can be run manually from the
 
 1. Page component in `client/src/pages/<page>.tsx`
 2. Route in `client/src/App.tsx` with appropriate guard (`PrivateRoute`, `AdminRoute`)
+
+Public pages that should work for logged-out visitors must not use `PrivateRoute`; protected actions from those pages should route users to `/login` and preserve the return path.
 
 ### Modifying a Schema
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # YURA Research Database
 
-A research lab and fellowship discovery platform for Yale University.
+A research lab and fellowship discovery platform for Yale University, with public research browsing and authenticated tools for favorites, contact, and management.
 
 **Live:** [yalelabs.io](https://yalelabs.io/) · **Beta:** [ylabs-dev.onrender.com](https://ylabs-dev.onrender.com)
 
@@ -31,7 +31,7 @@ yarn dev:client
 yarn dev:server
 ```
 
-Go to **http://localhost:3000**. Use `http://localhost:4000/api/dev-login` to bypass CAS auth locally.
+Go to **http://localhost:3000**. Public research discovery is available at **http://localhost:3000/research**; use `http://localhost:4000/api/dev-login` to bypass CAS auth locally for authenticated actions.
 
 ## Documentation
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -42,6 +42,8 @@ const App = () => {
                         path="/"
                         element={<PrivateRoute Component={Home} unknownBlocked={true} />}
                       />
+                      <Route path="/research" element={<Home />} />
+                      <Route path="/research/:slug" element={<Home />} />
                       <Route
                         path="/fellowships"
                         element={<PrivateRoute Component={Fellowships} unknownBlocked={true} />}

--- a/client/src/__tests__/App.publicResearchRoutes.test.tsx
+++ b/client/src/__tests__/App.publicResearchRoutes.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import UserContext from '../contexts/UserContext';
+import App from '../App';
+
+vi.mock('../pages/home', () => ({
+  default: () => <div>Research browse page</div>,
+}));
+
+vi.mock('../pages/login', () => ({
+  default: () => <div>Login page</div>,
+}));
+
+vi.mock('../components/Navbar', () => ({
+  default: () => <div />,
+}));
+
+vi.mock('../components/Footer', () => ({
+  default: () => <div />,
+}));
+
+vi.mock('../components/shared/ScrollToTop', () => ({
+  default: () => null,
+}));
+
+vi.mock('../providers/ConfigContextProvider', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../providers/SearchContextProvider', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../providers/FellowshipSearchContextProvider', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../providers/UIContextProvider', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+describe('public research routes', () => {
+  it('lets logged-out visitors open a shared research detail URL', () => {
+    window.history.pushState({}, '', '/research/507f1f77bcf86cd799439011');
+
+    render(
+      <UserContext.Provider
+        value={{
+          isLoading: false,
+          isAuthenticated: false,
+          checkContext: vi.fn(),
+        }}
+      >
+        <App />
+      </UserContext.Provider>,
+    );
+
+    expect(screen.getByText('Research browse page')).toBeTruthy();
+    expect(screen.queryByText('Login page')).toBeNull();
+  });
+});

--- a/client/src/components/AdminRoute.tsx
+++ b/client/src/components/AdminRoute.tsx
@@ -1,7 +1,7 @@
 /**
  * Route guard that restricts access to admin users only.
  */
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import { useContext, FunctionComponent } from 'react';
 import UserContext from '../contexts/UserContext';
 
@@ -11,12 +11,17 @@ interface AdminRouteProps {
 
 const AdminRoute = ({ Component }: AdminRouteProps) => {
   const { user, isLoading, isAuthenticated } = useContext(UserContext);
+  const location = useLocation();
 
   if (isLoading) {
     return null;
   }
 
   if (!isAuthenticated) {
+    localStorage.setItem(
+      'logoutReturnPath',
+      window.location.origin + location.pathname + location.search,
+    );
     return <Navigate to="/login" />;
   }
 

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -328,6 +328,9 @@ export default function Navbar() {
 
   const isAdmin = user?.userType === 'admin';
   const isHomePage = location.pathname === '/';
+  const isResearchPage =
+    location.pathname === '/research' || location.pathname.startsWith('/research/');
+  const isLabsBrowsePage = isHomePage || isResearchPage;
   const isFellowshipsPage = location.pathname === '/fellowships';
   const isAccountPage = location.pathname === '/account';
 
@@ -670,7 +673,7 @@ export default function Navbar() {
           <Toolbar sx={{ height: '64px', width: '100%', justifyContent: 'flex-start' }}>
             <Box sx={{ flexShrink: 0 }}>{isAuthenticated ? <HomeButton /> : <YURAButton />}</Box>
 
-            {isAuthenticated && isHomePage && (
+            {isLabsBrowsePage && (
               <Box
                 sx={{
                   display: { xs: 'none', md: 'flex' },
@@ -711,13 +714,13 @@ export default function Navbar() {
             {isAuthenticated && (
               <>
                 <Box sx={{ display: 'flex', gap: '8px', alignItems: 'center', ml: 'auto' }}>
-                  {(isHomePage || isFellowshipsPage) && isMobile && (
+                  {(isLabsBrowsePage || isFellowshipsPage) && isMobile && (
                     <IconButton
                       size="small"
                       color="inherit"
                       aria-label="search"
                       onClick={() => {
-                        if (isHomePage) setMobileSearchOpen(!mobileSearchOpen);
+                        if (isLabsBrowsePage) setMobileSearchOpen(!mobileSearchOpen);
                         if (isFellowshipsPage)
                           setMobileFellowshipSearchOpen(!mobileFellowshipSearchOpen);
                       }}
@@ -752,10 +755,27 @@ export default function Navbar() {
                 </Drawer>
               </>
             )}
+            {!isAuthenticated && isResearchPage && isMobile && (
+              <Box sx={{ display: 'flex', gap: '8px', alignItems: 'center', ml: 'auto' }}>
+                <IconButton
+                  size="small"
+                  color="inherit"
+                  aria-label="search"
+                  onClick={() => setMobileSearchOpen(!mobileSearchOpen)}
+                  sx={{
+                    borderRadius: '4px',
+                    padding: '8px',
+                    '&:hover': { backgroundColor: 'transparent' },
+                  }}
+                >
+                  <SearchIcon />
+                </IconButton>
+              </Box>
+            )}
           </Toolbar>
         </AppBar>
 
-        {isAuthenticated && isHomePage && isMobile && (
+        {isLabsBrowsePage && isMobile && (
           <Collapse in={mobileSearchOpen}>
             <Box
               sx={{
@@ -797,7 +817,7 @@ export default function Navbar() {
           </Collapse>
         )}
 
-        {isAuthenticated && isHomePage && (
+        {isLabsBrowsePage && (
           <ActiveFilters
             quickFilters={listingQuickFilters}
             activeQuickFilter={quickFilter}

--- a/client/src/components/PrivateRoute.tsx
+++ b/client/src/components/PrivateRoute.tsx
@@ -1,7 +1,7 @@
 /**
  * Route guard that redirects unauthenticated users to login.
  */
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import { useContext, FunctionComponent } from 'react';
 import UserContext from '../contexts/UserContext';
 
@@ -13,12 +13,17 @@ interface PrivateRouteProps {
 
 const PrivateRoute = ({ Component, unknownBlocked, knownBlocked }: PrivateRouteProps) => {
   const { user, isLoading, isAuthenticated } = useContext(UserContext);
+  const location = useLocation();
 
   if (isLoading) {
     return null;
   }
 
   if (!isAuthenticated) {
+    localStorage.setItem(
+      'logoutReturnPath',
+      window.location.origin + location.pathname + location.search,
+    );
     return <Navigate to="/login" />;
   }
 

--- a/client/src/components/navbar/NavbarSortDropdown.tsx
+++ b/client/src/components/navbar/NavbarSortDropdown.tsx
@@ -5,7 +5,8 @@ import { useContext, useRef, useState } from 'react';
 import SearchContext from '../../contexts/SearchContext';
 
 const NavbarSortDropdown = () => {
-  const { sortBy, setSortBy, sortDirection, onToggleSortDirection } = useContext(SearchContext);
+  const { sortBy, setSortBy, sortDirection, onToggleSortDirection, sortableKeys } =
+    useContext(SearchContext);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [focusedIndex, setFocusedIndex] = useState(-1);
 
@@ -15,10 +16,11 @@ const NavbarSortDropdown = () => {
   const sortOptions = [
     { value: 'default', label: 'Best Match' },
     { value: 'createdAt', label: 'Date Added' },
+    { value: 'updatedAt', label: 'Recently Updated' },
     { value: 'ownerLastName', label: 'Last Name' },
     { value: 'ownerFirstName', label: 'First Name' },
     { value: 'title', label: 'Lab Title' },
-  ];
+  ].filter((option) => sortableKeys.includes(option.value));
 
   const handleSelect = (value: string) => {
     setSortBy(value);

--- a/client/src/components/shared/ListingDetailModal.tsx
+++ b/client/src/components/shared/ListingDetailModal.tsx
@@ -17,6 +17,7 @@ interface ListingDetailModalProps {
   listing: Listing;
   isFavorite: boolean;
   onToggleFavorite: (e: React.MouseEvent) => void;
+  onRequireAuth?: () => void;
   onNavigateToResearchArea?: (area: string) => void;
   onNavigateToDepartment?: (dept: string) => void;
 }
@@ -27,12 +28,13 @@ const ListingDetailModal = ({
   listing,
   isFavorite,
   onToggleFavorite,
+  onRequireAuth,
   onNavigateToResearchArea,
   onNavigateToDepartment,
 }: ListingDetailModalProps) => {
   const isCreated = listing.id === 'create';
   const [restrictedStats, setRestrictedStats] = useState(true);
-  const { user } = useContext(UserContext);
+  const { user, isAuthenticated } = useContext(UserContext);
   const { getColorForResearchArea, getDepartmentByAbbr } = useContext(ConfigContext);
 
   const researchAreas =
@@ -152,10 +154,20 @@ const ListingDetailModal = ({
                       </a>
                     )}
                     <a
-                      href={`mailto:${listing.ownerEmail}`}
-                      onClick={(e) => e.stopPropagation()}
+                      href={
+                        isAuthenticated && listing.ownerEmail
+                          ? `mailto:${listing.ownerEmail}`
+                          : undefined
+                      }
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        if (!isAuthenticated) {
+                          e.preventDefault();
+                          onRequireAuth?.();
+                        }
+                      }}
                       className="p-2 rounded-lg hover:bg-gray-100 transition-colors text-gray-500 hover:text-blue-600"
-                      title="Send email"
+                      title={isAuthenticated ? 'Send email' : 'Sign in to inquire'}
                     >
                       <svg
                         xmlns="http://www.w3.org/2000/svg"
@@ -333,10 +345,35 @@ const ListingDetailModal = ({
                     Contact
                   </h3>
                   <div className="space-y-2">
-                    {[listing.ownerEmail, ...listing.emails].map((email, i) => (
-                      <a
-                        key={i}
-                        href={`mailto:${email}`}
+                    {isAuthenticated ? (
+                      [listing.ownerEmail, ...listing.emails].filter(Boolean).map((email, i) => (
+                        <a
+                          key={i}
+                          href={`mailto:${email}`}
+                          className="flex items-center gap-2 text-sm text-blue-600 hover:text-blue-800 hover:underline"
+                        >
+                          <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="14"
+                            height="14"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            className="flex-shrink-0"
+                          >
+                            <rect x="2" y="4" width="20" height="16" rx="2" />
+                            <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+                          </svg>
+                          <span className="truncate">{email}</span>
+                        </a>
+                      ))
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={onRequireAuth}
                         className="flex items-center gap-2 text-sm text-blue-600 hover:text-blue-800 hover:underline"
                       >
                         <svg
@@ -354,9 +391,9 @@ const ListingDetailModal = ({
                           <rect x="2" y="4" width="20" height="16" rx="2" />
                           <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
                         </svg>
-                        <span className="truncate">{email}</span>
-                      </a>
-                    ))}
+                        <span>Sign in to inquire</span>
+                      </button>
+                    )}
                     {listing.websites &&
                       listing.websites.length > 0 &&
                       listing.websites.map((website, i) => (

--- a/client/src/components/shared/ListingDetailModal.tsx
+++ b/client/src/components/shared/ListingDetailModal.tsx
@@ -43,6 +43,8 @@ const ListingDetailModal = ({
   const institutionCode = getInstitutionAffiliation(listing.departments);
   const institutionLabel = getInstitutionLabel(institutionCode);
   const professorName = `${listing.ownerFirstName} ${listing.ownerLastName}`;
+  const contactEmails = [listing.ownerEmail, ...(listing.emails || [])].filter(Boolean);
+  const canEmailContact = isAuthenticated && contactEmails.length > 0;
 
   const handleBackdropClick = (e: React.MouseEvent) => {
     if (e.target === e.currentTarget) onClose();
@@ -154,11 +156,7 @@ const ListingDetailModal = ({
                       </a>
                     )}
                     <a
-                      href={
-                        isAuthenticated && listing.ownerEmail
-                          ? `mailto:${listing.ownerEmail}`
-                          : undefined
-                      }
+                      href={canEmailContact ? `mailto:${contactEmails[0]}` : undefined}
                       onClick={(e) => {
                         e.stopPropagation();
                         if (!isAuthenticated) {
@@ -167,7 +165,13 @@ const ListingDetailModal = ({
                         }
                       }}
                       className="p-2 rounded-lg hover:bg-gray-100 transition-colors text-gray-500 hover:text-blue-600"
-                      title={isAuthenticated ? 'Send email' : 'Sign in to inquire'}
+                      title={
+                        canEmailContact
+                          ? 'Send email'
+                          : isAuthenticated
+                            ? 'Contact details unavailable'
+                            : 'Sign in to inquire'
+                      }
                     >
                       <svg
                         xmlns="http://www.w3.org/2000/svg"
@@ -345,8 +349,8 @@ const ListingDetailModal = ({
                     Contact
                   </h3>
                   <div className="space-y-2">
-                    {isAuthenticated ? (
-                      [listing.ownerEmail, ...listing.emails].filter(Boolean).map((email, i) => (
+                    {canEmailContact ? (
+                      contactEmails.map((email, i) => (
                         <a
                           key={i}
                           href={`mailto:${email}`}
@@ -370,7 +374,7 @@ const ListingDetailModal = ({
                           <span className="truncate">{email}</span>
                         </a>
                       ))
-                    ) : (
+                    ) : !isAuthenticated ? (
                       <button
                         type="button"
                         onClick={onRequireAuth}
@@ -393,6 +397,25 @@ const ListingDetailModal = ({
                         </svg>
                         <span>Sign in to inquire</span>
                       </button>
+                    ) : (
+                      <div className="flex items-center gap-2 text-sm text-gray-500">
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="14"
+                          height="14"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          className="flex-shrink-0"
+                        >
+                          <rect x="2" y="4" width="20" height="16" rx="2" />
+                          <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+                        </svg>
+                        <span>Contact details unavailable</span>
+                      </div>
                     )}
                     {listing.websites &&
                       listing.websites.length > 0 &&

--- a/client/src/components/shared/__tests__/ListingDetailModal.public.test.tsx
+++ b/client/src/components/shared/__tests__/ListingDetailModal.public.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import ConfigContext, { defaultConfigContext } from '../../../contexts/ConfigContext';
+import UserContext from '../../../contexts/UserContext';
+import ListingDetailModal from '../ListingDetailModal';
+import { Listing } from '../../../types/types';
+
+const listing: Listing = {
+  id: '507f1f77bcf86cd799439011',
+  ownerId: '',
+  ownerFirstName: 'Ada',
+  ownerLastName: 'Lovelace',
+  ownerEmail: '',
+  ownerTitle: 'Professor',
+  ownerPrimaryDepartment: 'Computer Science',
+  professorIds: [],
+  professorNames: [],
+  title: 'Computing lab',
+  departments: ['Computer Science'],
+  emails: [],
+  websites: [],
+  description: 'Research description',
+  applicantDescription: '',
+  keywords: [],
+  researchAreas: ['Algorithms'],
+  established: '',
+  views: 0,
+  favorites: 0,
+  hiringStatus: 1,
+  archived: false,
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  confirmed: true,
+  audited: false,
+};
+
+const renderModal = (onRequireAuth = vi.fn()) =>
+  render(
+    <MemoryRouter>
+      <UserContext.Provider
+        value={{
+          isLoading: false,
+          isAuthenticated: false,
+          checkContext: vi.fn(),
+        }}
+      >
+        <ConfigContext.Provider
+          value={{
+            ...defaultConfigContext,
+            departments: [],
+            departmentCategories: [],
+            researchAreas: [],
+            researchFields: [],
+            fieldOrder: [],
+            isLoading: false,
+            isLoaded: true,
+            error: null,
+            getDepartmentByAbbr: () => undefined,
+            getColorForResearchArea: () => ({
+              bg: 'bg-blue-50',
+              text: 'text-blue-700',
+              border: 'border-blue-100',
+            }),
+          }}
+        >
+          <ListingDetailModal
+            isOpen
+            onClose={vi.fn()}
+            listing={listing}
+            isFavorite={false}
+            onToggleFavorite={vi.fn()}
+            onRequireAuth={onRequireAuth}
+          />
+        </ConfigContext.Provider>
+      </UserContext.Provider>
+    </MemoryRouter>,
+  );
+
+describe('ListingDetailModal public discovery behavior', () => {
+  it('prompts login for inquiry instead of rendering redacted mail links', () => {
+    const onRequireAuth = vi.fn();
+    renderModal(onRequireAuth);
+
+    expect(screen.queryByRole('link', { name: /@/ })).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /sign in to inquire/i }));
+
+    expect(onRequireAuth).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/components/shared/__tests__/ListingDetailModal.public.test.tsx
+++ b/client/src/components/shared/__tests__/ListingDetailModal.public.test.tsx
@@ -36,13 +36,14 @@ const listing: Listing = {
   audited: false,
 };
 
-const renderModal = (onRequireAuth = vi.fn()) =>
+const renderModal = (options: { isAuthenticated?: boolean; onRequireAuth?: () => void } = {}) =>
   render(
     <MemoryRouter>
       <UserContext.Provider
         value={{
           isLoading: false,
-          isAuthenticated: false,
+          isAuthenticated: options.isAuthenticated || false,
+          user: options.isAuthenticated ? ({ userType: 'student' } as any) : undefined,
           checkContext: vi.fn(),
         }}
       >
@@ -71,7 +72,7 @@ const renderModal = (onRequireAuth = vi.fn()) =>
             listing={listing}
             isFavorite={false}
             onToggleFavorite={vi.fn()}
-            onRequireAuth={onRequireAuth}
+            onRequireAuth={options.onRequireAuth}
           />
         </ConfigContext.Provider>
       </UserContext.Provider>
@@ -81,12 +82,19 @@ const renderModal = (onRequireAuth = vi.fn()) =>
 describe('ListingDetailModal public discovery behavior', () => {
   it('prompts login for inquiry instead of rendering redacted mail links', () => {
     const onRequireAuth = vi.fn();
-    renderModal(onRequireAuth);
+    renderModal({ onRequireAuth });
 
     expect(screen.queryByRole('link', { name: /@/ })).toBeNull();
 
     fireEvent.click(screen.getByRole('button', { name: /sign in to inquire/i }));
 
     expect(onRequireAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows an authenticated fallback when contact fields are redacted', () => {
+    renderModal({ isAuthenticated: true });
+
+    expect(screen.queryByRole('link', { name: /@/ })).toBeNull();
+    expect(screen.getByText(/contact details unavailable/i)).toBeTruthy();
   });
 });

--- a/client/src/pages/__tests__/home.publicResearch.test.tsx
+++ b/client/src/pages/__tests__/home.publicResearch.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { render, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi, beforeEach } from 'vitest';
 import SearchContext, { defaultSearchContext } from '../../contexts/SearchContext';
 import UserContext from '../../contexts/UserContext';
 import axios from '../../utils/axios';
@@ -22,7 +22,12 @@ vi.mock('../../components/shared/BrowseGrid', () => ({
 }));
 
 vi.mock('../../components/shared/ListingDetailModal', () => ({
-  default: () => <div />,
+  default: ({ isOpen, onNavigateToResearchArea }: any) =>
+    isOpen ? (
+      <button type="button" onClick={() => onNavigateToResearchArea('Artificial Intelligence')}>
+        Artificial Intelligence
+      </button>
+    ) : null,
 }));
 
 vi.mock('../../components/admin/AdminListingEditModal', () => ({
@@ -35,7 +40,16 @@ vi.mock('sweetalert', () => ({
 
 const mockedAxiosGet = vi.mocked(axios.get);
 
+const LocationDisplay = () => {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}</div>;
+};
+
 describe('Home public research detail route', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   beforeEach(() => {
     mockedAxiosGet.mockReset();
     mockedAxiosGet.mockImplementation((url: string) => {
@@ -106,6 +120,64 @@ describe('Home public research detail route', () => {
 
     expect(mockedAxiosGet).not.toHaveBeenCalledWith('/listings/507f1f77bcf86cd799439011', {
       withCredentials: true,
+    });
+  });
+
+  it('clears share URL slug when navigating to a research area from the modal', async () => {
+    const slug = 'public-research-507f1f77bcf86cd799439011';
+    const setSelectedListingResearchAreas = vi.fn();
+
+    render(
+      <MemoryRouter initialEntries={[`/research/${slug}`]}>
+        <UserContext.Provider
+          value={{
+            isLoading: false,
+            isAuthenticated: false,
+            user: null,
+            checkContext: vi.fn(),
+          }}
+        >
+          <SearchContext.Provider
+            value={{
+              ...defaultSearchContext,
+              refreshListings: vi.fn(),
+              setQueryString: vi.fn(),
+              setSelectedDepartments: vi.fn(),
+              setSelectedResearchAreas: vi.fn(),
+              setSelectedListingResearchAreas,
+            }}
+          >
+            <Routes>
+              <Route
+                path="/research/:slug"
+                element={
+                  <>
+                    <LocationDisplay />
+                    <Home />
+                  </>
+                }
+              />
+              <Route
+                path="/research"
+                element={
+                  <>
+                    <LocationDisplay />
+                    <Home />
+                  </>
+                }
+              />
+            </Routes>
+          </SearchContext.Provider>
+        </UserContext.Provider>
+      </MemoryRouter>,
+    );
+
+    await screen.findByRole('button', { name: 'Artificial Intelligence' });
+    fireEvent.click(screen.getByRole('button', { name: 'Artificial Intelligence' }));
+
+    expect(setSelectedListingResearchAreas).toHaveBeenCalledWith(['Artificial Intelligence']);
+    await waitFor(() => {
+      expect(screen.getByTestId('location').textContent).toBe('/research');
     });
   });
 });

--- a/client/src/pages/__tests__/home.publicResearch.test.tsx
+++ b/client/src/pages/__tests__/home.publicResearch.test.tsx
@@ -43,6 +43,18 @@ describe('Home public research detail route', () => {
         return Promise.resolve({ data: { favListingsIds: [] } });
       }
 
+      if (url.endsWith('/contact')) {
+        return Promise.resolve({
+          data: {
+            listing: {
+              _id: '507f1f77bcf86cd799439011',
+              title: 'Public research listing',
+              ownerEmail: 'ada@yale.edu',
+            },
+          },
+        });
+      }
+
       return Promise.resolve({
         data: {
           listing: {
@@ -84,6 +96,12 @@ describe('Home public research detail route', () => {
 
     await waitFor(() => {
       expect(mockedAxiosGet).toHaveBeenCalledWith(`/research/${slug}`, { withCredentials: true });
+    });
+
+    await waitFor(() => {
+      expect(mockedAxiosGet).toHaveBeenCalledWith(`/research/${slug}/contact`, {
+        withCredentials: true,
+      });
     });
 
     expect(mockedAxiosGet).not.toHaveBeenCalledWith('/listings/507f1f77bcf86cd799439011', {

--- a/client/src/pages/__tests__/home.publicResearch.test.tsx
+++ b/client/src/pages/__tests__/home.publicResearch.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import SearchContext, { defaultSearchContext } from '../../contexts/SearchContext';
+import UserContext from '../../contexts/UserContext';
+import axios from '../../utils/axios';
+import Home from '../home';
+
+vi.mock('../../utils/axios', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock('../../hooks/useInfiniteScroll', () => ({
+  useInfiniteScroll: () => ({ current: null }),
+}));
+
+vi.mock('../../components/shared/BrowseGrid', () => ({
+  default: () => <div />,
+}));
+
+vi.mock('../../components/shared/ListingDetailModal', () => ({
+  default: () => <div />,
+}));
+
+vi.mock('../../components/admin/AdminListingEditModal', () => ({
+  default: () => <div />,
+}));
+
+vi.mock('sweetalert', () => ({
+  default: vi.fn(),
+}));
+
+const mockedAxiosGet = vi.mocked(axios.get);
+
+describe('Home public research detail route', () => {
+  beforeEach(() => {
+    mockedAxiosGet.mockReset();
+    mockedAxiosGet.mockImplementation((url: string) => {
+      if (url === '/users/favListingsIds') {
+        return Promise.resolve({ data: { favListingsIds: [] } });
+      }
+
+      return Promise.resolve({
+        data: {
+          listing: {
+            _id: '507f1f77bcf86cd799439011',
+            title: 'Public research listing',
+          },
+        },
+      });
+    });
+  });
+
+  it('loads share URLs through the public detail endpoint for authenticated users', async () => {
+    const slug = 'public-research-507f1f77bcf86cd799439011';
+
+    render(
+      <MemoryRouter initialEntries={[`/research/${slug}`]}>
+        <UserContext.Provider
+          value={{
+            isLoading: false,
+            isAuthenticated: true,
+            user: { userType: 'student' } as any,
+            checkContext: vi.fn(),
+          }}
+        >
+          <SearchContext.Provider
+            value={{
+              ...defaultSearchContext,
+              refreshListings: vi.fn(),
+              setQueryString: vi.fn(),
+            }}
+          >
+            <Routes>
+              <Route path="/research/:slug" element={<Home />} />
+            </Routes>
+          </SearchContext.Provider>
+        </UserContext.Provider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(mockedAxiosGet).toHaveBeenCalledWith(`/research/${slug}`, { withCredentials: true });
+    });
+
+    expect(mockedAxiosGet).not.toHaveBeenCalledWith('/listings/507f1f77bcf86cd799439011', {
+      withCredentials: true,
+    });
+  });
+});

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -89,21 +89,42 @@ const Home = () => {
 
   useEffect(() => {
     if (!slug) return;
+    let cancelled = false;
 
     axios
       .get(`/research/${slug}`, { withCredentials: true })
-      .then((response) => {
+      .then(async (response) => {
+        if (cancelled) return;
+        let listing = response.data.listing;
+
+        if (isAuthenticated) {
+          try {
+            const authenticatedResponse = await axios.get(`/research/${slug}/contact`, {
+              withCredentials: true,
+            });
+            if (cancelled) return;
+            listing = authenticatedResponse.data.listing;
+          } catch (error) {
+            console.error('Error loading authenticated research listing details:', error);
+          }
+        }
+
         dispatch({
           type: 'OPEN_DETAIL_MODAL',
-          item: createListing(response.data.listing),
+          item: createListing(listing),
         });
       })
       .catch((error) => {
+        if (cancelled) return;
         console.error('Error loading research listing:', error);
         swal({ text: 'Unable to load this research listing.', icon: 'warning' });
         navigate('/research', { replace: true });
       });
-  }, [slug, navigate]);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [slug, navigate, isAuthenticated]);
 
   const filteredListings = useMemo(() => {
     if (quickFilter === 'open') {

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -2,6 +2,7 @@
  * Main listings browse page with search, filters, and grid/list view.
  */
 import { useReducer, useEffect, useContext, useMemo } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import SearchContext from '../contexts/SearchContext';
 import UserContext from '../contexts/UserContext';
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
@@ -11,12 +12,10 @@ import AdminListingEditModal from '../components/admin/AdminListingEditModal';
 import { BrowsableItem } from '../types/browsable';
 import { Listing } from '../types/types';
 import axios from '../utils/axios';
+import { createListing } from '../utils/apiCleaner';
 import swal from 'sweetalert';
 import { getInstitutionAffiliation } from '../utils/institutionAffiliation';
-import {
-  browsePageReducer,
-  createInitialBrowsePageState,
-} from '../reducers/browsePageReducer';
+import { browsePageReducer, createInitialBrowsePageState } from '../reducers/browsePageReducer';
 
 const Home = () => {
   const {
@@ -33,8 +32,13 @@ const Home = () => {
     setSelectedListingResearchAreas,
   } = useContext(SearchContext);
 
-  const { user } = useContext(UserContext);
+  const { user, isAuthenticated, isLoading: authLoading } = useContext(UserContext);
   const isAdmin = user?.userType === 'admin';
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { slug } = useParams();
+  const isResearchRoute =
+    location.pathname === '/research' || location.pathname.startsWith('/research/');
 
   const [state, dispatch] = useReducer(
     browsePageReducer<Listing>,
@@ -52,7 +56,18 @@ const Home = () => {
     setQueryString('');
   }, []);
 
+  const requireLogin = () => {
+    const returnUrl = window.location.origin + location.pathname + location.search;
+    localStorage.setItem('logoutReturnPath', returnUrl);
+    navigate('/login');
+  };
+
   const reloadFavorites = async () => {
+    if (!isAuthenticated) {
+      dispatch({ type: 'SET_FAVORITES', ids: [] });
+      return;
+    }
+
     axios
       .get('/users/favListingsIds', { withCredentials: true })
       .then((response) => {
@@ -67,8 +82,30 @@ const Home = () => {
 
   useEffect(() => {
     refreshListings();
-    reloadFavorites();
-  }, []);
+    if (!authLoading) {
+      reloadFavorites();
+    }
+  }, [authLoading, isAuthenticated]);
+
+  useEffect(() => {
+    if (!slug) return;
+
+    const listingId = slug.match(/[a-fA-F0-9]{24}/)?.[0] || slug;
+    const endpoint = isAuthenticated ? `/listings/${listingId}` : `/research/${slug}`;
+    axios
+      .get(endpoint, { withCredentials: true })
+      .then((response) => {
+        dispatch({
+          type: 'OPEN_DETAIL_MODAL',
+          item: createListing(response.data.listing),
+        });
+      })
+      .catch((error) => {
+        console.error('Error loading research listing:', error);
+        swal({ text: 'Unable to load this research listing.', icon: 'warning' });
+        navigate('/research', { replace: true });
+      });
+  }, [slug, isAuthenticated, navigate]);
 
   const filteredListings = useMemo(() => {
     if (quickFilter === 'open') {
@@ -106,6 +143,11 @@ const Home = () => {
   });
 
   const updateFavorite = (listingId: string, favorite: boolean) => {
+    if (!isAuthenticated) {
+      requireLogin();
+      return;
+    }
+
     const prevFavListingsIds = favListingsIds;
 
     if (favorite) {
@@ -142,6 +184,9 @@ const Home = () => {
   const handleOpenModal = (item: BrowsableItem) => {
     if (item.type === 'listing') {
       dispatch({ type: 'OPEN_DETAIL_MODAL', item: item.data });
+      if (isResearchRoute) {
+        navigate(`/research/${item.data.id}`, { replace: false });
+      }
     }
   };
 
@@ -189,6 +234,9 @@ const Home = () => {
           isOpen={isModalOpen}
           onClose={() => {
             dispatch({ type: 'CLOSE_DETAIL_MODAL' });
+            if (slug) {
+              navigate('/research');
+            }
           }}
           listing={selectedListing}
           isFavorite={favListingsIds.includes(selectedListing.id)}
@@ -196,6 +244,7 @@ const Home = () => {
             e.stopPropagation();
             updateFavorite(selectedListing.id, !favListingsIds.includes(selectedListing.id));
           }}
+          onRequireAuth={requireLogin}
           onNavigateToResearchArea={handleNavigateToResearchArea}
           onNavigateToDepartment={handleNavigateToDepartment}
         />

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -90,10 +90,8 @@ const Home = () => {
   useEffect(() => {
     if (!slug) return;
 
-    const listingId = slug.match(/[a-fA-F0-9]{24}/)?.[0] || slug;
-    const endpoint = isAuthenticated ? `/listings/${listingId}` : `/research/${slug}`;
     axios
-      .get(endpoint, { withCredentials: true })
+      .get(`/research/${slug}`, { withCredentials: true })
       .then((response) => {
         dispatch({
           type: 'OPEN_DETAIL_MODAL',
@@ -105,7 +103,7 @@ const Home = () => {
         swal({ text: 'Unable to load this research listing.', icon: 'warning' });
         navigate('/research', { replace: true });
       });
-  }, [slug, isAuthenticated, navigate]);
+  }, [slug, navigate]);
 
   const filteredListings = useMemo(() => {
     if (quickFilter === 'open') {

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,7 +1,7 @@
 /**
  * Main listings browse page with search, filters, and grid/list view.
  */
-import { useReducer, useEffect, useContext, useMemo } from 'react';
+import { useReducer, useEffect, useContext, useMemo, useCallback } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import SearchContext from '../contexts/SearchContext';
 import UserContext from '../contexts/UserContext';
@@ -54,7 +54,7 @@ const Home = () => {
 
   useEffect(() => {
     setQueryString('');
-  }, []);
+  }, [setQueryString]);
 
   const requireLogin = () => {
     const returnUrl = window.location.origin + location.pathname + location.search;
@@ -62,7 +62,7 @@ const Home = () => {
     navigate('/login');
   };
 
-  const reloadFavorites = async () => {
+  const reloadFavorites = useCallback(async () => {
     if (!isAuthenticated) {
       dispatch({ type: 'SET_FAVORITES', ids: [] });
       return;
@@ -78,14 +78,14 @@ const Home = () => {
         dispatch({ type: 'SET_FAVORITES', ids: [] });
         swal({ text: 'Could not load your favorite listings', icon: 'warning' });
       });
-  };
+  }, [isAuthenticated]);
 
   useEffect(() => {
     refreshListings();
     if (!authLoading) {
       reloadFavorites();
     }
-  }, [authLoading, isAuthenticated]);
+  }, [authLoading, isAuthenticated, refreshListings, reloadFavorites]);
 
   useEffect(() => {
     if (!slug) return;

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -215,12 +215,19 @@ const Home = () => {
     }
   };
 
+  const closeDetailModal = () => {
+    dispatch({ type: 'CLOSE_DETAIL_MODAL' });
+    if (slug) {
+      navigate('/research');
+    }
+  };
+
   const handleNavigateToResearchArea = (area: string) => {
     setQueryString('');
     setSelectedDepartments([]);
     setSelectedResearchAreas([]);
     setSelectedListingResearchAreas([area]);
-    dispatch({ type: 'CLOSE_DETAIL_MODAL' });
+    closeDetailModal();
   };
 
   const handleNavigateToDepartment = (dept: string) => {
@@ -228,7 +235,7 @@ const Home = () => {
     setSelectedDepartments([dept]);
     setSelectedResearchAreas([]);
     setSelectedListingResearchAreas([]);
-    dispatch({ type: 'CLOSE_DETAIL_MODAL' });
+    closeDetailModal();
   };
 
   return (
@@ -251,12 +258,7 @@ const Home = () => {
       {selectedListing && (
         <ListingDetailModal
           isOpen={isModalOpen}
-          onClose={() => {
-            dispatch({ type: 'CLOSE_DETAIL_MODAL' });
-            if (slug) {
-              navigate('/research');
-            }
-          }}
+          onClose={closeDetailModal}
           listing={selectedListing}
           isFavorite={favListingsIds.includes(selectedListing.id)}
           onToggleFavorite={(e) => {

--- a/client/src/providers/SearchContextProvider.tsx
+++ b/client/src/providers/SearchContextProvider.tsx
@@ -30,14 +30,17 @@ interface SearchContextProviderProps {
   children: ReactNode;
 }
 
+const LISTING_SORTABLE_KEYS = ['default', 'createdAt', 'ownerLastName', 'ownerFirstName', 'title'];
+const PUBLIC_RESEARCH_SORTABLE_KEYS = ['default', 'createdAt', 'updatedAt'];
+
 const SearchContextProvider: FC<SearchContextProviderProps> = ({ children }) => {
   const pageSize = 20;
-  const sortableKeys = ['default', 'createdAt', 'ownerLastName', 'ownerFirstName', 'title'];
 
   const { isAuthenticated, isLoading: authLoading } = useContext(UserContext);
   const location = useLocation();
   const isResearchRoute =
     location.pathname === '/research' || location.pathname.startsWith('/research/');
+  const sortableKeys = isResearchRoute ? PUBLIC_RESEARCH_SORTABLE_KEYS : LISTING_SORTABLE_KEYS;
 
   const { departments, departmentCategories, researchAreas, isLoaded: configLoaded } = useConfig();
 
@@ -139,6 +142,12 @@ const SearchContextProvider: FC<SearchContextProviderProps> = ({ children }) => 
   const onToggleSortDirection = useCallback(() => {
     dispatch({ type: 'TOGGLE_SORT_DIRECTION' });
   }, []);
+
+  useEffect(() => {
+    if (!sortableKeys.includes(sortBy)) {
+      dispatch({ type: 'SET_SORT_BY', payload: sortableKeys[0] });
+    }
+  }, [sortBy, sortableKeys]);
 
   // Keep latest filter values in a ref so handleSearch can remain stable.
   const filtersRef = useRef({

--- a/client/src/providers/SearchContextProvider.tsx
+++ b/client/src/providers/SearchContextProvider.tsx
@@ -169,7 +169,7 @@ const SearchContextProvider: FC<SearchContextProviderProps> = ({ children }) => 
       const f = filtersRef.current;
       const formattedQuery = f.queryString.trim();
 
-      const endpoint = isResearchRoute && !isAuthenticated ? '/research' : '/listings/search';
+      const endpoint = isResearchRoute ? '/research' : '/listings/search';
       let url = `${endpoint}?query=${encodeURIComponent(formattedQuery)}&page=${searchPage}&pageSize=${pageSize}`;
 
       if (f.sortBy !== 'default') {
@@ -222,7 +222,7 @@ const SearchContextProvider: FC<SearchContextProviderProps> = ({ children }) => 
           dispatch({ type: 'SEARCH_FAILURE' });
         });
     },
-    [isAuthenticated, isResearchRoute, pageSize],
+    [isResearchRoute, pageSize],
   );
 
   const refreshListings = useCallback(() => {

--- a/client/src/providers/SearchContextProvider.tsx
+++ b/client/src/providers/SearchContextProvider.tsx
@@ -15,6 +15,7 @@ import {
   useContext,
   ReactNode,
 } from 'react';
+import { useLocation } from 'react-router-dom';
 import axios from '../utils/axios';
 import swal from 'sweetalert';
 
@@ -34,6 +35,9 @@ const SearchContextProvider: FC<SearchContextProviderProps> = ({ children }) => 
   const sortableKeys = ['default', 'createdAt', 'ownerLastName', 'ownerFirstName', 'title'];
 
   const { isAuthenticated, isLoading: authLoading } = useContext(UserContext);
+  const location = useLocation();
+  const isResearchRoute =
+    location.pathname === '/research' || location.pathname.startsWith('/research/');
 
   const { departments, departmentCategories, researchAreas, isLoaded: configLoaded } = useConfig();
 
@@ -165,7 +169,8 @@ const SearchContextProvider: FC<SearchContextProviderProps> = ({ children }) => 
       const f = filtersRef.current;
       const formattedQuery = f.queryString.trim();
 
-      let url = `/listings/search?query=${encodeURIComponent(formattedQuery)}&page=${searchPage}&pageSize=${pageSize}`;
+      const endpoint = isResearchRoute && !isAuthenticated ? '/research' : '/listings/search';
+      let url = `${endpoint}?query=${encodeURIComponent(formattedQuery)}&page=${searchPage}&pageSize=${pageSize}`;
 
       if (f.sortBy !== 'default') {
         url += `&sortBy=${f.sortBy}&sortOrder=${f.sortOrder}`;
@@ -217,7 +222,7 @@ const SearchContextProvider: FC<SearchContextProviderProps> = ({ children }) => 
           dispatch({ type: 'SEARCH_FAILURE' });
         });
     },
-    [pageSize],
+    [isAuthenticated, isResearchRoute, pageSize],
   );
 
   const refreshListings = useCallback(() => {
@@ -226,15 +231,27 @@ const SearchContextProvider: FC<SearchContextProviderProps> = ({ children }) => 
   }, [handleSearch]);
 
   useEffect(() => {
-    if (configLoaded && !authLoading && isAuthenticated && !initialSearchDone) {
+    if (
+      configLoaded &&
+      !authLoading &&
+      (isAuthenticated || isResearchRoute) &&
+      !initialSearchDone
+    ) {
       dispatch({ type: 'SET_PAGE', payload: 1 });
       handleSearch(1);
       dispatch({ type: 'MARK_INITIAL_SEARCH_DONE' });
     }
-  }, [configLoaded, authLoading, isAuthenticated, initialSearchDone, handleSearch]);
+  }, [
+    configLoaded,
+    authLoading,
+    isAuthenticated,
+    isResearchRoute,
+    initialSearchDone,
+    handleSearch,
+  ]);
 
   useEffect(() => {
-    if (!configLoaded) return;
+    if (!configLoaded || authLoading || (!isAuthenticated && !isResearchRoute)) return;
 
     const debounceTimeout = setTimeout(() => {
       if (queryStringLoaded) {
@@ -247,10 +264,10 @@ const SearchContextProvider: FC<SearchContextProviderProps> = ({ children }) => 
     return () => {
       clearTimeout(debounceTimeout);
     };
-  }, [queryString, configLoaded]);
+  }, [queryString, configLoaded, authLoading, isAuthenticated, isResearchRoute]);
 
   useEffect(() => {
-    if (!configLoaded) return;
+    if (!configLoaded || authLoading || (!isAuthenticated && !isResearchRoute)) return;
 
     if (departmentsLoaded) {
       dispatch({ type: 'SET_PAGE', payload: 1 });
@@ -267,13 +284,16 @@ const SearchContextProvider: FC<SearchContextProviderProps> = ({ children }) => 
     sortBy,
     sortOrder,
     configLoaded,
+    authLoading,
+    isAuthenticated,
+    isResearchRoute,
   ]);
 
   useEffect(() => {
-    if (page > 1 && configLoaded) {
+    if (page > 1 && configLoaded && !authLoading && (isAuthenticated || isResearchRoute)) {
       handleSearch(page);
     }
-  }, [page, configLoaded]);
+  }, [page, configLoaded, authLoading, isAuthenticated, isResearchRoute]);
 
   return (
     <SearchContext.Provider

--- a/client/src/providers/SearchContextProvider.tsx
+++ b/client/src/providers/SearchContextProvider.tsx
@@ -81,10 +81,10 @@ const SearchContextProvider: FC<SearchContextProviderProps> = ({ children }) => 
     page,
     filterBarHeight,
     quickFilter,
-    queryStringLoaded,
-    departmentsLoaded,
     initialSearchDone,
   } = state;
+  const queryStringLoadedRef = useRef(false);
+  const departmentsLoadedRef = useRef(false);
 
   // Context setter API preserved for compatibility with existing call sites
   // (some pass a value, some pass an updater function).
@@ -263,25 +263,27 @@ const SearchContextProvider: FC<SearchContextProviderProps> = ({ children }) => 
     if (!configLoaded || authLoading || (!isAuthenticated && !isResearchRoute)) return;
 
     const debounceTimeout = setTimeout(() => {
-      if (queryStringLoaded) {
+      if (queryStringLoadedRef.current) {
         dispatch({ type: 'SET_PAGE', payload: 1 });
         handleSearch(1);
       }
+      queryStringLoadedRef.current = true;
       dispatch({ type: 'MARK_QUERY_STRING_LOADED' });
     }, 500);
 
     return () => {
       clearTimeout(debounceTimeout);
     };
-  }, [queryString, configLoaded, authLoading, isAuthenticated, isResearchRoute]);
+  }, [queryString, configLoaded, authLoading, isAuthenticated, isResearchRoute, handleSearch]);
 
   useEffect(() => {
     if (!configLoaded || authLoading || (!isAuthenticated && !isResearchRoute)) return;
 
-    if (departmentsLoaded) {
+    if (departmentsLoadedRef.current) {
       dispatch({ type: 'SET_PAGE', payload: 1 });
       handleSearch(1);
     }
+    departmentsLoadedRef.current = true;
     dispatch({ type: 'MARK_DEPARTMENTS_LOADED' });
   }, [
     selectedDepartments,
@@ -296,13 +298,14 @@ const SearchContextProvider: FC<SearchContextProviderProps> = ({ children }) => 
     authLoading,
     isAuthenticated,
     isResearchRoute,
+    handleSearch,
   ]);
 
   useEffect(() => {
     if (page > 1 && configLoaded && !authLoading && (isAuthenticated || isResearchRoute)) {
       handleSearch(page);
     }
-  }, [page, configLoaded, authLoading, isAuthenticated, isResearchRoute]);
+  }, [page, configLoaded, authLoading, isAuthenticated, isResearchRoute, handleSearch]);
 
   return (
     <SearchContext.Provider

--- a/client/src/providers/__tests__/SearchContextProvider.publicResearch.test.tsx
+++ b/client/src/providers/__tests__/SearchContextProvider.publicResearch.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import UserContext from '../../contexts/UserContext';
+import axios from '../../utils/axios';
+import SearchContextProvider from '../SearchContextProvider';
+
+vi.mock('../../utils/axios', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock('../../hooks/useConfig', () => ({
+  useConfig: () => ({
+    departments: [],
+    departmentCategories: [],
+    researchAreas: [],
+    isLoaded: true,
+  }),
+}));
+
+vi.mock('sweetalert', () => ({
+  default: vi.fn(),
+}));
+
+const mockedAxiosGet = vi.mocked(axios.get);
+
+describe('SearchContextProvider public research route', () => {
+  beforeEach(() => {
+    mockedAxiosGet.mockReset();
+    mockedAxiosGet.mockResolvedValue({ data: { results: [], totalCount: 0 } });
+  });
+
+  it('uses the public search endpoint on research routes for authenticated users', async () => {
+    render(
+      <MemoryRouter initialEntries={['/research']}>
+        <UserContext.Provider
+          value={{
+            isLoading: false,
+            isAuthenticated: true,
+            user: { userType: 'student' } as any,
+            checkContext: vi.fn(),
+          }}
+        >
+          <SearchContextProvider>
+            <div />
+          </SearchContextProvider>
+        </UserContext.Provider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(mockedAxiosGet).toHaveBeenCalledWith(
+        '/research?query=&page=1&pageSize=20&departmentsMode=union&academicDisciplinesMode=union&researchAreasMode=union',
+      );
+    });
+
+    expect(mockedAxiosGet).not.toHaveBeenCalledWith(
+      '/listings/search?query=&page=1&pageSize=20&departmentsMode=union&academicDisciplinesMode=union&researchAreasMode=union',
+    );
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -63,6 +63,17 @@ const writeLimiter = rateLimit({
   skip: () => isCI() || isDevelopment() || isTest(),
 });
 
+// Public research discovery limiter for anonymous browse/detail traffic.
+export const publicDiscoveryLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 120,
+  keyGenerator: getRateLimitKey,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many discovery requests, please try again later.' },
+  skip: () => isCI() || isDevelopment() || isTest(),
+});
+
 const allowList = new Set([
   'http://localhost:3000',
   'https://yalelabs.onrender.com',
@@ -107,6 +118,7 @@ const app = express()
   .use(passport.session())
   .use('/api', sanitizeMongo)
   .use('/api', apiLimiter)
+  .use('/api/research', publicDiscoveryLimiter)
   .use('/api/listings', (req, res, next) => {
     if (req.method === 'GET' || req.method === 'HEAD' || req.method === 'OPTIONS') {
       return next();

--- a/server/src/controllers/listingController.search.test.ts
+++ b/server/src/controllers/listingController.search.test.ts
@@ -104,7 +104,10 @@ void describe('public research search inputs', () => {
 
   void it('allows only public-safe sort fields', () => {
     assert.equal(getPublicResearchSortBy('createdAt'), 'createdAt');
-    assert.equal(getPublicResearchSortBy('title'), 'title');
+    assert.equal(getPublicResearchSortBy('updatedAt'), 'updatedAt');
+    assert.equal(getPublicResearchSortBy('title'), undefined);
+    assert.equal(getPublicResearchSortBy('ownerFirstName'), undefined);
+    assert.equal(getPublicResearchSortBy('ownerLastName'), undefined);
     assert.equal(getPublicResearchSortBy('ownerEmail'), undefined);
     assert.equal(getPublicResearchSortBy('views'), undefined);
   });

--- a/server/src/controllers/listingController.search.test.ts
+++ b/server/src/controllers/listingController.search.test.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { searchListingsWithDegradation } from './listingController';
+import {
+  buildPublicResearchSearchInputs,
+  getPublicResearchSortBy,
+  searchListingsWithDegradation,
+} from './listingController';
 
 const baseMongoParams = {
   query: 'cell signaling',
@@ -72,5 +76,36 @@ void describe('searchListingsWithDegradation', () => {
       totalCount: 1,
       degraded: true,
     });
+  });
+});
+
+void describe('public research search inputs', () => {
+  void it('removes private fields from public search and sort inputs', async () => {
+    const result = await buildPublicResearchSearchInputs({
+      query: 'private@example.edu',
+      sortBy: 'ownerEmail',
+      sortOrder: '1',
+      page: '2',
+      pageSize: '10',
+    });
+
+    assert.equal(result.page, 2);
+    assert.equal(result.pageSize, 10);
+    assert.equal(result.searchParams.sort, undefined);
+    assert.equal(result.mongoParams.sortBy, undefined);
+    assert.deepEqual(result.searchParams.attributesToSearchOn, result.mongoParams.searchableFields);
+    assert.equal(result.searchParams.attributesToSearchOn.includes('ownerEmail'), false);
+    assert.equal(result.searchParams.attributesToSearchOn.includes('emails'), false);
+    assert.equal(result.searchParams.attributesToSearchOn.includes('ownerId'), false);
+    assert.equal(result.searchParams.attributesToSearchOn.includes('professorIds'), false);
+    assert.equal(result.searchParams.attributesToSearchOn.includes('views'), false);
+    assert.equal(result.searchParams.attributesToSearchOn.includes('favorites'), false);
+  });
+
+  void it('allows only public-safe sort fields', () => {
+    assert.equal(getPublicResearchSortBy('createdAt'), 'createdAt');
+    assert.equal(getPublicResearchSortBy('title'), 'title');
+    assert.equal(getPublicResearchSortBy('ownerEmail'), undefined);
+    assert.equal(getPublicResearchSortBy('views'), undefined);
   });
 });

--- a/server/src/controllers/listingController.ts
+++ b/server/src/controllers/listingController.ts
@@ -53,9 +53,6 @@ const PUBLIC_LISTING_SEARCHABLE_FIELDS = [
 const PUBLIC_LISTING_SORT_FIELDS = new Set([
   'createdAt',
   'updatedAt',
-  'title',
-  'ownerFirstName',
-  'ownerLastName',
 ]);
 
 const getIdFromSlug = (slug: string): string | null => {

--- a/server/src/controllers/listingController.ts
+++ b/server/src/controllers/listingController.ts
@@ -36,6 +36,39 @@ import { buildSafeSearchRegex } from '../utils/regex';
 const escapeMeiliFilterValue = (value: string): string =>
   value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 
+const getIdFromSlug = (slug: string): string | null => {
+  const match = slug.match(/[a-fA-F0-9]{24}/);
+  return match ? match[0] : null;
+};
+
+const redactPublicListing = (listing: any) => {
+  const source = typeof listing?.toObject === 'function' ? listing.toObject() : listing;
+  const redacted = { ...(source || {}) };
+  const rawId = redacted._id?.toString?.() || redacted.id;
+  delete redacted.__v;
+  delete redacted.ownerEmail;
+  delete redacted.emails;
+  delete redacted.views;
+  delete redacted.favorites;
+  delete redacted.archived;
+  delete redacted.confirmed;
+  delete redacted.audited;
+
+  return {
+    ...redacted,
+    _id: rawId,
+    id: rawId,
+    ownerId: undefined,
+    ownerEmail: undefined,
+    professorIds: [],
+    emails: [],
+    views: 0,
+    favorites: 0,
+    archived: false,
+    confirmed: true,
+  };
+};
+
 const buildRobustFilterMatch = async (params: {
   departments?: string;
   departmentsMode: string;
@@ -452,6 +485,91 @@ export const searchListings = async (request: Request, response: Response) => {
     console.error('Listing search failed:', error);
     return response.status(500).json({ error: 'Search failed', degraded: true });
   }
+};
+
+export const searchPublicResearch = async (request: Request, response: Response) => {
+  try {
+    const {
+      query,
+      sortBy,
+      sortOrder,
+      departments,
+      academicDisciplines,
+      researchAreas,
+      departmentsMode = 'union',
+      academicDisciplinesMode = 'union',
+      researchAreasMode = 'union',
+      page = 1,
+      pageSize = 10,
+    } = request.query;
+
+    const filterString = await buildRobustFilterMatch({
+      departments: departments as string,
+      departmentsMode: departmentsMode as string,
+      academicDisciplines: academicDisciplines as string,
+      academicDisciplinesMode: academicDisciplinesMode as string,
+      researchAreas: researchAreas as string,
+      researchAreasMode: researchAreasMode as string,
+    });
+
+    const limit = Number(pageSize);
+    const offset = (Number(page) - 1) * limit;
+    const sortConfig = [];
+    if (sortBy) {
+      const order = sortOrder === '1' ? 'asc' : 'desc';
+      sortConfig.push(`${sortBy}:${order}`);
+    } else if (!query || (query as string).trim() === '') {
+      sortConfig.push('createdAt:desc');
+    }
+
+    const searchParams: any = {
+      filter: filterString,
+      limit,
+      offset,
+    };
+
+    if (sortConfig.length > 0) {
+      searchParams.sort = sortConfig;
+    }
+
+    const trimmedQuery = ((query as string) || '').trim();
+    if (trimmedQuery !== '' && trimmedQuery.split(/\s+/).length > 1) {
+      searchParams.hybrid = {
+        semanticRatio: 0.8,
+        embedder: 'default',
+      };
+    }
+
+    const index = await getMeiliIndex('listings');
+    const { hits, estimatedTotalHits } = await index.search((query as string) || '', searchParams);
+
+    return response.json({
+      results: hits.map((hit: any) => redactPublicListing({ ...hit, _id: hit.id })),
+      totalCount: estimatedTotalHits,
+      page: Number(page),
+      pageSize: Number(pageSize),
+    });
+  } catch (error) {
+    console.error('Public research search failed:', error);
+    return response.status(500).json({ error: 'Search failed' });
+  }
+};
+
+export const getPublicResearchBySlug = async (request: Request, response: Response) => {
+  const id = getIdFromSlug(request.params.slug);
+  if (!id) {
+    return response.status(404).json({ error: 'Research listing not found' });
+  }
+
+  const listing = await getListingModel()
+    .findOne({ _id: id, archived: false, confirmed: true })
+    .lean();
+
+  if (!listing) {
+    return response.status(404).json({ error: 'Research listing not found' });
+  }
+
+  return response.status(200).json({ listing: redactPublicListing(listing) });
 };
 
 export const createListingForCurrentUser = async (request: Request, response: Response) => {

--- a/server/src/controllers/listingController.ts
+++ b/server/src/controllers/listingController.ts
@@ -36,6 +36,28 @@ import { buildSafeSearchRegex } from '../utils/regex';
 const escapeMeiliFilterValue = (value: string): string =>
   value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 
+const PUBLIC_LISTING_SEARCHABLE_FIELDS = [
+  'title',
+  'description',
+  'applicantDescription',
+  'ownerFirstName',
+  'ownerLastName',
+  'ownerTitle',
+  'ownerPrimaryDepartment',
+  'professorNames',
+  'departments',
+  'researchAreas',
+  'keywords',
+];
+
+const PUBLIC_LISTING_SORT_FIELDS = new Set([
+  'createdAt',
+  'updatedAt',
+  'title',
+  'ownerFirstName',
+  'ownerLastName',
+]);
+
 const getIdFromSlug = (slug: string): string | null => {
   const match = slug.match(/[a-fA-F0-9]{24}/);
   return match ? match[0] : null;
@@ -199,6 +221,7 @@ const buildMongoFilterMatch = async (params: {
   academicDisciplinesMode: string;
   researchAreas?: string;
   researchAreasMode: string;
+  searchableFields?: string[];
 }) => {
   const {
     query,
@@ -208,6 +231,20 @@ const buildMongoFilterMatch = async (params: {
     academicDisciplinesMode,
     researchAreas,
     researchAreasMode,
+    searchableFields = [
+      'title',
+      'description',
+      'applicantDescription',
+      'ownerFirstName',
+      'ownerLastName',
+      'ownerEmail',
+      'ownerTitle',
+      'ownerPrimaryDepartment',
+      'professorNames',
+      'departments',
+      'researchAreas',
+      'keywords',
+    ],
   } = params;
 
   const baseFilter: Record<string, any> = { archived: false, confirmed: true };
@@ -267,21 +304,6 @@ const buildMongoFilterMatch = async (params: {
 
   const trimmedQuery = (query || '').trim();
   if (trimmedQuery !== '') {
-    const searchableFields = [
-      'title',
-      'description',
-      'applicantDescription',
-      'ownerFirstName',
-      'ownerLastName',
-      'ownerEmail',
-      'ownerTitle',
-      'ownerPrimaryDepartment',
-      'professorNames',
-      'departments',
-      'researchAreas',
-      'keywords',
-    ];
-
     const queryConditions = trimmedQuery.split(/\s+/).map((term) => ({
       $or: searchableFields.map((field) => ({ [field]: buildSafeSearchRegex(term) })),
     }));
@@ -306,6 +328,8 @@ type MongoListingSearchParams = {
   researchAreasMode: string;
   limit: number;
   offset: number;
+  searchableFields?: string[];
+  defaultSort?: Record<string, 1 | -1>;
 };
 
 type ListingSearchEnvelope = {
@@ -323,9 +347,11 @@ export const searchListingsViaMongo = async (
   if (params.sortBy) {
     sort[params.sortBy] = params.sortOrder === '1' ? 1 : -1;
   } else if (!params.query || params.query.trim() === '') {
-    sort.browseRankScore = -1;
-    sort.lastObservedAt = -1;
-    sort.createdAt = -1;
+    Object.assign(sort, params.defaultSort || {
+      browseRankScore: -1,
+      lastObservedAt: -1,
+      createdAt: -1,
+    });
   } else {
     sort.updatedAt = -1;
   }
@@ -487,84 +513,107 @@ export const searchListings = async (request: Request, response: Response) => {
   }
 };
 
+export const getPublicResearchSortBy = (sortBy: unknown): string | undefined => {
+  return typeof sortBy === 'string' && PUBLIC_LISTING_SORT_FIELDS.has(sortBy) ? sortBy : undefined;
+};
+
+export const buildPublicResearchSearchInputs = async (queryParams: Request['query']) => {
+  const {
+    query,
+    sortBy,
+    sortOrder,
+    departments,
+    academicDisciplines,
+    researchAreas,
+    departmentsMode = 'union',
+    academicDisciplinesMode = 'union',
+    researchAreasMode = 'union',
+    page = 1,
+    pageSize = 10,
+  } = queryParams;
+
+  const filterString = await buildRobustFilterMatch({
+    departments: departments as string,
+    departmentsMode: departmentsMode as string,
+    academicDisciplines: academicDisciplines as string,
+    academicDisciplinesMode: academicDisciplinesMode as string,
+    researchAreas: researchAreas as string,
+    researchAreasMode: researchAreasMode as string,
+  });
+
+  const limit = Number(pageSize);
+  const offset = (Number(page) - 1) * limit;
+  const publicSortBy = getPublicResearchSortBy(sortBy);
+  const sortConfig = [];
+  if (publicSortBy) {
+    const order = sortOrder === '1' ? 'asc' : 'desc';
+    sortConfig.push(`${publicSortBy}:${order}`);
+  } else if (!query || (query as string).trim() === '') {
+    sortConfig.push('createdAt:desc');
+  }
+
+  const searchParams: any = {
+    filter: filterString,
+    limit,
+    offset,
+  };
+
+  if (sortConfig.length > 0) {
+    searchParams.sort = sortConfig;
+  }
+
+  const trimmedQuery = ((query as string) || '').trim();
+  if (trimmedQuery !== '') {
+    searchParams.attributesToSearchOn = PUBLIC_LISTING_SEARCHABLE_FIELDS;
+  }
+
+  if (trimmedQuery !== '' && trimmedQuery.split(/\s+/).length > 1) {
+    searchParams.hybrid = {
+      semanticRatio: 0.8,
+      embedder: 'default',
+    };
+  }
+
+  const mongoParams = {
+    query: query as string,
+    sortBy: publicSortBy,
+    sortOrder: sortOrder as string,
+    departments: departments as string,
+    academicDisciplines: academicDisciplines as string,
+    researchAreas: researchAreas as string,
+    departmentsMode: departmentsMode as string,
+    academicDisciplinesMode: academicDisciplinesMode as string,
+    researchAreasMode: researchAreasMode as string,
+    limit,
+    offset,
+    searchableFields: PUBLIC_LISTING_SEARCHABLE_FIELDS,
+    defaultSort: { createdAt: -1 as const },
+  };
+
+  return {
+    query: (query as string) || '',
+    searchParams,
+    mongoParams,
+    page: Number(page),
+    pageSize: Number(pageSize),
+  };
+};
+
 export const searchPublicResearch = async (request: Request, response: Response) => {
   try {
-    const {
-      query,
-      sortBy,
-      sortOrder,
-      departments,
-      academicDisciplines,
-      researchAreas,
-      departmentsMode = 'union',
-      academicDisciplinesMode = 'union',
-      researchAreasMode = 'union',
-      page = 1,
-      pageSize = 10,
-    } = request.query;
-
-    const filterString = await buildRobustFilterMatch({
-      departments: departments as string,
-      departmentsMode: departmentsMode as string,
-      academicDisciplines: academicDisciplines as string,
-      academicDisciplinesMode: academicDisciplinesMode as string,
-      researchAreas: researchAreas as string,
-      researchAreasMode: researchAreasMode as string,
-    });
-
-    const limit = Number(pageSize);
-    const offset = (Number(page) - 1) * limit;
-    const sortConfig = [];
-    if (sortBy) {
-      const order = sortOrder === '1' ? 'asc' : 'desc';
-      sortConfig.push(`${sortBy}:${order}`);
-    } else if (!query || (query as string).trim() === '') {
-      sortConfig.push('createdAt:desc');
-    }
-
-    const searchParams: any = {
-      filter: filterString,
-      limit,
-      offset,
-    };
-
-    if (sortConfig.length > 0) {
-      searchParams.sort = sortConfig;
-    }
-
-    const trimmedQuery = ((query as string) || '').trim();
-    if (trimmedQuery !== '' && trimmedQuery.split(/\s+/).length > 1) {
-      searchParams.hybrid = {
-        semanticRatio: 0.8,
-        embedder: 'default',
-      };
-    }
-
-    const mongoParams = {
-      query: query as string,
-      sortBy: sortBy as string,
-      sortOrder: sortOrder as string,
-      departments: departments as string,
-      academicDisciplines: academicDisciplines as string,
-      researchAreas: researchAreas as string,
-      departmentsMode: departmentsMode as string,
-      academicDisciplinesMode: academicDisciplinesMode as string,
-      researchAreasMode: researchAreasMode as string,
-      limit,
-      offset,
-    };
+    const publicSearch = await buildPublicResearchSearchInputs(request.query);
 
     const searchResult = await searchListingsWithDegradation({
-      query: (query as string) || '',
-      searchParams,
-      mongoParams,
+      query: publicSearch.query,
+      searchParams: publicSearch.searchParams,
+      mongoParams: publicSearch.mongoParams,
     });
 
     return response.json({
       results: searchResult.results.map((hit: any) => redactPublicListing(hit)),
       totalCount: searchResult.totalCount,
-      page: Number(page),
-      pageSize: Number(pageSize),
+      page: publicSearch.page,
+      pageSize: publicSearch.pageSize,
       degraded: searchResult.degraded,
     });
   } catch (error) {

--- a/server/src/controllers/listingController.ts
+++ b/server/src/controllers/listingController.ts
@@ -540,18 +540,36 @@ export const searchPublicResearch = async (request: Request, response: Response)
       };
     }
 
-    const index = await getMeiliIndex('listings');
-    const { hits, estimatedTotalHits } = await index.search((query as string) || '', searchParams);
+    const mongoParams = {
+      query: query as string,
+      sortBy: sortBy as string,
+      sortOrder: sortOrder as string,
+      departments: departments as string,
+      academicDisciplines: academicDisciplines as string,
+      researchAreas: researchAreas as string,
+      departmentsMode: departmentsMode as string,
+      academicDisciplinesMode: academicDisciplinesMode as string,
+      researchAreasMode: researchAreasMode as string,
+      limit,
+      offset,
+    };
+
+    const searchResult = await searchListingsWithDegradation({
+      query: (query as string) || '',
+      searchParams,
+      mongoParams,
+    });
 
     return response.json({
-      results: hits.map((hit: any) => redactPublicListing({ ...hit, _id: hit.id })),
-      totalCount: estimatedTotalHits,
+      results: searchResult.results.map((hit: any) => redactPublicListing(hit)),
+      totalCount: searchResult.totalCount,
       page: Number(page),
       pageSize: Number(pageSize),
+      degraded: searchResult.degraded,
     });
   } catch (error) {
     console.error('Public research search failed:', error);
-    return response.status(500).json({ error: 'Search failed' });
+    return response.status(500).json({ error: 'Search failed', degraded: true });
   }
 };
 

--- a/server/src/controllers/listingController.ts
+++ b/server/src/controllers/listingController.ts
@@ -639,6 +639,26 @@ export const getPublicResearchBySlug = async (request: Request, response: Respon
   return response.status(200).json({ listing: redactPublicListing(listing) });
 };
 
+export const getAuthenticatedPublicResearchBySlug = async (
+  request: Request,
+  response: Response,
+) => {
+  const id = getIdFromSlug(request.params.slug);
+  if (!id) {
+    return response.status(404).json({ error: 'Research listing not found' });
+  }
+
+  const listing = await getListingModel()
+    .findOne({ _id: id, archived: false, confirmed: true })
+    .lean();
+
+  if (!listing) {
+    return response.status(404).json({ error: 'Research listing not found' });
+  }
+
+  return response.status(200).json({ listing });
+};
+
 export const createListingForCurrentUser = async (request: Request, response: Response) => {
   try {
     const currentUser = request.user as {

--- a/server/src/controllers/listingController.ts
+++ b/server/src/controllers/listingController.ts
@@ -50,10 +50,7 @@ const PUBLIC_LISTING_SEARCHABLE_FIELDS = [
   'keywords',
 ];
 
-const PUBLIC_LISTING_SORT_FIELDS = new Set([
-  'createdAt',
-  'updatedAt',
-]);
+const PUBLIC_LISTING_SORT_FIELDS = new Set(['createdAt', 'updatedAt']);
 
 const getIdFromSlug = (slug: string): string | null => {
   const match = slug.match(/[a-fA-F0-9]{24}/);
@@ -344,11 +341,14 @@ export const searchListingsViaMongo = async (
   if (params.sortBy) {
     sort[params.sortBy] = params.sortOrder === '1' ? 1 : -1;
   } else if (!params.query || params.query.trim() === '') {
-    Object.assign(sort, params.defaultSort || {
-      browseRankScore: -1,
-      lastObservedAt: -1,
-      createdAt: -1,
-    });
+    Object.assign(
+      sort,
+      params.defaultSort || {
+        browseRankScore: -1,
+        lastObservedAt: -1,
+        createdAt: -1,
+      },
+    );
   } else {
     sort.updatedAt = -1;
   }

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -11,10 +11,12 @@ import ConfigRoutes from './config';
 import AdminRoutes from './admin';
 import ProfileRoutes from './profiles';
 import SeedRoutes from './seed';
+import ResearchRoutes from './research';
 
 const router = Router();
 
 router.use('/listings', ListingsRoutes);
+router.use('/research', ResearchRoutes);
 router.use('/fellowships', FellowshipsRoutes);
 router.use('/users', UsersRoutes);
 router.use('/profiles', ProfileRoutes);

--- a/server/src/routes/research.ts
+++ b/server/src/routes/research.ts
@@ -1,0 +1,13 @@
+/**
+ * Public read-only routes for research discovery.
+ */
+import { Router } from 'express';
+import { validatePagination } from '../middleware/index';
+import * as listingController from '../controllers/listingController';
+
+const router = Router();
+
+router.get('/', validatePagination, listingController.searchPublicResearch);
+router.get('/:slug', listingController.getPublicResearchBySlug);
+
+export default router;

--- a/server/src/routes/research.ts
+++ b/server/src/routes/research.ts
@@ -2,12 +2,17 @@
  * Public read-only routes for research discovery.
  */
 import { Router } from 'express';
-import { validatePagination } from '../middleware/index';
+import { asyncHandler, isAuthenticated, validatePagination } from '../middleware/index';
 import * as listingController from '../controllers/listingController';
 
 const router = Router();
 
 router.get('/', validatePagination, listingController.searchPublicResearch);
-router.get('/:slug', listingController.getPublicResearchBySlug);
+router.get(
+  '/:slug/contact',
+  isAuthenticated,
+  asyncHandler(listingController.getAuthenticatedPublicResearchBySlug),
+);
+router.get('/:slug', asyncHandler(listingController.getPublicResearchBySlug));
 
 export default router;


### PR DESCRIPTION
## Intent

Unlock logged-out public research discovery using strict-redacted public browse/detail endpoints and shareable modal URLs while keeping authenticated actions behind login prompts

## What Changed

- Added logged-out `/research` browse and shareable detail routes backed by public research API endpoints that only expose confirmed, unarchived listings with sensitive listing fields redacted.
- Hardened public research search/detail behavior to use the existing degraded search path, restrict public-safe sort/search fields, fetch contact details only after authentication, and clear stale modal slugs during in-modal navigation.
- Updated route/modal/search provider coverage and project docs for public discovery, including focused client tests and the existing server search degradation test.

## Risk Assessment

✅ Low: The change is well-bounded to public research discovery, with prior redaction/degradation/contact issues addressed and no remaining material merge blockers found in the reviewed diff.

## Testing

Exercised logged-out public route access, public search endpoint selection, shareable detail loading, modal contact redaction/login prompts, and server public search redaction/sort guards plus search fallback behavior; all checks passed, and visual evidence was captured as rendered HTML because Chrome screenshot capture was unavailable in this container due to no Chrome/Chromium executable.

<details>
<summary>Evidence: Logged-out public research modal evidence</summary>

```text
<!doctype html>
<html lang="en">
<head>
  <meta charset="utf-8" />
  <meta name="viewport" content="width=device-width, initial-scale=1" />
  <title>Public Research Discovery Evidence</title>
  <script src="https://cdn.tailwindcss.com"></script>
  <style>body{background:#f3f4f6}.evidence-modal>div{position:relative;inset:auto;min-height:760px}.evidence-modal .fixed{position:relative}.evidence-modal .h-[85vh]{height:760px}</style>
</head>
<body>
  <main class="mx-auto max-w-6xl p-6 space-y-6">
    <section class="bg-white rounded-lg border border-gray-200 p-5">
      <h1 class="text-2xl font-bold text-gray-900">Logged-out public research share URL evidence</h1>
      <p class="mt-2 text-gray-600">Rendered from the actual <code>ListingDetailModal</code> React component with a public-redacted listing payload for <code>/research/507f1f77bcf86cd799439011</code>.</p>
      <ul class="mt-4 grid gap-2 text-sm">
        <li class="flex items-center gap-2"><span class="inline-flex h-5 w-5 items-center justify-center rounded-full bg-green-100 text-green-700">✓</span>Logged-out detail URL renders public listing title</li><li class="flex items-center gap-2"><span class="inline-flex h-5 w-5 items-center justify-center rounded-full bg-green-100 text-green-700">✓</span>Contact email is not present in rendered logged-out modal</li><li class="flex items-center gap-2"><span class="inline-flex h-5 w-5 items-center justify-center rounded-full bg-green-100 text-green-700">✓</span>Authenticated action is presented as a login prompt</li><li class="flex items-center gap-2"><span class="inline-flex h-5 w-5 items-center justify-center rounded-full bg-green-100 text-green-700">✓</span>Public discovery remains useful with description and research area visible</li>
      </ul>
    </section>
    <section class="evidence-modal"><div class="fixed inset-0 bg-black/60 z-[1200] flex items-center justify-center overflow-y-auto p-4 pt-20"><div class="bg-white rounded-xl shadow-2xl w-full max-w-4xl h-[85vh] flex flex-col overflow-hidden"><div class="flex-shrink-0 border-b border-gray-100"><div class="h-1 w-full" style="background:linear-gradient(90deg, #0055A4 0%, #3b82f6 50%, #93c5fd 100%)"></div><div class="px-6 py-5"><div class="flex items-start justify-between gap-4"><div class="flex-1 min-w-0"><div class="flex flex-wrap items-center gap-2 mb-2"><span class="text-sm font-semibold text-blue-700">COMP</span><span class="text-xs px-2 py-0.5 rounded-full bg-blue-50 text-blue-600 font-medium">YC — Yale College</span><span class="text-xs px-2 py-0.5 rounded-full font-medium bg-green-50 text-green-700">Accepting Applications</span></div><h2 class="text-xl font-bold text-gray-900 leading-tight">Ada Lovelace</h2><p class="text-sm text-gray-500 mt-0.5">Professor</p><p class="text-base text-gray-600 mt-0.5">Public research listing</p></div><div class="flex items-center gap-1 flex-shrink-0"><a href="https://example.edu/lab" target="_blank" rel="noopener noreferrer" class="p-2 rounded-lg hover:bg-gray-100 transition-colors text-gray-500 hover:text-blue-600" title="Visit website"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg></a><a class="p-2 rounded-lg hover:bg-gray-100 transition-colors text-gray-500 hover:text-blue-600" title="Sign in to inquire"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"></rect><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"></path></svg></a><span class="px-1"><button class="p-1 rounded-full transition-colors text-gray-300 hover:text-blue-600" aria-label="Add to favorites"><svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"></path></svg></button></span><button class="p-2 rounded-lg hover:bg-gray-100 transition-colors text-gray-400 hover:text-gray-600" aria-label="Close"><svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg></button></div></div></div></div><div class="flex-1 overflow-y-auto"><div class="p-6"><div class="grid grid-cols-1 md:grid-cols-3 gap-8"><div class="col-span-1 space-y-6"><section><h3 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Investigators</h3><div class="space-y-2.5"><div class="flex items-center gap-2.5"><div class="w-8 h-8 rounded-full bg-gradient-to-br from-blue-100 to-blue-200 flex items-center justify-center text-blue-700 font-semibold text-sm flex-shrink-0">A</div><span class="text-sm text-gray-800 font-medium">Ada Lovelace</span></div></div></section><section><h3 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Research Areas</h3><p class="text-xs text-gray-400 mb-2">Click to find similar labs</p><div class="flex flex-wrap gap-1.5"><button class="bg-blue-200 text-blue-800 text-xs rounded-md px-2 py-1 hover:ring-2 hover:ring-offset-1 cursor-pointer transition-all">Algorithms</button></div></section><section><h3 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Departments</h3><div class="flex flex-wrap gap-1.5"><button class="bg-gray-100 text-gray-700 text-xs rounded-md px-2 py-1 hover:bg-gray-200 hover:ring-2 hover:ring-gray-300 cursor-pointer transition-all">Computer Science</button></div></section><section><h3 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Contact</h3><div class="space-y-2"><button type="button" class="flex items-center gap-2 text-sm text-blue-600 hover:text-blue-800 hover:underline"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="flex-shrink-0"><rect x="2" y="4" width="20" height="16" rx="2"></rect><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"></path></svg><span>Sign in to inquire</span></button><a href="https://example.edu/lab" target="_blank" rel="noopener noreferrer" class="flex items-center gap-2 text-sm text-blue-600 hover:text-blue-800 hover:underline"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="flex-shrink-0"><circle cx="12" cy="12" r="10"></circle><line x1="2" y1="12" x2="22" y2="12"></line><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path></svg><span class="truncate">https://example.edu/lab</span></a></div></section><section><h3 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Details</h3><div class="space-y-1.5 text-sm"><div class="flex justify-between"><span class="text-gray-500">Established</span><span class="font-medium text-gray-800">2020</span></div><div class="flex justify-between"><span class="text-gray-500">Added</span><span class="font-medium text-gray-800">12/31/2025</span></div></div></section></div><div class="col-span-1 md:col-span-2 space-y-6"><section><h3 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Research Description</h3><div class="text-sm text-gray-700 leading-relaxed whitespace-pre-wrap">This public description is visible to logged-out visitors while contact details stay redacted.</div></section><section><h3 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Applicant Prerequisites</h3><div class="text-sm text-gray-700 leading-relaxed whitespace-pre-wrap bg-amber-50/50 border border-amber-100 rounded-lg p-4">Prior programming experience is helpful.</div></section></div></div></div></div></div></div></section>
  </main>
</body>
</html>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `AGENTS.md` - merge conflict rebasing onto origin/main
- ⚠️ `server/src/controllers/listingController.ts` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (5) ✅</summary>

- ⚠️ `server/src/controllers/listingController.ts:543` - Public browse/search does not use the existing Meilisearch degradation path. `searchPublicResearch` calls `index.search()` directly and returns 500 on any Meili outage or hybrid-search failure, while the authenticated `/listings/search` path retries keyword-only and then falls back to MongoDB. That means logged-out discovery can go down in exactly the degraded states the app already handles for logged-in users; reuse `searchListingsWithDegradation` here and redact the returned hits before responding.
- ⚠️ `client/src/pages/home.tsx:94` - Authenticated visits to shareable `/research/:slug` URLs bypass the new public detail filter/redaction by fetching `/listings/:id` instead of `/research/:slug`. Since `readListing` only checks that the caller is authenticated, a logged-in user can open archived or unconfirmed listings through the public share route if they have the ID. If research share URLs are meant to show only public listings, fetch the public detail endpoint first or add an authenticated detail endpoint that still enforces `{ archived: false, confirmed: true }`.

🔧 Fix: Harden public research discovery routes
1 error still open:
- 🚨 `server/src/controllers/listingController.ts:557` - Public search redacts sensitive fields only after running the query through the private listing search path. Because the Meilisearch documents still contain fields like `ownerEmail`, `emails`, `ownerId`, `professorIds`, `views`, and `favorites`, and the Mongo fallback also searches/sorts private fields, a logged-out caller can query or sort on redacted data and infer matches or ordering. Use a public-safe searchable/sortable field allowlist, or a separate redacted public search document/index, before returning public results.

🔧 Fix: Harden public research search
2 warnings still open:
- ⚠️ `server/src/controllers/listingController.ts:631` - `getPublicResearchBySlug` awaits Mongo directly without a try/catch or `asyncHandler`. In Express 4, a rejected `findOne()` promise, for example during a database outage, will bypass the normal error handler and can become an unhandled rejection instead of returning a controlled 5xx response. Wrap this route/controller in the existing async error handling pattern or add a local catch like `searchPublicResearch`.
- ⚠️ `client/src/components/shared/ListingDetailModal.tsx:348` - Authenticated users who arrive from the new public flow still receive redacted listing data, but the modal switches to the authenticated contact UI. After a logged-out user clicks “Sign in to inquire” and returns to `/research/:slug`, `[listing.ownerEmail, ...listing.emails]` is empty, so the contact CTA disappears and the header email icon has no `mailto`. If sign-in is meant to unlock inquiry, fetch an authenticated-safe detail payload after login or keep a clear login/permission CTA for redacted data.

🔧 Fix: Harden public research detail flow
1 warning still open:
- ⚠️ `server/src/controllers/listingController.ts:56` - Public research allows sorting by `title`, `ownerFirstName`, and `ownerLastName`, but the Meilisearch index is configured as sortable only for `createdAt`, `updatedAt`, and `searchScore`. Selecting the visible public sort options for title/name will make Meilisearch reject the request and force every such search through the Mongo fallback, adding latency and noisy degraded responses. Either configure these fields as sortable in Meilisearch or remove them from the public sort allowlist/UI until supported.

🔧 Fix: Align public research sort options
1 warning still open:
- ⚠️ `client/src/pages/home.tsx:223` - Clicking a research-area chip inside a shareable `/research/:slug` modal closes the modal and changes the filters, but it leaves the URL on the old slug. The visible page is now filtered browse results while refresh/copy/back still points to the previous listing and reopens it, so clear the slug route when these in-modal navigation actions close the modal, like the close button already does.

🔧 Fix: Clear stale research modal URLs
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `yarn --cwd client test:ci src/__tests__/App.publicResearchRoutes.test.tsx src/pages/__tests__/home.publicResearch.test.tsx src/providers/__tests__/SearchContextProvider.publicResearch.test.tsx src/components/shared/__tests__/ListingDetailModal.public.test.tsx`
- `yarn --cwd server test:search-degrade`
- <code>Started a local mock API on `http://localhost:4011` and Vite on `http://127.0.0.1:3001` with `VITE_APP_SERVER=http://localhost:4011` to exercise the logged-out `/research/507f1f77bcf86cd799439011` route.</code>
- `NODE_PATH=/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KWQRA4ZDK0MV9V5G33M1BMG6/client/node_modules yarn --cwd server tsx /tmp/no-mistakes-evidence/01KWQRA4ZDK0MV9V5G33M1BMG6/render-public-research-evidence.tsx`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
