### PR TITLE
feat(client): add research listing evidence rail

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ The server follows a layered architecture: **Routes → Middleware → Controlle
 | Server          | Express 4, TypeScript 5.3, Passport.js 0.5 (CAS strategy), Mongoose 8                          |
 | Search          | Meilisearch 0.57 (hybrid search with OpenAI `text-embedding-3-small` embedder)                 |
 | Database        | MongoDB Atlas (single cluster, separate databases per environment)                             |
-| Error Tracking  | Sentry for client and server runtime exception reporting                                        |
+| Error Tracking  | Sentry for client and server runtime exception reporting                                       |
 | Package Manager | Yarn 4 via Corepack                                                                            |
 | Tooling         | concurrently, nodemon, ts-node, cross-env                                                      |
 
@@ -314,19 +314,19 @@ User → Yale CAS SSO → passport.ts findOrCreateUser
 | `MEILISEARCH_HOST`         | No (default: `http://localhost:7700`) | Meilisearch instance URL                                                                                                                                         |
 | `MEILISEARCH_API_KEY`      | No                                    | Meilisearch API key                                                                                                                                              |
 | `MEILISEARCH_INDEX_PREFIX` | No                                    | Environment prefix for index names (e.g., `prod`, `beta`). When set, indexes become `{prefix}_listings`. Allows prod and beta to share one Meilisearch instance. |
-| `SENTRY_DSN`               | No                                    | Enables server-side Sentry error tracking when set                                                                                                                |
-| `SENTRY_ENVIRONMENT`       | No                                    | Sentry environment label; falls back to `NODE_ENV`                                                                                                                |
-| `SENTRY_RELEASE`           | No                                    | Sentry release identifier                                                                                                                                         |
+| `SENTRY_DSN`               | No                                    | Enables server-side Sentry error tracking when set                                                                                                               |
+| `SENTRY_ENVIRONMENT`       | No                                    | Sentry environment label; falls back to `NODE_ENV`                                                                                                               |
+| `SENTRY_RELEASE`           | No                                    | Sentry release identifier                                                                                                                                        |
 | `PORT`                     | No (default: 4000)                    | Server port                                                                                                                                                      |
 
 ### `client/.env`
 
-| Variable                   | Required | Description                                                |
-| -------------------------- | -------- | ---------------------------------------------------------- |
-| `VITE_APP_SERVER`          | Yes      | Backend API URL (e.g., `http://localhost:4000`)            |
-| `VITE_SENTRY_DSN`          | No       | Enables client-side Sentry error tracking when set         |
-| `VITE_SENTRY_ENVIRONMENT`  | No       | Sentry environment label; falls back to Vite mode          |
-| `VITE_SENTRY_RELEASE`      | No       | Sentry release identifier                                  |
+| Variable                  | Required | Description                                        |
+| ------------------------- | -------- | -------------------------------------------------- |
+| `VITE_APP_SERVER`         | Yes      | Backend API URL (e.g., `http://localhost:4000`)    |
+| `VITE_SENTRY_DSN`         | No       | Enables client-side Sentry error tracking when set |
+| `VITE_SENTRY_ENVIRONMENT` | No       | Sentry environment label; falls back to Vite mode  |
+| `VITE_SENTRY_RELEASE`     | No       | Sentry release identifier                          |
 
 ## Sensitive Files
 
@@ -337,11 +337,11 @@ User → Yale CAS SSO → passport.ts findOrCreateUser
 
 ## Known Technical Debt
 
-| Issue                                    | Location                          | Status                                                                                                                                                                                                                          |
-| ---------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Issue                                    | Location                          | Status                                                                                                                                                                                                                                         |
+| ---------------------------------------- | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | No general server-side test suite        | `server/`                         | Focused Vitest coverage exists for error handling/tracking and a focused Node test covers listing-search degradation; broader server coverage is not wired into CI. Client uses Vitest; reducer modules in `client/src/reducers/` are covered. |
-| ESLint/Prettier configured but not in CI | `eslint.config.js`, `.prettierrc` | Flat-config ESLint + Prettier set up at repo root. Currently reports ~15 errors / ~55 warnings across the codebase; not wired to CI until pre-existing violations are triaged. Run `yarn lint`, `yarn lint:fix`, `yarn format`. |
-| Console-only logging                     | Server                            | No structured logging (Winston/Pino)                                                                                                                                                                                            |
+| ESLint/Prettier configured but not in CI | `eslint.config.js`, `.prettierrc` | Flat-config ESLint + Prettier set up at repo root. Currently reports ~15 errors / ~55 warnings across the codebase; not wired to CI until pre-existing violations are triaged. Run `yarn lint`, `yarn lint:fix`, `yarn format`.                |
+| Console-only logging                     | Server                            | No structured logging (Winston/Pino)                                                                                                                                                                                                           |
 
 ## Adding a New Endpoint
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Architecture
 
-Monorepo with a React client and Express server communicating over REST. MongoDB Atlas is the primary data store. Meilisearch handles search (semantic + keyword) with an OpenAI embedder configured server-side. Yale CAS provides SSO authentication, while the public research discovery flow exposes redacted confirmed listings to logged-out visitors.
+Monorepo with a React client and Express server communicating over REST. MongoDB Atlas is the primary data store. Meilisearch handles search (semantic + keyword) with an OpenAI embedder configured server-side. Yale CAS provides SSO authentication, while the public research discovery flow exposes redacted confirmed listings and public-safe evidence/source metadata to logged-out visitors.
 
 ```
 React (Vite) → Express (Passport.js) → MongoDB Atlas + Meilisearch
@@ -87,6 +87,8 @@ If the client cannot reach the auth endpoint, `/login` renders an inline retry s
 
 MongoDB via Mongoose 8. All environments use `MONGODBURL` — the connection string determines which database (Production, Beta, or Development) is used. An optional `productionMigration` mode (via `API_MODE=productionMigration`) adds a second connection to `MONGODBURL_MIGRATION` for dual-DB migrations; `getListingModel()` returns the migration model in this mode.
 
+Listing documents may include an `evidence` object with `status`, `summary`, `confidence`, generation/verification timestamps, public `sources`, and optional `internalNotes`. `internalNotes` is `select: false`, is removed before Meilisearch indexing, and is not exposed by public research responses.
+
 ## Search
 
 Search has migrated from MongoDB Atlas Vector Search to **Meilisearch**. The old `embeddingService.ts` (OpenAI client-side embedding generation + in-memory LRU cache) has been removed.
@@ -99,15 +101,15 @@ Current authenticated listing search flow:
 4. If hybrid search fails, the controller retries keyword-only Meilisearch; if Meilisearch is unavailable, it falls back to MongoDB filtering
 5. Results are returned with `totalCount` for pagination and a `degraded` boolean indicating whether fallback behavior was used
 
-Public research discovery uses the same degradation path through `/api/research`, but only returns confirmed, unarchived listings after redacting contact/private fields (`ownerEmail`, `emails`, owner/professor IDs, views, favorites, archived/confirmed/audit internals). Client routes `/research` and `/research/:slug` render the browse page without `PrivateRoute`; opening a card updates the URL to a shareable modal route. Authenticated users on those public routes additionally call `/api/research/:slug/contact` to retrieve the full listing with contact fields. Public research search uses a contact-redacted searchable field set and only accepts `createdAt` or `updatedAt` sort fields.
+Public research discovery uses the same degradation path through `/api/research`, but only returns confirmed, unarchived listings after redacting contact/private fields (`ownerEmail`, `emails`, owner/professor IDs, views, favorites, archived/confirmed/audit internals). Public responses keep sanitized `evidence` metadata for the listing detail evidence rail, limited to status/summary/confidence/timestamps and up to eight source records; source URLs are restricted to `http`/`https` and stripped of credentials, query strings, and fragments. Client routes `/research` and `/research/:slug` render the browse page without `PrivateRoute`; opening a card updates the URL to a shareable modal route. Authenticated users on those public routes additionally call `/api/research/:slug/contact` to retrieve the full listing with contact fields, while evidence remains sanitized through the public evidence allowlist. Public research search uses a contact-redacted searchable field set and only accepts `createdAt` or `updatedAt` sort fields.
 
 The authenticated Find Labs page distinguishes an empty local/unfiltered dataset from an empty search result: no unfiltered listings shows "No research labs are available right now" with a `/fellowships` action, while active searches or filters show "No labs match your current search or filters."
 
 The Meilisearch client (`server/src/utils/meiliClient.ts`) lazy-loads and caches the connection. Configuration: `MEILISEARCH_HOST` (defaults to `http://localhost:7700`), `MEILISEARCH_API_KEY`, and `MEILISEARCH_INDEX_PREFIX` (optional, for multi-environment isolation on a shared instance). The module exports `getMeiliIndex(name)` which resolves prefixed index names and `resolveIndexName(name)` for use in migration scripts.
 
