### PR TITLE
fix(client): improve auth outage and empty labs states

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,11 +213,11 @@ The only other workflow is `keep-alive.yml`, which pings the Beta Render service
 
 Three rate limiters in `app.ts`, all keyed by authenticated user's `netId` with IP fallback for unauthenticated requests:
 
-| Limiter        | Scope                                                      | Limit            |
-| -------------- | ---------------------------------------------------------- | ---------------- |
-| `apiLimiter`   | All `/api` routes                                          | 200 req / 15 min |
-| `publicDiscoveryLimiter` | `/api/research` public browse/detail traffic      | 120 req / 15 min |
-| `writeLimiter` | Non-GET requests to `/api/listings` and `/api/fellowships` | 50 req / 15 min  |
+| Limiter                  | Scope                                                      | Limit            |
+| ------------------------ | ---------------------------------------------------------- | ---------------- |
+| `apiLimiter`             | All `/api` routes                                          | 200 req / 15 min |
+| `publicDiscoveryLimiter` | `/api/research` public browse/detail traffic               | 120 req / 15 min |
+| `writeLimiter`           | Non-GET requests to `/api/listings` and `/api/fellowships` | 50 req / 15 min  |
 
 All three limiters are skipped in CI, development, and test environments.
 
@@ -253,18 +253,18 @@ Exported from `server/src/middleware/`:
 
 All routes mount under `/api` in `app.ts`. Route files in `server/src/routes/`:
 
-| Prefix            | File               | Auth                                           |
-| ----------------- | ------------------ | ---------------------------------------------- |
+| Prefix            | File               | Auth                                                  |
+| ----------------- | ------------------ | ----------------------------------------------------- |
 | `/listings`       | `listings.ts`      | Varies (authenticated search, mutations require auth) |
-| `/research`       | `research.ts`      | Public browse/detail; contact detail requires auth |
-| `/fellowships`    | `fellowships.ts`   | Varies                                         |
-| `/users`          | `users.ts`         | Yes                                            |
-| `/profiles`       | `profiles.ts`      | Varies                                         |
-| `/analytics`      | `analytics.ts`     | Admin                                          |
-| `/config`         | `config.ts`        | No                                             |
-| `/research-areas` | `researchAreas.ts` | Admin for writes                               |
-| `/admin`          | `admin.ts`         | Admin                                          |
-| `/seed`           | `seed.ts`          | Dev mode only                                  |
+| `/research`       | `research.ts`      | Public browse/detail; contact detail requires auth    |
+| `/fellowships`    | `fellowships.ts`   | Varies                                                |
+| `/users`          | `users.ts`         | Yes                                                   |
+| `/profiles`       | `profiles.ts`      | Varies                                                |
+| `/analytics`      | `analytics.ts`     | Admin                                                 |
+| `/config`         | `config.ts`        | No                                                    |
+| `/research-areas` | `researchAreas.ts` | Admin for writes                                      |
+| `/admin`          | `admin.ts`         | Admin                                                 |
+| `/seed`           | `seed.ts`          | Dev mode only                                         |
 
 Passport auth routes (CAS login/logout, dev-login) are mounted separately via `passportRoutes` before the main routes.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,8 @@ Migration scripts run from `data-migration/` with `npx ts-node --transpile-only 
 
 Dev login bypass: `GET http://localhost:4000/api/dev-login` creates a test session (`test123` / `student`) without CAS.
 
+If the client cannot reach the auth endpoint, `/login` renders an inline retry state and hides the Yale CAS sign-in link until a retry succeeds.
+
 ## TypeScript Configuration
 
 **Server**: target ES2022, module NodeNext, moduleResolution NodeNext, strict true, output to `build/`.
@@ -96,6 +98,8 @@ Current authenticated listing search flow:
 5. Results are returned with `totalCount` for pagination and a `degraded` boolean indicating whether fallback behavior was used
 
 Public research discovery uses the same degradation path through `/api/research`, but only returns confirmed, unarchived listings after redacting contact/private fields (`ownerEmail`, `emails`, owner/professor IDs, views, favorites, archived/confirmed/audit internals). Client routes `/research` and `/research/:slug` render the browse page without `PrivateRoute`; opening a card updates the URL to a shareable modal route. Authenticated users on those public routes additionally call `/api/research/:slug/contact` to retrieve the full listing with contact fields. Public research search uses a contact-redacted searchable field set and only accepts `createdAt` or `updatedAt` sort fields.
+
+The authenticated Find Labs page distinguishes an empty local/unfiltered dataset from an empty search result: no unfiltered listings shows "No research labs are available right now" with a `/fellowships` action, while active searches or filters show "No labs match your current search or filters."
 
 The Meilisearch client (`server/src/utils/meiliClient.ts`) lazy-loads and caches the connection. Configuration: `MEILISEARCH_HOST` (defaults to `http://localhost:7700`), `MEILISEARCH_API_KEY`, and `MEILISEARCH_INDEX_PREFIX` (optional, for multi-environment isolation on a shared instance). The module exports `getMeiliIndex(name)` which resolves prefixed index names and `resolveIndexName(name)` for use in migration scripts.
 
