### PR TITLE
feat: add public research share metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ ylabs/
 │       ├── providers/        # Context providers with data fetching logic
 │       ├── hooks/            # Custom hooks (useConfig, useInfiniteScroll, useViewTracking)
 │       ├── types/            # TypeScript interfaces (Listing, Fellowship, FacultyProfile, User)
-│       └── utils/            # Helpers: axios instance, MUI theme, department names, research areas
+│       └── utils/            # Helpers: axios instance, MUI theme, department names, research areas, SEO metadata
 ├── server/                   # Express backend (port 4000)
 │   └── src/
 │       ├── index.ts          # Server startup entry point
@@ -51,7 +51,7 @@ ylabs/
 │       ├── models/           # Mongoose schemas (user, listing, fellowship, analytics, department, researchArea)
 │       ├── middleware/        # Auth guards, validation, error handling
 │       ├── db/               # Multi-mode database connections
-│       ├── utils/            # smartTitle, errors, permissions (legacy), environment, meiliClient
+│       ├── utils/            # smartTitle, errors, permissions (legacy), environment, meiliClient, public research SEO
 │       └── scripts/          # One-off import/cleanup scripts
 └── data-migration/           # Standalone migration scripts (run with ts-node --transpile-only)
 ```
@@ -102,6 +102,8 @@ Current authenticated listing search flow:
 5. Results are returned with `totalCount` for pagination and a `degraded` boolean indicating whether fallback behavior was used
 
 Public research discovery uses the same degradation path through `/api/research`, but only returns confirmed, unarchived listings after redacting contact/private fields (`ownerEmail`, `emails`, owner/professor IDs, views, favorites, archived/confirmed/audit internals). Public responses keep sanitized `evidence` metadata for the listing detail evidence rail, limited to status/summary/confidence/timestamps and up to eight source records; source URLs are restricted to `http`/`https` and stripped of credentials, query strings, and fragments. Client routes `/research` and `/research/:slug` render the browse page without `PrivateRoute`; opening a card updates the URL to a shareable modal route. Authenticated users on those public routes additionally call `/api/research/:slug/contact` to retrieve the full listing with contact fields, while evidence remains sanitized through the public evidence allowlist. Public research search uses a contact-redacted searchable field set and only accepts `createdAt` or `updatedAt` sort fields.
+
+Public research share URLs expose SEO/social metadata. The built client shell has a generic metadata block in `client/index.html` bounded by `YL_SEO_META_START`/`YL_SEO_META_END`; production Express routes for `/research` and `/research/:slug` in `server/src/app.ts` replace that block with canonical, description, Open Graph, and Twitter card metadata from `server/src/utils/publicResearchSeo.ts`. Listing-specific metadata is derived only after loading a confirmed, unarchived listing and passing it through `redactPublicListing()`. `client/src/utils/seo.ts` mirrors the same head updates after SPA load for Vite development or static-only hosting and restores default YaleLabs metadata when users leave public research routes.
 
 The authenticated Find Labs page distinguishes an empty local/unfiltered dataset from an empty search result: no unfiltered listings shows "No research labs are available right now" with a `/fellowships` action, while active searches or filters show "No labs match your current search or filters."
 
@@ -181,7 +183,7 @@ Client-side tests run under **Vitest 3** with a `jsdom` environment. Config live
 
 Coverage focuses on pure reducer modules in `client/src/reducers/`, with matching test files in `client/src/reducers/__tests__/`. The pattern extracts state transitions out of providers/components (as `createInitial<Name>State()` + `<name>Reducer(state, action)`) so they can be tested without mounting React or mocking network. Side effects (axios, localStorage, timers) stay in the component that uses `useReducer`.
 
-Focused component accessibility tests cover research discovery/listing behavior outside the reducer pattern: `client/src/components/shared/__tests__/BrowseGrid.a11y.test.tsx` verifies keyboard-openable browse cards/list rows and separate favorite controls, `client/src/components/shared/__tests__/ListingDetailModal.public.test.tsx` covers public listing dialog naming, Escape close behavior, focus trapping/restoration, and redacted contact actions, and `client/src/components/accounts/ListingForm/FormFields/__tests__/ResearchAreaInput.a11y.test.tsx` covers listing-form research-area field selector dialog focus behavior.
+Focused component accessibility tests cover research discovery/listing behavior outside the reducer pattern: `client/src/components/shared/__tests__/BrowseGrid.a11y.test.tsx` verifies keyboard-openable browse cards/list rows and separate favorite controls, `client/src/components/shared/__tests__/ListingDetailModal.public.test.tsx` covers public listing dialog naming, Escape close behavior, focus trapping/restoration, and redacted contact actions, and `client/src/components/accounts/ListingForm/FormFields/__tests__/ResearchAreaInput.a11y.test.tsx` covers listing-form research-area field selector dialog focus behavior. Public research SEO coverage lives in `client/src/utils/__tests__/seo.test.ts`, `client/src/pages/__tests__/home.publicResearch.test.tsx`, and `server/src/utils/__tests__/publicResearchSeo.test.ts`.
 
 Current reducers with test coverage (all in `client/src/reducers/`, tests in `client/src/reducers/__tests__/`):
 
@@ -276,6 +278,8 @@ All routes mount under `/api` in `app.ts`. Route files in `server/src/routes/`:
 
 Passport auth routes (CAS login/logout, dev-login) are mounted separately via `passportRoutes` before the main routes.
 
+Public HTML routes `/research` and `/research/:slug` are mounted separately in `server/src/app.ts` after static assets so shared research URLs can receive crawler-visible SEO metadata before the SPA hydrates.
+
 ## Authentication Flow
 
 ```
@@ -343,7 +347,7 @@ User → Yale CAS SSO → passport.ts findOrCreateUser
 
 | Issue                                    | Location                          | Status                                                                                                                                                                                                                          |
 | ---------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| No general server-side test suite        | `server/`                         | Focused Vitest coverage exists for error handling/tracking and a focused Node test covers listing-search degradation; broader server coverage is not wired into CI. Client uses Vitest; reducer modules in `client/src/reducers/` and focused research/listing accessibility flows are covered. |
+| No general server-side test suite        | `server/`                         | Focused Vitest coverage exists for error handling/tracking, public research SEO, and a focused Node test covers listing-search degradation; broader server coverage is not wired into CI. Client uses Vitest; reducer modules in `client/src/reducers/` and focused research/listing accessibility flows are covered. |
 | ESLint/Prettier configured but not in CI | `eslint.config.js`, `.prettierrc` | Flat-config ESLint + Prettier set up at repo root. Currently reports ~15 errors / ~55 warnings across the codebase; not wired to CI until pre-existing violations are triaged. Run `yarn lint`, `yarn lint:fix`, `yarn format`. |
 | Console-only logging                     | Server                            | No structured logging (Winston/Pino)                                                                                                                                                                                            |
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -178,7 +178,7 @@ ylabs/
 │       ├── providers/        # Context providers with data fetching
 │       ├── hooks/            # Custom hooks
 │       ├── types/            # TypeScript interfaces