-Listing mutations in `listingService.ts` sync to Meilisearch after MongoDB writes — create uses `addDocuments()`, update uses `updateDocuments()`, delete uses `deleteDocument()`. Documents are indexed with `primaryKey: 'id'` (string-cast `_id`), with `embedding`, `_id`, and `__v` fields stripped.
+Listing mutations in `listingService.ts` sync to Meilisearch after MongoDB writes — create uses `addDocuments()`, update uses `updateDocuments()`, delete uses `deleteDocument()`. Documents are indexed with `primaryKey: 'id'` (string-cast `_id`), with `embedding`, `_id`, `__v`, and private `evidence.internalNotes` fields stripped.
 
-The migration script `data-migration/MigrateToMeilisearch.ts` configures the Meilisearch index with filterable attributes (`departments`, `researchAreas`, `archived`, `confirmed`), sortable attributes (`createdAt`, `updatedAt`, `searchScore`), and the OpenAI embedder. Run it with `MEILISEARCH_INDEX_PREFIX` set to populate the correct index per environment.
+The migration script `data-migration/MigrateToMeilisearch.ts` configures the Meilisearch index with filterable attributes (`departments`, `researchAreas`, `archived`, `confirmed`), sortable attributes (`createdAt`, `updatedAt`, `searchScore`), and the OpenAI embedder. It also strips private `evidence.internalNotes` from migrated documents. Run it with `MEILISEARCH_INDEX_PREFIX` set to populate the correct index per environment.
 
 ## Environments
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -6,7 +6,7 @@
 
 ## What Is This?
 
-Y/Labs is a **Yale research lab discovery platform**. Visitors can browse public research listings, students find labs and fellowships, professors create and manage listings, and admins oversee everything.
+Y/Labs is a **Yale research lab discovery platform**. Visitors can browse public research listings with supporting evidence/source metadata, students find labs and fellowships, professors create and manage listings, and admins oversee everything.
 
 ---
 
@@ -115,7 +115,7 @@ cd data-migration
 npx ts-node --transpile-only MigrateToMeilisearch.ts
 ```
 
-This reads listings from your `Development` MongoDB and pushes them to the local Meilisearch with the OpenAI embedder configured.
+This reads listings from your `Development` MongoDB and pushes them to the local Meilisearch with the OpenAI embedder configured. Listing evidence is indexed with public-safe source metadata only; `evidence.internalNotes` is stripped before documents are sent to Meilisearch.
 
 ### 5. Start dev servers
 
@@ -210,11 +210,13 @@ Logged-out visitors use the public research discovery path instead:
 
 - Client routes `/research` and `/research/:slug` render the listings browse page without the `PrivateRoute` guard.
 - The client sends public browse requests to `/api/research` and public detail requests to `/api/research/:slug`.
-- Public responses include only confirmed, unarchived listings and redact contact/private fields such as owner email, additional emails, owner/professor IDs, view counts, favorites, and audit fields.
-- Authenticated users opening a public detail modal also request `/api/research/:slug/contact` to load the full listing, including contact fields.
+- Public responses include only confirmed, unarchived listings and redact contact/private fields such as owner email, additional emails, owner/professor IDs, view counts, favorites, and audit fields. They retain sanitized evidence metadata so the detail modal can show why a listing appears and which public sources support it.
+- Authenticated users opening a public detail modal also request `/api/research/:slug/contact` to load the full listing, including contact fields. Evidence metadata on this response is still sanitized through the public evidence allowlist.
 - Public research search only allows `createdAt` and `updatedAt` sort fields and searches a contact-redacted field set.
 
-Listing CRUD in `listingService.ts` automatically syncs to Meilisearch after MongoDB writes.
+Listing detail modals render an evidence rail for listings, including an empty state when source metadata is unavailable. The public evidence payload supports `status`, `summary`, `confidence`, `generatedAt`, `lastVerifiedAt`, and up to eight sources with `label`, `url`, `sourceType`, `description`, and `lastCheckedAt`. Loading and error states are handled in the same rail. Public source URLs are limited to `http`/`https`; credentials, query strings, and fragments are removed before they are returned by the API or rendered by the client.
+
+Listing CRUD in `listingService.ts` automatically syncs to Meilisearch after MongoDB writes. Indexed listing documents strip `_id`, `__v`, legacy `embedding`, and private `evidence.internalNotes` fields.
 
 On the authenticated Find Labs page, an empty unfiltered result set is treated as "no research labs are available right now" and includes a link to `/fellowships`; empty filtered/search results instead tell the user no labs match the current search or filters.
 
@@ -341,6 +343,8 @@ Public pages that should work for logged-out visitors must not use `PrivateRoute
 2. TypeScript interfaces in `client/src/types/`
 3. Migration script in `data-migration/` if existing data needs transformation
 4. If the model is `listing`, update Meilisearch index config if new fields need filtering/sorting
+
+Listing evidence metadata lives under `listing.evidence` in MongoDB. Keep any analyst-only notes in `evidence.internalNotes`; that field is excluded by default from Mongoose query results, stripped from Meilisearch indexing, and never returned by public research endpoints.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ A research lab and fellowship discovery platform for Yale University, with publi
 
 ## Tech Stack
 
-| Layer | Tech |
-|-------|------|
-| Client | React 19, TypeScript, Vite, TailwindCSS, MUI |
-| Server | Express 4, TypeScript, Passport.js (Yale CAS) |
-| Database | MongoDB Atlas (Mongoose 8) |
-| Search | Meilisearch (hybrid: keyword + semantic via OpenAI embedder) |
-| Error Tracking | Sentry for client and server runtime exceptions |
-| Package Manager | Yarn 4 via Corepack |
+| Layer           | Tech                                                         |
+| --------------- | ------------------------------------------------------------ |
+| Client          | React 19, TypeScript, Vite, TailwindCSS, MUI                 |
+| Server          | Express 4, TypeScript, Passport.js (Yale CAS)                |
+| Database        | MongoDB Atlas (Mongoose 8)                                   |
+| Search          | Meilisearch (hybrid: keyword + semantic via OpenAI embedder) |
+| Error Tracking  | Sentry for client and server runtime exceptions              |
+| Package Manager | Yarn 4 via Corepack                                          |
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # YURA Research Database
 