@@ -179,7 +183,7 @@ Current reducers with test coverage (all in `client/src/reducers/`, tests in `cl
 | `fellowshipSearchReducer`          | `FellowshipSearchContextProvider`      | Fellowship equivalent with filter-options fetch lifecycle                                                                                                          |
 | `browsePageReducer`                | `pages/home`, `pages/fellowships`      | Generic over `<T>`. Browse-page UI: favorites, detail-modal selection, admin-edit modal. Open/close modal flips `selectedItem` and `isDetailModalOpen` atomically. |
 | `configReducer`                    | `ConfigContextProvider`                | Config fetch (idle → loading → loaded/error)                                                                                                                       |
-| `userReducer`                      | `UserContextProvider`                  | Auth-check lifecycle (loading → authenticated/unauthenticated) + explicit LOGOUT                                                                                   |
+| `userReducer`                      | `UserContextProvider`                  | Auth-check lifecycle, inline `authError` retry state, stale-user preservation on fetch failure, and explicit LOGOUT                                                |
 | `favoritesReducer`                 | `components/accounts/FavoritesManager` | Favorited listings + fellowships, sort/filter/view state, optimistic add/remove                                                                                    |
 | `ownListingsReducer`               | `components/accounts/ListingEditor`    | Professor's own listings + edit/create lifecycle (isEditing/isCreating), skeleton-listing handling                                                                 |
 | `unknownUserReducer`               | Unknown-user flow                      | State for the "unknown user" verification path                                                                                                                     |
@@ -231,6 +235,8 @@ Defined in `server/src/middleware/auth.ts`:
 | `isConfirmed`      | `userConfirmed === true`                              |
 
 Client-side route guards: `PrivateRoute` (auth required, redirects unknown users when `unknownBlocked=true`), `AdminRoute` (admin only), `UnprivateRoute` (no auth required, for error pages). Public `/research` routes intentionally bypass `PrivateRoute`; favorites, contact actions, and other authenticated actions preserve the return path and send logged-out users to `/login`.
+
+`UserContext` exposes `authError` alongside `isLoading`, `isAuthenticated`, `user`, and `checkContext()`. `UserContextProvider` sets `authError` when the `/users/context` check fails, preserves the prior authenticated user if one exists, and relies on `/login` to show the retry UI instead of firing a global SweetAlert.
 
 ## Validation Middleware
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -125,6 +125,8 @@ yarn dev:server    # Express with nodemon on port 4000
 
 Visit `http://localhost:4000/api/dev-login` to log in as a test user (`test123` / `student`) without CAS.
 
+If the client cannot reach the auth endpoint, `/login` shows an inline retry state and hides the Yale CAS sign-in link until the auth check succeeds.
+
 ---
 
 ## Common Commands
@@ -210,6 +212,8 @@ Logged-out visitors use the public research discovery path instead:
 
 Listing CRUD in `listingService.ts` automatically syncs to Meilisearch after MongoDB writes.
 
+On the authenticated Find Labs page, an empty unfiltered result set is treated as "no research labs are available right now" and includes a link to `/fellowships`; empty filtered/search results instead tell the user no labs match the current search or filters.
+
 The Meilisearch client (`server/src/utils/meiliClient.ts`) exports:
 
 - `getMeiliClient()` — lazy-loaded singleton
@@ -228,6 +232,8 @@ User → Yale CAS SSO → passport.ts findOrCreateUser
      → Fallback: userType "unknown"
      → Create/Update User → cookie-session
 ```
+
+Client auth state is owned by `UserContextProvider` and `userReducer`. Failed auth refreshes set `authError` for inline UI, clear loading, and preserve any previously authenticated user so a transient outage does not blank the session; retrying `checkContext()` clears the stale error while the next auth check runs.
 
 ### Auth Middleware (`server/src/middleware/auth.ts`)
 
@@ -278,7 +284,7 @@ Tests are discovered from `client/src/**/*.{test,spec}.{ts,tsx}`.
 
 ### What is tested
 
-Pure reducer modules under [client/src/reducers/](client/src/reducers/) have unit-test coverage in [client/src/reducers/**tests**/](client/src/reducers/__tests__/). Each reducer file has a matching `*.test.ts`. The reducers back the search, fellowship-search, config, listing-form, and account-tracking (kanban/notes) flows — extracting state transitions from providers/components into pure functions makes them testable without mounting React or mocking network.
+Pure reducer modules under [client/src/reducers/](client/src/reducers/) have unit-test coverage in [client/src/reducers/**tests**/](client/src/reducers/__tests__/). Each reducer file has a matching `*.test.ts`. The reducers back the auth, search, fellowship-search, config, listing-form, and account-tracking (kanban/notes) flows — extracting state transitions from providers/components into pure functions makes them testable without mounting React or mocking network.
 
 When adding a new reducer:
 
@@ -330,7 +336,8 @@ Public pages that should work for logged-out visitors must not use `PrivateRoute
 | Issue                           | Solution                                                          |
 | ------------------------------- | ----------------------------------------------------------------- |
 | CAS login not working locally   | Use dev-login: `http://localhost:4000/api/dev-login`              |
-| Search returns no results       | Check Meilisearch is running: `curl http://localhost:7700/health` |
+| Find Labs has no local results  | Seed Development listings or use the empty-state link to browse fellowships |
+| Search is degraded or stale     | Check Meilisearch is running: `curl http://localhost:7700/health` |
 | Meilisearch connection refused  | Start Docker container or check `MEILISEARCH_HOST` in `.env`      |
 | CORS errors                     | Add origin to `allowList` in `app.ts` or use dev mode             |
 | "Forbidden" on listing creation | Professor needs `profileVerified: true`                           |

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -250,18 +250,18 @@ Client auth state is owned by `UserContextProvider` and `userReducer`. Failed au
 
 All mount under `/api`.
 
-| Prefix            | Description                                             | Auth                                            |
-| ----------------- | ------------------------------------------------------- | ----------------------------------------------- |
-| `/listings`       | Listing CRUD and authenticated search                   | Varies                                          |
+| Prefix            | Description                                                  | Auth                                             |
+| ----------------- | ------------------------------------------------------------ | ------------------------------------------------ |
+| `/listings`       | Listing CRUD and authenticated search                        | Varies                                           |
 | `/research`       | Public read-only listing discovery and shareable detail URLs | Public; `/research/:slug/contact` requires login |
-| `/fellowships`    | Fellowship CRUD and search                              | Varies                                          |
-| `/users`          | User CRUD                                               | Yes                                             |
-| `/profiles`       | Faculty profiles                                        | Varies                                          |
-| `/analytics`      | Analytics dashboards                                    | Admin                                           |
-| `/config`         | Departments + research areas                            | No                                              |
-| `/research-areas` | Research area CRUD                                      | Admin for writes                                |
-| `/admin`          | Admin operations                                        | Admin                                           |
-| `/seed`           | Dev seeding routes                                      | Dev mode only                                   |
+| `/fellowships`    | Fellowship CRUD and search                                   | Varies                                           |
+| `/users`          | User CRUD                                                    | Yes                                              |
+| `/profiles`       | Faculty profiles                                             | Varies                                           |
+| `/analytics`      | Analytics dashboards                                         | Admin                                            |
+| `/config`         | Departments + research areas                                 | No                                               |
+| `/research-areas` | Research area CRUD                                           | Admin for writes                                 |
+| `/admin`          | Admin operations                                             | Admin                                            |
+| `/seed`           | Dev seeding routes                                           | Dev mode only                                    |
 
 ---
 
@@ -333,11 +333,11 @@ Public pages that should work for logged-out visitors must not use `PrivateRoute
 
 ## Troubleshooting
 
-| Issue                           | Solution                                                          |
-| ------------------------------- | ----------------------------------------------------------------- |
-| CAS login not working locally   | Use dev-login: `http://localhost:4000/api/dev-login`              |
+| Issue                           | Solution                                                                    |
+| ------------------------------- | --------------------------------------------------------------------------- |
+| CAS login not working locally   | Use dev-login: `http://localhost:4000/api/dev-login`                        |
 | Find Labs has no local results  | Seed Development listings or use the empty-state link to browse fellowships |
-| Search is degraded or stale     | Check Meilisearch is running: `curl http://localhost:7700/health` |
-| Meilisearch connection refused  | Start Docker container or check `MEILISEARCH_HOST` in `.env`      |
-| CORS errors                     | Add origin to `allowList` in `app.ts` or use dev mode             |
-| "Forbidden" on listing creation | Professor needs `profileVerified: true`                           |
+| Search is degraded or stale     | Check Meilisearch is running: `curl http://localhost:7700/health`           |
+| Meilisearch connection refused  | Start Docker container or check `MEILISEARCH_HOST` in `.env`                |
+| CORS errors                     | Add origin to `allowList` in `app.ts` or use dev mode                       |
+| "Forbidden" on listing creation | Professor needs `profileVerified: true`                                     |

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ A research lab and fellowship discovery platform for Yale University, with publi
 
 ## Tech Stack
 
-| Layer | Tech |
-|-------|------|
-| Client | React 19, TypeScript, Vite, TailwindCSS, MUI |
-| Server | Express 4, TypeScript, Passport.js (Yale CAS) |
-| Database | MongoDB Atlas (Mongoose 8) |
-| Search | Meilisearch (hybrid: keyword + semantic via OpenAI embedder) |
-| Package Manager | Yarn 4 via Corepack |
+| Layer           | Tech                                                         |
+| --------------- | ------------------------------------------------------------ |
+| Client          | React 19, TypeScript, Vite, TailwindCSS, MUI                 |
+| Server          | Express 4, TypeScript, Passport.js (Yale CAS)                |
+| Database        | MongoDB Atlas (Mongoose 8)                                   |
+| Search          | Meilisearch (hybrid: keyword + semantic via OpenAI embedder) |
+| Package Manager | Yarn 4 via Corepack                                          |
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ yarn dev:client
 yarn dev:server
 ```
 
-Go to **http://localhost:3000**. Public research discovery is available at **http://localhost:3000/research**; use `http://localhost:4000/api/dev-login` to bypass CAS auth locally for authenticated actions.
+Go to **http://localhost:3000**. Public research discovery is available at **http://localhost:3000/research**; the authenticated Find Labs page may show an empty state locally until the Development database has listings, and it links to fellowships when fellowship data is available. Use `http://localhost:4000/api/dev-login` to bypass CAS auth locally for authenticated actions.
 
 ## Documentation
 

--- a/client/src/components/shared/BrowseGrid.tsx
+++ b/client/src/components/shared/BrowseGrid.tsx
@@ -20,6 +20,7 @@ interface BrowseGridProps {
   quickFilter?: string | null;
   onClearQuickFilter?: () => void;
   emptyMessage?: string;
+  emptyAction?: React.ReactNode;
 }
 
 const BrowseGrid = ({
@@ -34,6 +35,7 @@ const BrowseGrid = ({
   quickFilter,
   onClearQuickFilter,
   emptyMessage = 'No results match the current filter',
+  emptyAction,
 }: BrowseGridProps) => {
   const { viewMode } = useContext(UIContext);
   const showLoader = isLoading && items.length > 0;
@@ -42,10 +44,11 @@ const BrowseGrid = ({
     return (
       <div className="text-center py-8 text-gray-500">
         <p>{emptyMessage}</p>
+        {emptyAction && <div className="mt-3">{emptyAction}</div>}
         {quickFilter && onClearQuickFilter && (
           <button
             onClick={onClearQuickFilter}
-            className="mt-2 text-blue-600 hover:underline text-sm"
+            className="mt-3 text-blue-600 hover:underline text-sm"
           >
             Clear filter
           </button>

--- a/client/src/contexts/UserContext.ts
+++ b/client/src/contexts/UserContext.ts
@@ -8,6 +8,7 @@ import { User } from '../types/types';
 export const defaultUserContext = {
   isLoading: true,
   isAuthenticated: false,
+  authError: undefined,
   checkContext: () => {},
 };
 
@@ -15,5 +16,6 @@ export default createContext<{
   isLoading: boolean;
   isAuthenticated: boolean;
   user?: User;
+  authError?: string;
   checkContext: () => void;
 }>(defaultUserContext);

--- a/client/src/pages/__tests__/home.test.ts
+++ b/client/src/pages/__tests__/home.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { getListingEmptyMessage } from '../home';
+
+const baseParams = {
+  queryString: '',
+  selectedDepartments: [],
+  selectedResearchAreas: [],
+  selectedListingResearchAreas: [],
+  quickFilter: null,
+};
+
+describe('getListingEmptyMessage', () => {
+  it('explains that no labs are available when no search criteria are active', () => {
+    expect(getListingEmptyMessage(baseParams)).toBe('No research labs are available right now');
+  });
+
+  it('mentions search or filters when a text query is active', () => {
+    expect(getListingEmptyMessage({ ...baseParams, queryString: 'neuroscience' })).toBe(
+      'No labs match your current search or filters',
+    );
+  });
+
+  it('mentions search or filters when any filter is active', () => {
+    expect(
+      getListingEmptyMessage({
+        ...baseParams,
+        selectedDepartments: ['Computer Science'],
+      }),
+    ).toBe('No labs match your current search or filters');
+
+    expect(getListingEmptyMessage({ ...baseParams, quickFilter: 'open' })).toBe(
+      'No labs match your current search or filters',
+    );
+  });
+});

--- a/client/src/pages/__tests__/home.test.ts
+++ b/client/src/pages/__tests__/home.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { getListingEmptyMessage } from '../home';
+import { getListingEmptyMessage, hasListingSearchCriteria } from '../home';
 
 const baseParams = {
   queryString: '',
@@ -32,5 +32,21 @@ describe('getListingEmptyMessage', () => {
     expect(getListingEmptyMessage({ ...baseParams, quickFilter: 'open' })).toBe(
       'No labs match your current search or filters',
     );
+  });
+});
+
+describe('hasListingSearchCriteria', () => {
+  it('returns false when the user has not searched or filtered', () => {
+    expect(hasListingSearchCriteria(baseParams)).toBe(false);
+  });
+
+  it('returns true when the user has searched or filtered', () => {
+    expect(hasListingSearchCriteria({ ...baseParams, queryString: 'biology' })).toBe(true);
+    expect(
+      hasListingSearchCriteria({
+        ...baseParams,
+        selectedListingResearchAreas: ['Genomics'],
+      }),
+    ).toBe(true);
   });
 });

--- a/client/src/pages/__tests__/login.test.tsx
+++ b/client/src/pages/__tests__/login.test.tsx
@@ -1,0 +1,58 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import UserContext from '../../contexts/UserContext';
+import Login from '../login';
+
+afterEach(() => {
+  cleanup();
+});
+
+const renderLogin = (context: Partial<React.ContextType<typeof UserContext>> = {}) => {
+  const checkContext = vi.fn();
+
+  render(
+    <MemoryRouter>
+      <UserContext.Provider
+        value={{
+          isLoading: false,
+          isAuthenticated: false,
+          user: undefined,
+          authError: undefined,
+          checkContext,
+          ...context,
+        }}
+      >
+        <Login />
+      </UserContext.Provider>
+    </MemoryRouter>,
+  );
+
+  return { checkContext };
+};
+
+describe('Login', () => {
+  it('shows Yale CAS sign in when auth is available', () => {
+    renderLogin();
+
+    expect(screen.getByRole('link', { name: /sign in with yale cas/i })).toBeTruthy();
+  });
+
+  it('replaces CAS sign in with retry when auth check fails', async () => {
+    const user = userEvent.setup();
+    const { checkContext } = renderLogin({
+      authError: 'Unable to reach Yale Labs right now.',
+    });
+
+    expect(screen.getByRole('status').textContent).toContain(
+      'Unable to reach Yale Labs right now.',
+    );
+    expect(screen.queryByRole('link', { name: /sign in with yale cas/i })).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: /retry connection/i }));
+
+    expect(checkContext).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -17,8 +17,28 @@ import swal from 'sweetalert';
 import { getInstitutionAffiliation } from '../utils/institutionAffiliation';
 import { browsePageReducer, createInitialBrowsePageState } from '../reducers/browsePageReducer';
 
+export const getListingEmptyMessage = (params: {
+  queryString: string;
+  selectedDepartments: string[];
+  selectedResearchAreas: string[];
+  selectedListingResearchAreas: string[];
+  quickFilter: string | null;
+}) => {
+  const hasSearchCriteria =
+    params.queryString.trim() !== '' ||
+    params.selectedDepartments.length > 0 ||
+    params.selectedResearchAreas.length > 0 ||
+    params.selectedListingResearchAreas.length > 0 ||
+    Boolean(params.quickFilter);
+
+  return hasSearchCriteria
+    ? 'No labs match your current search or filters'
+    : 'No research labs are available right now';
+};
+
 const Home = () => {
   const {
+    queryString,
     listings,
     isLoading,
     searchExhausted,
@@ -27,8 +47,11 @@ const Home = () => {
     setQuickFilter,
     refreshListings,
     setQueryString,
+    selectedDepartments,
     setSelectedDepartments,
+    selectedResearchAreas,
     setSelectedResearchAreas,
+    selectedListingResearchAreas,
     setSelectedListingResearchAreas,
   } = useContext(SearchContext);
 
@@ -161,6 +184,14 @@ const Home = () => {
     quickFilterActive: !!quickFilter,
   });
 
+  const emptyMessage = getListingEmptyMessage({
+    queryString,
+    selectedDepartments,
+    selectedResearchAreas,
+    selectedListingResearchAreas,
+    quickFilter,
+  });
+
   const updateFavorite = (listingId: string, favorite: boolean) => {
     if (!isAuthenticated) {
       requireLogin();
@@ -252,7 +283,7 @@ const Home = () => {
         searchExhausted={searchExhausted}
         quickFilter={quickFilter}
         onClearQuickFilter={() => setQuickFilter(null)}
-        emptyMessage="No results match the search criteria"
+        emptyMessage={emptyMessage}
       />
 
       {selectedListing && (

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -2,7 +2,7 @@
  * Main listings browse page with search, filters, and grid/list view.
  */
 import { useReducer, useEffect, useContext, useMemo, useCallback } from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 import SearchContext from '../contexts/SearchContext';
 import UserContext from '../contexts/UserContext';
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
@@ -17,21 +17,23 @@ import swal from 'sweetalert';
 import { getInstitutionAffiliation } from '../utils/institutionAffiliation';
 import { browsePageReducer, createInitialBrowsePageState } from '../reducers/browsePageReducer';
 
-export const getListingEmptyMessage = (params: {
+type ListingSearchCriteria = {
   queryString: string;
   selectedDepartments: string[];
   selectedResearchAreas: string[];
   selectedListingResearchAreas: string[];
   quickFilter: string | null;
-}) => {
-  const hasSearchCriteria =
-    params.queryString.trim() !== '' ||
-    params.selectedDepartments.length > 0 ||
-    params.selectedResearchAreas.length > 0 ||
-    params.selectedListingResearchAreas.length > 0 ||
-    Boolean(params.quickFilter);
+};
 
-  return hasSearchCriteria
+export const hasListingSearchCriteria = (params: ListingSearchCriteria) =>
+  params.queryString.trim() !== '' ||
+  params.selectedDepartments.length > 0 ||
+  params.selectedResearchAreas.length > 0 ||
+  params.selectedListingResearchAreas.length > 0 ||
+  Boolean(params.quickFilter);
+
+export const getListingEmptyMessage = (params: ListingSearchCriteria) => {
+  return hasListingSearchCriteria(params)
     ? 'No labs match your current search or filters'
     : 'No research labs are available right now';
 };
@@ -184,13 +186,15 @@ const Home = () => {
     quickFilterActive: !!quickFilter,
   });
 
-  const emptyMessage = getListingEmptyMessage({
+  const listingSearchCriteria = {
     queryString,
     selectedDepartments,
     selectedResearchAreas,
     selectedListingResearchAreas,
     quickFilter,
-  });
+  };
+  const emptyMessage = getListingEmptyMessage(listingSearchCriteria);
+  const showFellowshipsEmptyAction = !hasListingSearchCriteria(listingSearchCriteria);
 
   const updateFavorite = (listingId: string, favorite: boolean) => {
     if (!isAuthenticated) {
@@ -284,6 +288,16 @@ const Home = () => {
         quickFilter={quickFilter}
         onClearQuickFilter={() => setQuickFilter(null)}
         emptyMessage={emptyMessage}
+        emptyAction={
+          showFellowshipsEmptyAction ? (
+            <Link
+              to="/fellowships"
+              className="inline-flex items-center justify-center rounded-md border border-blue-600 px-4 py-2 text-sm font-medium text-blue-700 hover:bg-blue-50"
+            >
+              Browse fellowships
+            </Link>
+          ) : undefined
+        }
       />
 
       {selectedListing && (

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -88,7 +88,6 @@ const Description = styled.div`
   }
 `;
 
-
 const TitleText = styled.h1`
   color: #000000;
   font-size: 32px;

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -10,7 +10,7 @@ import UserContext from '../contexts/UserContext';
 import { Navigate } from 'react-router-dom';
 
 const Login = () => {
-  const { isLoading, isAuthenticated, user } = useContext(UserContext);
+  const { isLoading, isAuthenticated, user, authError } = useContext(UserContext);
 
   const getRedirectPath = () => {
     if (user?.userType === 'professor') {
@@ -46,7 +46,14 @@ const Login = () => {
         ) : isAuthenticated ? (
           <Navigate to={getRedirectPath()} replace />
         ) : (
-          <SignInButton />
+          <>
+            {authError && (
+              <AuthError role="status">
+                {authError} If this keeps happening, refresh the page or try again later.
+              </AuthError>
+            )}
+            <SignInButton />
+          </>
         )}
       </AuthContainer>
     </Container>
@@ -118,6 +125,18 @@ const AuthContainer = styled.div`
   @media (max-width: 768px) {
     margin-top: 20px;
   }
+`;
+
+const AuthError = styled.p`
+  width: 100%;
+  margin: 0 0 16px;
+  padding: 12px 14px;
+  border: 1px solid #bfdbfe;
+  border-radius: 8px;
+  background: #eff6ff;
+  color: #1e3a8a;
+  font-size: 14px;
+  line-height: 1.45;
 `;
 
 export default Login;

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -4,13 +4,14 @@
 import PulseLoader from 'react-spinners/PulseLoader';
 import styled from 'styled-components';
 import { useContext } from 'react';
+import Button from '@mui/material/Button';
 
 import SignInButton from '../components/SignInButton';
 import UserContext from '../contexts/UserContext';
 import { Navigate } from 'react-router-dom';
 
 const Login = () => {
-  const { isLoading, isAuthenticated, user, authError } = useContext(UserContext);
+  const { isLoading, isAuthenticated, user, authError, checkContext } = useContext(UserContext);
 
   const getRedirectPath = () => {
     if (user?.userType === 'professor') {
@@ -45,15 +46,17 @@ const Login = () => {
           <PulseLoader color="#66CCFF" size={10} />
         ) : isAuthenticated ? (
           <Navigate to={getRedirectPath()} replace />
-        ) : (
+        ) : authError ? (
           <>
-            {authError && (
-              <AuthError role="status">
-                {authError} If this keeps happening, refresh the page or try again later.
-              </AuthError>
-            )}
-            <SignInButton />
+            <AuthError role="status">
+              {authError} Check your connection and try again before signing in.
+            </AuthError>
+            <Button variant="outlined" onClick={checkContext}>
+              Retry Connection
+            </Button>
           </>
+        ) : (
+          <SignInButton />
         )}
       </AuthContainer>
     </Container>

--- a/client/src/providers/UserContextProvider.tsx
+++ b/client/src/providers/UserContextProvider.tsx
@@ -2,7 +2,6 @@
  * Provider component managing user authentication and session state.
  */
 import { FC, useCallback, useEffect, useReducer } from 'react';
-import swal from 'sweetalert';
 
 import axios from '../utils/axios';
 import UserContext from '../contexts/UserContext';
@@ -11,7 +10,7 @@ import { createInitialUserState, userReducer } from '../reducers/userReducer';
 
 const UserContextProvider: FC = ({ children }) => {
   const [state, dispatch] = useReducer(userReducer, undefined, createInitialUserState);
-  const { isLoading, isAuthenticated, user } = state;
+  const { isLoading, isAuthenticated, user, authError } = state;
 
   const checkContext = useCallback(() => {
     dispatch({ type: 'FETCH_START' });
@@ -32,12 +31,9 @@ const UserContextProvider: FC = ({ children }) => {
       })
       .catch((error) => {
         console.error('Auth check failed:', error);
-        dispatch({ type: 'LOGOUT' });
-        dispatch({ type: 'FETCH_FAILURE' });
-
-        swal({
-          text: 'Something went wrong while checking authentication status.',
-          icon: 'warning',
+        dispatch({
+          type: 'FETCH_FAILURE',
+          error: 'Unable to reach Yale Labs right now. Please try again in a moment.',
         });
       });
   }, []);
@@ -47,7 +43,7 @@ const UserContextProvider: FC = ({ children }) => {
   }, [checkContext]);
 
   return (
-    <UserContext.Provider value={{ isLoading, isAuthenticated, user, checkContext }}>
+    <UserContext.Provider value={{ isLoading, isAuthenticated, user, authError, checkContext }}>
       {children}
     </UserContext.Provider>
   );

--- a/client/src/reducers/__tests__/userReducer.test.ts
+++ b/client/src/reducers/__tests__/userReducer.test.ts
@@ -17,12 +17,17 @@ describe('userReducer', () => {
     expect(state.isLoading).toBe(true);
     expect(state.isAuthenticated).toBe(false);
     expect(state.user).toBeUndefined();
+    expect(state.authError).toBeUndefined();
   });
 
-  it('FETCH_START sets loading true', () => {
-    const state = createInitialUserState({ isLoading: false });
+  it('FETCH_START sets loading true and clears stale auth errors', () => {
+    const state = createInitialUserState({
+      isLoading: false,
+      authError: 'Unable to reach server',
+    });
     const next = userReducer(state, { type: 'FETCH_START' });
     expect(next.isLoading).toBe(true);
+    expect(next.authError).toBeUndefined();
   });
 
   it('FETCH_SUCCESS with auth populates the user and flips authenticated', () => {
@@ -34,6 +39,7 @@ describe('userReducer', () => {
     expect(next.isLoading).toBe(false);
     expect(next.isAuthenticated).toBe(true);
     expect(next.user).toBe(sampleUser);
+    expect(next.authError).toBeUndefined();
   });
 
   it('FETCH_SUCCESS without auth clears the user even if one was present', () => {
@@ -48,18 +54,31 @@ describe('userReducer', () => {
     expect(next.isLoading).toBe(false);
     expect(next.isAuthenticated).toBe(false);
     expect(next.user).toBeUndefined();
+    expect(next.authError).toBeUndefined();
   });
 
-  it('FETCH_FAILURE clears loading without affecting prior user', () => {
+  it('FETCH_FAILURE clears loading, sets an auth error, and preserves prior user', () => {
     const prior = userReducer(createInitialUserState(), {
       type: 'FETCH_SUCCESS',
       payload: { isAuthenticated: true, user: sampleUser },
     });
-    const next = userReducer(prior, { type: 'FETCH_FAILURE' });
+    const next = userReducer(prior, {
+      type: 'FETCH_FAILURE',
+      error: 'Unable to reach Yale Labs.',
+    });
     expect(next.isLoading).toBe(false);
     // Prior user and authenticated flag are preserved — stale is better than empty
     expect(next.isAuthenticated).toBe(true);
     expect(next.user).toBe(sampleUser);
+    expect(next.authError).toBe('Unable to reach Yale Labs.');
+  });
+
+  it('FETCH_FAILURE falls back to a useful default message', () => {
+    const state = createInitialUserState();
+    const next = userReducer(state, { type: 'FETCH_FAILURE' });
+    expect(next.authError).toBe(
+      'Unable to check your Yale Labs session. Please try again in a moment.',
+    );
   });
 
   it('LOGOUT clears user and sets isAuthenticated false', () => {
@@ -70,6 +89,7 @@ describe('userReducer', () => {
     const next = userReducer(prior, { type: 'LOGOUT' });
     expect(next.isAuthenticated).toBe(false);
     expect(next.user).toBeUndefined();
+    expect(next.authError).toBeUndefined();
   });
 
   it('reducer does not mutate prior state', () => {

--- a/client/src/reducers/userReducer.ts
+++ b/client/src/reducers/userReducer.ts
@@ -49,8 +49,7 @@ export function userReducer(state: UserState, action: UserAction): UserState {
         ...state,
         isLoading: false,
         authError:
-          action.error ||
-          'Unable to check your Yale Labs session. Please try again in a moment.',
+          action.error || 'Unable to check your Yale Labs session. Please try again in a moment.',
       };
 
     case 'LOGOUT':

--- a/client/src/reducers/userReducer.ts
+++ b/client/src/reducers/userReducer.ts
@@ -11,25 +11,27 @@ export interface UserState {
   isLoading: boolean;
   isAuthenticated: boolean;
   user?: User;
+  authError?: string;
 }
 
 export type UserAction =
   | { type: 'FETCH_START' }
   | { type: 'FETCH_SUCCESS'; payload: { isAuthenticated: boolean; user?: User } }
-  | { type: 'FETCH_FAILURE' }
+  | { type: 'FETCH_FAILURE'; error?: string }
   | { type: 'LOGOUT' };
 
 export const createInitialUserState = (overrides: Partial<UserState> = {}): UserState => ({
   isLoading: true,
   isAuthenticated: false,
   user: undefined,
+  authError: undefined,
   ...overrides,
 });
 
 export function userReducer(state: UserState, action: UserAction): UserState {
   switch (action.type) {
     case 'FETCH_START':
-      return { ...state, isLoading: true };
+      return { ...state, isLoading: true, authError: undefined };
 
     case 'FETCH_SUCCESS':
       return {
@@ -37,6 +39,7 @@ export function userReducer(state: UserState, action: UserAction): UserState {
         isLoading: false,
         isAuthenticated: action.payload.isAuthenticated,
         user: action.payload.isAuthenticated ? action.payload.user : undefined,
+        authError: undefined,
       };
 
     case 'FETCH_FAILURE':
@@ -45,6 +48,9 @@ export function userReducer(state: UserState, action: UserAction): UserState {
       return {
         ...state,
         isLoading: false,
+        authError:
+          action.error ||
+          'Unable to check your Yale Labs session. Please try again in a moment.',
       };
 
     case 'LOGOUT':
@@ -52,6 +58,7 @@ export function userReducer(state: UserState, action: UserAction): UserState {
         ...state,
         isAuthenticated: false,
         user: undefined,
+        authError: undefined,
       };
 
     default:


### PR DESCRIPTION
## Intent

Act as an undergraduate looking for Yale research opportunities and improve the local Yale Research/YLabs flow from the first screen through the available local data. The committed stack starts at 49fdec6 and includes: replacing generic auth-check popups with inline login state, hiding the CAS link and offering retry during auth outages, degrading listing search to MongoDB when Meilisearch is unavailable, clarifying the empty Find Labs state when the local database has no listings, and linking that empty labs state to the available fellowships path because the local data has fellowships even when labs are empty. Constraints from the task: preserve the existing stack, work only in this isolated worktree, validate locally, raise a PR for the full stack, do not merge, and do not print or commit secret env values.

## What Changed
- Added inline login error handling for failed auth context checks, preserving retry behavior and hiding the Yale CAS sign-in action while the auth endpoint is unavailable.
- Clarified the Find Labs empty state so a truly empty local listings dataset is distinct from no search/filter matches, with a path from empty labs to available fellowships.
- Updated reducer and page coverage plus project docs to reflect the auth retry and empty research/fellowship flow changes.

## Risk Assessment

✅ Low: The changes are narrowly scoped to client auth-state messaging and empty-state UI, with reducer/provider behavior remaining consistent with existing route and search-context flows.

## Testing

Exercised the auth-outage login retry, hidden CAS link, user auth-error reducer state, empty Find Labs copy, and Browse fellowships link with targeted Vitest tests, a rendered HTML evidence artifact from the real React components, and the full client CI test suite; all tests passed, with screenshot capture replaced by rendered HTML because Chrome is not installed in the runner.

<details>
<summary>Evidence: Rendered local research flow evidence</summary>

```text
<!doctype html>
<html lang="en">
<head>
  <meta charset="utf-8" />
  <meta name="viewport" content="width=device-width, initial-scale=1" />
  <title>YLabs local research flow evidence</title>
  <style>
    body { margin: 0; background: #f1f5f9; color: #111827; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
    main { max-width: 1040px; margin: 0 auto; padding: 32px; }
    h1 { font-size: 28px; margin: 0 0 8px; }
    .note { color: #475569; margin: 0 0 24px; }
    .surface { background: white; border: 1px solid #e5e7eb; border-radius: 8px; margin: 18px 0; overflow: hidden; }
    .surface h2 { font-size: 16px; margin: 0; padding: 14px 18px; border-bottom: 1px solid #e5e7eb; background: #f8fafc; }
    .app-frame { min-height: 180px; padding: 28px; display: flex; align-items: center; justify-content: center; }
    .text-center { text-align: center; } .py-8 { padding-top: 2rem; padding-bottom: 2rem; } .text-gray-500 { color: #6b7280; }
    .mt-3 { margin-top: .75rem; } .inline-flex { display: inline-flex; } .items-center { align-items: center; } .justify-center { justify-content: center; }
    .rounded-md { border-radius: .375rem; } .border { border-width: 1px; border-style: solid; } .border-blue-600 { border-color: #2563eb; }
    .px-4 { padding-left: 1rem; padding-right: 1rem; } .py-2 { padding-top: .5rem; padding-bottom: .5rem; } .text-sm { font-size: .875rem; }
    .font-medium { font-weight: 500; } .text-blue-700 { color: #1d4ed8; } a { text-decoration: none; }
    button, .MuiButton-root, a[role='button'] { font: inherit; }
  </style>
</head>
<body>
  <main>
    <h1>Local Yale Research / YLabs flow evidence</h1>
    <p class="note">Rendered from the actual React components under local auth-outage and empty-labs states.</p>
    
  <section class="surface">
    <h2>Login during auth outage: CAS link is hidden and retry is offered</h2>
    <div class="app-frame"><meta name="emotion-insertion-point" content=""><style></style><style data-styled="active" data-styled-version="6.1.19">.htzbTR{width:100%;background:#ffffff;display:flex;flex-direction:column;align-items:center;padding:5% 20px;box-sizing:border-box;}.kkzwGe{width:100%;max-width:600px;margin-top:60px;display:flex;align-items:center;flex-direction:column;justify-content:top;text-align:center;}@media (max-width: 768px){.kkzwGe{padding:0 15px;}}.iZImox{color:#000000;font-size:32px;}@media (max-width: 768px){.iZImox{font-size:28px;margin-top:20px!important;}}@media (max-width: 480px){.iZImox{font-size:24px;}}.bwhIth{color:#000000;font-size:20px;}@media (max-width: 768px){.bwhIth{font-size:18px;}}@media (max-width: 480px){.bwhIth{font-size:16px;}}.hwOwaf{margin-top:30px;width:100%;max-width:600px;display:flex;align-items:center;flex-direction:column;text-align:center;}@media (max-width: 768px){.hwOwaf{margin-top:20px;}}.cAxKtc{width:100%;margin:0 0 16px;padding:12px 14px;border:1px solid #bfdbfe;border-radius:8px;background:#eff6ff;color:#1e3a8a;font-size:14px;line-height:1.45;}</style><style data-emotion="css" data-s="">.css-lvexzb-MuiButton-root{font-family:"Roboto","Helvetica","Arial",sans-serif;font-weight:500;font-size:0.875rem;line-height:1.75;letter-spacing:0.02857em;text-transform:uppercase;min-width:64px;padding:6px 16px;border:0;border-radius:4px;-webkit-transition:background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;transition:background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;padding:5px 15px;border:1px solid currentColor;border-color:var(--variant-outlinedBorder, currentColor);background-color:var(--variant-outlinedBg);color:var(--variant-outlinedColor);--variant-textColor:#1976d2;--variant-outlinedColor:#1976d2;--variant-outlinedBorder:rgba(25, 118, 210, 0.5);--variant-containedColor:#fff;--variant-containedBg:#1976d2;-webkit-transition:background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;transition:background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;}</style><style data-emotion="css" data-s="">.css-lvexzb-MuiButton-root:hover{-webkit-text-decoration:none;text-decoration:none;}</style><style data-emotion="css" data-s="">.css-lvexzb-MuiButton-root.Mui-disabled{color:rgba(0, 0, 0, 0.26);}</style><style data-emotion="css" data-s="">.css-lvexzb-MuiButton-root.Mui-disabled{border:1px solid rgba(0, 0, 0, 0.12);}</style><style data-emotion="css" data-s="">@media (hover: hover){.css-lvexzb-MuiButton-root:hover{--variant-containedBg:#1565c0;--variant-textBg:rgba(25, 118, 210, 0.04);--variant-outlinedBorder:#1976d2;--variant-outlinedBg:rgba(25, 118, 210, 0.04);}}</style><style data-emotion="css" data-s="">.css-lvexzb-MuiButton-root.MuiButton-loading{color:transparent;}</style><style data-emotion="css" data-s="">.css-1blvszr-MuiButtonBase-root-MuiButton-root{display:-webkit-inline-box;display:-webkit-inline-flex;display:-ms-inline-flexbox;display:inline-flex;-webkit-align-items:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;-webkit-box-pack:center;-ms-flex-pack:center;-webkit-justify-content:center;justify-content:center;position:relative;box-sizing:border-box;-webkit-tap-highlight-color:transparent;background-color:transparent;outline:0;border:0;margin:0;border-radius:0;padding:0;cursor:pointer;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;vertical-align:middle;-moz-appearance:none;-webkit-appearance:none;-webkit-text-decoration:none;text-decoration:none;color:inherit;font-family:"Roboto","Helvetica","Arial",sans-serif;font-weight:500;font-size:0.875rem;line-height:1.75;letter-spacing:0.02857em;text-transform:uppercase;min-width:64px;padding:6px 16px;border:0;border-radius:4px;-webkit-transition:background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;transition:background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;padding:5px 15px;border:1px solid currentColor;border-color:var(--variant-outlinedBorder, currentColor);background-color:var(--variant-outlinedBg);color:var(--variant-outlinedColor);--variant-textColor:#1976d2;--variant-outlinedColor:#1976d2;--variant-outlinedBorder:rgba(25, 118, 210, 0.5);--variant-containedColor:#fff;--variant-containedBg:#1976d2;-webkit-transition:background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;transition:background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;}</style><style data-emotion="css" data-s="">.css-1blvszr-MuiButtonBase-root-MuiButton-root::-moz-focus-inner{border-style:none;}</style><style data-emotion="css" data-s="">.css-1blvszr-MuiButtonBase-root-MuiButton-root.Mui-disabled{pointer-events:none;cursor:default;}</style><style data-emotion="css" data-s="">@media print{.css-1blvszr-MuiButtonBase-root-MuiButton-root{-webkit-print-color-adjust:exact;color-adjust:exact;}}</style><style data-emotion="css" data-s="">.css-1blvszr-MuiButtonBase-root-MuiButton-root:hover{-webkit-text-decoration:none;text-decoration:none;}</style><style data-emotion="css" data-s="">.css-1blvszr-MuiButtonBase-root-MuiButton-root.Mui-disabled{color:rgba(0, 0, 0, 0.26);}</style><style data-emotion="css" data-s="">.css-1blvszr-MuiButtonBase-root-MuiButton-root.Mui-disabled{border:1px solid rgba(0, 0, 0, 0.12);}</style><style data-emotion="css" data-s="">@media (hover: hover){.css-1blvszr-MuiButtonBase-root-MuiButton-root:hover{--variant-containedBg:#1565c0;--variant-textBg:rgba(25, 118, 210, 0.04);--variant-outlinedBorder:#1976d2;--variant-outlinedBg:rgba(25, 118, 210, 0.04);}}</style><style data-emotion="css" data-s="">.css-1blvszr-MuiButtonBase-root-MuiButton-root.MuiButton-loading{color:transparent;}</style><style data-emotion="css" data-s="">.css-r3djoj-MuiTouchRipple-root{overflow:hidden;pointer-events:none;position:absolute;z-index:0;top:0;right:0;bottom:0;left:0;border-radius:inherit;}</style><style data-emotion="css" data-s="">.css-y4cjyz-MuiTouchRipple-ripple{opacity:0;position:absolute;}</style><style data-emotion="css" data-s="">.css-y4cjyz-MuiTouchRipple-ripple.MuiTouchRipple-rippleVisible{opacity:0.3;-webkit-transform:scale(1);-moz-transform:scale(1);-ms-transform:scale(1);transform:scale(1);-webkit-animation-name:animation-1taevns;animation-name:animation-1taevns;-webkit-animation-duration:550ms;animation-duration:550ms;-webkit-animation-timing-function:cubic-bezier(0.4, 0, 0.2, 1);animation-timing-function:cubic-bezier(0.4, 0, 0.2, 1);}</style><style data-emotion="css" data-s="">.css-y4cjyz-MuiTouchRipple-ripple.MuiTouchRipple-ripplePulsate{-webkit-animation-duration:200ms;animation-duration:200ms;}</style><style data-emotion="css" data-s="">.css-y4cjyz-MuiTouchRipple-ripple .MuiTouchRipple-child{opacity:1;display:block;width:100%;height:100%;border-radius:50%;background-color:currentColor;}</style><style data-emotion="css" data-s="">.css-y4cjyz-MuiTouchRipple-ripple .MuiTouchRipple-childLeaving{opacity:0;-webkit-animation-name:animation-5ich1p;animation-name:animation-5ich1p;-webkit-animation-duration:550ms;animation-duration:550ms;-webkit-animation-timing-function:cubic-bezier(0.4, 0, 0.2, 1);animation-timing-function:cubic-bezier(0.4, 0, 0.2, 1);}</style><style data-emotion="css" data-s="">.css-y4cjyz-MuiTouchRipple-ripple .MuiTouchRipple-childPulsate{position:absolute;left:0px;top:0;-webkit-animation-name:animation-f6tr5a;animation-name:animation-f6tr5a;-webkit-animation-duration:2500ms;animation-duration:2500ms;-webkit-animation-timing-function:cubic-bezier(0.4, 0, 0.2, 1);animation-timing-function:cubic-bezier(0.4, 0, 0.2, 1);-webkit-animation-iteration-count:infinite;animation-iteration-count:infinite;-webkit-animation-delay:200ms;animation-delay:200ms;}</style><style data-emotion="css" data-s="">@-webkit-keyframes animation-f6tr5a{0%{-webkit-transform:scale(1);-moz-transform:scale(1);-ms-transform:scale(1);transform:scale(1);}50%{-webkit-transform:scale(0.92);-moz-transform:scale(0.92);-ms-transform:scale(0.92);transform:scale(0.92);}100%{-webkit-transform:scale(1);-moz-transform:scale(1);-ms-transform:scale(1);transform:scale(1);}}</style><style data-emotion="css" data-s="">@keyframes animation-f6tr5a{0%{-webkit-transform:scale(1);-moz-transform:scale(1);-ms-transform:scale(1);transform:scale(1);}50%{-webkit-transform:scale(0.92);-moz-transform:scale(0.92);-ms-transform:scale(0.92);transform:scale(0.92);}100%{-webkit-transform:scale(1);-moz-transform:scale(1);-ms-transform:scale(1);transform:scale(1);}}</style><style data-emotion="css" data-s="">@-webkit-keyframes animation-5ich1p{0%{opacity:1;}100%{opacity:0;}}</style><style data-emotion="css" data-s="">@keyframes animation-5ich1p{0%{opacity:1;}100%{opacity:0;}}</style><style data-emotion="css" data-s="">@-webkit-keyframes animation-1taevns{0%{-webkit-transform:scale(0);-moz-transform:scale(0);-ms-transform:scale(0);transform:scale(0);opacity:0.1;}100%{-webkit-transform:scale(1);-moz-transform:scale(1);-ms-transform:scale(1);transform:scale(1);opacity:0.3;}}</style><style data-emotion="css" data-s="">@keyframes animation-1taevns{0%{-webkit-transform:scale(0);-moz-transform:scale(0);-ms-transform:scale(0);transform:scale(0);opacity:0.1;}100%{-webkit-transform:scale(1);-moz-transform:scale(1);-ms-transform:scale(1);transform:scale(1);opacity:0.3;}}</style><div><div class="sc-bRKDuR htzbTR"><div class="sc-hvigdm kkzwGe"><div class="flex items-center"><img alt="ylabs-logo" class="mr-2 w-[3.5rem] h-[3rem] md:w-[6.33rem] md:h-[5.4rem] sm:w-[4.5rem] sm:h-[4rem] " src="/assets/logos/paperclip.png"><img alt="ylabs-logo" class="w-[7rem] h-[3rem] md:w-[13.03rem] md:h-[5.4rem] sm:w-[9rem] sm:h-[4rem]" src="/assets/logos/ylabs-blue.png"></div><h1 class="sc-fhHczv iZImox mt-12">A Yale Research Database</h1><p class="sc-ggWZvA bwhIth mt-2">Search through 1400+ Yale faculty listings across 60+ fields of study. Learn about professors who share your research interests and find potential research mentors.</p></div><div class="sc-dTvVRJ hwOwaf"><p role="status" class="sc-jwTyAe cAxKtc">Unable to reach Yale Labs right now. Check your connection and try again before signing in.</p><button class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary Mui-focusVisible MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary css-1blvszr-MuiButtonBase-root-MuiButton-root" tabindex="0" type="button">Retry Connection<span class="MuiTouchRipple-root css-r3djoj-MuiTouchRipple-root"><span class="css-y4cjyz-MuiTouchRipple-ripple MuiTouchRipple-ripple MuiTouchRipple-rippleVisible MuiTouchRipple-ripplePulsate" style="width: 1px; height: 1px; top: -0.5px; left: -0.5px;"><span class="MuiTouchRipple-child MuiTouchRipple-childPulsate"></span></span></span></button></div></div></div></div>
  </section>


  <section class="surface">
    <h2>Find Labs with local empty data: explains no labs and links to fellowships</h2>
    <div class="app-frame"><div><div class="text-center py-8 text-gray-500"><p>No research labs are available right now</p><div class="mt-3"><a class="inline-flex items-center justify-center rounded-md border border-blue-600 px-4 py-2 text-sm font-medium text-blue-700 hover:bg-blue-50" href="/fellowships">Browse fellowships</a></div></div></div></div>
  </section>

  </main>
</body>
</html>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `server/src/controllers/listingController.ts` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`yarn install` followed by `yarn install:all` to bootstrap missing project dependencies for testing</code>
- `yarn --cwd client vitest --run src/pages/__tests__/login.test.tsx src/pages/__tests__/home.test.ts src/reducers/__tests__/userReducer.test.ts`
- <code>Started a local mock API on `http://127.0.0.1:4100` with auth failure, empty research results, and one fellowship result; started Vite with `VITE_APP_SERVER=http://127.0.0.1:4100 yarn --cwd client dev --host 127.0.0.1`</code>
- <code>Attempted `chrome-devtools-axi` screenshot capture, but the runner has no Chrome executable installed</code>
- <code>Temporarily ran `yarn --cwd client vitest --run src/__tests__/noMistakesRenderEvidence.test.tsx` to render actual React Login and BrowseGrid states into `/tmp/no-mistakes-evidence/01KWR621GSYRZJR6WJC1R2D21Y/rendered-local-research-flow.html`</code>
- `yarn --cwd client test:ci`
- <code>Removed temporary in-tree evidence test plus generated `node_modules` and `.yarn` directories; verified `git status --short` is clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