-│       └── utils/            # Helpers, axios instance, MUI theme, error tracking
+│       └── utils/            # Helpers, axios instance, MUI theme, error tracking, SEO metadata
 ├── server/                   # Express backend (port 4000)
 │   └── src/
 │       ├── index.ts          # Server entry point
@@ -190,7 +190,7 @@ ylabs/
 │       ├── models/           # Mongoose schemas
 │       ├── middleware/        # Auth guards, validation, error handling
 │       ├── db/               # Database connections
-│       └── utils/            # smartTitle, errors, environment, meiliClient, error tracking
+│       └── utils/            # smartTitle, errors, environment, meiliClient, error tracking, public research SEO
 └── data-migration/           # Standalone migration scripts
 ```
 
@@ -215,6 +215,13 @@ Logged-out visitors use the public research discovery path instead:
 - Public responses include only confirmed, unarchived listings and redact contact/private fields such as owner email, additional emails, owner/professor IDs, view counts, favorites, and audit fields. They retain sanitized evidence metadata so the detail modal can show why a listing appears and which public sources support it.
 - Authenticated users opening a public detail modal also request `/api/research/:slug/contact` to load the full listing, including contact fields. Evidence metadata on this response is still sanitized through the public evidence allowlist.
 - Public research search only allows `createdAt` and `updatedAt` sort fields and searches a contact-redacted field set.
+
+Public research share URLs also receive SEO/social metadata:
+
+- The built client shell contains a generic metadata block in `client/index.html` bounded by `YL_SEO_META_START` and `YL_SEO_META_END`.
+- In production-style server rendering, Express serves `/research` and `/research/:slug` outside `/api`, loads the built `index.html`, and replaces that block with canonical, description, Open Graph, and Twitter card metadata from `server/src/utils/publicResearchSeo.ts`.
+- Listing metadata is built only from the confirmed, unarchived listing after `redactPublicListing()` has removed private fields. If a listing cannot be loaded, the server falls back to generic YaleLabs Research metadata.
+- During Vite development or static-only hosting, `client/src/utils/seo.ts` applies the same metadata after React loads and restores the default site metadata when leaving public research routes.
 
 Listing detail modals render an evidence rail for listings, including an empty state when source metadata is unavailable. The public evidence payload supports `status`, `summary`, `confidence`, `generatedAt`, `lastVerifiedAt`, and up to eight sources with `label`, `url`, `sourceType`, `description`, and `lastCheckedAt`. Loading and error states are handled in the same rail. Public source URLs are limited to `http`/`https`; credentials, query strings, and fragments are removed before they are returned by the API or rendered by the client.
 
@@ -287,6 +294,8 @@ All mount under `/api`.
 | `/admin`          | Admin operations                                             | Admin                                            |
 | `/seed`           | Dev seeding routes                                           | Dev mode only                                    |
 
+The public HTML routes `/research` and `/research/:slug` are mounted separately in `server/src/app.ts` after static assets so shared research URLs can receive crawler-visible metadata before the SPA hydrates.
+
 ---
 
 ## Testing
@@ -305,13 +314,15 @@ yarn test                 # focused middleware and utility coverage
 yarn test:search-degrade  # listing-search fallback coverage
 ```
 
-Client tests are discovered from `client/src/**/*.{test,spec}.{ts,tsx}`. Server Vitest coverage currently includes error handling and error tracking utilities.
+Client tests are discovered from `client/src/**/*.{test,spec}.{ts,tsx}`. Server Vitest coverage currently includes error handling, error tracking, and public research SEO utilities.
 
 ### What is tested
 
 Pure reducer modules under [client/src/reducers/](client/src/reducers/) have unit-test coverage in [client/src/reducers/**tests**/](client/src/reducers/__tests__/). Each reducer file has a matching `*.test.ts`. The reducers back the auth, search, fellowship-search, config, listing-form, and account-tracking (kanban/notes) flows — extracting state transitions from providers/components into pure functions makes them testable without mounting React or mocking network.
 
 Focused component accessibility coverage also exists for the research discovery/listing flows: [BrowseGrid.a11y.test.tsx](client/src/components/shared/__tests__/BrowseGrid.a11y.test.tsx) verifies keyboard-openable browse cards/list rows and separate favorite controls, [ListingDetailModal.public.test.tsx](client/src/components/shared/__tests__/ListingDetailModal.public.test.tsx) covers the public listing dialog name, Escape close behavior, focus trapping/restoration, and redacted contact actions, and [ResearchAreaInput.a11y.test.tsx](client/src/components/accounts/ListingForm/FormFields/__tests__/ResearchAreaInput.a11y.test.tsx) covers the listing-form research-area field selector dialog focus behavior.
+
+Public research SEO coverage lives in [client/src/utils/__tests__/seo.test.ts](client/src/utils/__tests__/seo.test.ts), [client/src/pages/__tests__/home.publicResearch.test.tsx](client/src/pages/__tests__/home.publicResearch.test.tsx), and [server/src/utils/__tests__/publicResearchSeo.test.ts](server/src/utils/__tests__/publicResearchSeo.test.ts). These tests cover public-safe metadata construction, client head updates/restoration, and server injection into the built SPA shell.
 
 When adding a new reducer:
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ yarn dev:client
 yarn dev:server
 ```
 
-Go to **http://localhost:3000**. Public research discovery is available at **http://localhost:3000/research** with shareable URLs for search text, filters, sorting, quick filters, and detail modals; the authenticated Find Labs page may show an empty state locally until the Development database has listings, and it links to fellowships when fellowship data is available. Use `http://localhost:4000/api/dev-login` to bypass CAS auth locally for authenticated actions.
+Go to **http://localhost:3000**. Public research discovery is available at **http://localhost:3000/research** with shareable URLs for search text, filters, sorting, quick filters, detail modals, and SEO/social metadata; the authenticated Find Labs page may show an empty state locally until the Development database has listings, and it links to fellowships when fellowship data is available. Use `http://localhost:4000/api/dev-login` to bypass CAS auth locally for authenticated actions.
 
 ## Documentation
 

--- a/client/README.md
+++ b/client/README.md
@@ -2,6 +2,8 @@
 
 React 19 + TypeScript client built with Vite. The app talks to the Express API configured by `VITE_APP_SERVER`.
 