-A research lab and fellowship discovery platform for Yale University, with public research browsing and authenticated tools for favorites, contact, and management.
+A research lab and fellowship discovery platform for Yale University, with public research browsing, evidence/source metadata on research details, and authenticated tools for favorites, contact, and management.
 
 **Live:** [yalelabs.io](https://yalelabs.io/) · **Beta:** [ylabs-dev.onrender.com](https://ylabs-dev.onrender.com)
 

--- a/client/src/components/shared/ListingDetailModal.tsx
+++ b/client/src/components/shared/ListingDetailModal.tsx
@@ -7,7 +7,7 @@ import { Listing } from '../../types/types';
 import UserContext from '../../contexts/UserContext';
 import ConfigContext from '../../contexts/ConfigContext';
 import { getDepartmentAbbreviation } from '../../utils/departmentNames';
-import { ensureHttpPrefix } from '../../utils/url';
+import { ensureHttpPrefix, safeUrl } from '../../utils/url';
 import { getInstitutionAffiliation, getInstitutionLabel } from '../../utils/institutionAffiliation';
 import FavoriteButton from './FavoriteButton';
 
@@ -21,6 +21,146 @@ interface ListingDetailModalProps {
   onNavigateToResearchArea?: (area: string) => void;
   onNavigateToDepartment?: (dept: string) => void;
 }
+
+const getSafeEvidenceUrl = (url: unknown): string => {
+  const href = safeUrl(url);
+  if (!href) return '';
+  try {
+    const parsed = new URL(href);
+    if (!['http:', 'https:'].includes(parsed.protocol)) return '';
+    parsed.username = '';
+    parsed.password = '';
+    parsed.search = '';
+    parsed.hash = '';
+    return parsed.toString();
+  } catch {
+    return '';
+  }
+};
+
+const getEvidenceHost = (url: string): string => {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '');
+  } catch {
+    return '';
+  }
+};
+
+const formatEvidenceDate = (date?: string): string => {
+  if (!date) return '';
+  const parsed = new Date(date);
+  if (Number.isNaN(parsed.getTime())) return '';
+  return parsed.toLocaleDateString();
+};
+
+const EvidenceRail = ({ evidence }: { evidence: Listing['evidence'] }) => {
+  const status = evidence?.status || 'unavailable';
+  const sources = (evidence?.sources || [])
+    .map((source) => {
+      const href = getSafeEvidenceUrl(source.url);
+      return {
+        ...source,
+        href,
+        displayLabel: source.label || (href ? getEvidenceHost(href) : 'Source material'),
+      };
+    })
+    .filter((source) => source.displayLabel || source.href);
+  const verifiedDate = formatEvidenceDate(evidence?.lastVerifiedAt || evidence?.generatedAt);
+
+  return (
+    <section className="border border-gray-200 rounded-lg p-4 bg-gray-50/60">
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <div>
+          <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Evidence</h3>
+          {verifiedDate && <p className="text-xs text-gray-400 mt-1">Verified {verifiedDate}</p>}
+        </div>
+        {typeof evidence?.confidence === 'number' && (
+          <span className="text-xs font-medium text-gray-600 bg-white border border-gray-200 rounded-md px-2 py-1">
+            {Math.round(evidence.confidence * 100)}%
+          </span>
+        )}
+      </div>
+
+      {status === 'loading' ? (
+        <p className="text-sm text-gray-500">Checking evidence metadata...</p>
+      ) : status === 'error' ? (
+        <p className="text-sm text-red-600">Evidence metadata could not be loaded.</p>
+      ) : (
+        <>
+          {evidence?.summary && (
+            <p className="text-sm text-gray-700 leading-relaxed mb-3">{evidence.summary}</p>
+          )}
+
+          {sources.length > 0 ? (
+            <div className="space-y-3">
+              {sources.map((source, index) => {
+                const checkedDate = formatEvidenceDate(source.lastCheckedAt);
+                const content = (
+                  <>
+                    <div className="min-w-0">
+                      <div className="text-sm font-medium text-gray-800 truncate">
+                        {source.displayLabel}
+                      </div>
+                      <div className="text-xs text-gray-500">
+                        {[
+                          source.sourceType,
+                          source.href ? getEvidenceHost(source.href) : '',
+                          checkedDate,
+                        ]
+                          .filter(Boolean)
+                          .join(' · ')}
+                      </div>
+                    </div>
+                    {source.href && (
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="14"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        className="flex-shrink-0 text-gray-400"
+                        aria-hidden="true"
+                      >
+                        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                        <polyline points="15 3 21 3 21 9" />
+                        <line x1="10" y1="14" x2="21" y2="3" />
+                      </svg>
+                    )}
+                  </>
+                );
+
+                return source.href ? (
+                  <a
+                    key={`${source.displayLabel}-${index}`}
+                    href={source.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-start justify-between gap-2 rounded-md bg-white border border-gray-200 px-3 py-2 hover:border-blue-200 hover:text-blue-700 transition-colors"
+                  >
+                    {content}
+                  </a>
+                ) : (
+                  <div
+                    key={`${source.displayLabel}-${index}`}
+                    className="flex items-start justify-between gap-2 rounded-md bg-white border border-gray-200 px-3 py-2"
+                  >
+                    {content}
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <p className="text-sm text-gray-500">No source metadata available yet.</p>
+          )}
+        </>
+      )}
+    </section>
+  );
+};
 
 const ListingDetailModal = ({
   isOpen,
@@ -480,6 +620,8 @@ const ListingDetailModal = ({
                     </div>
                   </div>
                 </section>
+
+                <EvidenceRail evidence={listing.evidence} />
               </div>
 
               <div className="col-span-1 md:col-span-2 space-y-6">

--- a/client/src/components/shared/__tests__/ListingDetailModal.public.test.tsx
+++ b/client/src/components/shared/__tests__/ListingDetailModal.public.test.tsx
@@ -36,7 +36,9 @@ const listing: Listing = {
   audited: false,
 };
 
-const renderModal = (options: { isAuthenticated?: boolean; onRequireAuth?: () => void } = {}) =>
+const renderModal = (
+  options: { isAuthenticated?: boolean; onRequireAuth?: () => void; listing?: Listing } = {},
+) =>
   render(
     <MemoryRouter>
       <UserContext.Provider
@@ -69,7 +71,7 @@ const renderModal = (options: { isAuthenticated?: boolean; onRequireAuth?: () =>
           <ListingDetailModal
             isOpen
             onClose={vi.fn()}
-            listing={listing}
+            listing={options.listing || listing}
             isFavorite={false}
             onToggleFavorite={vi.fn()}
             onRequireAuth={options.onRequireAuth}
@@ -96,5 +98,84 @@ describe('ListingDetailModal public discovery behavior', () => {
 
     expect(screen.queryByRole('link', { name: /@/ })).toBeNull();
     expect(screen.getByText(/contact details unavailable/i)).toBeTruthy();
+  });
+
+  it('shows an empty evidence state when public metadata is unavailable', () => {
+    renderModal();
+
+    expect(screen.getByText(/evidence/i)).toBeTruthy();
+    expect(screen.getByText(/no source metadata available yet/i)).toBeTruthy();
+  });
+
+  it('renders safe source links without showing raw private URL parts', () => {
+    renderModal({
+      listing: {
+        ...listing,
+        evidence: {
+          status: 'available',
+          summary: 'Matched from public profile and publication records.',
+          confidence: 0.92,
+          lastVerifiedAt: '2026-02-03T00:00:00.000Z',
+          sources: [
+            {
+              label: 'OpenAlex work',
+              url: 'https://example.edu/path?token=secret#private',
+              sourceType: 'Publication',
+              lastCheckedAt: '2026-02-01T00:00:00.000Z',
+            },
+            {
+              label: 'Unsafe script',
+              url: 'javascript:alert(1)',
+            },
+          ],
+        },
+      },
+    });
+
+    const link = screen.getByRole('link', { name: /openalex work/i });
+    expect(link.getAttribute('href')).toBe('https://example.edu/path');
+    expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+    expect(screen.getByText(/matched from public profile/i)).toBeTruthy();
+    expect(screen.getByText('92%')).toBeTruthy();
+    expect(screen.getByText(/example.edu/i)).toBeTruthy();
+    expect(screen.getByText(/unsafe script/i)).toBeTruthy();
+    expect(screen.queryByRole('link', { name: /unsafe script/i })).toBeNull();
+    expect(screen.queryByText(/token=secret/i)).toBeNull();
+  });
+
+  it('renders loading and error evidence states', () => {
+    const { rerender } = renderModal({
+      listing: {
+        ...listing,
+        evidence: { status: 'loading', sources: [] },
+      },
+    });
+
+    expect(screen.getByText(/checking evidence metadata/i)).toBeTruthy();
+
+    rerender(
+      <MemoryRouter>
+        <UserContext.Provider
+          value={{
+            isLoading: false,
+            isAuthenticated: false,
+            user: undefined,
+            checkContext: vi.fn(),
+          }}
+        >
+          <ConfigContext.Provider value={defaultConfigContext}>
+            <ListingDetailModal
+              isOpen
+              onClose={vi.fn()}
+              listing={{ ...listing, evidence: { status: 'error', sources: [] } }}
+              isFavorite={false}
+              onToggleFavorite={vi.fn()}
+            />
+          </ConfigContext.Provider>
+        </UserContext.Provider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText(/evidence metadata could not be loaded/i)).toBeTruthy();
   });
 });

--- a/client/src/pages/__tests__/home.publicResearch.test.tsx
+++ b/client/src/pages/__tests__/home.publicResearch.test.tsx
@@ -22,11 +22,14 @@ vi.mock('../../components/shared/BrowseGrid', () => ({
 }));
 
 vi.mock('../../components/shared/ListingDetailModal', () => ({
-  default: ({ isOpen, onNavigateToResearchArea }: any) =>
+  default: ({ isOpen, listing, onNavigateToResearchArea }: any) =>
     isOpen ? (
-      <button type="button" onClick={() => onNavigateToResearchArea('Artificial Intelligence')}>
-        Artificial Intelligence
-      </button>
+      <div>
+        {listing?.evidence?.summary && <span>{listing.evidence.summary}</span>}
+        <button type="button" onClick={() => onNavigateToResearchArea('Artificial Intelligence')}>
+          Artificial Intelligence
+        </button>
+      </div>
     ) : null,
 }));
 
@@ -121,6 +124,57 @@ describe('Home public research detail route', () => {
     expect(mockedAxiosGet).not.toHaveBeenCalledWith('/listings/507f1f77bcf86cd799439011', {
       withCredentials: true,
     });
+  });
+
+  it('preserves public evidence metadata from detail responses for the modal', async () => {
+    const slug = 'public-research-507f1f77bcf86cd799439011';
+
+    mockedAxiosGet.mockImplementation((url: string) => {
+      if (url === '/users/favListingsIds') {
+        return Promise.resolve({ data: { favListingsIds: [] } });
+      }
+
+      return Promise.resolve({
+        data: {
+          listing: {
+            _id: '507f1f77bcf86cd799439011',
+            title: 'Public research listing',
+            evidence: {
+              status: 'available',
+              summary: 'Matched from public source metadata.',
+              sources: [{ label: 'Faculty profile', url: 'https://example.edu/profile' }],
+            },
+          },
+        },
+      });
+    });
+
+    render(
+      <MemoryRouter initialEntries={[`/research/${slug}`]}>
+        <UserContext.Provider
+          value={{
+            isLoading: false,
+            isAuthenticated: false,
+            user: null,
+            checkContext: vi.fn(),
+          }}
+        >
+          <SearchContext.Provider
+            value={{
+              ...defaultSearchContext,
+              refreshListings: vi.fn(),
+              setQueryString: vi.fn(),
+            }}
+          >
+            <Routes>
+              <Route path="/research/:slug" element={<Home />} />
+            </Routes>
+          </SearchContext.Provider>
+        </UserContext.Provider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('Matched from public source metadata.')).toBeTruthy();
   });
 
   it('clears share URL slug when navigating to a research area from the modal', async () => {

--- a/client/src/providers/__tests__/SearchContextProvider.publicResearch.test.tsx
+++ b/client/src/providers/__tests__/SearchContextProvider.publicResearch.test.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import React, { useContext } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import SearchContext from '../../contexts/SearchContext';
 import UserContext from '../../contexts/UserContext';
 import axios from '../../utils/axios';
 import SearchContextProvider from '../SearchContextProvider';
@@ -26,6 +27,11 @@ vi.mock('sweetalert', () => ({
 }));
 
 const mockedAxiosGet = vi.mocked(axios.get);
+
+const EvidenceSummary = () => {
+  const { listings } = useContext(SearchContext);
+  return <div>{listings[0]?.evidence?.summary || ''}</div>;
+};
 
 describe('SearchContextProvider public research route', () => {
   beforeEach(() => {
@@ -60,5 +66,43 @@ describe('SearchContextProvider public research route', () => {
     expect(mockedAxiosGet).not.toHaveBeenCalledWith(
       '/listings/search?query=&page=1&pageSize=20&departmentsMode=union&academicDisciplinesMode=union&researchAreasMode=union',
     );
+  });
+
+  it('preserves evidence metadata from public search results', async () => {
+    mockedAxiosGet.mockResolvedValue({
+      data: {
+        results: [
+          {
+            _id: '507f1f77bcf86cd799439011',
+            title: 'Public research listing',
+            evidence: {
+              status: 'available',
+              summary: 'Matched from public search metadata.',
+              sources: [{ label: 'Publication', url: 'https://example.edu/work' }],
+            },
+          },
+        ],
+        totalCount: 1,
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/research']}>
+        <UserContext.Provider
+          value={{
+            isLoading: false,
+            isAuthenticated: false,
+            user: null,
+            checkContext: vi.fn(),
+          }}
+        >
+          <SearchContextProvider>
+            <EvidenceSummary />
+          </SearchContextProvider>
+        </UserContext.Provider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('Matched from public search metadata.')).toBeTruthy();
   });
 });

--- a/client/src/providers/__tests__/SearchContextProvider.publicResearch.test.tsx
+++ b/client/src/providers/__tests__/SearchContextProvider.publicResearch.test.tsx
@@ -1,6 +1,6 @@
-import React, { useContext } from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, useLocation, useNavigate } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import SearchContext from '../../contexts/SearchContext';
 import UserContext from '../../contexts/UserContext';
@@ -28,8 +28,103 @@ vi.mock('sweetalert', () => ({
 
 const mockedAxiosGet = vi.mocked(axios.get);
 
+const PublicResearchControls = () => {
+  const location = useLocation();
+  const {
+    queryString,
+    selectedDepartments,
+    selectedListingResearchAreas,
+    setQueryString,
+    setSelectedDepartments,
+    setSelectedListingResearchAreas,
+    setListingResearchAreasFilterMode,
+    setSortBy,
+    onToggleSortDirection,
+    setQuickFilter,
+  } = React.useContext(SearchContext);
+
+  return (
+    <div>
+      <div data-testid="query">{queryString}</div>
+      <div data-testid="departments">{selectedDepartments.join('|')}</div>
+      <div data-testid="research-areas">{selectedListingResearchAreas.join('|')}</div>
+      <div data-testid="search">{location.search}</div>
+      <button type="button" onClick={() => setQueryString('genomics')}>
+        query
+      </button>
+      <button type="button" onClick={() => setSelectedDepartments(['Computer Science'])}>
+        department
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          setSelectedListingResearchAreas(['AI', 'Genomics']);
+          setListingResearchAreasFilterMode('intersection');
+        }}
+      >
+        areas
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          setSortBy('updatedAt');
+          onToggleSortDirection();
+        }}
+      >
+        sort
+      </button>
+      <button type="button" onClick={() => setQuickFilter('open')}>
+        quick
+      </button>
+    </div>
+  );
+};
+
+const RefreshOnMount = () => {
+  const { refreshListings } = React.useContext(SearchContext);
+
+  React.useEffect(() => {
+    refreshListings();
+  }, [refreshListings]);
+
+  return null;
+};
+
+const NavigateToResearch = () => {
+  const navigate = useNavigate();
+
+  return (
+    <button
+      type="button"
+      onClick={() => navigate('/research?query=cell%20signaling&departments=Biology')}
+    >
+      research
+    </button>
+  );
+};
+
+const renderProvider = (
+  initialEntry: string,
+  isAuthenticated = true,
+  children: React.ReactNode = <PublicResearchControls />,
+) =>
+  render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <UserContext.Provider
+        value={{
+          isLoading: false,
+          isAuthenticated,
+          user: isAuthenticated ? ({ userType: 'student' } as any) : null,
+          checkContext: vi.fn(),
+        }}
+      >
+        <SearchContextProvider>{children}</SearchContextProvider>
+      </UserContext.Provider>
+    </MemoryRouter>,
+  );
+
 const EvidenceSummary = () => {
-  const { listings } = useContext(SearchContext);
+  const { listings } = React.useContext(SearchContext);
   return <div>{listings[0]?.evidence?.summary || ''}</div>;
 };
 
@@ -51,6 +146,87 @@ describe('SearchContextProvider public research route', () => {
     expect(mockedAxiosGet).not.toHaveBeenCalledWith(
       '/listings/search?query=&page=1&pageSize=20&departmentsMode=union&academicDisciplinesMode=union&researchAreasMode=union',
     );
+  });
+
+  it('restores shareable public research URLs before searching', async () => {
+    renderProvider(
+      '/research?query=cell%20signaling&departments=Computer%20Science%7C%7CBiology&researchAreas=Genomics,AI&researchAreasMode=intersection&sortBy=updatedAt&sortOrder=-1&quickFilter=open',
+      false,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('query').textContent).toBe('cell signaling');
+    });
+    expect(screen.getByTestId('departments').textContent).toBe('Computer Science|Biology');
+    expect(screen.getByTestId('research-areas').textContent).toBe('Genomics|AI');
+
+    await waitFor(() => {
+      expect(mockedAxiosGet).toHaveBeenCalledWith(
+        '/research?query=cell%20signaling&page=1&pageSize=20&sortBy=updatedAt&sortOrder=-1&departments=Computer%20Science%7C%7CBiology&researchAreas=Genomics%2CAI&departmentsMode=union&academicDisciplinesMode=union&researchAreasMode=intersection',
+      );
+    });
+  });
+
+  it('does not clobber an incoming research URL after entering from another route', async () => {
+    renderProvider(
+      '/listings',
+      true,
+      <>
+        <NavigateToResearch />
+        <PublicResearchControls />
+      </>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'research' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('query').textContent).toBe('cell signaling');
+    });
+    expect(screen.getByTestId('departments').textContent).toBe('Biology');
+    expect(screen.getByTestId('search').textContent).toBe(
+      '?query=cell%20signaling&departments=Biology',
+    );
+  });
+
+  it('does not refresh public research results before URL hydration', async () => {
+    renderProvider(
+      '/research?query=cell%20signaling&departments=Biology',
+      false,
+      <>
+        <RefreshOnMount />
+        <PublicResearchControls />
+      </>,
+    );
+
+    await waitFor(() => {
+      expect(mockedAxiosGet).toHaveBeenCalledWith(
+        '/research?query=cell%20signaling&page=1&pageSize=20&departments=Biology&departmentsMode=union&academicDisciplinesMode=union&researchAreasMode=union',
+      );
+    });
+
+    expect(mockedAxiosGet).not.toHaveBeenCalledWith(
+      '/research?query=&page=1&pageSize=20&departmentsMode=union&academicDisciplinesMode=union&researchAreasMode=union',
+    );
+  });
+
+  it('mirrors public research search state into the URL', async () => {
+    renderProvider('/research', false);
+
+    await waitFor(() => {
+      expect(mockedAxiosGet).toHaveBeenCalled();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'query' }));
+    fireEvent.click(screen.getByRole('button', { name: 'department' }));
+    fireEvent.click(screen.getByRole('button', { name: 'areas' }));
+    fireEvent.click(screen.getByRole('button', { name: 'sort' }));
+    fireEvent.click(screen.getByRole('button', { name: 'quick' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('search').textContent).toBe(
+        '?query=genomics&departments=Computer+Science&researchAreas=AI%2CGenomics&researchAreasMode=intersection&sortBy=updatedAt&sortOrder=-1&quickFilter=open',
+      );
+    });
   });
 
   it('preserves evidence metadata from public search results', async () => {

--- a/client/src/types/types.tsx
+++ b/client/src/types/types.tsx
@@ -29,6 +29,24 @@ export type Listing = {
   createdAt: string;
   confirmed: boolean;
   audited: boolean;
+  evidence?: ListingEvidence;
+};
+
+export type ListingEvidenceSource = {
+  label?: string;
+  url?: string;
+  sourceType?: string;
+  description?: string;
+  lastCheckedAt?: string;
+};
+
+export type ListingEvidence = {
+  status?: 'available' | 'unavailable' | 'loading' | 'error' | string;
+  summary?: string;
+  confidence?: number;
+  generatedAt?: string;
+  lastVerifiedAt?: string;
+  sources?: ListingEvidenceSource[];
 };
 
 export type FellowshipLink = {

--- a/client/src/utils/apiCleaner.ts
+++ b/client/src/utils/apiCleaner.ts
@@ -33,5 +33,6 @@ export const createListing = (listing: any) => {
     updatedAt: listing.updatedAt || currentDate.toISOString(),
     createdAt: listing.createdAt || currentDate.toISOString(),
     confirmed: listing.confirmed === undefined ? true : listing.confirmed,
+    evidence: listing.evidence,
   };
 };

--- a/data-migration/MigrateToMeilisearch.ts
+++ b/data-migration/MigrateToMeilisearch.ts
@@ -44,6 +44,9 @@ async function migrateToMeilisearch() {
       delete meiliDoc._id;
       delete meiliDoc.__v;
       delete meiliDoc.embedding; // Ensure legacy vectors aren't pushed
+      if (meiliDoc.evidence && typeof meiliDoc.evidence === 'object') {
+        delete meiliDoc.evidence.internalNotes;
+      }
       return meiliDoc;
     });
 

--- a/data-migration/MigrateToMeilisearch.ts
+++ b/data-migration/MigrateToMeilisearch.ts
@@ -11,7 +11,7 @@ const MEILISEARCH_INDEX_PREFIX = process.env.MEILISEARCH_INDEX_PREFIX || '';
 
 async function migrateToMeilisearch() {
   const { Meilisearch } = await import('meilisearch');
-  
+
   const meiliClient = new Meilisearch({
     host: MEILISEARCH_HOST,
     apiKey: MEILISEARCH_API_KEY,
@@ -50,33 +50,32 @@ async function migrateToMeilisearch() {
       return meiliDoc;
     });
 
-    const indexName = MEILISEARCH_INDEX_PREFIX ? `${MEILISEARCH_INDEX_PREFIX}_listings` : 'listings';
+    const indexName = MEILISEARCH_INDEX_PREFIX
+      ? `${MEILISEARCH_INDEX_PREFIX}_listings`
+      : 'listings';
     console.log(`Configuring Meilisearch Index: ${indexName}...`);
     const index = meiliClient.index(indexName);
-    
+
     await index.updateFilterableAttributes([
       'departments',
       'researchAreas',
       'archived',
-      'confirmed'
-    ]);
-    
-    await index.updateSortableAttributes([
-      'createdAt',
-      'updatedAt',
-      'searchScore'
+      'confirmed',
     ]);
 
+    await index.updateSortableAttributes(['createdAt', 'updatedAt', 'searchScore']);
+
     if (process.env.OPENAI_API_KEY) {
-        console.log('Configuring OpenAI Embedder native Meilisearch support...');
-        await index.updateEmbedders({
-            default: {
-                source: 'openAi',
-                apiKey: process.env.OPENAI_API_KEY,
-                model: 'text-embedding-3-small',
-                documentTemplate: "Title: {{doc.title}}\nProfessors: {{doc.professorNames}}\nDescription: {{doc.description}}\nKeywords: {{doc.keywords}}",
-            }
-        });
+      console.log('Configuring OpenAI Embedder native Meilisearch support...');
+      await index.updateEmbedders({
+        default: {
+          source: 'openAi',
+          apiKey: process.env.OPENAI_API_KEY,
+          model: 'text-embedding-3-small',
+          documentTemplate:
+            'Title: {{doc.title}}\nProfessors: {{doc.professorNames}}\nDescription: {{doc.description}}\nKeywords: {{doc.keywords}}',
+        },
+      });
     }
 
     console.log('Pushing to Meilisearch...');
@@ -99,7 +98,7 @@ async function migrateToMeilisearch() {
   }
 }
 
-migrateToMeilisearch().catch(err => {
+migrateToMeilisearch().catch((err) => {
   console.error('Fatal error:', err);
   process.exit(1);
 });

--- a/data-migration/README.md
+++ b/data-migration/README.md
@@ -6,3 +6,6 @@ Yale Labs has been collecting data over a somewhat long period of time. For this
 
 The purpose of data migration is to give a way for us to easily migrate data to new models updating or deleting old listings.
 
+### Meilisearch Listing Migration
+
+`MigrateToMeilisearch.ts` reads listings from `MONGODBURL`, configures the listings index, and pushes searchable documents into Meilisearch. Before indexing, it removes legacy vectors and private evidence notes (`embedding`, `_id`, `__v`, and `evidence.internalNotes`) so the search index only receives public-safe evidence/source metadata.

--- a/data-migration/README.md
+++ b/data-migration/README.md
@@ -1,6 +1,7 @@
 ### Purpose of Data Migration
 
 Yale Labs has been collecting data over a somewhat long period of time. For this reason we have data from 2017 that is:
+
 - Either out of date
 - Not good enough
 

--- a/server/src/controllers/listingController.search.test.ts
+++ b/server/src/controllers/listingController.search.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from 'node:test';
 import {
   buildPublicResearchSearchInputs,
   getPublicResearchSortBy,
+  redactPublicListing,
   searchListingsWithDegradation,
 } from './listingController';
 
@@ -110,5 +111,79 @@ void describe('public research search inputs', () => {
     assert.equal(getPublicResearchSortBy('ownerLastName'), undefined);
     assert.equal(getPublicResearchSortBy('ownerEmail'), undefined);
     assert.equal(getPublicResearchSortBy('views'), undefined);
+  });
+});
+
+void describe('public listing redaction', () => {
+  void it('returns sanitized public evidence without private listing fields or raw source URLs', () => {
+    const redacted = redactPublicListing({
+      _id: { toString: () => '507f1f77bcf86cd799439011' },
+      title: 'Evidence-backed lab',
+      ownerEmail: 'private@yale.edu',
+      emails: ['private-list@yale.edu'],
+      ownerId: 'private-netid',
+      professorIds: ['private-prof'],
+      views: 42,
+      favorites: 9,
+      archived: false,
+      confirmed: true,
+      audited: true,
+      evidence: {
+        status: 'available',
+        summary: 'Matched from faculty profile and publication records.',
+        confidence: 0.83,
+        generatedAt: '2026-01-02T00:00:00.000Z',
+        lastVerifiedAt: '2026-02-03T00:00:00.000Z',
+        internalNotes: 'Do not expose this analyst note.',
+        apiKey: 'secret',
+        sources: [
+          {
+            label: 'OpenAlex work',
+            url: 'https://user:pass@example.edu/path?token=secret#private',
+            sourceType: 'publication',
+            description: 'Public publication metadata',
+            lastCheckedAt: '2026-02-01T00:00:00.000Z',
+          },
+          {
+            label: 'Unsafe script',
+            url: 'javascript:alert(1)',
+          },
+        ],
+      },
+    });
+
+    assert.equal(redacted.ownerEmail, undefined);
+    assert.deepEqual(redacted.emails, []);
+    assert.equal(redacted.ownerId, undefined);
+    assert.deepEqual(redacted.professorIds, []);
+    assert.equal(redacted.views, 0);
+    assert.equal(redacted.favorites, 0);
+    assert.equal(redacted.archived, false);
+    assert.equal(redacted.confirmed, true);
+    assert.equal(redacted.audited, undefined);
+    assert.equal(redacted.evidence.internalNotes, undefined);
+    assert.equal(redacted.evidence.apiKey, undefined);
+    assert.equal(redacted.evidence.status, 'available');
+    assert.equal(
+      redacted.evidence.summary,
+      'Matched from faculty profile and publication records.',
+    );
+    assert.equal(redacted.evidence.confidence, 0.83);
+    assert.equal(redacted.evidence.sources[0].url, 'https://example.edu/path');
+    assert.equal(redacted.evidence.sources[0].label, 'OpenAlex work');
+    assert.equal(redacted.evidence.sources[1].url, undefined);
+    assert.equal(redacted.evidence.sources[1].label, 'Unsafe script');
+  });
+
+  void it('normalizes missing evidence to an empty public rail payload', () => {
+    const redacted = redactPublicListing({
+      _id: '507f1f77bcf86cd799439011',
+      title: 'Lab without evidence',
+    });
+
+    assert.deepEqual(redacted.evidence, {
+      status: 'unavailable',
+      sources: [],
+    });
   });
 });

--- a/server/src/controllers/listingController.ts
+++ b/server/src/controllers/listingController.ts
@@ -57,10 +57,89 @@ const getIdFromSlug = (slug: string): string | null => {
   return match ? match[0] : null;
 };
 
-const redactPublicListing = (listing: any) => {
+const PUBLIC_EVIDENCE_SOURCE_LIMIT = 8;
+
+const toOptionalString = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed === '' ? undefined : trimmed;
+};
+
+const toIsoString = (value: unknown): string | undefined => {
+  if (!value) return undefined;
+  const date = value instanceof Date ? value : new Date(value as string);
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+};
+
+const sanitizePublicSourceUrl = (value: unknown): string | undefined => {
+  const raw = toOptionalString(value);
+  if (!raw) return undefined;
+  const withScheme = /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(raw) ? raw : `https://${raw}`;
+
+  try {
+    const parsed = new URL(withScheme);
+    if (!['http:', 'https:'].includes(parsed.protocol)) return undefined;
+    parsed.username = '';
+    parsed.password = '';
+    parsed.search = '';
+    parsed.hash = '';
+    return parsed.toString();
+  } catch {
+    return undefined;
+  }
+};
+
+export const sanitizePublicEvidence = (evidence: any) => {
+  if (!evidence || typeof evidence !== 'object') {
+    return {
+      status: 'unavailable',
+      sources: [],
+    };
+  }
+
+  const sources = Array.isArray(evidence.sources)
+    ? evidence.sources
+        .map((source: any) => {
+          const url = sanitizePublicSourceUrl(source?.url);
+          const label =
+            toOptionalString(source?.label) ||
+            toOptionalString(source?.title) ||
+            (url ? new URL(url).hostname.replace(/^www\./, '') : undefined);
+          if (!url && !label) return null;
+
+          return {
+            label,
+            url,
+            sourceType: toOptionalString(source?.sourceType),
+            description: toOptionalString(source?.description),
+            lastCheckedAt: toIsoString(source?.lastCheckedAt),
+          };
+        })
+        .filter(Boolean)
+        .slice(0, PUBLIC_EVIDENCE_SOURCE_LIMIT)
+    : [];
+
+  return {
+    status: toOptionalString(evidence.status) || (sources.length > 0 ? 'available' : 'unavailable'),
+    summary: toOptionalString(evidence.summary),
+    confidence:
+      typeof evidence.confidence === 'number' &&
+      Number.isFinite(evidence.confidence) &&
+      evidence.confidence >= 0 &&
+      evidence.confidence <= 1
+        ? evidence.confidence
+        : undefined,
+    generatedAt: toIsoString(evidence.generatedAt),
+    lastVerifiedAt: toIsoString(evidence.lastVerifiedAt),
+    sources,
+  };
+};
+
+export const redactPublicListing = (listing: any) => {
   const source = typeof listing?.toObject === 'function' ? listing.toObject() : listing;
   const redacted = { ...(source || {}) };
   const rawId = redacted._id?.toString?.() || redacted.id;
+  const evidence = sanitizePublicEvidence(redacted.evidence);
   delete redacted.__v;
   delete redacted.ownerEmail;
   delete redacted.emails;
@@ -82,6 +161,7 @@ const redactPublicListing = (listing: any) => {
     favorites: 0,
     archived: false,
     confirmed: true,
+    evidence,
   };
 };
 
@@ -653,7 +733,12 @@ export const getAuthenticatedPublicResearchBySlug = async (
     return response.status(404).json({ error: 'Research listing not found' });
   }
 
-  return response.status(200).json({ listing });
+  return response.status(200).json({
+    listing: {
+      ...listing,
+      evidence: sanitizePublicEvidence((listing as any).evidence),
+    },
+  });
 };
 
 export const createListingForCurrentUser = async (request: Request, response: Response) => {

--- a/server/src/controllers/listingController.ts
+++ b/server/src/controllers/listingController.ts
@@ -59,6 +59,53 @@ const getIdFromSlug = (slug: string): string | null => {
   return match ? match[0] : null;
 };
 
+const PUBLIC_RESEARCH_OUTREACH_OUTCOMES = new Set(['emailed', 'will_contact_later', 'not_a_fit']);
+
+const PUBLIC_RESEARCH_OUTREACH_ACTIONS = new Set(['email_click', 'outcome']);
+
+export const buildPublicResearchOutreachEvent = (params: {
+  action?: unknown;
+  outcome?: unknown;
+  source?: unknown;
+  contactCount?: number;
+}) => {
+  const action = typeof params.action === 'string' ? params.action : '';
+  if (!PUBLIC_RESEARCH_OUTREACH_ACTIONS.has(action)) {
+    return null;
+  }
+
+  const source = typeof params.source === 'string' ? params.source.slice(0, 80) : 'research_detail';
+  const baseMetadata = {
+    channel: 'email',
+    source,
+    contactCount: params.contactCount || 0,
+  };
+
+  if (action === 'email_click') {
+    return {
+      eventType: AnalyticsEventType.OUTREACH_CONTACT_ATTEMPT,
+      metadata: {
+        ...baseMetadata,
+        action,
+      },
+    };
+  }
+
+  const outcome = typeof params.outcome === 'string' ? params.outcome : '';
+  if (!PUBLIC_RESEARCH_OUTREACH_OUTCOMES.has(outcome)) {
+    return null;
+  }
+
+  return {
+    eventType: AnalyticsEventType.OUTREACH_OUTCOME,
+    metadata: {
+      ...baseMetadata,
+      action,
+      outcome,
+    },
+  };
+};
+
 const PUBLIC_EVIDENCE_SOURCE_LIMIT = 8;
 
 const toOptionalString = (value: unknown): string | undefined => {

--- a/server/src/models/listing.ts
+++ b/server/src/models/listing.ts
@@ -3,6 +3,32 @@
  */
 import mongoose from 'mongoose';
 
+const evidenceSourceSchema = new mongoose.Schema(
+  {
+    label: {
+      type: String,
+      required: false,
+    },
+    url: {
+      type: String,
+      required: false,
+    },
+    sourceType: {
+      type: String,
+      required: false,
+    },
+    description: {
+      type: String,
+      required: false,
+    },
+    lastCheckedAt: {
+      type: Date,
+      required: false,
+    },
+  },
+  { _id: false },
+);
+
 const listingSchema = new mongoose.Schema(
   {
     ownerId: {
@@ -97,6 +123,37 @@ const listingSchema = new mongoose.Schema(
     audited: {
       type: Boolean,
       default: false,
+    },
+    evidence: {
+      status: {
+        type: String,
+        required: false,
+      },
+      summary: {
+        type: String,
+        required: false,
+      },
+      confidence: {
+        type: Number,
+        required: false,
+      },
+      generatedAt: {
+        type: Date,
+        required: false,
+      },
+      lastVerifiedAt: {
+        type: Date,
+        required: false,
+      },
+      sources: {
+        type: [evidenceSourceSchema],
+        default: [],
+      },
+      internalNotes: {
+        type: String,
+        required: false,
+        select: false,
+      },
     },
     embedding: {
       type: [Number],

--- a/server/src/services/listingService.ts
+++ b/server/src/services/listingService.ts
@@ -10,6 +10,17 @@ import { getListingModel } from '../db/connections';
 import { processListingTitle, isCustomTitle, generateSmartTitle } from '../utils/smartTitle';
 import * as itemOps from './itemOperations';
 
+const prepareListingForMeili = (doc: any) => {
+  const meiliDoc = { ...doc, id: doc._id.toString() };
+  delete meiliDoc._id;
+  delete meiliDoc.__v;
+  delete meiliDoc.embedding;
+  if (meiliDoc.evidence && typeof meiliDoc.evidence === 'object') {
+    delete meiliDoc.evidence.internalNotes;
+  }
+  return meiliDoc;
+};
+
 export const createListing = async (data: any, owner: any) => {
   if (!owner.netid || !owner.email || !owner.fname || !owner.lname) {
     throw new Error('Incomplete user data for owner');
@@ -74,9 +85,7 @@ export const createListing = async (data: any, owner: any) => {
 
   try {
     const doc = listing.toObject();
-    const meiliDoc = { ...doc, id: doc._id.toString() };
-    delete meiliDoc._id;
-    delete meiliDoc.__v;
+    const meiliDoc = prepareListingForMeili(doc);
     const index = await getMeiliIndex('listings');
     await index.addDocuments([meiliDoc]);
   } catch (error) {
@@ -227,9 +236,7 @@ export const updateListing = async (
 
     try {
       const doc = listing.toObject();
-      const meiliDoc = { ...doc, id: doc._id.toString() };
-      delete meiliDoc._id;
-      delete meiliDoc.__v;
+      const meiliDoc = prepareListingForMeili(doc);
       const index = await getMeiliIndex('listings');
       await index.updateDocuments([meiliDoc]);
     } catch (error) {


### PR DESCRIPTION
## Intent

Implement fix.md item 8: add an evidence/source rail to research listing/detail surfaces so users can inspect why an entity appears and what sources support displayed claims. The implementation must safely render evidence metadata and external source links, handle empty/loading/error states, and preserve public-safe redaction boundaries.

## What Changed

- Added evidence metadata to listings, public research responses, and Meilisearch migration/indexing while preserving public redaction boundaries for internal notes and unsafe source URLs.
- Updated research listing detail modals to render an evidence/source rail with confidence, verification state, timestamps, empty states, and sanitized external source links.
- Preserved evidence through client listing normalization and added focused coverage for public research search/detail flows and listing search evidence handling.

## Risk Assessment

✅ Low: The changes are well-bounded to carrying sanitized listing evidence through search/detail responses and rendering it in the existing modal, with focused server/client coverage added and no substantiated merge-blocking risks found.

## Testing

Inspected the target diff, ran focused client public research/detail tests and the server search/redaction test suite successfully, attempted browser screenshot capture but the environment has no Chrome binary, then generated rendered HTML and JSON evidence artifacts from the actual modal and server redaction code; temporary harness files were removed and the worktree was left clean.

<details>
<summary>Evidence: Rendered evidence rail HTML from actual React modal</summary>

```text
<!doctype html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <title>Rendered Evidence Rail</title>
  </head>
  <body>
    <div><div class="fixed inset-0 bg-black/60 z-[1200] flex items-center justify-center overflow-y-auto p-4 pt-20"><div class="bg-white rounded-xl shadow-2xl w-full max-w-4xl h-[85vh] flex flex-col overflow-hidden"><div class="flex-shrink-0 border-b border-gray-100"><div class="h-1 w-full" style="background: linear-gradient(90deg, #0055A4 0%, #3b82f6 50%, #93c5fd 100%);"></div><div class="px-6 py-5"><div class="flex items-start justify-between gap-4"><div class="flex-1 min-w-0"><div class="flex flex-wrap items-center gap-2 mb-2"><span class="text-sm font-semibold text-blue-700">COMP</span><span class="text-xs px-2 py-0.5 rounded-full bg-blue-50 text-blue-600 font-medium">YC — Yale College</span><span class="text-xs px-2 py-0.5 rounded-full font-medium bg-green-50 text-green-700">Accepting Applications</span></div><h2 class="text-xl font-bold text-gray-900 leading-tight">Ada Lovelace</h2><p class="text-sm text-gray-500 mt-0.5">Professor</p><p class="text-base text-gray-600 mt-0.5">Computing lab</p></div><div class="flex items-center gap-1 flex-shrink-0"><a href="https://example.edu/lab" target="_blank" rel="noopener noreferrer" class="p-2 rounded-lg hover:bg-gray-100 transition-colors text-gray-500 hover:text-blue-600" title="Visit website"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg></a><a class="p-2 rounded-lg hover:bg-gray-100 transition-colors text-gray-500 hover:text-blue-600" title="Sign in to inquire"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"></rect><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"></path></svg></a><span class="px-1"><button class="p-1 rounded-full transition-colors text-gray-300 hover:text-blue-600" aria-label="Add to favorites"><svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"></path></svg></button></span><button class="p-2 rounded-lg hover:bg-gray-100 transition-colors text-gray-400 hover:text-gray-600" aria-label="Close"><svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg></button></div></div></div></div><div class="flex-1 overflow-y-auto"><div class="p-6"><div class="grid grid-cols-1 md:grid-cols-3 gap-8"><div class="col-span-1 space-y-6"><section><h3 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Investigators</h3><div class="space-y-2.5"><div class="flex items-center gap-2.5"><div class="w-8 h-8 rounded-full bg-gradient-to-br from-blue-100 to-blue-200 flex items-center justify-center text-blue-700 font-semibold text-sm flex-shrink-0">A</div><span class="text-sm text-gray-800 font-medium">Ada Lovelace</span></div></div></section><section><h3 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Research Areas</h3><div class="flex flex-wrap gap-1.5"><span class="bg-blue-50 text-blue-700 text-xs rounded-md px-2 py-1">Algorithms</span></div></section><section><h3 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Departments</h3><div class="flex flex-wrap gap-1.5"><span class="bg-gray-100 text-gray-700 text-xs rounded-md px-2 py-1">Computer Science</span></div></section><section><h3 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Contact</h3><div class="space-y-2"><button type="button" class="flex items-center gap-2 text-sm text-blue-600 hover:text-blue-800 hover:underline"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="flex-shrink-0"><rect x="2" y="4" width="20" height="16" rx="2"></rect><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"></path></svg><span>Sign in to inquire</span></button><a href="https://example.edu/lab" target="_blank" rel="noopener noreferrer" class="flex items-center gap-2 text-sm text-blue-600 hover:text-blue-800 hover:underline"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="flex-shrink-0"><circle cx="12" cy="12" r="10"></circle><line x1="2" y1="12" x2="22" y2="12"></line><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path></svg><span class="truncate">https://example.edu/lab</span></a></div></section><section><h3 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Details</h3><div class="space-y-1.5 text-sm"><div class="flex justify-between"><span class="text-gray-500">Added</span><span class="font-medium text-gray-800">12/31/2025</span></div></div></section><section class="border border-gray-200 rounded-lg p-4 bg-gray-50/60"><div class="flex items-start justify-between gap-3 mb-3"><div><h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Evidence</h3><p class="text-xs text-gray-400 mt-1">Verified 2/2/2026</p></div><span class="text-xs font-medium text-gray-600 bg-white border border-gray-200 rounded-md px-2 py-1">92%</span></div><p class="text-sm text-gray-700 leading-relaxed mb-3">Matched from public profile and publication records.</p><div class="space-y-3"><a href="https://example.edu/path" target="_blank" rel="noopener noreferrer" class="flex items-start justify-between gap-2 rounded-md bg-white border border-gray-200 px-3 py-2 hover:border-blue-200 hover:text-blue-700 transition-colors"><div class="min-w-0"><div class="text-sm font-medium text-gray-800 truncate">OpenAlex work</div><div class="text-xs text-gray-500">Publication · example.edu · 1/31/2026</div></div><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="flex-shrink-0 text-gray-400" aria-hidden="true"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg></a><div class="flex items-start justify-between gap-2 rounded-md bg-white border border-gray-200 px-3 py-2"><div class="min-w-0"><div class="text-sm font-medium text-gray-800 truncate">Unsafe script</div><div class="text-xs text-gray-500"></div></div></div></div></section></div><div class="col-span-1 md:col-span-2 space-y-6"><section><h3 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Research Description</h3><div class="text-sm text-gray-700 leading-relaxed whitespace-pre-wrap">Research description for the public discovery detail modal. This copy verifies that the evidence rail appears alongside the listing content without exposing contact details.</div></section></div></div></div></div></div></div></div>
  </body>
</html>
```
</details>
<details>
<summary>Evidence: Public redacted evidence response from server redaction function</summary>

```text
{
  "_id": "507f1f77bcf86cd799439011",
  "title": "Evidence-backed lab",
  "professorIds": [],
  "evidence": {
    "status": "available",
    "summary": "Matched from faculty profile and publication records.",
    "confidence": 0.83,
    "generatedAt": "2026-01-02T00:00:00.000Z",
    "lastVerifiedAt": "2026-02-03T00:00:00.000Z",
    "sources": [
      {
        "label": "OpenAlex work",
        "url": "https://example.edu/path",
        "sourceType": "publication",
        "description": "Public publication metadata",
        "lastCheckedAt": "2026-02-01T00:00:00.000Z"
      },
      {
        "label": "Unsafe script"
      }
    ]
  },
  "id": "507f1f77bcf86cd799439011",
  "emails": [],
  "views": 0,
  "favorites": 0,
  "archived": false,
  "confirmed": true
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `client/src/utils/apiCleaner.ts:10` - The API normalizer used by the search/detail flows does not copy `listing.evidence`, so API responses with evidence are converted into client listings without that field before reaching `ListingDetailModal`; the new rail will show the empty state for real research listings even when the server returns sources. Add `evidence: listing.evidence` to this mapper and cover the public detail/search path that calls `createListing`.

🔧 Fix: Preserve listing evidence through client normalization
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat 8542a7a9d5312dd04b11dc2d55e4401513a57397..c9813d79a3c6dfa3fbe1513c17e2c933f405c2c0` and `git diff --name-only 8542a7a9d5312dd04b11dc2d55e4401513a57397..c9813d79a3c6dfa3fbe1513c17e2c933f405c2c0`</code>
- `yarn --cwd client test:ci src/components/shared/__tests__/ListingDetailModal.public.test.tsx src/pages/__tests__/home.publicResearch.test.tsx src/providers/__tests__/SearchContextProvider.publicResearch.test.tsx`
- <code>`yarn --cwd server test src/controllers/listingController.search.test.ts` (confirmed this is not the right entry point because the server test script excludes that file)</code>
- `yarn --cwd server test:search-degrade`
- <code>`yarn --cwd client dev --host 127.0.0.1 --port 5176` with a temporary harness for browser evidence</code>
- <code>`chrome-devtools-axi resize 1440 1000 &amp;&amp; chrome-devtools-axi open &#39;http://127.0.0.1:5176/evidence-rail-harness.html?state=available&#39; &amp;&amp; chrome-devtools-axi wait 1000 &amp;&amp; chrome-devtools-axi screenshot /tmp/no-mistakes-evidence/01KWSV0RWG9PFAS705MS5A4QSR/evidence-rail-available.png` (attempted screenshot; no Chrome binary was installed, so no screenshot file was produced)</code>
- <code>`yarn --cwd client test:ci src/__evidence__/renderEvidenceRailHtml.test.tsx` using a temporary evidence-only test to render the real modal HTML to `/tmp/no-mistakes-evidence/01KWSV0RWG9PFAS705MS5A4QSR/evidence-rail-rendered.html`</code>
- <code>`yarn --cwd server node --import tsx -e &#34;...redactPublicListing(...)...&#34;` to write `/tmp/no-mistakes-evidence/01KWSV0RWG9PFAS705MS5A4QSR/public-redacted-evidence-response.json`</code>
- `rg -n "token=secret|javascript:alert|private@yale|apiKey|internalNotes" /tmp/no-mistakes-evidence/01KWSV0RWG9PFAS705MS5A4QSR || true`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
