### PR TITLE
feat(analytics): add research surface analytics events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,7 @@ export const asyncHandler = (fn: Function) => {
 
 ## Analytics Interception
 
-Analytics events are logged by intercepting `res.send` or `res.json` in route-level middleware (`server/src/routes/listings.ts`). The original method is bound, replaced with a wrapper that fires a log event on 2xx responses, then calls the original. This keeps analytics logic out of controllers and services.
+Analytics events are logged by intercepting `res.send` or `res.json` in route-level middleware (`server/src/routes/listings.ts`, `server/src/routes/fellowships.ts`, `server/src/routes/profiles.ts`, and `server/src/routes/users.ts`). The original method is bound, replaced with a wrapper that fires a log event on 2xx responses, then calls the original. This keeps analytics logic out of controllers and services.
 
 ```typescript
 const logListingEvent = (eventType: AnalyticsEventType) => {
@@ -161,6 +161,10 @@ const logListingEvent = (eventType: AnalyticsEventType) => {
 ```
 
 Listing creation uses the same pattern but intercepts `res.json` to extract the created listing's `_id` from the response body.
+
+Research-surface analytics use the same fire-and-forget pattern through `server/src/services/researchAnalytics.ts`. The canonical research events are `research_view`, `pathway_save`, `ways_in_click`, `contact_route_click`, and `source_link_click`, targeted at `profile`, `listing`, or `fellowship` entities. Client-only interactions post to `POST /api/analytics/research`; server-observed views and favorite/save actions are emitted from route middleware.
+
+Research analytics payloads are sanitized before persistence: contact clicks keep only a coarse `contactMethod`, source clicks keep only `sourceCategory` plus a bare hostname, and free-text labels reject raw contact addresses and URL-like values. The admin analytics dashboard segments research engagement by event type, entity type, user type, and top viewed entities over 30 days.
 
 Analytics events have a 3-year TTL via MongoDB's `expireAfterSeconds` index.
 
@@ -251,7 +255,7 @@ All routes mount under `/api` in `app.ts`. Route files in `server/src/routes/`:
 | `/fellowships`    | `fellowships.ts`   | Varies                                         |
 | `/users`          | `users.ts`         | Yes                                            |
 | `/profiles`       | `profiles.ts`      | Varies                                         |
-| `/analytics`      | `analytics.ts`     | Admin                                          |
+| `/analytics`      | `analytics.ts`     | Admin for dashboard, authenticated for research event writes |
 | `/config`         | `config.ts`        | No                                             |
 | `/research-areas` | `researchAreas.ts` | Admin for writes                               |
 | `/admin`          | `admin.ts`         | Admin                                          |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ ylabs/
 | `yarn clean:all`                        | Remove all node_modules directories                         |
 | `yarn --cwd client test`                | Run Vitest in watch mode                                    |
 | `yarn --cwd client test:ci`             | Run Vitest once (used by CI)                                |
+| `yarn --cwd server test`                | Run server-side Node test files                             |
 | `yarn --cwd server test:search-degrade` | Run focused listing-search degradation tests                |
 
 Migration scripts run from `data-migration/` with `npx ts-node --transpile-only <script>.ts`.
@@ -165,7 +166,7 @@ Analytics events have a 3-year TTL via MongoDB's `expireAfterSeconds` index.
 
 ## Testing
 
-Client-side tests run under **Vitest 3** with a `jsdom` environment. Config lives in the `test` block of `client/vite.config.js`; tests are discovered from `client/src/**/*.{test,spec}.{ts,tsx}`. The server has a focused Node test script for listing-search degradation (`yarn --cwd server test:search-degrade`), but no general server-side test suite is wired into CI.
+Client-side tests run under **Vitest 3** with a `jsdom` environment. Config lives in the `test` block of `client/vite.config.js`; tests are discovered from `client/src/**/*.{test,spec}.{ts,tsx}`. Server tests run with Node's test runner via `tsx` (`yarn --cwd server test`), with a focused listing-search degradation script available as `yarn --cwd server test:search-degrade`.
 
 Coverage focuses on pure reducer modules in `client/src/reducers/`, with matching test files in `client/src/reducers/__tests__/`. The pattern extracts state transitions out of providers/components (as `createInitial<Name>State()` + `<name>Reducer(state, action)`) so they can be tested without mounting React or mocking network. Side effects (axios, localStorage, timers) stay in the component that uses `useReducer`.
 
@@ -319,7 +320,7 @@ User → Yale CAS SSO → passport.ts findOrCreateUser
 
 | Issue                                    | Location                          | Status                                                                                                                                                                                                                          |
 | ---------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| No general server-side test suite        | `server/`                         | A focused Node test covers listing-search degradation; broader server coverage is not wired into CI. Client uses Vitest; reducer modules in `client/src/reducers/` are covered.                                                 |
+| Limited server-side test coverage        | `server/`                         | Node tests cover focused server behavior, including listing-search degradation. Client uses Vitest; reducer modules in `client/src/reducers/` are covered.                                                                       |
 | ESLint/Prettier configured but not in CI | `eslint.config.js`, `.prettierrc` | Flat-config ESLint + Prettier set up at repo root. Currently reports ~15 errors / ~55 warnings across the codebase; not wired to CI until pre-existing violations are triaged. Run `yarn lint`, `yarn lint:fix`, `yarn format`. |
 | Console-only logging                     | Server                            | No structured logging (Winston/Pino)                                                                                                                                                                                            |
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -139,6 +139,7 @@ Visit `http://localhost:4000/api/dev-login` to log in as a test user (`test123` 
 | `yarn clean:all`                        | Remove all node_modules                          |
 | `yarn --cwd client test`                | Run Vitest in watch mode                         |
 | `yarn --cwd client test:ci`             | Run Vitest once (used by CI)                     |
+| `yarn --cwd server test`                | Run server-side Node test files                  |
 | `yarn --cwd server test:search-degrade` | Run the focused listing-search degradation tests |
 
 ### Migration Scripts
@@ -210,6 +211,26 @@ The Meilisearch client (`server/src/utils/meiliClient.ts`) exports:
 
 ---
 
+## Analytics
+
+Analytics events are stored in MongoDB with a 3-year TTL. Route-level middleware logs successful server-observed events by wrapping `res.send` or `res.json`, so analytics stay outside controller and service business logic.
+
+Research-surface analytics cover the canonical research entities (`profile`, `listing`, and `fellowship`) and use these event types:
+
+| Event type            | Meaning                                                  |
+| --------------------- | -------------------------------------------------------- |
+| `research_view`       | A profile, listing, or fellowship detail surface opened  |
+| `pathway_save`        | A listing or fellowship was saved, unsaved, or re-staged |
+| `ways_in_click`       | A best-next-step, apply, listings, courses, or similar action was clicked |
+| `contact_route_click` | A contact route such as email or phone was clicked       |
+| `source_link_click`   | A source link such as a lab site, publication, or application was clicked |
+
+Client-only interactions are sent to `POST /api/analytics/research` for authenticated users. Server-observed views and save/favorite actions are emitted from route middleware in listings, fellowships, profiles, and users.
+
+Research analytics sanitize payloads before persistence: contact clicks keep only a coarse `contactMethod`, source clicks keep only `sourceCategory` plus the bare hostname, and labels reject raw contact addresses or URL-like values. The admin analytics dashboard segments research engagement by event type, entity type, user type, and top viewed entities over the trailing 30 days.
+
+---
+
 ## Authentication
 
 ```
@@ -236,23 +257,23 @@ User → Yale CAS SSO → passport.ts findOrCreateUser
 
 All mount under `/api`.
 
-| Prefix            | Description                  | Auth             |
-| ----------------- | ---------------------------- | ---------------- |
-| `/listings`       | Listing CRUD and search      | Varies           |
-| `/fellowships`    | Fellowship CRUD and search   | Varies           |
-| `/users`          | User CRUD                    | Yes              |
-| `/profiles`       | Faculty profiles             | Varies           |
-| `/analytics`      | Analytics dashboards         | Admin            |
-| `/config`         | Departments + research areas | No               |
-| `/research-areas` | Research area CRUD           | Admin for writes |
-| `/admin`          | Admin operations             | Admin            |
-| `/seed`           | Dev seeding routes           | Dev mode only    |
+| Prefix            | Description                                 | Auth                                             |
+| ----------------- | ------------------------------------------- | ------------------------------------------------ |
+| `/listings`       | Listing CRUD and search                     | Varies                                           |
+| `/fellowships`    | Fellowship CRUD and search                  | Varies                                           |
+| `/users`          | User CRUD                                   | Yes                                              |
+| `/profiles`       | Faculty profiles                            | Varies                                           |
+| `/analytics`      | Analytics dashboard + research event writes | Admin for dashboard, authenticated for research writes |
+| `/config`         | Departments + research areas                | No                                               |
+| `/research-areas` | Research area CRUD                          | Admin for writes                                 |
+| `/admin`          | Admin operations                            | Admin                                            |
+| `/seed`           | Dev seeding routes                          | Dev mode only                                    |
 
 ---
 
 ## Testing
 
-Client-side tests run under **Vitest 3** with a `jsdom` environment. Configuration lives in the `test` block of [client/vite.config.js](client/vite.config.js). The server has a focused Node test script for listing-search degradation, but no general server-side test suite is wired into CI.
+Client-side tests run under **Vitest 3** with a `jsdom` environment. Configuration lives in the `test` block of [client/vite.config.js](client/vite.config.js). Server tests run with Node's test runner via `tsx`; the focused listing-search degradation script is available separately.
 
 ### Running tests
 
@@ -262,10 +283,11 @@ yarn test        # watch mode — reruns on file changes
 yarn test:ci     # single run — used by CI
 
 cd ../server
+yarn test                 # server-side Node test files
 yarn test:search-degrade  # listing-search fallback coverage
 ```
 
-Tests are discovered from `client/src/**/*.{test,spec}.{ts,tsx}`.
+Client tests are discovered from `client/src/**/*.{test,spec}.{ts,tsx}`. Server tests are discovered from `server/src/**/*.test.ts`.
 
 ### What is tested
 

--- a/client/src/components/fellowship/FellowshipModal.tsx
+++ b/client/src/components/fellowship/FellowshipModal.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import { Fellowship } from '../../types/types';
 import FellowshipSearchContext from '../../contexts/FellowshipSearchContext';
 import { ensureHttpPrefix, safeUrl } from '../../utils/url';
+import { trackResearchEvent } from '../../utils/researchAnalytics';
 import FavoriteButton from '../shared/FavoriteButton';
 
 interface FellowshipModalProps {
@@ -116,6 +117,12 @@ const FellowshipModal = ({
         break;
     }
 
+    trackResearchEvent({
+      eventType: 'ways_in_click',
+      entityType: 'fellowship',
+      entityId: fellowship.id,
+      payload: { waysInKind: 'best_next_step', label: filterType },
+    });
     onClose();
     navigate('/fellowships');
   };
@@ -185,7 +192,24 @@ const FellowshipModal = ({
                     href={ensureHttpPrefix(fellowship.applicationLink)}
                     target="_blank"
                     rel="noopener noreferrer"
-                    onClick={(e) => e.stopPropagation()}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      trackResearchEvent({
+                        eventType: 'source_link_click',
+                        entityType: 'fellowship',
+                        entityId: fellowship.id,
+                        payload: {
+                          sourceCategory: 'external',
+                          url: ensureHttpPrefix(fellowship.applicationLink),
+                        },
+                      });
+                      trackResearchEvent({
+                        eventType: 'ways_in_click',
+                        entityType: 'fellowship',
+                        entityId: fellowship.id,
+                        payload: { waysInKind: 'apply', label: 'Apply' },
+                      });
+                    }}
                     className="p-2 rounded-lg hover:bg-gray-100 transition-colors text-gray-500 hover:text-blue-600"
                     title="Apply"
                   >
@@ -209,7 +233,15 @@ const FellowshipModal = ({
                 {fellowship.contactEmail && (
                   <a
                     href={`mailto:${fellowship.contactEmail}`}
-                    onClick={(e) => e.stopPropagation()}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      trackResearchEvent({
+                        eventType: 'contact_route_click',
+                        entityType: 'fellowship',
+                        entityId: fellowship.id,
+                        payload: { contactMethod: 'email' },
+                      });
+                    }}
                     className="p-2 rounded-lg hover:bg-gray-100 transition-colors text-gray-500 hover:text-blue-600"
                     title="Email contact"
                   >
@@ -315,6 +347,14 @@ const FellowshipModal = ({
                       {fellowship.contactEmail && (
                         <a
                           href={`mailto:${fellowship.contactEmail}`}
+                          onClick={() =>
+                            trackResearchEvent({
+                              eventType: 'contact_route_click',
+                              entityType: 'fellowship',
+                              entityId: fellowship.id,
+                              payload: { contactMethod: 'email' },
+                            })
+                          }
                           className="flex items-center gap-2 text-sm text-blue-600 hover:text-blue-800 hover:underline"
                         >
                           <svg
@@ -357,6 +397,17 @@ const FellowshipModal = ({
                           href={ensureHttpPrefix(link.url)}
                           target="_blank"
                           rel="noopener noreferrer"
+                          onClick={() =>
+                            trackResearchEvent({
+                              eventType: 'source_link_click',
+                              entityType: 'fellowship',
+                              entityId: fellowship.id,
+                              payload: {
+                                sourceCategory: 'external',
+                                url: ensureHttpPrefix(link.url),
+                              },
+                            })
+                          }
                           className="flex items-center gap-2 text-sm text-blue-600 hover:text-blue-800 hover:underline"
                         >
                           <svg
@@ -551,6 +602,23 @@ const FellowshipModal = ({
                       href={ensureHttpPrefix(fellowship.applicationLink)}
                       target="_blank"
                       rel="noopener noreferrer"
+                      onClick={() => {
+                        trackResearchEvent({
+                          eventType: 'source_link_click',
+                          entityType: 'fellowship',
+                          entityId: fellowship.id,
+                          payload: {
+                            sourceCategory: 'external',
+                            url: ensureHttpPrefix(fellowship.applicationLink),
+                          },
+                        });
+                        trackResearchEvent({
+                          eventType: 'ways_in_click',
+                          entityType: 'fellowship',
+                          entityId: fellowship.id,
+                          payload: { waysInKind: 'apply', label: 'Apply' },
+                        });
+                      }}
                       className="inline-flex items-center px-6 py-2.5 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors text-sm"
                     >
                       Apply Now

--- a/client/src/components/profile/ProfileHeader.tsx
+++ b/client/src/components/profile/ProfileHeader.tsx
@@ -2,6 +2,7 @@
  * Profile header with name, department, contact, and metrics.
  */
 import { FacultyProfile } from '../../types/types';
+import { trackResearchEvent } from '../../utils/researchAnalytics';
 import { safeUrl } from '../../utils/url';
 
 interface ProfileHeaderProps {
@@ -62,6 +63,14 @@ const ProfileHeader = ({ profile, onTabChange }: ProfileHeaderProps) => {
           {profile.email && (
             <a
               href={`mailto:${profile.email}`}
+              onClick={() =>
+                trackResearchEvent({
+                  eventType: 'contact_route_click',
+                  entityType: 'profile',
+                  entityId: profile.netid,
+                  payload: { contactMethod: 'email' },
+                })
+              }
               className="flex items-center gap-1.5 text-blue-600 hover:text-blue-800 hover:underline"
             >
               <svg
@@ -105,7 +114,15 @@ const ProfileHeader = ({ profile, onTabChange }: ProfileHeaderProps) => {
         <div className="flex flex-wrap items-center gap-4 mt-3">
           {profile.ownListings && profile.ownListings.length > 0 && (
             <button
-              onClick={() => onTabChange?.('listings')}
+              onClick={() => {
+                trackResearchEvent({
+                  eventType: 'ways_in_click',
+                  entityType: 'profile',
+                  entityId: profile.netid,
+                  payload: { waysInKind: 'view_listings', label: 'Profile listings' },
+                });
+                onTabChange?.('listings');
+              }}
               className="text-xs px-2 py-1 rounded-full bg-blue-50 text-blue-700 font-medium hover:bg-blue-100 transition-colors cursor-pointer"
             >
               {profile.ownListings.length} listing{profile.ownListings.length !== 1 ? 's' : ''}
@@ -123,6 +140,17 @@ const ProfileHeader = ({ profile, onTabChange }: ProfileHeaderProps) => {
                     href={href}
                     target="_blank"
                     rel="noopener noreferrer"
+                    onClick={() =>
+                      trackResearchEvent({
+                        eventType: 'source_link_click',
+                        entityType: 'profile',
+                        entityId: profile.netid,
+                        payload: {
+                          sourceCategory: key === 'website' ? 'profile' : 'external',
+                          url: href,
+                        },
+                      })
+                    }
                     className="text-xs px-2 py-1 rounded-full bg-gray-50 text-gray-600 font-medium hover:bg-gray-100 transition-colors capitalize"
                   >
                     {key.replace(/_/g, ' ')}

--- a/client/src/components/profile/PublicationsTable.tsx
+++ b/client/src/components/profile/PublicationsTable.tsx
@@ -4,6 +4,7 @@
 import { useReducer, useEffect } from 'react';
 import { Publication } from '../../types/types';
 import axios from '../../utils/axios';
+import { trackResearchEvent } from '../../utils/researchAnalytics';
 import { safeUrl } from '../../utils/url';
 import {
   PublicationsSortField,
@@ -140,6 +141,17 @@ const PublicationsTable = ({ netid }: PublicationsTableProps) => {
                         href={`https://doi.org/${pub.doi}`}
                         target="_blank"
                         rel="noopener noreferrer"
+                        onClick={() =>
+                          trackResearchEvent({
+                            eventType: 'source_link_click',
+                            entityType: 'profile',
+                            entityId: netid,
+                            payload: {
+                              sourceCategory: 'publication',
+                              url: `https://doi.org/${pub.doi}`,
+                            },
+                          })
+                        }
                         className="flex-shrink-0 text-blue-500 hover:text-blue-700"
                         title="Open DOI"
                       >
@@ -165,6 +177,17 @@ const PublicationsTable = ({ netid }: PublicationsTableProps) => {
                         href={safeUrl(pub.open_access_url)}
                         target="_blank"
                         rel="noopener noreferrer"
+                        onClick={() => {
+                          const href = safeUrl(pub.open_access_url);
+                          if (href) {
+                            trackResearchEvent({
+                              eventType: 'source_link_click',
+                              entityType: 'profile',
+                              entityId: netid,
+                              payload: { sourceCategory: 'publication', url: href },
+                            });
+                          }
+                        }}
                         className="flex-shrink-0 text-green-500 hover:text-green-700"
                         title="Open Access"
                       >

--- a/client/src/components/shared/ListingDetailModal.tsx
+++ b/client/src/components/shared/ListingDetailModal.tsx
@@ -9,6 +9,7 @@ import ConfigContext from '../../contexts/ConfigContext';
 import { getDepartmentAbbreviation } from '../../utils/departmentNames';
 import { ensureHttpPrefix } from '../../utils/url';
 import { getInstitutionAffiliation, getInstitutionLabel } from '../../utils/institutionAffiliation';
+import { trackResearchEvent } from '../../utils/researchAnalytics';
 import FavoriteButton from './FavoriteButton';
 
 interface ListingDetailModalProps {
@@ -128,7 +129,18 @@ const ListingDetailModal = ({
                     {listing.websites && listing.websites.length > 0 && (
                       <a
                         href={ensureHttpPrefix(listing.websites[0])}
-                        onClick={(e) => e.stopPropagation()}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          trackResearchEvent({
+                            eventType: 'source_link_click',
+                            entityType: 'listing',
+                            entityId: listing.id,
+                            payload: {
+                              sourceCategory: 'lab_website',
+                              url: ensureHttpPrefix(listing.websites[0]),
+                            },
+                          });
+                        }}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="p-2 rounded-lg hover:bg-gray-100 transition-colors text-gray-500 hover:text-blue-600"
@@ -153,7 +165,15 @@ const ListingDetailModal = ({
                     )}
                     <a
                       href={`mailto:${listing.ownerEmail}`}
-                      onClick={(e) => e.stopPropagation()}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        trackResearchEvent({
+                          eventType: 'contact_route_click',
+                          entityType: 'listing',
+                          entityId: listing.id,
+                          payload: { contactMethod: 'email' },
+                        });
+                      }}
                       className="p-2 rounded-lg hover:bg-gray-100 transition-colors text-gray-500 hover:text-blue-600"
                       title="Send email"
                     >
@@ -229,7 +249,15 @@ const ListingDetailModal = ({
                         {netid ? (
                           <Link
                             to={`/profile/${netid}`}
-                            onClick={onClose}
+                            onClick={() => {
+                              trackResearchEvent({
+                                eventType: 'ways_in_click',
+                                entityType: 'listing',
+                                entityId: listing.id,
+                                payload: { waysInKind: 'best_next_step', label: 'View profile' },
+                              });
+                              onClose();
+                            }}
                             className="text-sm text-blue-600 hover:text-blue-800 hover:underline font-medium"
                           >
                             {name}
@@ -257,7 +285,15 @@ const ListingDetailModal = ({
                           return (
                             <button
                               key={area}
-                              onClick={() => onNavigateToResearchArea(area)}
+                              onClick={() => {
+                                trackResearchEvent({
+                                  eventType: 'ways_in_click',
+                                  entityType: 'listing',
+                                  entityId: listing.id,
+                                  payload: { waysInKind: 'view_listings', label: 'Research area' },
+                                });
+                                onNavigateToResearchArea(area);
+                              }}
                               className={`${colors.bg} ${colors.text} text-xs rounded-md px-2 py-1 hover:ring-2 hover:ring-offset-1 cursor-pointer transition-all`}
                             >
                               {area}
@@ -308,7 +344,15 @@ const ListingDetailModal = ({
                           return (
                             <button
                               key={dept}
-                              onClick={() => onNavigateToDepartment(fullName)}
+                              onClick={() => {
+                                trackResearchEvent({
+                                  eventType: 'ways_in_click',
+                                  entityType: 'listing',
+                                  entityId: listing.id,
+                                  payload: { waysInKind: 'view_listings', label: 'Department' },
+                                });
+                                onNavigateToDepartment(fullName);
+                              }}
                               className="bg-gray-100 text-gray-700 text-xs rounded-md px-2 py-1 hover:bg-gray-200 hover:ring-2 hover:ring-gray-300 cursor-pointer transition-all"
                             >
                               {fullName}
@@ -337,6 +381,14 @@ const ListingDetailModal = ({
                       <a
                         key={i}
                         href={`mailto:${email}`}
+                        onClick={() =>
+                          trackResearchEvent({
+                            eventType: 'contact_route_click',
+                            entityType: 'listing',
+                            entityId: listing.id,
+                            payload: { contactMethod: 'email' },
+                          })
+                        }
                         className="flex items-center gap-2 text-sm text-blue-600 hover:text-blue-800 hover:underline"
                       >
                         <svg
@@ -365,6 +417,17 @@ const ListingDetailModal = ({
                           href={ensureHttpPrefix(website)}
                           target="_blank"
                           rel="noopener noreferrer"
+                          onClick={() =>
+                            trackResearchEvent({
+                              eventType: 'source_link_click',
+                              entityType: 'listing',
+                              entityId: listing.id,
+                              payload: {
+                                sourceCategory: 'lab_website',
+                                url: ensureHttpPrefix(website),
+                              },
+                            })
+                          }
                           className="flex items-center gap-2 text-sm text-blue-600 hover:text-blue-800 hover:underline"
                         >
                           <svg

--- a/client/src/pages/analytics.tsx
+++ b/client/src/pages/analytics.tsx
@@ -88,6 +88,12 @@ const Analytics = () => {
     return typeMap[type] || type;
   };
 
+  const formatEventType = (type: string) =>
+    type
+      .split('_')
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ');
+
   return (
     <div className="container mx-auto px-4 py-8 max-w-7xl">
       <div className="flex justify-between items-center mb-8">
@@ -323,6 +329,87 @@ const Analytics = () => {
           </div>
         </section>
       )}
+
+      <section className="mb-10">
+        <h2 className="text-2xl font-bold mb-4 text-gray-800 border-b-2 border-blue-600 pb-2">
+          Research Engagement
+        </h2>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
+          {data.research.byEventType.slice(0, 3).map((item) => (
+            <StatCard
+              key={item.eventType}
+              title={formatEventType(item.eventType)}
+              value={item.total}
+              subtitle={`${item.last7Days} last 7 days, ${item.today} today`}
+            />
+          ))}
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <div className="bg-white rounded-lg shadow-md p-6 border border-gray-200">
+            <h3 className="text-lg font-semibold text-gray-700 mb-4">Events by Entity</h3>
+            <div className="space-y-2">
+              {data.research.byEntityType.length > 0 ? (
+                data.research.byEntityType.slice(0, 8).map((item) => (
+                  <div
+                    key={`${item.entityType}-${item.eventType}`}
+                    className="flex justify-between gap-3 text-sm"
+                  >
+                    <span className="text-gray-600 capitalize">
+                      {item.entityType} / {formatEventType(item.eventType)}
+                    </span>
+                    <span className="font-medium">{item.count}</span>
+                  </div>
+                ))
+              ) : (
+                <p className="text-sm text-gray-500">No research events yet</p>
+              )}
+            </div>
+          </div>
+
+          <div className="bg-white rounded-lg shadow-md p-6 border border-gray-200">
+            <h3 className="text-lg font-semibold text-gray-700 mb-4">Research Users</h3>
+            <div className="space-y-2">
+              {data.research.byUserType.length > 0 ? (
+                data.research.byUserType.map((item) => (
+                  <div key={item.userType} className="flex justify-between text-sm">
+                    <span className="text-gray-600">{formatUserType(item.userType)}</span>
+                    <span className="font-medium">{item.count}</span>
+                  </div>
+                ))
+              ) : (
+                <p className="text-sm text-gray-500">No research users yet</p>
+              )}
+            </div>
+          </div>
+
+          <div className="bg-white rounded-lg shadow-md p-6 border border-gray-200">
+            <h3 className="text-lg font-semibold text-gray-700 mb-4">
+              Top Research Entities (30 Days)
+            </h3>
+            <div className="space-y-2">
+              {data.research.topEntities.length > 0 ? (
+                data.research.topEntities.slice(0, 8).map((item) => (
+                  <div
+                    key={`${item.entityType}-${item.entityId}`}
+                    className="flex justify-between gap-3 text-sm"
+                  >
+                    <span className="text-gray-600 truncate">
+                      <span className="capitalize">{item.entityType}</span> {item.entityId}
+                    </span>
+                    <span className="font-medium whitespace-nowrap">
+                      {item.views} views / {item.uniqueViewers} users
+                    </span>
+                  </div>
+                ))
+              ) : (
+                <p className="text-sm text-gray-500">No viewed entities yet</p>
+              )}
+            </div>
+          </div>
+        </div>
+      </section>
 
       <section className="mb-10">
         <h2 className="text-2xl font-bold mb-4 text-gray-800 border-b-2 border-blue-600 pb-2">

--- a/client/src/pages/analytics.tsx
+++ b/client/src/pages/analytics.tsx
@@ -5,16 +5,11 @@ import { useEffect, useReducer } from 'react';
 import axios from '../utils/axios';
 import swal from 'sweetalert';
 import AdminPanel from '../components/admin/AdminPanel';
-import {
-  analyticsReducer,
-  createInitialAnalyticsState,
-} from '../reducers/analyticsReducer';
+import { analyticsReducer, createInitialAnalyticsState } from '../reducers/analyticsReducer';
 
 const Analytics = () => {
-  const [state, dispatch] = useReducer(
-    analyticsReducer,
-    undefined,
-    () => createInitialAnalyticsState()
+  const [state, dispatch] = useReducer(analyticsReducer, undefined, () =>
+    createInitialAnalyticsState(),
   );
   const { data, isLoading, lastUpdated } = state;
 

--- a/client/src/reducers/analyticsReducer.ts
+++ b/client/src/reducers/analyticsReducer.ts
@@ -108,7 +108,7 @@ export type AnalyticsAction =
   | { type: 'FETCH_FAILURE'; payload: string };
 
 export const createInitialAnalyticsState = (
-  overrides: Partial<AnalyticsState> = {}
+  overrides: Partial<AnalyticsState> = {},
 ): AnalyticsState => ({
   data: null,
   isLoading: true,

--- a/client/src/reducers/analyticsReducer.ts
+++ b/client/src/reducers/analyticsReducer.ts
@@ -59,6 +59,17 @@ export interface AnalyticsData {
       avgViews: number;
     }>;
   };
+  research: {
+    byEventType: Array<{ eventType: string; total: number; last7Days: number; today: number }>;
+    byEntityType: Array<{ entityType: string; eventType: string; count: number }>;
+    byUserType: Array<{ userType: string; count: number }>;
+    topEntities: Array<{
+      entityType: string;
+      entityId: string;
+      views: number;
+      uniqueViewers: number;
+    }>;
+  };
   listings: {
     overview: {
       total: number;

--- a/client/src/utils/researchAnalytics.ts
+++ b/client/src/utils/researchAnalytics.ts
@@ -1,0 +1,37 @@
+import axios from './axios';
+
+export type ResearchEventType =
+  | 'research_view'
+  | 'pathway_save'
+  | 'ways_in_click'
+  | 'contact_route_click'
+  | 'source_link_click';
+
+export type ResearchEntityType = 'profile' | 'listing' | 'fellowship';
+
+interface TrackResearchEventParams {
+  eventType: ResearchEventType;
+  entityType: ResearchEntityType;
+  entityId: string;
+  payload?: Record<string, string>;
+}
+
+export const trackResearchEvent = ({
+  eventType,
+  entityType,
+  entityId,
+  payload,
+}: TrackResearchEventParams) => {
+  axios
+    .post(
+      '/analytics/research',
+      {
+        eventType,
+        entityType,
+        entityId,
+        payload,
+      },
+      { withCredentials: true },
+    )
+    .catch(() => undefined);
+};

--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,7 @@
     "build:clean": "rm -rf build",
     "dev": "cross-env NODE_ENV=development tsx watch src/index.ts",
     "start": "node build/index.js",
-    "test": "cross-env NODE_ENV=test jest --config ./src/testUtils/jest.config.js",
+    "test": "cross-env NODE_ENV=test tsx --test \"src/**/*.test.ts\"",
     "test:search-degrade": "cross-env NODE_ENV=test node --import tsx --test src/controllers/listingController.search.test.ts",
     "prod": "cross-env NODE_ENV=prod tsx watch src/index.ts"
   },

--- a/server/src/models/analytics.ts
+++ b/server/src/models/analytics.ts
@@ -16,7 +16,24 @@ export enum AnalyticsEventType {
   LISTING_ARCHIVE = 'listing_archive',
   LISTING_UNARCHIVE = 'listing_unarchive',
   PROFILE_UPDATE = 'profile_update',
+  // Research product surface events. These track engagement with the canonical
+  // research entities (faculty profiles, listings, fellowships) and their
+  // client-side interaction affordances. Payloads carried in `metadata` are
+  // sanitized to a privacy-safe shape (see services/researchAnalytics.ts) so
+  // that raw contact addresses and source URLs are never persisted.
+  RESEARCH_VIEW = 'research_view',
+  PATHWAY_SAVE = 'pathway_save',
+  WAYS_IN_CLICK = 'ways_in_click',
+  CONTACT_ROUTE_CLICK = 'contact_route_click',
+  SOURCE_LINK_CLICK = 'source_link_click',
 }
+
+/**
+ * Research entity kinds that a research-surface event can target. Profiles are
+ * keyed by netid (a public identifier); listings and fellowships by ObjectId.
+ */
+export const RESEARCH_ENTITY_TYPES = ['profile', 'listing', 'fellowship'] as const;
+export type ResearchEntityType = (typeof RESEARCH_ENTITY_TYPES)[number];
 
 const analyticsEventSchema = new mongoose.Schema(
   {
@@ -39,6 +56,18 @@ const analyticsEventSchema = new mongoose.Schema(
     },
     listingId: {
       type: mongoose.Schema.Types.ObjectId,
+      index: true,
+    },
+    // Research-surface targeting. `entityType` distinguishes profile/listing/
+    // fellowship events; `entityId` holds the target's identifier (netid for
+    // profiles, ObjectId string for listings/fellowships).
+    entityType: {
+      type: String,
+      enum: RESEARCH_ENTITY_TYPES,
+      index: true,
+    },
+    entityId: {
+      type: String,
       index: true,
     },
     searchQuery: {
@@ -64,6 +93,7 @@ const analyticsEventSchema = new mongoose.Schema(
 analyticsEventSchema.index({ eventType: 1, timestamp: -1 });
 analyticsEventSchema.index({ netid: 1, timestamp: -1 });
 analyticsEventSchema.index({ eventType: 1, netid: 1, timestamp: -1 });
+analyticsEventSchema.index({ eventType: 1, entityType: 1, timestamp: -1 });
 analyticsEventSchema.index({ timestamp: -1 });
 
 analyticsEventSchema.index({ timestamp: 1 }, { expireAfterSeconds: 94608000 });

--- a/server/src/routes/analytics.ts
+++ b/server/src/routes/analytics.ts
@@ -5,8 +5,43 @@ import { Request, Response, Router } from 'express';
 import { isAuthenticated, isAdmin } from '../middleware/auth';
 import { getAnalytics } from '../services/analyticsService';
 import { AnalyticsEvent, AnalyticsEventType } from '../models/analytics';
+import {
+  emitResearchEvent,
+  isResearchEntityType,
+  isResearchEventType,
+} from '../services/researchAnalytics';
 
 const router = Router();
+
+router.post('/research', isAuthenticated, async (request: Request, response: Response) => {
+  const { eventType, entityType, entityId, payload } = request.body || {};
+
+  if (!isResearchEventType(eventType)) {
+    return response.status(400).json({ error: 'Invalid research analytics eventType' });
+  }
+
+  if (!isResearchEntityType(entityType)) {
+    return response.status(400).json({ error: 'Invalid research analytics entityType' });
+  }
+
+  if (typeof entityId !== 'string' || entityId.trim() === '') {
+    return response.status(400).json({ error: 'Invalid research analytics entityId' });
+  }
+
+  const emitted = await emitResearchEvent({
+    eventType,
+    entityType,
+    entityId,
+    payload,
+    user: request.user as { netId?: string; userType?: string },
+  });
+
+  if (!emitted) {
+    return response.status(400).json({ error: 'Unable to record research analytics event' });
+  }
+
+  return response.status(202).json({ ok: true });
+});
 
 router.get('/', isAuthenticated, isAdmin, async (request: Request, response: Response) => {
   try {

--- a/server/src/routes/analytics.ts
+++ b/server/src/routes/analytics.ts
@@ -3,6 +3,7 @@
  */
 import { Request, Response, Router } from 'express';
 import { isAuthenticated, isAdmin } from '../middleware/auth';
+import { asyncHandler } from '../middleware/errorHandler';
 import { getAnalytics } from '../services/analyticsService';
 import { AnalyticsEvent, AnalyticsEventType } from '../models/analytics';
 import {
@@ -14,39 +15,43 @@ import {
 
 const router = Router();
 
-router.post('/research', isAuthenticated, async (request: Request, response: Response) => {
-  const { eventType, entityType, entityId, payload } = request.body || {};
+router.post(
+  '/research',
+  isAuthenticated,
+  asyncHandler(async (request: Request, response: Response) => {
+    const { eventType, entityType, entityId, payload } = request.body || {};
 
-  if (!isResearchEventType(eventType)) {
-    return response.status(400).json({ error: 'Invalid research analytics eventType' });
-  }
+    if (!isResearchEventType(eventType)) {
+      return response.status(400).json({ error: 'Invalid research analytics eventType' });
+    }
 
-  if (!isResearchEntityType(entityType)) {
-    return response.status(400).json({ error: 'Invalid research analytics entityType' });
-  }
+    if (!isResearchEntityType(entityType)) {
+      return response.status(400).json({ error: 'Invalid research analytics entityType' });
+    }
 
-  if (typeof entityId !== 'string' || entityId.trim() === '') {
-    return response.status(400).json({ error: 'Invalid research analytics entityId' });
-  }
+    if (typeof entityId !== 'string' || entityId.trim() === '') {
+      return response.status(400).json({ error: 'Invalid research analytics entityId' });
+    }
 
-  if (!(await researchEntityExists(entityType, entityId))) {
-    return response.status(404).json({ error: 'Research analytics entity not found' });
-  }
+    if (!(await researchEntityExists(entityType, entityId))) {
+      return response.status(404).json({ error: 'Research analytics entity not found' });
+    }
 
-  const emitted = await emitResearchEvent({
-    eventType,
-    entityType,
-    entityId,
-    payload,
-    user: request.user as { netId?: string; userType?: string },
-  });
+    const emitted = await emitResearchEvent({
+      eventType,
+      entityType,
+      entityId,
+      payload,
+      user: request.user as { netId?: string; userType?: string },
+    });
 
-  if (!emitted) {
-    return response.status(400).json({ error: 'Unable to record research analytics event' });
-  }
+    if (!emitted) {
+      return response.status(400).json({ error: 'Unable to record research analytics event' });
+    }
 
-  return response.status(202).json({ ok: true });
-});
+    return response.status(202).json({ ok: true });
+  }),
+);
 
 router.get('/', isAuthenticated, isAdmin, async (request: Request, response: Response) => {
   try {

--- a/server/src/routes/analytics.ts
+++ b/server/src/routes/analytics.ts
@@ -9,6 +9,7 @@ import {
   emitResearchEvent,
   isResearchEntityType,
   isResearchEventType,
+  researchEntityExists,
 } from '../services/researchAnalytics';
 
 const router = Router();
@@ -26,6 +27,10 @@ router.post('/research', isAuthenticated, async (request: Request, response: Res
 
   if (typeof entityId !== 'string' || entityId.trim() === '') {
     return response.status(400).json({ error: 'Invalid research analytics entityId' });
+  }
+
+  if (!(await researchEntityExists(entityType, entityId))) {
+    return response.status(404).json({ error: 'Research analytics entity not found' });
   }
 
   const emitted = await emitResearchEvent({

--- a/server/src/routes/fellowships.ts
+++ b/server/src/routes/fellowships.ts
@@ -32,6 +32,12 @@ router.put(
   '/:id/addFavorite',
   isAuthenticated,
   validateObjectId('id'),
+  logResearchEventOnSuccess(
+    AnalyticsEventType.PATHWAY_SAVE,
+    'fellowship',
+    (req) => req.params.id,
+    () => ({ action: 'save' }),
+  ),
   fellowshipController.addFavoriteToFellowship,
 );
 
@@ -39,6 +45,12 @@ router.put(
   '/:id/removeFavorite',
   isAuthenticated,
   validateObjectId('id'),
+  logResearchEventOnSuccess(
+    AnalyticsEventType.PATHWAY_SAVE,
+    'fellowship',
+    (req) => req.params.id,
+    () => ({ action: 'unsave' }),
+  ),
   fellowshipController.removeFavoriteFromFellowship,
 );
 

--- a/server/src/routes/fellowships.ts
+++ b/server/src/routes/fellowships.ts
@@ -4,6 +4,8 @@
 import { Router } from 'express';
 import { isAuthenticated, validateObjectId, validatePagination } from '../middleware/index';
 import * as fellowshipController from '../controllers/fellowshipController';
+import { AnalyticsEventType } from '../models/index';
+import { logResearchEventOnSuccess } from '../services/researchAnalytics';
 
 const router = Router();
 
@@ -22,6 +24,7 @@ router.put(
   '/:id/addView',
   isAuthenticated,
   validateObjectId('id'),
+  logResearchEventOnSuccess(AnalyticsEventType.RESEARCH_VIEW, 'fellowship'),
   fellowshipController.addViewToFellowship,
 );
 

--- a/server/src/routes/listings.ts
+++ b/server/src/routes/listings.ts
@@ -11,6 +11,7 @@ import {
 import * as listingController from '../controllers/listingController';
 import { logEvent } from '../services/analyticsService';
 import { AnalyticsEventType } from '../models/index';
+import { logResearchEventOnSuccess } from '../services/researchAnalytics';
 
 const router = Router();
 
@@ -132,6 +133,7 @@ router.put(
   isAuthenticated,
   validateObjectId('id'),
   logListingEvent(AnalyticsEventType.LISTING_VIEW),
+  logResearchEventOnSuccess(AnalyticsEventType.RESEARCH_VIEW, 'listing'),
   listingController.addViewToListing,
 );
 

--- a/server/src/routes/profiles.ts
+++ b/server/src/routes/profiles.ts
@@ -2,7 +2,7 @@
  * Express routes for faculty profile viewing and self-editing.
  */
 import { Router } from 'express';
-import { isAuthenticated, isProfessor } from '../middleware/index';
+import { isAuthenticated, isProfessor, validateNetid } from '../middleware/index';
 import {
   getProfile,
   getPublications,
@@ -11,10 +11,18 @@ import {
   updateProfile,
   verifyProfile,
 } from '../controllers/profileController';
+import { AnalyticsEventType } from '../models/index';
+import { logResearchEventOnSuccess } from '../services/researchAnalytics';
 
 const router = Router();
 
-router.get('/:netid', isAuthenticated, getProfile);
+router.get(
+  '/:netid',
+  isAuthenticated,
+  validateNetid('netid'),
+  logResearchEventOnSuccess(AnalyticsEventType.RESEARCH_VIEW, 'profile', (req) => req.params.netid),
+  getProfile,
+);
 router.get('/:netid/publications', isAuthenticated, getPublications);
 router.get('/:netid/listings', isAuthenticated, getProfileListings);
 router.get('/:netid/courses', isAuthenticated, getProfileCourses);

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -6,6 +6,7 @@ import { isAuthenticated } from '../middleware/index';
 import * as userController from '../controllers/userController';
 import { logEvent } from '../services/analyticsService';
 import { AnalyticsEventType } from '../models/index';
+import { emitResearchEvent } from '../services/researchAnalytics';
 
 const router = Router();
 
@@ -16,10 +17,9 @@ const logFavoriteEvent = (isFavorite: boolean) => {
     res.send = function (data: any) {
       if (res.statusCode >= 200 && res.statusCode < 300) {
         const currentUser = req.user as { netId?: string; userType: string };
-        if (currentUser?.netId && req.body.favListings) {
-          const listings = Array.isArray(req.body.favListings)
-            ? req.body.favListings
-            : [req.body.favListings];
+        const favListings = req.body?.data?.favListings ?? req.body?.favListings;
+        if (currentUser?.netId && favListings) {
+          const listings = Array.isArray(favListings) ? favListings : [favListings];
 
           listings.forEach((listingId: string) => {
             logEvent({
@@ -30,6 +30,43 @@ const logFavoriteEvent = (isFavorite: boolean) => {
               userType: currentUser.userType,
               listingId: listingId,
             }).catch((err) => console.error('Error logging favorite event:', err));
+            emitResearchEvent({
+              eventType: AnalyticsEventType.PATHWAY_SAVE,
+              entityType: 'listing',
+              entityId: listingId,
+              user: currentUser,
+              payload: { action: isFavorite ? 'save' : 'unsave' },
+            }).catch((err) => console.error('Error logging pathway save event:', err));
+          });
+        }
+      }
+
+      return originalSend(data);
+    };
+
+    next();
+  };
+};
+
+const logFellowshipFavoriteEvent = (isFavorite: boolean) => {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const originalSend = res.send.bind(res);
+
+    res.send = function (data: any) {
+      if (res.statusCode >= 200 && res.statusCode < 300) {
+        const currentUser = req.user as { netId?: string; userType: string };
+        const favFellowships = req.body?.data?.favFellowships ?? req.body?.favFellowships;
+        if (currentUser?.netId && favFellowships) {
+          const fellowships = Array.isArray(favFellowships) ? favFellowships : [favFellowships];
+
+          fellowships.forEach((fellowshipId: string) => {
+            emitResearchEvent({
+              eventType: AnalyticsEventType.PATHWAY_SAVE,
+              entityType: 'fellowship',
+              entityId: fellowshipId,
+              user: currentUser,
+              payload: { action: isFavorite ? 'save' : 'unsave' },
+            }).catch((err) => console.error('Error logging fellowship pathway save event:', err));
           });
         }
       }
@@ -76,8 +113,18 @@ router.delete(
 
 router.get('/favFellowshipIds', isAuthenticated, userController.getFavFellowshipIds);
 router.get('/favFellowships', isAuthenticated, userController.getFavFellowships);
-router.put('/favFellowships', isAuthenticated, userController.addFavFellowships);
-router.delete('/favFellowships', isAuthenticated, userController.removeFavFellowships);
+router.put(
+  '/favFellowships',
+  isAuthenticated,
+  logFellowshipFavoriteEvent(true),
+  userController.addFavFellowships,
+);
+router.delete(
+  '/favFellowships',
+  isAuthenticated,
+  logFellowshipFavoriteEvent(false),
+  userController.removeFavFellowships,
+);
 
 router.get('/listings', isAuthenticated, userController.getUserListings);
 router.put('/', isAuthenticated, logProfileUpdateEvent, userController.updateCurrentUser);

--- a/server/src/services/__tests__/researchAnalytics.test.ts
+++ b/server/src/services/__tests__/researchAnalytics.test.ts
@@ -1,0 +1,164 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { AnalyticsEventType } from '../../models/analytics';
+import { emitResearchEvent } from '../researchAnalytics';
+import type { LogEventParams } from '../analyticsService';
+
+const user = { netId: 'abc123', userType: 'undergraduate' };
+
+void describe('research analytics event emission', () => {
+  void it('emits research view events for canonical entities', async () => {
+    const events: LogEventParams[] = [];
+
+    const emitted = await emitResearchEvent(
+      {
+        eventType: AnalyticsEventType.RESEARCH_VIEW,
+        entityType: 'listing',
+        entityId: '507f1f77bcf86cd799439010',
+        user,
+        payload: { surface: 'detail' },
+      },
+      async (event) => {
+        events.push(event);
+      },
+    );
+
+    assert.equal(emitted, true);
+    assert.deepEqual(events[0], {
+      eventType: AnalyticsEventType.RESEARCH_VIEW,
+      netid: 'abc123',
+      userType: 'undergraduate',
+      entityType: 'listing',
+      entityId: '507f1f77bcf86cd799439010',
+      metadata: {
+        surface: 'detail',
+      },
+    });
+  });
+
+  void it('emits canonical research surface events with safe common fields', async () => {
+    const events: LogEventParams[] = [];
+
+    const emitted = await emitResearchEvent(
+      {
+        eventType: AnalyticsEventType.WAYS_IN_CLICK,
+        entityType: 'profile',
+        entityId: 'fac123',
+        user,
+        payload: {
+          waysInKind: 'best_next_step',
+          label: 'Read recent publications',
+          ignoredRawContact: 'professor@example.edu',
+        },
+      },
+      async (event) => {
+        events.push(event);
+      },
+    );
+
+    assert.equal(emitted, true);
+    assert.equal(events.length, 1);
+    assert.deepEqual(events[0], {
+      eventType: AnalyticsEventType.WAYS_IN_CLICK,
+      netid: 'abc123',
+      userType: 'undergraduate',
+      entityType: 'profile',
+      entityId: 'fac123',
+      metadata: {
+        waysInKind: 'best_next_step',
+        label: 'Read recent publications',
+      },
+    });
+  });
+
+  void it('reduces contact-route clicks to method categories without private addresses', async () => {
+    const events: LogEventParams[] = [];
+
+    await emitResearchEvent(
+      {
+        eventType: AnalyticsEventType.CONTACT_ROUTE_CLICK,
+        entityType: 'listing',
+        entityId: '507f1f77bcf86cd799439011',
+        user,
+        payload: {
+          contactMethod: 'email',
+          email: 'mentor@yale.edu',
+          label: 'Email mentor@yale.edu',
+        },
+      },
+      async (event) => {
+        events.push(event);
+      },
+    );
+
+    assert.deepEqual(events[0].metadata, { contactMethod: 'email' });
+    assert.equal(JSON.stringify(events[0]).includes('mentor@yale.edu'), false);
+  });
+
+  void it('stores only source category and hostname for source-link clicks', async () => {
+    const events: LogEventParams[] = [];
+
+    await emitResearchEvent(
+      {
+        eventType: AnalyticsEventType.SOURCE_LINK_CLICK,
+        entityType: 'fellowship',
+        entityId: '507f1f77bcf86cd799439012',
+        user,
+        payload: {
+          sourceCategory: 'publication',
+          url: 'https://www.example.edu/private/path?token=secret#fragment',
+        },
+      },
+      async (event) => {
+        events.push(event);
+      },
+    );
+
+    assert.deepEqual(events[0].metadata, {
+      sourceCategory: 'publication',
+      sourceHost: 'example.edu',
+    });
+    assert.equal(JSON.stringify(events[0]).includes('/private/path'), false);
+    assert.equal(JSON.stringify(events[0]).includes('secret'), false);
+  });
+
+  void it('emits pathway save events and rejects invalid research event inputs', async () => {
+    const events: LogEventParams[] = [];
+
+    const emitted = await emitResearchEvent(
+      {
+        eventType: AnalyticsEventType.PATHWAY_SAVE,
+        entityType: 'listing',
+        entityId: '507f1f77bcf86cd799439013',
+        user,
+        payload: {
+          action: 'stage_change',
+          stage: 'Interviewing',
+        },
+      },
+      async (event) => {
+        events.push(event);
+      },
+    );
+
+    const invalidEmitted = await emitResearchEvent(
+      {
+        eventType: 'listing_view',
+        entityType: 'listing',
+        entityId: '507f1f77bcf86cd799439013',
+        user,
+      },
+      async (event) => {
+        events.push(event);
+      },
+    );
+
+    assert.equal(emitted, true);
+    assert.equal(invalidEmitted, false);
+    assert.equal(events.length, 1);
+    assert.deepEqual(events[0].metadata, {
+      action: 'stage_change',
+      stage: 'Interviewing',
+    });
+  });
+});

--- a/server/src/services/analyticsService.ts
+++ b/server/src/services/analyticsService.ts
@@ -10,6 +10,8 @@ export interface LogEventParams {
   netid: string;
   userType: string;
   listingId?: string;
+  entityType?: string;
+  entityId?: string;
   searchQuery?: string;
   searchDepartments?: string[];
   metadata?: any;
@@ -22,6 +24,8 @@ export const logEvent = async (params: LogEventParams): Promise<void> => {
       netid: params.netid,
       userType: params.userType,
       listingId: params.listingId,
+      entityType: params.entityType,
+      entityId: params.entityId,
       searchQuery: params.searchQuery,
       searchDepartments: params.searchDepartments,
       metadata: params.metadata,
@@ -383,6 +387,116 @@ export const getAnalytics = async () => {
     },
   ]);
 
+  const researchEventTypes = [
+    AnalyticsEventType.RESEARCH_VIEW,
+    AnalyticsEventType.PATHWAY_SAVE,
+    AnalyticsEventType.WAYS_IN_CLICK,
+    AnalyticsEventType.CONTACT_ROUTE_CLICK,
+    AnalyticsEventType.SOURCE_LINK_CLICK,
+  ];
+
+  const researchStats = await AnalyticsEvent.aggregate([
+    {
+      $match: {
+        eventType: { $in: researchEventTypes },
+      },
+    },
+    {
+      $facet: {
+        // Per-event-type totals with rolling windows: the core segmentation
+        // for the research product surfaces.
+        byEventType: [
+          {
+            $group: {
+              _id: '$eventType',
+              total: { $sum: 1 },
+              last7Days: {
+                $sum: { $cond: [{ $gte: ['$timestamp', sevenDaysAgo] }, 1, 0] },
+              },
+              today: {
+                $sum: { $cond: [{ $gte: ['$timestamp', today] }, 1, 0] },
+              },
+            },
+          },
+          {
+            $project: {
+              _id: 0,
+              eventType: '$_id',
+              total: 1,
+              last7Days: 1,
+              today: 1,
+            },
+          },
+          { $sort: { total: -1 } },
+        ],
+        // Which research entity kind (profile / listing / fellowship) drives
+        // engagement.
+        byEntityType: [
+          { $match: { entityType: { $exists: true, $ne: null } } },
+          {
+            $group: {
+              _id: { entityType: '$entityType', eventType: '$eventType' },
+              count: { $sum: 1 },
+            },
+          },
+          {
+            $project: {
+              _id: 0,
+              entityType: '$_id.entityType',
+              eventType: '$_id.eventType',
+              count: 1,
+            },
+          },
+          { $sort: { count: -1 } },
+        ],
+        byUserType: [
+          {
+            $group: {
+              _id: '$userType',
+              count: { $sum: 1 },
+            },
+          },
+          {
+            $project: {
+              _id: 0,
+              userType: '$_id',
+              count: 1,
+            },
+          },
+          { $sort: { count: -1 } },
+        ],
+        // Most-viewed research entities over the trailing 30 days.
+        topEntities: [
+          {
+            $match: {
+              eventType: AnalyticsEventType.RESEARCH_VIEW,
+              timestamp: { $gte: thirtyDaysAgo },
+              entityId: { $exists: true, $ne: null },
+            },
+          },
+          {
+            $group: {
+              _id: { entityType: '$entityType', entityId: '$entityId' },
+              views: { $sum: 1 },
+              uniqueViewers: { $addToSet: '$netid' },
+            },
+          },
+          {
+            $project: {
+              _id: 0,
+              entityType: '$_id.entityType',
+              entityId: '$_id.entityId',
+              views: 1,
+              uniqueViewers: { $size: '$uniqueViewers' },
+            },
+          },
+          { $sort: { views: -1 } },
+          { $limit: 10 },
+        ],
+      },
+    },
+  ]);
+
   const listingStats = await getListingModel().aggregate([
     {
       $facet: {
@@ -604,6 +718,7 @@ export const getAnalytics = async () => {
 
   const visitors = visitorStats[0];
   const engagement = engagementStats[0];
+  const research = researchStats[0];
   const listings = listingStats[0];
   const users = userStats[0];
 
@@ -661,6 +776,12 @@ export const getAnalytics = async () => {
       avgViews: listings.viewsAndFavorites[0]?.avgViews || 0,
       avgFavorites: listings.viewsAndFavorites[0]?.avgFavorites || 0,
       viewsByDepartment: listings.viewsByDepartment || [],
+    },
+    research: {
+      byEventType: research.byEventType || [],
+      byEntityType: research.byEntityType || [],
+      byUserType: research.byUserType || [],
+      topEntities: research.topEntities || [],
     },
     listings: {
       overview: listings.overview[0] || { total: 0, active: 0, archived: 0, unconfirmed: 0 },

--- a/server/src/services/researchAnalytics.ts
+++ b/server/src/services/researchAnalytics.ts
@@ -1,0 +1,260 @@
+/**
+ * Pure helpers for the research-surface analytics events.
+ *
+ * These functions build and sanitize the analytics payloads for the canonical
+ * research product surfaces (profile / listing / fellowship views and their
+ * interaction affordances). They are deliberately side-effect free so the event
+ * shape and, critically, the privacy guarantees can be unit tested without a
+ * database or an Express request. The route/controller layer calls
+ * {@link buildResearchEvent} and hands the result to `analyticsService.logEvent`.
+ *
+ * Privacy contract: raw contact addresses (emails, phone numbers) and full
+ * source URLs are NEVER persisted. Contact clicks are reduced to a coarse
+ * method category; source clicks are reduced to a category plus the bare
+ * hostname (no path, query, or fragment, which can carry identifying tokens).
+ */
+import { Request, Response, NextFunction } from 'express';
+import { AnalyticsEventType, RESEARCH_ENTITY_TYPES, ResearchEntityType } from '../models/analytics';
+import { logEvent } from './analyticsService';
+import type { LogEventParams } from './analyticsService';
+
+/** The subset of AnalyticsEventType that describes research-surface activity. */
+export const RESEARCH_EVENT_TYPES: readonly AnalyticsEventType[] = [
+  AnalyticsEventType.RESEARCH_VIEW,
+  AnalyticsEventType.PATHWAY_SAVE,
+  AnalyticsEventType.WAYS_IN_CLICK,
+  AnalyticsEventType.CONTACT_ROUTE_CLICK,
+  AnalyticsEventType.SOURCE_LINK_CLICK,
+];
+
+/** Allowed coarse categories for a contact-route click. Never the address. */
+export const CONTACT_METHODS = ['email', 'phone', 'website', 'directory', 'other'] as const;
+export type ContactMethod = (typeof CONTACT_METHODS)[number];
+
+/** Allowed coarse categories for a source-link click. */
+export const SOURCE_CATEGORIES = [
+  'coursetable',
+  'publication',
+  'lab_website',
+  'directory',
+  'profile',
+  'external',
+] as const;
+export type SourceCategory = (typeof SOURCE_CATEGORIES)[number];
+
+/** Allowed "way in" / best-next-step affordance kinds. */
+export const WAYS_IN_KINDS = [
+  'best_next_step',
+  'apply',
+  'email_intro',
+  'view_listings',
+  'view_publications',
+  'view_courses',
+  'other',
+] as const;
+export type WaysInKind = (typeof WAYS_IN_KINDS)[number];
+
+/** Allowed pathway/save actions and stages (kanban-style tracking). */
+export const PATHWAY_ACTIONS = ['save', 'unsave', 'stage_change'] as const;
+export type PathwayAction = (typeof PATHWAY_ACTIONS)[number];
+
+const MAX_LABEL_LENGTH = 80;
+const EMAIL_REGEX = /[^\s@]+@[^\s@]+\.[^\s@]+/;
+const URL_LIKE_REGEX = /:\/\/|www\.|\.[a-z]{2,}(?:[/?#]|$)/i;
+
+const isPlainString = (value: unknown): value is string => typeof value === 'string';
+
+/** Coerce to a trimmed, length-capped string, or undefined if empty/invalid. */
+const cleanLabel = (value: unknown): string | undefined => {
+  if (!isPlainString(value)) return undefined;
+  const trimmed = value.trim();
+  if (trimmed === '') return undefined;
+  // Reject anything that carries a contact address or a URL. These are the
+  // fields most likely to smuggle in private data through a free-text label.
+  if (EMAIL_REGEX.test(trimmed) || URL_LIKE_REGEX.test(trimmed)) return undefined;
+  return trimmed.slice(0, MAX_LABEL_LENGTH);
+};
+
+/** Pick a value only if it is one of the allowed enum members. */
+const oneOf = <T extends string>(value: unknown, allowed: readonly T[]): T | undefined =>
+  isPlainString(value) && (allowed as readonly string[]).includes(value)
+    ? (value as T)
+    : undefined;
+
+/**
+ * Extract only the bare hostname from a raw URL. Returns undefined if the value
+ * cannot be parsed as an http(s) URL. Path, query, and fragment are discarded
+ * because they can contain identifying tokens.
+ */
+export const extractHostname = (value: unknown): string | undefined => {
+  if (!isPlainString(value)) return undefined;
+  const trimmed = value.trim();
+  if (trimmed === '') return undefined;
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return undefined;
+    return url.hostname.replace(/^www\./, '').toLowerCase() || undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Reduce an arbitrary client-supplied payload to the privacy-safe metadata we
+ * are willing to persist for a given research event type. Unknown keys are
+ * dropped; contact addresses and source URLs never survive.
+ */
+export const sanitizeResearchPayload = (
+  eventType: AnalyticsEventType,
+  raw: unknown,
+): Record<string, string> | undefined => {
+  const input: Record<string, unknown> =
+    raw && typeof raw === 'object' && !Array.isArray(raw) ? (raw as Record<string, unknown>) : {};
+  const out: Record<string, string> = {};
+
+  switch (eventType) {
+    case AnalyticsEventType.CONTACT_ROUTE_CLICK: {
+      const method = oneOf(input.contactMethod ?? input.method, CONTACT_METHODS) ?? 'other';
+      out.contactMethod = method;
+      break;
+    }
+    case AnalyticsEventType.SOURCE_LINK_CLICK: {
+      out.sourceCategory =
+        oneOf(input.sourceCategory ?? input.category, SOURCE_CATEGORIES) ?? 'external';
+      // Accept an explicit hostname, otherwise derive one from a raw url; either
+      // way only the bare host is ever stored.
+      const host = extractHostname(input.url) ?? cleanHost(input.sourceHost ?? input.host);
+      if (host) out.sourceHost = host;
+      break;
+    }
+    case AnalyticsEventType.WAYS_IN_CLICK: {
+      out.waysInKind = oneOf(input.waysInKind ?? input.kind, WAYS_IN_KINDS) ?? 'other';
+      const label = cleanLabel(input.label);
+      if (label) out.label = label;
+      break;
+    }
+    case AnalyticsEventType.PATHWAY_SAVE: {
+      out.action = oneOf(input.action, PATHWAY_ACTIONS) ?? 'save';
+      const stage = cleanLabel(input.stage);
+      if (stage) out.stage = stage;
+      break;
+    }
+    case AnalyticsEventType.RESEARCH_VIEW:
+    default: {
+      const surface = cleanLabel(input.surface);
+      if (surface) out.surface = surface;
+      break;
+    }
+  }
+
+  return Object.keys(out).length > 0 ? out : undefined;
+};
+
+/** A hostname supplied directly (not a full URL): validate it is host-shaped. */
+const cleanHost = (value: unknown): string | undefined => {
+  if (!isPlainString(value)) return undefined;
+  const trimmed = value.trim().toLowerCase().replace(/^www\./, '');
+  if (trimmed === '' || trimmed.length > 253) return undefined;
+  // A hostname has no scheme, path, whitespace, or '@'.
+  if (/[\s/@?#]/.test(trimmed) || trimmed.includes('://')) return undefined;
+  if (!/^[a-z0-9.-]+\.[a-z]{2,}$/.test(trimmed)) return undefined;
+  return trimmed;
+};
+
+export const isResearchEventType = (value: unknown): value is AnalyticsEventType =>
+  isPlainString(value) && (RESEARCH_EVENT_TYPES as readonly string[]).includes(value);
+
+export const isResearchEntityType = (value: unknown): value is ResearchEntityType =>
+  isPlainString(value) && (RESEARCH_ENTITY_TYPES as readonly string[]).includes(value);
+
+export interface BuildResearchEventInput {
+  eventType: AnalyticsEventType;
+  netid: string;
+  userType: string;
+  entityType: ResearchEntityType;
+  entityId: string;
+  payload?: unknown;
+}
+
+type AnalyticsUser = { netId?: string; userType?: string };
+type ResearchLogFn = (params: LogEventParams) => Promise<void> | void;
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim() !== '';
+
+/**
+ * Build a fully-sanitized {@link LogEventParams} for a research-surface event.
+ * The result carries only non-private data and is safe to persist as-is.
+ */
+export const buildResearchEvent = (input: BuildResearchEventInput): LogEventParams => {
+  const metadata = sanitizeResearchPayload(input.eventType, input.payload);
+  return {
+    eventType: input.eventType,
+    netid: input.netid,
+    userType: input.userType,
+    entityType: input.entityType,
+    entityId: String(input.entityId).slice(0, 128),
+    ...(metadata ? { metadata } : {}),
+  };
+};
+
+export interface EmitResearchEventInput {
+  eventType: unknown;
+  entityType: unknown;
+  entityId: unknown;
+  user?: AnalyticsUser;
+  payload?: unknown;
+}
+
+export const emitResearchEvent = async (
+  input: EmitResearchEventInput,
+  log: ResearchLogFn = logEvent,
+): Promise<boolean> => {
+  if (
+    !isResearchEventType(input.eventType) ||
+    !isResearchEntityType(input.entityType) ||
+    !isNonEmptyString(input.entityId) ||
+    !isNonEmptyString(input.user?.netId)
+  ) {
+    return false;
+  }
+
+  await log(
+    buildResearchEvent({
+      eventType: input.eventType,
+      netid: input.user.netId,
+      userType: input.user.userType || 'unknown',
+      entityType: input.entityType,
+      entityId: input.entityId.trim(),
+      payload: input.payload,
+    }),
+  );
+
+  return true;
+};
+
+export const logResearchEventOnSuccess = (
+  eventType: AnalyticsEventType,
+  entityType: ResearchEntityType,
+  getEntityId: (req: Request) => string | undefined = (req) => req.params.id,
+) => {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const originalSend = res.send.bind(res);
+
+    res.send = function (data: any) {
+      if (res.statusCode >= 200 && res.statusCode < 300) {
+        emitResearchEvent({
+          eventType,
+          entityType,
+          entityId: getEntityId(req),
+          user: req.user as AnalyticsUser | undefined,
+          payload: { surface: entityType },
+        }).catch((err) => console.error(`Error logging ${eventType} event:`, err));
+      }
+
+      return originalSend(data);
+    };
+
+    next();
+  };
+};

--- a/server/src/services/researchAnalytics.ts
+++ b/server/src/services/researchAnalytics.ts
@@ -80,9 +80,7 @@ const cleanLabel = (value: unknown): string | undefined => {
 
 /** Pick a value only if it is one of the allowed enum members. */
 const oneOf = <T extends string>(value: unknown, allowed: readonly T[]): T | undefined =>
-  isPlainString(value) && (allowed as readonly string[]).includes(value)
-    ? (value as T)
-    : undefined;
+  isPlainString(value) && (allowed as readonly string[]).includes(value) ? (value as T) : undefined;
 
 /**
  * Extract only the bare hostname from a raw URL. Returns undefined if the value
@@ -156,7 +154,10 @@ export const sanitizeResearchPayload = (
 /** A hostname supplied directly (not a full URL): validate it is host-shaped. */
 const cleanHost = (value: unknown): string | undefined => {
   if (!isPlainString(value)) return undefined;
-  const trimmed = value.trim().toLowerCase().replace(/^www\./, '');
+  const trimmed = value
+    .trim()
+    .toLowerCase()
+    .replace(/^www\./, '');
   if (trimmed === '' || trimmed.length > 253) return undefined;
   // A hostname has no scheme, path, whitespace, or '@'.
   if (/[\s/@?#]/.test(trimmed) || trimmed.includes('://')) return undefined;

--- a/server/src/services/researchAnalytics.ts
+++ b/server/src/services/researchAnalytics.ts
@@ -14,7 +14,10 @@
  * hostname (no path, query, or fragment, which can carry identifying tokens).
  */
 import { Request, Response, NextFunction } from 'express';
+import mongoose from 'mongoose';
 import { AnalyticsEventType, RESEARCH_ENTITY_TYPES, ResearchEntityType } from '../models/analytics';
+import { Fellowship, User } from '../models/index';
+import { getListingModel } from '../db/connections';
 import { logEvent } from './analyticsService';
 import type { LogEventParams } from './analyticsService';
 
@@ -167,6 +170,27 @@ export const isResearchEventType = (value: unknown): value is AnalyticsEventType
 export const isResearchEntityType = (value: unknown): value is ResearchEntityType =>
   isPlainString(value) && (RESEARCH_ENTITY_TYPES as readonly string[]).includes(value);
 
+export const researchEntityExists = async (
+  entityType: ResearchEntityType,
+  entityId: string,
+): Promise<boolean> => {
+  const id = entityId.trim();
+
+  if (entityType === 'profile') {
+    return Boolean(await User.exists({ netid: id }));
+  }
+
+  if (!mongoose.isValidObjectId(id)) {
+    return false;
+  }
+
+  if (entityType === 'listing') {
+    return Boolean(await getListingModel().exists({ _id: id }));
+  }
+
+  return Boolean(await Fellowship.exists({ _id: id }));
+};
+
 export interface BuildResearchEventInput {
   eventType: AnalyticsEventType;
   netid: string;
@@ -237,6 +261,7 @@ export const logResearchEventOnSuccess = (
   eventType: AnalyticsEventType,
   entityType: ResearchEntityType,
   getEntityId: (req: Request) => string | undefined = (req) => req.params.id,
+  getPayload: (req: Request) => unknown = () => ({ surface: entityType }),
 ) => {
   return (req: Request, res: Response, next: NextFunction) => {
     const originalSend = res.send.bind(res);
@@ -248,7 +273,7 @@ export const logResearchEventOnSuccess = (
           entityType,
           entityId: getEntityId(req),
           user: req.user as AnalyticsUser | undefined,
-          payload: { surface: entityType },
+          payload: getPayload(req),
         }).catch((err) => console.error(`Error logging ${eventType} event:`, err));
       }
 


### PR DESCRIPTION
## Intent

Implement fix.md item 4: add analytics events for the canonical research product surfaces, including research entity views, pathway/save actions, ways-in or best-next-step clicks, contact-route clicks, and source-link clicks. Use the existing analytics middleware/service patterns, expose admin/dashboard segmentation for the new research events, and ensure privacy-safe payloads that do not persist raw contact addresses or full source URLs.

## What Changed
- Added canonical research analytics events for profile, listing, and fellowship surfaces, including views, saves, ways-in clicks, contact-route clicks, and source-link clicks.
- Added privacy-safe research analytics ingestion and aggregation on the server, with entity validation and sanitized metadata for contact/source events.
- Updated the admin analytics dashboard and documentation to expose research engagement segmentation for the new event types.

## Risk Assessment

✅ Low: The change is well-bounded to research analytics instrumentation, validation, and dashboard display, with privacy sanitization centralized and no material merge-blocking issues found.

## Testing

Focused automated tests passed, evidence files show canonical research events are accepted with raw emails/full URLs stripped, and `getAnalytics()` exposes research segmentation; no UI screenshot was captured because this isolated test worktree had no authenticated seeded backend session/MongoDB available for rendering the admin dashboard end-to-end.

<details>
<summary>Evidence: Research analytics emitted event evidence</summary>

```text
{
  "scenario": "Research product analytics events emitted from canonical user actions",
  "results": [
    {
      "action": "Listing detail view records canonical research entity view",
      "accepted": true,
      "emittedEvent": {
        "eventType": "research_view",
        "netid": "student123",
        "userType": "undergraduate",
        "entityType": "listing",
        "entityId": "507f1f77bcf86cd799439010",
        "metadata": {
          "surface": "listing"
        }
      }
    },
    {
      "action": "Saving a listing records pathway save without contact data",
      "accepted": true,
      "emittedEvent": {
        "eventType": "pathway_save",
        "netid": "student123",
        "userType": "undergraduate",
        "entityType": "listing",
        "entityId": "507f1f77bcf86cd799439010",
        "metadata": {
          "action": "save",
          "stage": "Interested"
        }
      }
    },
    {
      "action": "Best-next-step click records way-in category and safe label",
      "accepted": true,
      "emittedEvent": {
        "eventType": "ways_in_click",
        "netid": "student123",
        "userType": "undergraduate",
        "entityType": "profile",
        "entityId": "faculty123",
        "metadata": {
          "waysInKind": "best_next_step",
          "label": "View profile"
        }
      }
    },
    {
      "action": "Email click stores only contact method category",
      "accepted": true,
      "emittedEvent": {
        "eventType": "contact_route_click",
        "netid": "student123",
        "userType": "undergraduate",
        "entityType": "fellowship",
        "entityId": "507f1f77bcf86cd799439011",
        "metadata": {
          "contactMethod": "email"
        }
      }
    },
    {
      "action": "Source click strips URL path, query token, and fragment",
      "accepted": true,
      "emittedEvent": {
        "eventType": "source_link_click",
        "netid": "student123",
        "userType": "undergraduate",
        "entityType": "profile",
        "entityId": "faculty123",
        "metadata": {
          "sourceCategory": "publication",
          "sourceHost": "example.edu"
        }
      }
    }
  ],
  "privacyAssertions": {
    "rawContactAddressesPersisted": false,
    "fullSourceUrlPersisted": false,
    "persistedSourceHost": "example.edu"
  },
  "dashboardSegmentationShape": {
    "research": {
      "byEventType": [
        {
          "eventType": "research_view",
          "total": 1,
          "last7Days": 1,
          "today": 1
        },
        {
          "eventType": "pathway_save",
          "total": 1,
          "last7Days": 1,
          "today": 1
        },
        {
          "eventType": "ways_in_click",
          "total": 1,
          "last7Days": 1,
          "today": 1
        },
        {
          "eventType": "contact_route_click",
          "total": 1,
          "last7Days": 1,
          "today": 1
        },
        {
          "eventType": "source_link_click",
          "total": 1,
          "last7Days": 1,
          "today": 1
        }
      ],
      "byEntityType": [
        {
          "entityType": "listing",
          "eventType": "research_view",
          "count": 1
        },
        {
          "entityType": "listing",
          "eventType": "pathway_save",
          "count": 1
        },
        {
          "entityType": "profile",
          "eventType": "ways_in_click",
          "count": 1
        },
        {
          "entityType": "profile",
          "eventType": "source_link_click",
          "count": 1
        },
        {
          "entityType": "fellowship",
          "eventType": "contact_route_click",
          "count": 1
        }
      ],
      "byUserType": [
        {
          "userType": "undergraduate",
          "count": 5
        }
      ],
      "topEntities": [
        {
          "entityType": "listing",
          "entityId": "507f1f77bcf86cd799439010",
          "views": 1,
          "uniqueViewers": 1
        }
      ]
    }
  }
}
```
</details>
<details>
<summary>Evidence: Admin dashboard research segmentation evidence</summary>

```text
{
  "scenario": "Admin analytics dashboard response from getAnalytics()",
  "analyticsAggregateCalls": 3,
  "research": {
    "byEventType": [
      {
        "eventType": "research_view",
        "total": 4,
        "last7Days": 3,
        "today": 1
      },
      {
        "eventType": "pathway_save",
        "total": 2,
        "last7Days": 2,
        "today": 1
      },
      {
        "eventType": "ways_in_click",
        "total": 3,
        "last7Days": 3,
        "today": 0
      },
      {
        "eventType": "contact_route_click",
        "total": 1,
        "last7Days": 1,
        "today": 0
      },
      {
        "eventType": "source_link_click",
        "total": 2,
        "last7Days": 2,
        "today": 1
      }
    ],
    "byEntityType": [
      {
        "entityType": "listing",
        "eventType": "research_view",
        "count": 3
      },
      {
        "entityType": "profile",
        "eventType": "source_link_click",
        "count": 2
      },
      {
        "entityType": "fellowship",
        "eventType": "pathway_save",
        "count": 1
      }
    ],
    "byUserType": [
      {
        "userType": "undergraduate",
        "count": 9
      },
      {
        "userType": "graduate",
        "count": 3
      }
    ],
    "topEntities": [
      {
        "entityType": "listing",
        "entityId": "507f1f77bcf86cd799439010",
        "views": 3,
        "uniqueViewers": 2
      },
      {
        "entityType": "profile",
        "entityId": "faculty123",
        "views": 1,
        "uniqueViewers": 1
      }
    ]
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `AGENTS.md` - merge conflict rebasing onto origin/main
- ⚠️ `server/package.json` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `server/src/routes/analytics.ts:16` - Only view routes were wired to emit research analytics. The new generic `/analytics/research` endpoint can record pathway/save, ways-in, contact-route, and source-link events, but none of the existing favorite/save handlers or contact/source links call it, so most of the requested event types will remain empty unless another unshown client change is expected.
- ⚠️ `server/src/routes/analytics.ts:27` - The client-reported analytics endpoint accepts any non-empty `entityId` for any entity type. Authenticated users can record events against nonexistent profiles/listings/fellowships and pollute `topEntities`/segmentation; validate `profile` ids as netids and listing/fellowship ids as real existing records before logging.
- ⚠️ `server/src/services/analyticsService.ts:780` - The backend now returns `research` segmentation, but the admin dashboard still renders only the old visitor/engagement/listing/user sections. If the requirement is to expose this in the admin dashboard UI, this API addition is not enough because admins have no visible research event breakdown.

🔧 Fix: Wire validated research analytics surfaces
1 error still open:
- 🚨 `server/src/routes/analytics.ts:17` - The new async `/analytics/research` handler is not wrapped in `try/catch` or `asyncHandler`. In Express 4, a rejection from `researchEntityExists()` or later awaited work will bypass the error middleware and can surface as an unhandled rejection instead of a controlled 500 response; wrap this route the same way as other async handlers or add a local `try/catch`.

🔧 Fix: Wrap research analytics route errors
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`yarn --cwd server test --test-name-pattern &#34;research analytics event emission&#34;` (the repo script also ran the existing listing search degradation test files; all passed)</code>
- `yarn --cwd client test:ci src/reducers/__tests__/analyticsReducer.test.ts`
- <code>Generated `/tmp/no-mistakes-evidence/01KWQRMTKY6EM4PSKY7E8AZPNM/research-analytics-events.json` by emitting realistic research analytics events through the server service with a captured logger</code>
- <code>Generated `/tmp/no-mistakes-evidence/01KWQRMTKY6EM4PSKY7E8AZPNM/admin-dashboard-research-response.json` by calling `getAnalytics()` with model-boundary stubs to verify the research dashboard response shape</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