+Public research routes update the document title, canonical URL, description, Open Graph tags, and Twitter card tags from public-safe listing fields after the SPA loads. The production Express server also injects crawler-visible metadata into the built `index.html` for `/research` and `/research/:slug`; the client updater is the Vite/static-host fallback.
+
 ## Environment
 
 Create `client/.env` for local development:

--- a/client/index.html
+++ b/client/index.html
@@ -4,11 +4,22 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Find research labs at Yale University"
-    />
+    <meta name="theme-color" content="#00356b" />
+    <!-- YLabs SEO metadata is replaced server-side for public research share URLs. -->
+    <!--YL_SEO_META_START-->
+    <meta name="description" content="Discover confirmed Yale research labs and opportunities by topic, department, and faculty mentor." />
+    <link rel="canonical" href="/" />
+    <meta property="og:site_name" content="YaleLabs" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="YaleLabs Research" />
+    <meta property="og:description" content="Discover confirmed Yale research labs and opportunities by topic, department, and faculty mentor." />
+    <meta property="og:url" content="/" />
+    <meta property="og:image" content="/logo192.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="YaleLabs Research" />
+    <meta name="twitter:description" content="Discover confirmed Yale research labs and opportunities by topic, department, and faculty mentor." />
+    <meta name="twitter:image" content="/logo192.png" />
+    <!--YL_SEO_META_END-->
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
     <title>YaleLabs</title>

--- a/client/index.html
+++ b/client/index.html
@@ -7,17 +7,17 @@
     <meta name="theme-color" content="#00356b" />
     <!-- YLabs SEO metadata is replaced server-side for public research share URLs. -->
     <!--YL_SEO_META_START-->
-    <meta name="description" content="Discover confirmed Yale research labs and opportunities by topic, department, and faculty mentor." />
+    <meta name="description" content="Find research labs at Yale University" />
     <link rel="canonical" href="/" />
     <meta property="og:site_name" content="YaleLabs" />
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="YaleLabs Research" />
-    <meta property="og:description" content="Discover confirmed Yale research labs and opportunities by topic, department, and faculty mentor." />
+    <meta property="og:title" content="YaleLabs" />
+    <meta property="og:description" content="Find research labs at Yale University" />
     <meta property="og:url" content="/" />
     <meta property="og:image" content="/logo192.png" />
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:title" content="YaleLabs Research" />
-    <meta name="twitter:description" content="Discover confirmed Yale research labs and opportunities by topic, department, and faculty mentor." />
+    <meta name="twitter:title" content="YaleLabs" />
+    <meta name="twitter:description" content="Find research labs at Yale University" />
     <meta name="twitter:image" content="/logo192.png" />
     <!--YL_SEO_META_END-->
     <link rel="apple-touch-icon" href="/logo192.png" />

--- a/client/index.html
+++ b/client/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -21,7 +21,10 @@
     <meta name="twitter:image" content="/logo192.png" />
     <!--YL_SEO_META_END-->
     <link rel="apple-touch-icon" href="/logo192.png" />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
     <title>YaleLabs</title>
   </head>
   <body>
@@ -30,7 +33,9 @@
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-3SQLGT56ZM"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
+      function gtag() {
+        dataLayer.push(arguments);
+      }
       gtag('js', new Date());
 
       gtag('config', 'G-3SQLGT56ZM');

--- a/client/src/pages/__tests__/home.publicResearch.test.tsx
+++ b/client/src/pages/__tests__/home.publicResearch.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { Link, MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi, beforeEach } from 'vitest';
 import SearchContext, { defaultSearchContext } from '../../contexts/SearchContext';
 import UserContext from '../../contexts/UserContext';
