### PR TITLE
Recover global HTTP status handling on beta

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -25,6 +25,7 @@ import SearchContextProvider from './providers/SearchContextProvider';
 import FellowshipSearchContextProvider from './providers/FellowshipSearchContextProvider';
 import UIContextProvider from './providers/UIContextProvider';
 import ScrollToTop from './components/shared/ScrollToTop';
+import HttpStatusNotifier from './components/HttpStatusNotifier';
 
 const RetiredListingsRedirect = () => <Navigate to="/research" replace />;
 const RetiredFellowshipsRedirect = () => <Navigate to="/programs" replace />;
@@ -42,6 +43,7 @@ const App = () => {
                   <Navbar />
                 </div>
                 <div className="flex-grow overflow-y-auto flex flex-col" data-scroll-container>
+                  <HttpStatusNotifier />
                   <main className="flex-grow">
                     <Routes>
                       <Route

--- a/client/src/components/HttpStatusNotifier.tsx
+++ b/client/src/components/HttpStatusNotifier.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+import {
+  HTTP_AUTH_REQUIRED_EVENT,
+  HTTP_RATE_LIMITED_EVENT,
+  type HttpRateLimitDetail,
+} from '../utils/httpStatusEvents';
+
+const HttpStatusNotifier = () => {
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    const onAuthRequired = () => {
+      setMessage('Your session needs a fresh login.');
+    };
+    const onRateLimited = (event: Event) => {
+      const detail = (event as CustomEvent<HttpRateLimitDetail>).detail;
+      const retry =
+        detail?.retryAfterSeconds && detail.retryAfterSeconds > 0
+          ? ` Try again in about ${detail.retryAfterSeconds} seconds.`
+          : '';
+      setMessage(`${detail?.message || 'Too many requests.'}${retry}`);
+    };
+
+    window.addEventListener(HTTP_AUTH_REQUIRED_EVENT, onAuthRequired);
+    window.addEventListener(HTTP_RATE_LIMITED_EVENT, onRateLimited);
+    return () => {
+      window.removeEventListener(HTTP_AUTH_REQUIRED_EVENT, onAuthRequired);
+      window.removeEventListener(HTTP_RATE_LIMITED_EVENT, onRateLimited);
+    };
+  }, []);
+
+  if (!message) return null;
+
+  return (
+    <div className="mx-auto mt-3 w-full max-w-5xl px-4">
+      <div
+        role="status"
+        className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
+      >
+        <span>{message}</span>
+        <button
+          type="button"
+          className="ml-3 font-semibold underline"
+          onClick={() => setMessage('')}
+        >
+          Dismiss
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default HttpStatusNotifier;

--- a/client/src/utils/axios.ts
+++ b/client/src/utils/axios.ts
@@ -3,8 +3,32 @@
  */
 import axios from 'axios';
 import { getApiBaseUrl } from './apiBaseUrl';
+import { dispatchAuthRequired, dispatchRateLimited } from './httpStatusEvents';
 
-export default axios.create({
+const client = axios.create({
   withCredentials: true,
   baseURL: getApiBaseUrl(),
 });
+
+client.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    const status = error?.response?.status;
+    if (status === 401 && typeof window !== 'undefined') {
+      dispatchAuthRequired();
+    }
+    if (status === 429 && typeof window !== 'undefined') {
+      const retryHeader = error.response?.headers?.['retry-after'];
+      const retryAfterSeconds = Number.isFinite(Number(retryHeader))
+        ? Number(retryHeader)
+        : error.response?.data?.retryAfterSeconds;
+      dispatchRateLimited({
+        message: error.response?.data?.error || 'Too many requests.',
+        retryAfterSeconds,
+      });
+    }
+    return Promise.reject(error);
+  },
+);
+
+export default client;

--- a/client/src/utils/httpStatusEvents.ts
+++ b/client/src/utils/httpStatusEvents.ts
@@ -1,0 +1,15 @@
+export const HTTP_AUTH_REQUIRED_EVENT = 'ylabs:http-auth-required';
+export const HTTP_RATE_LIMITED_EVENT = 'ylabs:http-rate-limited';
+
+export interface HttpRateLimitDetail {
+  message: string;
+  retryAfterSeconds?: number;
+}
+
+export const dispatchAuthRequired = () => {
+  window.dispatchEvent(new CustomEvent(HTTP_AUTH_REQUIRED_EVENT));
+};
+
+export const dispatchRateLimited = (detail: HttpRateLimitDetail) => {
+  window.dispatchEvent(new CustomEvent(HTTP_RATE_LIMITED_EVENT, { detail }));
+};

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -18,6 +18,7 @@ import { sanitizeMongo } from './middleware/sanitizeMongo';
 import { csrfOriginGuard } from './middleware/csrfOriginGuard';
 import { createCorsOriginHandler } from './middleware/corsOrigin';
 import { sessionCookieName } from './utils/sessionCookie';
+import { createRateLimitHandler } from './middleware/rateLimitResponse';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const API_BODY_LIMIT = '64kb';
@@ -121,7 +122,7 @@ const apiLimiter = rateLimit({
   keyGenerator: getRateLimitKey,
   standardHeaders: true,
   legacyHeaders: false,
-  message: { error: 'Too many requests, please try again later.' },
+  handler: createRateLimitHandler('Too many requests, please try again later.'),
   skip: (req) => bypassRuntimeSecurity || isCasLoginCallback(req) || isPublicDiscoveryPath(req),
 });
 
@@ -132,7 +133,7 @@ const writeLimiter = rateLimit({
   keyGenerator: getRateLimitKey,
   standardHeaders: true,
   legacyHeaders: false,
-  message: { error: 'Too many write requests, please try again later.' },
+  handler: createRateLimitHandler('Too many write requests, please try again later.'),
   skip: () => bypassRuntimeSecurity,
 });
 
@@ -148,7 +149,7 @@ const publicDiscoveryLimiter = rateLimit({
   keyGenerator: getRateLimitKey,
   standardHeaders: true,
   legacyHeaders: false,
-  message: { error: 'Too many discovery requests, please try again later.' },
+  handler: createRateLimitHandler('Too many discovery requests, please try again later.'),
   skip: () => bypassRuntimeSecurity,
 });
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -122,6 +122,7 @@ const apiLimiter = rateLimit({
   keyGenerator: getRateLimitKey,
   standardHeaders: true,
   legacyHeaders: false,
+  message: { error: 'Too many requests, please try again later.' },
   handler: createRateLimitHandler('Too many requests, please try again later.'),
   skip: (req) => bypassRuntimeSecurity || isCasLoginCallback(req) || isPublicDiscoveryPath(req),
 });
@@ -133,6 +134,7 @@ const writeLimiter = rateLimit({
   keyGenerator: getRateLimitKey,
   standardHeaders: true,
   legacyHeaders: false,
+  message: { error: 'Too many write requests, please try again later.' },
   handler: createRateLimitHandler('Too many write requests, please try again later.'),
   skip: () => bypassRuntimeSecurity,
 });
@@ -149,6 +151,7 @@ const publicDiscoveryLimiter = rateLimit({
   keyGenerator: getRateLimitKey,
   standardHeaders: true,
   legacyHeaders: false,
+  message: { error: 'Too many discovery requests, please try again later.' },
   handler: createRateLimitHandler('Too many discovery requests, please try again later.'),
   skip: () => bypassRuntimeSecurity,
 });

--- a/server/src/middleware/__tests__/auth.test.ts
+++ b/server/src/middleware/__tests__/auth.test.ts
@@ -143,7 +143,7 @@ describe('authenticated principal shape', () => {
 
     expect(next).not.toHaveBeenCalled();
     expect(res.statusCode).toBe(401);
-    expect(res.body).toEqual({ error: 'Unauthorized' });
+    expect(res.body).toEqual({ error: 'Unauthorized', code: 'AUTH_REQUIRED' });
   });
 
   it('rejects malformed admin principal shapes before grant lookup', async () => {
@@ -158,7 +158,7 @@ describe('authenticated principal shape', () => {
     expect(mockedHasActiveAdminGrant).not.toHaveBeenCalled();
     expect(next).not.toHaveBeenCalled();
     expect(res.statusCode).toBe(401);
-    expect(res.body).toEqual({ error: 'Unauthorized' });
+    expect(res.body).toEqual({ error: 'Unauthorized', code: 'AUTH_REQUIRED' });
   });
 
   it('rejects confirmed-route access without a primitive bounded NetID', () => {
@@ -170,7 +170,7 @@ describe('authenticated principal shape', () => {
 
     expect(next).not.toHaveBeenCalled();
     expect(res.statusCode).toBe(401);
-    expect(res.body).toEqual({ error: 'Unauthorized' });
+    expect(res.body).toEqual({ error: 'Unauthorized', code: 'AUTH_REQUIRED' });
   });
 });
 

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -28,6 +28,12 @@ const requestNetid = (user: AuthenticatedUser | null | undefined): string =>
 const hasAuthenticatedPrincipal = (user: unknown): user is AuthenticatedUser =>
   Boolean(user && typeof user === 'object' && requestNetid(user as AuthenticatedUser));
 
+const sendAuthRequired = (res: express.Response) =>
+  res.status(401).json({
+    error: 'Unauthorized',
+    code: 'AUTH_REQUIRED',
+  });
+
 const hasAdminAuthority = async (user: AuthenticatedUser): Promise<boolean> => {
   const netid = requestNetid(user);
   if (user.userType !== 'admin' || !netid) return false;
@@ -47,7 +53,7 @@ export const isAuthenticated = (
   if (hasAuthenticatedPrincipal(req.user)) {
     return next();
   }
-  res.status(401).json({ error: 'Unauthorized' });
+  return sendAuthRequired(res);
 };
 
 /**
@@ -61,7 +67,7 @@ export const isTrustworthy = (
   const user = req.user as AuthenticatedUser;
 
   if (!hasAuthenticatedPrincipal(user)) {
-    return res.status(401).json({ error: 'Unauthorized' });
+    return sendAuthRequired(res);
   }
 
   if (!user.userConfirmed) {
@@ -96,7 +102,7 @@ export const canCreateListing = (
   const currentUser = req.user as AuthenticatedUser;
 
   if (!hasAuthenticatedPrincipal(currentUser)) {
-    return res.status(401).json({ error: 'Unauthorized' });
+    return sendAuthRequired(res);
   }
 
   if (currentUser.userType === 'admin') {
@@ -140,7 +146,7 @@ export const isAdmin = (
   const currentUser = req.user as AuthenticatedUser;
 
   if (!hasAuthenticatedPrincipal(currentUser)) {
-    return res.status(401).json({ error: 'Unauthorized' });
+    return sendAuthRequired(res);
   }
 
   return hasActiveAdminGrant(requestNetid(currentUser))
@@ -165,7 +171,7 @@ export const isProfessor = (
   const currentUser = req.user as AuthenticatedUser;
 
   if (!hasAuthenticatedPrincipal(currentUser)) {
-    return res.status(401).json({ error: 'Unauthorized' });
+    return sendAuthRequired(res);
   }
 
   if (currentUser.userType === 'admin') {
@@ -198,7 +204,7 @@ export const isConfirmed = (
   const currentUser = req.user as AuthenticatedUser;
 
   if (!hasAuthenticatedPrincipal(currentUser)) {
-    return res.status(401).json({ error: 'Unauthorized' });
+    return sendAuthRequired(res);
   }
 
   if (!currentUser.userConfirmed) {

--- a/server/src/middleware/rateLimitResponse.ts
+++ b/server/src/middleware/rateLimitResponse.ts
@@ -1,0 +1,18 @@
+import { Request, Response } from 'express';
+
+const retryAfterSeconds = (req: Request): number | undefined => {
+  const resetTime = (req as any).rateLimit?.resetTime;
+  if (!(resetTime instanceof Date)) return undefined;
+  return Math.max(1, Math.ceil((resetTime.getTime() - Date.now()) / 1000));
+};
+
+export const createRateLimitHandler =
+  (message: string) => (req: Request, res: Response) => {
+    const retryAfter = retryAfterSeconds(req);
+    if (retryAfter) res.set('Retry-After', String(retryAfter));
+    return res.status(429).json({
+      error: message,
+      code: 'RATE_LIMITED',
+      retryAfterSeconds: retryAfter,
+    });
+  };


### PR DESCRIPTION
Preserved beta's getApiBaseUrl() Axios setup and added a response interceptor for global 401/429 events.

Added a small global notifier mounted in the existing App layout.\n- Standardized auth middleware 401 payloads with code AUTH_REQUIRED without changing beta's admin grant or trust checks.

Added structured 429 payloads and Retry-After support through existing beta rate limiter locations without changing skip rules, CSRF, CORS, sessions, or public discovery budgets.