@@ -58,6 +58,8 @@ const LocationDisplay = () => {
 describe('Home public research detail route', () => {
   afterEach(() => {
     cleanup();
+    document.title = '';
+    document.head.innerHTML = '';
   });
 
   beforeEach(() => {
@@ -301,6 +303,59 @@ describe('Home public research detail route', () => {
     await waitFor(() => {
       expect(screen.getByTestId('location').textContent).toBe(
         '/research/public-research-507f1f77bcf86cd799439011?query=genomics',
+      );
+    });
+  });
+
+  it('restores default metadata when navigating away from public research routes', async () => {
+    render(
+      <MemoryRouter initialEntries={['/research']}>
+        <UserContext.Provider
+          value={{
+            isLoading: false,
+            isAuthenticated: false,
+            user: null,
+            checkContext: vi.fn(),
+          }}
+        >
+          <SearchContext.Provider
+            value={{
+              ...defaultSearchContext,
+              refreshListings: vi.fn(),
+              setQueryString: vi.fn(),
+            }}
+          >
+            <Routes>
+              <Route
+                path="/research"
+                element={
+                  <>
+                    <Link to="/fellowships">Fellowships</Link>
+                    <Home />
+                  </>
+                }
+              />
+              <Route path="/fellowships" element={<LocationDisplay />} />
+            </Routes>
+          </SearchContext.Provider>
+        </UserContext.Provider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(document.title).toBe('YaleLabs Research');
+    });
+
+    fireEvent.click(screen.getByRole('link', { name: 'Fellowships' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location').textContent).toBe('/fellowships');
+      expect(document.title).toBe('YaleLabs');
+      expect(document.querySelector('meta[property="og:title"]')?.getAttribute('content')).toBe(
+        'YaleLabs',
+      );
+      expect(document.querySelector('meta[name="twitter:title"]')?.getAttribute('content')).toBe(
+        'YaleLabs',
       );
     });
   });

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -16,6 +16,7 @@ import { createListing } from '../utils/apiCleaner';
 import swal from 'sweetalert';
 import { getInstitutionAffiliation } from '../utils/institutionAffiliation';
 import { browsePageReducer, createInitialBrowsePageState } from '../reducers/browsePageReducer';
+import { applySeoMetadata, buildResearchSeoMetadata } from '../utils/seo';
 
 type ListingSearchCriteria = {
   queryString: string;
@@ -197,6 +198,18 @@ const Home = () => {
   };
   const emptyMessage = getListingEmptyMessage(listingSearchCriteria);
   const showFellowshipsEmptyAction = !hasListingSearchCriteria(listingSearchCriteria);
+
+  useEffect(() => {
+    if (!isResearchRoute) return;
+
+    applySeoMetadata(
+      buildResearchSeoMetadata({
+        origin: window.location.origin,
+        pathname: location.pathname,
+        listing: selectedListing,
+      }),
+    );
+  }, [isResearchRoute, location.pathname, selectedListing]);
 
   const updateFavorite = (listingId: string, favorite: boolean) => {
     if (!isAuthenticated) {

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -16,7 +16,7 @@ import { createListing } from '../utils/apiCleaner';
 import swal from 'sweetalert';
 import { getInstitutionAffiliation } from '../utils/institutionAffiliation';
 import { browsePageReducer, createInitialBrowsePageState } from '../reducers/browsePageReducer';
-import { applySeoMetadata, buildResearchSeoMetadata } from '../utils/seo';
+import { applySeoMetadata, buildDefaultSeoMetadata, buildResearchSeoMetadata } from '../utils/seo';
 
 type ListingSearchCriteria = {
   queryString: string;
@@ -200,7 +200,15 @@ const Home = () => {
   const showFellowshipsEmptyAction = !hasListingSearchCriteria(listingSearchCriteria);
 
   useEffect(() => {
-    if (!isResearchRoute) return;
+    if (!isResearchRoute) {
+      applySeoMetadata(
+        buildDefaultSeoMetadata({
+          origin: window.location.origin,
+          pathname: location.pathname,
+        }),
+      );
+      return;
+    }
 
     applySeoMetadata(
       buildResearchSeoMetadata({
@@ -210,6 +218,17 @@ const Home = () => {
       }),
     );
   }, [isResearchRoute, location.pathname, selectedListing]);
+
+  useEffect(() => {
+    return () => {
+      applySeoMetadata(
+        buildDefaultSeoMetadata({
+          origin: window.location.origin,
+          pathname: window.location.pathname,
+        }),
+      );
+    };
+  }, []);
 
   const updateFavorite = (listingId: string, favorite: boolean) => {
     if (!isAuthenticated) {

--- a/client/src/utils/__tests__/seo.test.ts
+++ b/client/src/utils/__tests__/seo.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { applySeoMetadata, buildResearchSeoMetadata } from '../seo';
+import { applySeoMetadata, buildDefaultSeoMetadata, buildResearchSeoMetadata } from '../seo';
 
 describe('research SEO client fallback', () => {
   afterEach(() => {
@@ -49,6 +49,40 @@ describe('research SEO client fallback', () => {
     );
     expect(document.querySelector('meta[name="twitter:card"]')?.getAttribute('content')).toBe(
       'summary',
+    );
+  });
+
+  it('restores default YaleLabs metadata after research metadata has been applied', () => {
+    applySeoMetadata(
+      buildResearchSeoMetadata({
+        origin: 'https://yalelabs.io',
+        pathname: '/research/evidence-backed-lab-507f1f77bcf86cd799439011',
+        listing: {
+          title: 'Evidence-backed lab',
+          description: 'Study immune signaling in public datasets.',
+        } as any,
+      }),
+    );
+
+    applySeoMetadata(
+      buildDefaultSeoMetadata({
+        origin: 'https://yalelabs.io',
+        pathname: '/fellowships',
+      }),
+    );
+
+    expect(document.title).toBe('YaleLabs');
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://yalelabs.io/fellowships',
+    );
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'Find research labs at Yale University',
+    );
+    expect(document.querySelector('meta[property="og:title"]')?.getAttribute('content')).toBe(
+      'YaleLabs',
+    );
+    expect(document.querySelector('meta[name="twitter:title"]')?.getAttribute('content')).toBe(
+      'YaleLabs',
     );
   });
 });

--- a/client/src/utils/__tests__/seo.test.ts
+++ b/client/src/utils/__tests__/seo.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
 import { applySeoMetadata, buildDefaultSeoMetadata, buildResearchSeoMetadata } from '../seo';
 
 describe('research SEO client fallback', () => {
@@ -83,6 +84,21 @@ describe('research SEO client fallback', () => {
     );
     expect(document.querySelector('meta[name="twitter:title"]')?.getAttribute('content')).toBe(
       'YaleLabs',
+    );
+  });
+
+  it('keeps the static SPA shell metadata generic for non-research routes', () => {
+    const html = readFileSync('index.html', 'utf8');
+
+    expect(html).toContain('<title>YaleLabs</title>');
+    expect(html).toContain('<meta name="description" content="Find research labs at Yale University" />');
+    expect(html).toContain('<meta property="og:title" content="YaleLabs" />');
+    expect(html).toContain(
+      '<meta property="og:description" content="Find research labs at Yale University" />',
+    );
+    expect(html).toContain('<meta name="twitter:title" content="YaleLabs" />');
+    expect(html).toContain(
+      '<meta name="twitter:description" content="Find research labs at Yale University" />',
     );
   });
 });

--- a/client/src/utils/__tests__/seo.test.ts
+++ b/client/src/utils/__tests__/seo.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { applySeoMetadata, buildResearchSeoMetadata } from '../seo';
+
+describe('research SEO client fallback', () => {
+  afterEach(() => {
+    document.title = '';
+    document.head.innerHTML = '';
+  });
+
+  it('builds useful listing metadata without exposing private contact fields', () => {
+    const metadata = buildResearchSeoMetadata({
+      origin: 'https://yalelabs.io',
+      pathname: '/research/evidence-backed-lab-507f1f77bcf86cd799439011',
+      listing: {
+        title: 'Evidence-backed lab',
+        description: 'Study immune signaling in public datasets.',
+        ownerFirstName: 'Ada',
+        ownerLastName: 'Lovelace',
+        ownerPrimaryDepartment: 'Computer Science',
+        researchAreas: ['Computational Biology'],
+        ownerEmail: 'private@yale.edu',
+        emails: ['private-list@yale.edu'],
+      } as any,
+    });
+
+    expect(metadata.title).toBe('Evidence-backed lab | YaleLabs');
+    expect(metadata.description).toBe('Study immune signaling in public datasets.');
+    expect(JSON.stringify(metadata)).not.toContain('private@yale.edu');
+    expect(JSON.stringify(metadata)).not.toContain('private-list@yale.edu');
+  });
+
+  it('updates canonical and social tags after React loads when server injection is unavailable', () => {
+    const metadata = buildResearchSeoMetadata({
+      origin: 'https://yalelabs.io',
+      pathname: '/research',
+    });
+
+    applySeoMetadata(metadata);
+
+    expect(document.title).toBe('YaleLabs Research');
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://yalelabs.io/research',
+    );
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'Discover confirmed Yale research labs and opportunities by topic, department, and faculty mentor.',
+    );
+    expect(document.querySelector('meta[property="og:title"]')?.getAttribute('content')).toBe(
+      'YaleLabs Research',
+    );
+    expect(document.querySelector('meta[name="twitter:card"]')?.getAttribute('content')).toBe(
+      'summary',
+    );
+  });
+});

--- a/client/src/utils/__tests__/seo.test.ts
+++ b/client/src/utils/__tests__/seo.test.ts
@@ -91,7 +91,9 @@ describe('research SEO client fallback', () => {
     const html = readFileSync('index.html', 'utf8');
 
     expect(html).toContain('<title>YaleLabs</title>');
-    expect(html).toContain('<meta name="description" content="Find research labs at Yale University" />');
+    expect(html).toContain(
+      '<meta name="description" content="Find research labs at Yale University" />',
+    );
     expect(html).toContain('<meta property="og:title" content="YaleLabs" />');
     expect(html).toContain(
       '<meta property="og:description" content="Find research labs at Yale University" />',

--- a/client/src/utils/seo.ts
+++ b/client/src/utils/seo.ts
@@ -1,0 +1,147 @@
+/**
+ * Client-side SEO fallback for the SPA.
+ *
+ * Express injects crawler-visible metadata for built public research routes.
+ * During Vite development or static-only hosting, this updater provides the
+ * strongest practical fallback after React loads.
+ */
+import { Listing } from '../types/types';
+
+export type SeoMetadata = {
+  title: string;
+  description: string;
+  canonicalUrl: string;
+  imageUrl: string;
+  type: 'website' | 'article';
+};
+
+const SITE_NAME = 'YaleLabs';
+const DEFAULT_RESEARCH_TITLE = 'YaleLabs Research';
+const DEFAULT_RESEARCH_DESCRIPTION =
+  'Discover confirmed Yale research labs and opportunities by topic, department, and faculty mentor.';
+
+const compact = (value: string): string => value.replace(/\s+/g, ' ').trim();
+
+const stripHtml = (value: string): string => compact(value.replace(/<[^>]*>/g, ' '));
+
+const truncate = (value: string, maxLength: number): string => {
+  const clean = compact(value);
+  if (clean.length <= maxLength) return clean;
+  const truncated = clean.slice(0, maxLength - 1).trimEnd();
+  const lastSpace = truncated.lastIndexOf(' ');
+  return `${(lastSpace > 80 ? truncated.slice(0, lastSpace) : truncated).trimEnd()}...`;
+};
+
+const firstNonEmpty = (...values: Array<string | undefined>): string | undefined =>
+  values.map((value) => (value ? stripHtml(value) : '')).find(Boolean);
+
+const joinList = (values: unknown): string | undefined => {
+  if (!Array.isArray(values)) return undefined;
+  const clean = values.filter((value): value is string => typeof value === 'string').map(compact);
+  return clean.filter(Boolean).slice(0, 3).join(', ') || undefined;
+};
+
+const professorName = (listing: Partial<Listing>): string | undefined => {
+  const name = compact(`${listing.ownerFirstName || ''} ${listing.ownerLastName || ''}`);
+  return name || undefined;
+};
+
+export const buildResearchSeoMetadata = (params: {
+  origin: string;
+  pathname: string;
+  listing?: Partial<Listing> | null;
+}): SeoMetadata => {
+  const origin = params.origin.replace(/\/+$/, '');
+  const canonicalUrl = `${origin}${params.pathname.startsWith('/') ? params.pathname : `/${params.pathname}`}`;
+  const imageUrl = `${origin}/logo192.png`;
+
+  if (!params.listing) {
+    return {
+      title: DEFAULT_RESEARCH_TITLE,
+      description: DEFAULT_RESEARCH_DESCRIPTION,
+      canonicalUrl,
+      imageUrl,
+      type: 'website',
+    };
+  }
+
+  const listing = params.listing;
+  const owner = professorName(listing);
+  const title = truncate(`${listing.title || 'Research listing'} | ${SITE_NAME}`, 65);
+  const topicalContext =
+    joinList(listing.researchAreas) || joinList(listing.keywords) || joinList(listing.departments);
+  const attribution = [owner, listing.ownerPrimaryDepartment || joinList(listing.departments)]
+    .filter(Boolean)
+    .join(', ');
+  const fallbackDescription = compact(
+    [
+      listing.title || 'Yale research listing',
+      attribution ? `with ${attribution}` : undefined,
+      topicalContext ? `Research areas include ${topicalContext}.` : undefined,
+    ]
+      .filter(Boolean)
+      .join(' '),
+  );
+
+  return {
+    title,
+    description: truncate(
+      firstNonEmpty(listing.description, listing.applicantDescription, fallbackDescription) ||
+        DEFAULT_RESEARCH_DESCRIPTION,
+      160,
+    ),
+    canonicalUrl,
+    imageUrl,
+    type: 'article',
+  };
+};
+
+const upsertMeta = (selector: string, attrs: Record<string, string>) => {
+  let element = document.head.querySelector<HTMLMetaElement>(selector);
+  if (!element) {
+    element = document.createElement('meta');
+    document.head.appendChild(element);
+  }
+
+  Object.entries(attrs).forEach(([name, value]) => {
+    element!.setAttribute(name, value);
+  });
+};
+
+const upsertCanonical = (href: string) => {
+  let element = document.head.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+  if (!element) {
+    element = document.createElement('link');
+    element.setAttribute('rel', 'canonical');
+    document.head.appendChild(element);
+  }
+  element.setAttribute('href', href);
+};
+
+export const applySeoMetadata = (metadata: SeoMetadata) => {
+  document.title = metadata.title;
+  upsertCanonical(metadata.canonicalUrl);
+  upsertMeta('meta[name="description"]', {
+    name: 'description',
+    content: metadata.description,
+  });
+  upsertMeta('meta[property="og:site_name"]', {
+    property: 'og:site_name',
+    content: SITE_NAME,
+  });
+  upsertMeta('meta[property="og:type"]', { property: 'og:type', content: metadata.type });
+  upsertMeta('meta[property="og:title"]', { property: 'og:title', content: metadata.title });
+  upsertMeta('meta[property="og:description"]', {
+    property: 'og:description',
+    content: metadata.description,
+  });
+  upsertMeta('meta[property="og:url"]', { property: 'og:url', content: metadata.canonicalUrl });
+  upsertMeta('meta[property="og:image"]', { property: 'og:image', content: metadata.imageUrl });
+  upsertMeta('meta[name="twitter:card"]', { name: 'twitter:card', content: 'summary' });
+  upsertMeta('meta[name="twitter:title"]', { name: 'twitter:title', content: metadata.title });
+  upsertMeta('meta[name="twitter:description"]', {
+    name: 'twitter:description',
+    content: metadata.description,
+  });
+  upsertMeta('meta[name="twitter:image"]', { name: 'twitter:image', content: metadata.imageUrl });
+};

--- a/client/src/utils/seo.ts
+++ b/client/src/utils/seo.ts
@@ -16,6 +16,8 @@ export type SeoMetadata = {
 };
 
 const SITE_NAME = 'YaleLabs';
+const DEFAULT_SITE_TITLE = 'YaleLabs';
+const DEFAULT_SITE_DESCRIPTION = 'Find research labs at Yale University';
 const DEFAULT_RESEARCH_TITLE = 'YaleLabs Research';
 const DEFAULT_RESEARCH_DESCRIPTION =
   'Discover confirmed Yale research labs and opportunities by topic, department, and faculty mentor.';
@@ -93,6 +95,22 @@ export const buildResearchSeoMetadata = (params: {
     canonicalUrl,
     imageUrl,
     type: 'article',
+  };
+};
+
+export const buildDefaultSeoMetadata = (params: {
+  origin: string;
+  pathname: string;
+}): SeoMetadata => {
+  const origin = params.origin.replace(/\/+$/, '');
+  const canonicalUrl = `${origin}${params.pathname.startsWith('/') ? params.pathname : `/${params.pathname}`}`;
+
+  return {
+    title: DEFAULT_SITE_TITLE,
+    description: DEFAULT_SITE_DESCRIPTION,
+    canonicalUrl,
+    imageUrl: `${origin}/logo192.png`,
+    type: 'website',
   };
 };
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -10,11 +10,19 @@ import passport, { passportRoutes } from './passport';
 import routes from './routes/index';
 import cookieSession from 'cookie-session';
 import dotenv from 'dotenv';
+import { readFile } from 'fs/promises';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 import { errorHandler, notFoundHandler } from './middleware/errorHandler';
 import { securityHeaders } from './middleware/securityHeaders';
 import { sanitizeMongo } from './middleware/sanitizeMongo';
+import { getListingModel } from './db/connections';
+import { redactPublicListing } from './controllers/listingController';
+import {
+  buildPublicResearchSeoMetadata,
+  injectSeoMetadata,
+  resolvePublicBaseUrl,
+} from './utils/publicResearchSeo';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -136,10 +144,54 @@ const app = express()
 
 app.use('/api', notFoundHandler);
 
-app.use(express.static(path.join(__dirname, '../../client/dist')));
+const clientDistPath = path.join(__dirname, '../../client/dist');
+const clientIndexPath = path.join(clientDistPath, 'index.html');
+
+const getIdFromResearchSlug = (slug?: string): string | null => {
+  const match = slug?.match(/[a-fA-F0-9]{24}/);
+  return match ? match[0] : null;
+};
+
+const sendPublicResearchIndex = async (
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction,
+) => {
+  try {
+    const indexHtml = await readFile(clientIndexPath, 'utf8');
+    let listing = null;
+    const id = getIdFromResearchSlug(req.params.slug);
+
+    if (id) {
+      try {
+        const publicListing = await getListingModel()
+          .findOne({ _id: id, archived: false, confirmed: true })
+          .lean();
+        listing = publicListing ? redactPublicListing(publicListing) : null;
+      } catch (error) {
+        console.error('Unable to load public research SEO metadata:', error);
+      }
+    }
+
+    const metadata = buildPublicResearchSeoMetadata({
+      baseUrl: resolvePublicBaseUrl(req),
+      path: req.path,
+      listing,
+    });
+
+    res.type('html').send(injectSeoMetadata(indexHtml, metadata));
+  } catch (error) {
+    next(error);
+  }
+};
+
+app.use(express.static(clientDistPath));
+
+app.get('/research', sendPublicResearchIndex);
+app.get('/research/:slug', sendPublicResearchIndex);
 
 app.get('*', (req, res) => {
-  res.sendFile(path.join(__dirname, '../../client/dist/index.html'));
+  res.sendFile(clientIndexPath);
 });
 
 app.use(errorHandler);

--- a/server/src/utils/__tests__/publicResearchSeo.test.ts
+++ b/server/src/utils/__tests__/publicResearchSeo.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildPublicResearchSeoMetadata,
+  injectSeoMetadata,
+  renderSeoTags,
+} from '../publicResearchSeo';
+
+describe('public research SEO metadata', () => {
+  it('builds share metadata from public-safe listing fields only', () => {
+    const metadata = buildPublicResearchSeoMetadata({
+      baseUrl: 'https://yalelabs.io/',
+      path: '/research/evidence-backed-lab-507f1f77bcf86cd799439011',
+      listing: {
+        title: 'Evidence-backed lab',
+        description: 'Study immune signaling in public datasets.',
+        ownerFirstName: 'Ada',
+        ownerLastName: 'Lovelace',
+        ownerPrimaryDepartment: 'Computer Science',
+        departments: ['Computer Science'],
+        researchAreas: ['Computational Biology'],
+        ownerEmail: 'private@yale.edu',
+        emails: ['private-list@yale.edu'],
+      } as any,
+    });
+    const tags = renderSeoTags(metadata);
+
+    expect(metadata.title).toBe('Evidence-backed lab | YaleLabs');
+    expect(metadata.description).toBe('Study immune signaling in public datasets.');
+    expect(metadata.canonicalUrl).toBe(
+      'https://yalelabs.io/research/evidence-backed-lab-507f1f77bcf86cd799439011',
+    );
+    expect(tags).toContain('property="og:title" content="Evidence-backed lab | YaleLabs"');
+    expect(tags).not.toContain('private@yale.edu');
+    expect(tags).not.toContain('private-list@yale.edu');
+  });
+
+  it('injects crawler-visible public research metadata into the SPA shell', () => {
+    const html = `<!doctype html><html><head><title>YaleLabs</title><!--YL_SEO_META_START--><meta name="description" content="old" /><!--YL_SEO_META_END--></head><body></body></html>`;
+    const metadata = buildPublicResearchSeoMetadata({
+      baseUrl: 'https://yalelabs.io',
+      path: '/research',
+    });
+
+    const injected = injectSeoMetadata(html, metadata);
+
+    expect(injected).toContain('<title>YaleLabs Research</title>');
+    expect(injected).toContain('rel="canonical" href="https://yalelabs.io/research"');
+    expect(injected).toContain('property="og:type" content="website"');
+    expect(injected).toContain('name="twitter:card" content="summary"');
+    expect(injected).not.toContain('content="old"');
+  });
+});

--- a/server/src/utils/publicResearchSeo.ts
+++ b/server/src/utils/publicResearchSeo.ts
@@ -145,7 +145,10 @@ export const renderSeoTags = (metadata: SeoMetadata): string => {
 };
 
 export const injectSeoMetadata = (html: string, metadata: SeoMetadata): string => {
-  const withTitle = html.replace(/<title>.*?<\/title>/i, `<title>${escapeHtml(metadata.title)}</title>`);
+  const withTitle = html.replace(
+    /<title>.*?<\/title>/i,
+    `<title>${escapeHtml(metadata.title)}</title>`,
+  );
   const startIndex = withTitle.indexOf(SEO_START);
   const endIndex = withTitle.indexOf(SEO_END);
 

--- a/server/src/utils/publicResearchSeo.ts
+++ b/server/src/utils/publicResearchSeo.ts
@@ -1,0 +1,167 @@
+/**
+ * SEO helpers for public research pages.
+ *
+ * The app is still a client-rendered SPA. These helpers let the production
+ * Express server replace the built index.html metadata for public research
+ * share URLs; Vite-only/static hosts fall back to the client head updater.
+ */
+
+export type PublicResearchSeoListing = {
+  id?: string;
+  title?: string;
+  description?: string;
+  applicantDescription?: string;
+  ownerFirstName?: string;
+  ownerLastName?: string;
+  ownerTitle?: string;
+  ownerPrimaryDepartment?: string;
+  departments?: string[];
+  researchAreas?: string[];
+  keywords?: string[];
+};
+
+export type SeoMetadata = {
+  title: string;
+  description: string;
+  canonicalUrl: string;
+  imageUrl: string;
+  type: 'website' | 'article';
+};
+
+const SITE_NAME = 'YaleLabs';
+const DEFAULT_RESEARCH_TITLE = 'YaleLabs Research';
+const DEFAULT_RESEARCH_DESCRIPTION =
+  'Discover confirmed Yale research labs and opportunities by topic, department, and faculty mentor.';
+const SEO_START = '<!--YL_SEO_META_START-->';
+const SEO_END = '<!--YL_SEO_META_END-->';
+
+const compact = (value: string): string => value.replace(/\s+/g, ' ').trim();
+
+const stripHtml = (value: string): string => compact(value.replace(/<[^>]*>/g, ' '));
+
+const truncate = (value: string, maxLength: number): string => {
+  const clean = compact(value);
+  if (clean.length <= maxLength) return clean;
+  const truncated = clean.slice(0, maxLength - 1).trimEnd();
+  const lastSpace = truncated.lastIndexOf(' ');
+  return `${(lastSpace > 80 ? truncated.slice(0, lastSpace) : truncated).trimEnd()}...`;
+};
+
+const firstNonEmpty = (...values: Array<string | undefined>): string | undefined =>
+  values.map((value) => (value ? stripHtml(value) : '')).find(Boolean);
+
+const joinList = (values: unknown): string | undefined => {
+  if (!Array.isArray(values)) return undefined;
+  const clean = values.filter((value): value is string => typeof value === 'string').map(compact);
+  return clean.filter(Boolean).slice(0, 3).join(', ') || undefined;
+};
+
+const professorName = (listing: PublicResearchSeoListing): string | undefined => {
+  const name = compact(`${listing.ownerFirstName || ''} ${listing.ownerLastName || ''}`);
+  return name || undefined;
+};
+
+export const buildPublicResearchSeoMetadata = (params: {
+  baseUrl: string;
+  path: string;
+  listing?: PublicResearchSeoListing | null;
+}): SeoMetadata => {
+  const baseUrl = params.baseUrl.replace(/\/+$/, '');
+  const path = params.path.startsWith('/') ? params.path : `/${params.path}`;
+  const canonicalUrl = `${baseUrl}${path}`;
+  const imageUrl = `${baseUrl}/logo192.png`;
+
+  if (!params.listing) {
+    return {
+      title: DEFAULT_RESEARCH_TITLE,
+      description: DEFAULT_RESEARCH_DESCRIPTION,
+      canonicalUrl,
+      imageUrl,
+      type: 'website',
+    };
+  }
+
+  const listing = params.listing;
+  const owner = professorName(listing);
+  const title = truncate(`${listing.title || 'Research listing'} | ${SITE_NAME}`, 65);
+  const topicalContext =
+    joinList(listing.researchAreas) || joinList(listing.keywords) || joinList(listing.departments);
+  const attribution = [owner, listing.ownerPrimaryDepartment || joinList(listing.departments)]
+    .filter(Boolean)
+    .join(', ');
+  const fallbackDescription = compact(
+    [
+      listing.title || 'Yale research listing',
+      attribution ? `with ${attribution}` : undefined,
+      topicalContext ? `Research areas include ${topicalContext}.` : undefined,
+    ]
+      .filter(Boolean)
+      .join(' '),
+  );
+
+  return {
+    title,
+    description: truncate(
+      firstNonEmpty(listing.description, listing.applicantDescription, fallbackDescription) ||
+        DEFAULT_RESEARCH_DESCRIPTION,
+      160,
+    ),
+    canonicalUrl,
+    imageUrl,
+    type: 'article',
+  };
+};
+
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+export const renderSeoTags = (metadata: SeoMetadata): string => {
+  const title = escapeHtml(metadata.title);
+  const description = escapeHtml(metadata.description);
+  const canonicalUrl = escapeHtml(metadata.canonicalUrl);
+  const imageUrl = escapeHtml(metadata.imageUrl);
+
+  return [
+    SEO_START,
+    `<meta name="description" content="${description}" />`,
+    `<link rel="canonical" href="${canonicalUrl}" />`,
+    `<meta property="og:site_name" content="${SITE_NAME}" />`,
+    `<meta property="og:type" content="${metadata.type}" />`,
+    `<meta property="og:title" content="${title}" />`,
+    `<meta property="og:description" content="${description}" />`,
+    `<meta property="og:url" content="${canonicalUrl}" />`,
+    `<meta property="og:image" content="${imageUrl}" />`,
+    `<meta name="twitter:card" content="summary" />`,
+    `<meta name="twitter:title" content="${title}" />`,
+    `<meta name="twitter:description" content="${description}" />`,
+    `<meta name="twitter:image" content="${imageUrl}" />`,
+    SEO_END,
+  ].join('\n    ');
+};
+
+export const injectSeoMetadata = (html: string, metadata: SeoMetadata): string => {
+  const withTitle = html.replace(/<title>.*?<\/title>/i, `<title>${escapeHtml(metadata.title)}</title>`);
+  const startIndex = withTitle.indexOf(SEO_START);
+  const endIndex = withTitle.indexOf(SEO_END);
+
+  if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
+    return withTitle.replace('</head>', `    ${renderSeoTags(metadata)}\n  </head>`);
+  }
+
+  return `${withTitle.slice(0, startIndex)}${renderSeoTags(metadata)}${withTitle.slice(
+    endIndex + SEO_END.length,
+  )}`;
+};
+
+export const resolvePublicBaseUrl = (req: {
+  protocol: string;
+  get(name: string): string | undefined;
+}): string => {
+  const host = req.get('host') || 'localhost:4000';
+  return `${req.protocol}://${host}`;
+};


### PR DESCRIPTION
## Intent

Submit fix.md item 13 for PR: add SEO and share metadata for public research pages so public research URLs render meaningful title/description/social metadata while preserving existing public research behavior and providing server/client validation coverage.

## What Changed
- Added server-side SEO metadata injection for public research browse/detail routes, deriving listing-specific canonical, description, Open Graph, and Twitter metadata from redacted confirmed listings.
- Added client-side SEO head management for `/research` routes, including restoration of the default YaleLabs metadata when navigating away in the SPA.
- Updated public research SEO documentation and added focused client/server tests for metadata generation, route behavior, and default metadata restoration.

## Risk Assessment

✅ Low: The change is well-bounded to public research SEO metadata generation/injection and includes focused client/server coverage for the route and metadata lifecycle.

## Testing

Focused client tests verified SPA metadata fallback/reset and public research route behavior, focused server tests verified metadata construction/injection, and the generated HTML evidence shows the public detail URL renders meaningful title, description, canonical, Open Graph, and Twitter tags with `private_contact_leak=false`; no screenshot was captured because the changed surface is document head metadata rather than visible UI.

<details>
<summary>Evidence: Public research share metadata HTML</summary>

```text
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <link rel="icon" href="/favicon.ico" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <meta name="theme-color" content="#00356b" />
    <!-- YLabs SEO metadata is replaced server-side for public research share URLs. -->
    <!--YL_SEO_META_START-->
    <meta name="description" content="Study immune signaling in public datasets." />
    <link rel="canonical" href="https://yalelabs.io/research/evidence-backed-lab-507f1f77bcf86cd799439011" />
    <meta property="og:site_name" content="YaleLabs" />
    <meta property="og:type" content="article" />
    <meta property="og:title" content="Evidence-backed lab | YaleLabs" />
    <meta property="og:description" content="Study immune signaling in public datasets." />
    <meta property="og:url" content="https://yalelabs.io/research/evidence-backed-lab-507f1f77bcf86cd799439011" />
    <meta property="og:image" content="https://yalelabs.io/logo192.png" />
    <meta name="twitter:card" content="summary" />
    <meta name="twitter:title" content="Evidence-backed lab | YaleLabs" />
    <meta name="twitter:description" content="Study immune signaling in public datasets." />
    <meta name="twitter:image" content="https://yalelabs.io/logo192.png" />
    <!--YL_SEO_META_END-->
    <link rel="apple-touch-icon" href="/logo192.png" />
    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
    <title>Evidence-backed lab | YaleLabs</title>
  </head>
  <body>
    <div id="root"></div>
    <script type="module" src="/src/index.tsx"></script>
    <script async src="https://www.googletagmanager.com/gtag/js?id=G-3SQLGT56ZM"></script>
    <script>
      window.dataLayer = window.dataLayer || [];
      function gtag(){dataLayer.push(arguments);}
      gtag('js', new Date());

      gtag('config', 'G-3SQLGT56ZM');
    </script>
  </body>
</html>
```
</details>
<details>
<summary>Evidence: Injected head excerpt and private-field check</summary>

```text
<head>
    <meta charset="UTF-8" />
    <link rel="icon" href="/favicon.ico" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <meta name="theme-color" content="#00356b" />
    <!-- YLabs SEO metadata is replaced server-side for public research share URLs. -->
    <!--YL_SEO_META_START-->
    <meta name="description" content="Study immune signaling in public datasets." />
    <link rel="canonical" href="https://yalelabs.io/research/evidence-backed-lab-507f1f77bcf86cd799439011" />
    <meta property="og:site_name" content="YaleLabs" />
    <meta property="og:type" content="article" />
    <meta property="og:title" content="Evidence-backed lab | YaleLabs" />
    <meta property="og:description" content="Study immune signaling in public datasets." />
    <meta property="og:url" content="https://yalelabs.io/research/evidence-backed-lab-507f1f77bcf86cd799439011" />
    <meta property="og:image" content="https://yalelabs.io/logo192.png" />
    <meta name="twitter:card" content="summary" />
    <meta name="twitter:title" content="Evidence-backed lab | YaleLabs" />
    <meta name="twitter:description" content="Study immune signaling in public datasets." />
    <meta name="twitter:image" content="https://yalelabs.io/logo192.png" />
    <!--YL_SEO_META_END-->
    <link rel="apple-touch-icon" href="/logo192.png" />
    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
    <title>Evidence-backed lab | YaleLabs</title>
  </head>

private_contact_leak=false
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- ⚠️ `client/src/pages/home.tsx:203` - After `applySeoMetadata` runs on a public research page, navigating elsewhere in the SPA leaves the research/listing title and social metadata in `document.head` because this effect exits early for non-research routes and no other code restores the default head state. This regresses the existing always-`YaleLabs` tab title/metadata for pages visited after `/research`; restore default metadata when `isResearchRoute` becomes false or add a cleanup on unmount.

🔧 Fix: Restore default SEO metadata on navigation
1 warning still open:
- ⚠️ `client/index.html:14` - The built SPA shell now advertises `YaleLabs Research` in the default social metadata, but server injection only runs for `/research` URLs and most non-research routes do not run the new client cleanup. A direct request or share preview for `/`, `/fellowships`, `/login`, etc. will therefore expose research-specific OG/Twitter title and description instead of the default YaleLabs metadata. Keep `index.html` defaults generic and let the server/client research paths override them only for public research routes.

🔧 Fix: Restore generic SPA shell metadata
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `yarn --cwd client test:ci src/utils/__tests__/seo.test.ts src/pages/__tests__/home.publicResearch.test.tsx`
- <code>`yarn --cwd server install` to restore missing server workspace dependencies needed for tests</code>
- `yarn --cwd server test publicResearchSeo`
- <code>`node --import tsx --input-type=module - &lt;&lt;&#39;EOF&#39; ... EOF` (setup attempt failed because root workspace does not provide `tsx`)</code>
- <code>`./server/node_modules/.bin/tsx --input-type=module - &lt;&lt;&#39;EOF&#39; ... EOF` to generate `/tmp/no-mistakes-evidence/01KWT7K4KDTA49YA1E8VHAA69J/public-research-share-metadata.html` and head excerpt evidence</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
