### PR TITLE
Recover auth outage and empty posted-role states on beta

### DIFF
--- a/client/src/components/shared/BrowseGrid.tsx
+++ b/client/src/components/shared/BrowseGrid.tsx
@@ -25,6 +25,7 @@ interface BrowseGridProps {
   emptyMessage?: string;
   onLoadMore?: () => void;
   disableVirtualization?: boolean;
+  emptyAction?: React.ReactNode;
 }
 
 const BrowseGrid = ({
@@ -41,6 +42,7 @@ const BrowseGrid = ({
   emptyMessage = 'No results match the current filter',
   onLoadMore,
   disableVirtualization = false,
+  emptyAction,
 }: BrowseGridProps) => {
   const { viewMode } = useContext(UIContext);
   const isCompact = viewMode === 'compact';
@@ -59,10 +61,11 @@ const BrowseGrid = ({
     return (
       <div className="text-center py-8 text-gray-500">
         <p>{emptyMessage}</p>
+        {emptyAction && <div className="mt-3">{emptyAction}</div>}
         {quickFilter && onClearQuickFilter && (
           <button
             onClick={onClearQuickFilter}
-            className="mt-2 text-blue-600 hover:underline text-sm"
+            className="mt-3 text-blue-600 hover:underline text-sm"
           >
             Clear filter
           </button>

--- a/client/src/contexts/UserContext.ts
+++ b/client/src/contexts/UserContext.ts
@@ -8,6 +8,7 @@ import { User } from '../types/types';
 export const defaultUserContext = {
   isLoading: true,
   isAuthenticated: false,
+  authError: undefined,
   checkContext: () => {},
 };
 
@@ -15,5 +16,6 @@ export default createContext<{
   isLoading: boolean;
   isAuthenticated: boolean;
   user?: User;
+  authError?: string;
   checkContext: () => void;
 }>(defaultUserContext);

--- a/client/src/pages/__tests__/home.test.ts
+++ b/client/src/pages/__tests__/home.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { getListingEmptyMessage } from '../home';
+
+const baseParams = {
+  queryString: '',
+  selectedDepartments: [],
+  selectedResearchAreas: [],
+  selectedListingResearchAreas: [],
+  quickFilter: null,
+};
+
+describe('getListingEmptyMessage', () => {
+  it('explains that no labs are available when no search criteria are active', () => {
+    expect(getListingEmptyMessage(baseParams)).toBe('No research labs are available right now');
+  });
+
+  it('mentions search or filters when a text query is active', () => {
+    expect(getListingEmptyMessage({ ...baseParams, queryString: 'neuroscience' })).toBe(
+      'No labs match your current search or filters',
+    );
+  });
+
+  it('mentions search or filters when any filter is active', () => {
+    expect(
+      getListingEmptyMessage({
+        ...baseParams,
+        selectedDepartments: ['Computer Science'],
+      }),
+    ).toBe('No labs match your current search or filters');
+
+    expect(getListingEmptyMessage({ ...baseParams, quickFilter: 'open' })).toBe(
+      'No labs match your current search or filters',
+    );
+  });
+});

--- a/client/src/pages/__tests__/home.test.ts
+++ b/client/src/pages/__tests__/home.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { getListingEmptyMessage } from '../home';
+import { getListingEmptyMessage, hasListingSearchCriteria } from '../../utils/listingEmptyState';
 
 const baseParams = {
   queryString: '',
@@ -32,5 +32,21 @@ describe('getListingEmptyMessage', () => {
     expect(getListingEmptyMessage({ ...baseParams, quickFilter: 'open' })).toBe(
       'No labs match your current search or filters',
     );
+  });
+});
+
+describe('hasListingSearchCriteria', () => {
+  it('returns false when the user has not searched or filtered', () => {
+    expect(hasListingSearchCriteria(baseParams)).toBe(false);
+  });
+
+  it('returns true when the user has searched or filtered', () => {
+    expect(hasListingSearchCriteria({ ...baseParams, queryString: 'biology' })).toBe(true);
+    expect(
+      hasListingSearchCriteria({
+        ...baseParams,
+        selectedListingResearchAreas: ['Genomics'],
+      }),
+    ).toBe(true);
   });
 });

--- a/client/src/pages/__tests__/login.test.tsx
+++ b/client/src/pages/__tests__/login.test.tsx
@@ -1,17 +1,26 @@
 import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ContextType } from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import UserContext from '../../contexts/UserContext';
 import Login from '../login';
 
-const renderLogin = (from?: string) =>
+type UserContextValue = ContextType<typeof UserContext>;
+
+const renderLogin = (from?: string, context: Partial<UserContextValue> = {}) => {
+  const checkContext = vi.fn();
+
   render(
     <UserContext.Provider
       value={{
         isLoading: false,
         isAuthenticated: false,
-        checkContext: () => {},
+        user: undefined,
+        authError: undefined,
+        checkContext,
+        ...context,
       }}
     >
       <MemoryRouter
@@ -23,6 +32,9 @@ const renderLogin = (from?: string) =>
     </UserContext.Provider>,
   );
 
+  return { checkContext };
+};
+
 afterEach(() => {
   cleanup();
   localStorage.clear();
@@ -33,15 +45,15 @@ describe('Login', () => {
     renderLogin('/old-research-entry');
 
     expect(screen.getByRole('heading', { name: /continue to yale research/i })).toBeTruthy();
-    expect(
-      screen.getByText(/open the research discovery workspace/i),
-    ).toBeTruthy();
+    expect(screen.getByText(/open the research discovery workspace/i)).toBeTruthy();
   });
 
   it('keeps Programs destination context on the CAS gate', () => {
     renderLogin('/programs');
 
-    expect(screen.getByRole('heading', { name: /continue to programs & fellowships/i })).toBeTruthy();
+    expect(
+      screen.getByRole('heading', { name: /continue to programs & fellowships/i }),
+    ).toBeTruthy();
     expect(screen.getByText(/structured programs, funding cycles, and planning/i)).toBeTruthy();
   });
 
@@ -49,13 +61,17 @@ describe('Login', () => {
     renderLogin('/listings');
 
     expect(screen.getByRole('heading', { name: /continue to yale research/i })).toBeTruthy();
-    expect(screen.getByText(/browse research homes, evidence, and source-backed profiles/i)).toBeTruthy();
+    expect(
+      screen.getByText(/browse research homes, evidence, and source-backed profiles/i),
+    ).toBeTruthy();
   });
 
   it('keeps opportunity detail context on the CAS gate', () => {
     renderLogin('/opportunities/example-id');
 
-    expect(screen.getByRole('heading', { name: /continue to opportunity details/i })).toBeTruthy();
+    expect(
+      screen.getByRole('heading', { name: /continue to opportunity details/i }),
+    ).toBeTruthy();
     expect(screen.getByText(/review the evidence, deadline, and application next step/i)).toBeTruthy();
   });
 
@@ -70,13 +86,33 @@ describe('Login', () => {
     renderLogin('/account');
 
     expect(screen.getByRole('heading', { name: /continue to your account/i })).toBeTruthy();
-    expect(screen.getByText(/manage saved research plans, profile details, and program planning/i)).toBeTruthy();
+    expect(
+      screen.getByText(/manage saved research plans, profile details, and program planning/i),
+    ).toBeTruthy();
   });
 
   it('keeps about page context on the CAS gate', () => {
     renderLogin('/about');
 
-    expect(screen.getByRole('heading', { name: /continue to about yale research/i })).toBeTruthy();
+    expect(
+      screen.getByRole('heading', { name: /continue to about yale research/i }),
+    ).toBeTruthy();
     expect(screen.getByText(/learn how yale research is built and supported/i)).toBeTruthy();
+  });
+
+  it('replaces CAS sign in with retry when auth check fails', async () => {
+    const user = userEvent.setup();
+    const { checkContext } = renderLogin(undefined, {
+      authError: 'Unable to reach Yale Labs right now.',
+    });
+
+    expect(screen.getByRole('status').textContent).toContain(
+      'Unable to reach Yale Labs right now.',
+    );
+    expect(screen.queryByRole('link', { name: /sign in with yale cas/i })).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: /retry connection/i }));
+
+    expect(checkContext).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -19,25 +19,7 @@ import {
   createInitialBrowsePageState,
 } from '../reducers/browsePageReducer';
 import { createListing } from '../utils/apiCleaner';
-
-export const getListingEmptyMessage = (params: {
-  queryString: string;
-  selectedDepartments: string[];
-  selectedResearchAreas: string[];
-  selectedListingResearchAreas: string[];
-  quickFilter: string | null;
-}) => {
-  const hasSearchCriteria =
-    params.queryString.trim() !== '' ||
-    params.selectedDepartments.length > 0 ||
-    params.selectedResearchAreas.length > 0 ||
-    params.selectedListingResearchAreas.length > 0 ||
-    Boolean(params.quickFilter);
-
-  return hasSearchCriteria
-    ? 'No labs match your current search or filters'
-    : 'No research labs are available right now';
-};
+import { getListingEmptyMessage, hasListingSearchCriteria } from '../utils/listingEmptyState';
 
 const Home = () => {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -159,13 +141,15 @@ const Home = () => {
     quickFilterActive: !!quickFilter,
   });
 
-  const emptyMessage = getListingEmptyMessage({
+  const listingSearchCriteria = {
     queryString,
     selectedDepartments,
     selectedResearchAreas,
     selectedListingResearchAreas,
     quickFilter,
-  });
+  };
+  const emptyMessage = getListingEmptyMessage(listingSearchCriteria);
+  const showFellowshipsEmptyAction = !hasListingSearchCriteria(listingSearchCriteria);
 
   const updateFavorite = (listingId: string, favorite: boolean) => {
     const prevFavListingsIds = favListingsIds;
@@ -345,6 +329,16 @@ const Home = () => {
           searchError
             ? 'Posted-role search is unavailable. Use Yale Research for source-backed routes.'
             : emptyMessage
+        }
+        emptyAction={
+          showFellowshipsEmptyAction && !searchError ? (
+            <Link
+              to="/fellowships"
+              className="inline-flex items-center justify-center rounded-md border border-blue-600 px-4 py-2 text-sm font-medium text-blue-700 hover:bg-blue-50"
+            >
+              Browse fellowships
+            </Link>
+          ) : undefined
         }
         onLoadMore={() => {
           if (!isLoading && !searchExhausted) {

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -20,9 +20,29 @@ import {
 } from '../reducers/browsePageReducer';
 import { createListing } from '../utils/apiCleaner';
 
+export const getListingEmptyMessage = (params: {
+  queryString: string;
+  selectedDepartments: string[];
+  selectedResearchAreas: string[];
+  selectedListingResearchAreas: string[];
+  quickFilter: string | null;
+}) => {
+  const hasSearchCriteria =
+    params.queryString.trim() !== '' ||
+    params.selectedDepartments.length > 0 ||
+    params.selectedResearchAreas.length > 0 ||
+    params.selectedListingResearchAreas.length > 0 ||
+    Boolean(params.quickFilter);
+
+  return hasSearchCriteria
+    ? 'No labs match your current search or filters'
+    : 'No research labs are available right now';
+};
+
 const Home = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const {
+    queryString,
     listings,
     isLoading,
     error: searchError,
@@ -32,8 +52,11 @@ const Home = () => {
     setQuickFilter,
     refreshListings,
     setQueryString,
+    selectedDepartments,
     setSelectedDepartments,
+    selectedResearchAreas,
     setSelectedResearchAreas,
+    selectedListingResearchAreas,
     setSelectedListingResearchAreas,
   } = useContext(SearchContext);
 
@@ -134,6 +157,14 @@ const Home = () => {
     filteredCount: filteredListings.length,
     totalRawCount: listings.length,
     quickFilterActive: !!quickFilter,
+  });
+
+  const emptyMessage = getListingEmptyMessage({
+    queryString,
+    selectedDepartments,
+    selectedResearchAreas,
+    selectedListingResearchAreas,
+    quickFilter,
   });
 
   const updateFavorite = (listingId: string, favorite: boolean) => {
@@ -313,7 +344,7 @@ const Home = () => {
         emptyMessage={
           searchError
             ? 'Posted-role search is unavailable. Use Yale Research for source-backed routes.'
-            : 'No results match the search criteria'
+            : emptyMessage
         }
         onLoadMore={() => {
           if (!isLoading && !searchExhausted) {

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -10,7 +10,7 @@ import { Navigate, useLocation } from 'react-router-dom';
 import useDocumentTitle from '../hooks/useDocumentTitle';
 
 const Login = () => {
-  const { isLoading, isAuthenticated, user } = useContext(UserContext);
+  const { isLoading, isAuthenticated, user, authError, checkContext } = useContext(UserContext);
   useDocumentTitle('Sign in');
   const location = useLocation();
   const locationState = location.state as { from?: string } | null;
@@ -57,7 +57,6 @@ const Login = () => {
       description: 'Use your Yale account to open the research discovery workspace.',
     };
   })();
-
   const getRedirectPath = () => {
     if (user?.userType === 'professor') {
       return '/account';
@@ -114,13 +113,28 @@ const Login = () => {
               Authentication is handled by Yale CAS. Yale Research does not ask for your password.
             </p>
           </div>
+          {authError && (
+            <div
+              role="status"
+              className="mt-5 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm leading-relaxed text-blue-900"
+            >
+              <p>{authError}</p>
+              <button
+                type="button"
+                onClick={checkContext}
+                className="mt-3 rounded-md border border-blue-600 px-3 py-2 text-sm font-semibold text-blue-700 transition-colors hover:bg-blue-100"
+              >
+                Retry connection
+              </button>
+            </div>
+          )}
           <div className="mt-5 flex min-h-[44px] items-center">
             {isLoading ? (
               <PulseLoader color="#00356b" size={10} />
             ) : isAuthenticated ? (
               <Navigate to={getRedirectPath()} replace />
             ) : (
-              <SignInButton />
+              !authError && <SignInButton />
             )}
           </div>
         </section>

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -57,6 +57,7 @@ const Login = () => {
       description: 'Use your Yale account to open the research discovery workspace.',
     };
   })();
+
   const getRedirectPath = () => {
     if (user?.userType === 'professor') {
       return '/account';

--- a/client/src/providers/UserContextProvider.tsx
+++ b/client/src/providers/UserContextProvider.tsx
@@ -2,7 +2,6 @@
  * Provider component managing user authentication and session state.
  */
 import { PropsWithChildren, useCallback, useEffect, useReducer } from 'react';
-import swal from 'sweetalert';
 
 import axios from '../utils/axios';
 import UserContext from '../contexts/UserContext';
@@ -11,7 +10,7 @@ import { createInitialUserState, userReducer } from '../reducers/userReducer';
 
 const UserContextProvider = ({ children }: PropsWithChildren) => {
   const [state, dispatch] = useReducer(userReducer, undefined, createInitialUserState);
-  const { isLoading, isAuthenticated, user } = state;
+  const { isLoading, isAuthenticated, user, authError } = state;
 
   const checkContext = useCallback(() => {
     dispatch({ type: 'FETCH_START' });
@@ -30,14 +29,11 @@ const UserContextProvider = ({ children }: PropsWithChildren) => {
           });
         }
       })
-      .catch(() => {
-        console.error('Auth check failed.');
-        dispatch({ type: 'LOGOUT' });
-        dispatch({ type: 'FETCH_FAILURE' });
-
-        swal({
-          text: 'Something went wrong while checking authentication status.',
-          icon: 'warning',
+      .catch((error) => {
+        console.error('Auth check failed:', error);
+        dispatch({
+          type: 'FETCH_FAILURE',
+          error: 'Unable to reach Yale Labs right now. Please try again in a moment.',
         });
       });
   }, []);
@@ -47,7 +43,7 @@ const UserContextProvider = ({ children }: PropsWithChildren) => {
   }, [checkContext]);
 
   return (
-    <UserContext.Provider value={{ isLoading, isAuthenticated, user, checkContext }}>
+    <UserContext.Provider value={{ isLoading, isAuthenticated, user, authError, checkContext }}>
       {children}
     </UserContext.Provider>
   );

--- a/client/src/providers/UserContextProvider.tsx
+++ b/client/src/providers/UserContextProvider.tsx
@@ -29,8 +29,8 @@ const UserContextProvider = ({ children }: PropsWithChildren) => {
           });
         }
       })
-      .catch((error) => {
-        console.error('Auth check failed:', error);
+      .catch(() => {
+        console.error('Auth check failed.');
         dispatch({
           type: 'FETCH_FAILURE',
           error: 'Unable to reach Yale Labs right now. Please try again in a moment.',

--- a/client/src/reducers/__tests__/userReducer.test.ts
+++ b/client/src/reducers/__tests__/userReducer.test.ts
@@ -17,12 +17,17 @@ describe('userReducer', () => {
     expect(state.isLoading).toBe(true);
     expect(state.isAuthenticated).toBe(false);
     expect(state.user).toBeUndefined();
+    expect(state.authError).toBeUndefined();
   });
 
-  it('FETCH_START sets loading true', () => {
-    const state = createInitialUserState({ isLoading: false });
+  it('FETCH_START sets loading true and clears stale auth errors', () => {
+    const state = createInitialUserState({
+      isLoading: false,
+      authError: 'Unable to reach server',
+    });
     const next = userReducer(state, { type: 'FETCH_START' });
     expect(next.isLoading).toBe(true);
+    expect(next.authError).toBeUndefined();
   });
 
   it('FETCH_SUCCESS with auth populates the user and flips authenticated', () => {
@@ -34,6 +39,7 @@ describe('userReducer', () => {
     expect(next.isLoading).toBe(false);
     expect(next.isAuthenticated).toBe(true);
     expect(next.user).toBe(sampleUser);
+    expect(next.authError).toBeUndefined();
   });
 
   it('FETCH_SUCCESS without auth clears the user even if one was present', () => {
@@ -48,18 +54,31 @@ describe('userReducer', () => {
     expect(next.isLoading).toBe(false);
     expect(next.isAuthenticated).toBe(false);
     expect(next.user).toBeUndefined();
+    expect(next.authError).toBeUndefined();
   });
 
-  it('FETCH_FAILURE clears loading without affecting prior user', () => {
+  it('FETCH_FAILURE clears loading, sets an auth error, and preserves prior user', () => {
     const prior = userReducer(createInitialUserState(), {
       type: 'FETCH_SUCCESS',
       payload: { isAuthenticated: true, user: sampleUser },
     });
-    const next = userReducer(prior, { type: 'FETCH_FAILURE' });
+    const next = userReducer(prior, {
+      type: 'FETCH_FAILURE',
+      error: 'Unable to reach Yale Labs.',
+    });
     expect(next.isLoading).toBe(false);
     // Prior user and authenticated flag are preserved — stale is better than empty
     expect(next.isAuthenticated).toBe(true);
     expect(next.user).toBe(sampleUser);
+    expect(next.authError).toBe('Unable to reach Yale Labs.');
+  });
+
+  it('FETCH_FAILURE falls back to a useful default message', () => {
+    const state = createInitialUserState();
+    const next = userReducer(state, { type: 'FETCH_FAILURE' });
+    expect(next.authError).toBe(
+      'Unable to check your Yale Labs session. Please try again in a moment.',
+    );
   });
 
   it('LOGOUT clears user and sets isAuthenticated false', () => {
@@ -70,6 +89,7 @@ describe('userReducer', () => {
     const next = userReducer(prior, { type: 'LOGOUT' });
     expect(next.isAuthenticated).toBe(false);
     expect(next.user).toBeUndefined();
+    expect(next.authError).toBeUndefined();
   });
 
   it('reducer does not mutate prior state', () => {

--- a/client/src/reducers/userReducer.ts
+++ b/client/src/reducers/userReducer.ts
@@ -11,25 +11,27 @@ export interface UserState {
   isLoading: boolean;
   isAuthenticated: boolean;
   user?: User;
+  authError?: string;
 }
 
 export type UserAction =
   | { type: 'FETCH_START' }
   | { type: 'FETCH_SUCCESS'; payload: { isAuthenticated: boolean; user?: User } }
-  | { type: 'FETCH_FAILURE' }
+  | { type: 'FETCH_FAILURE'; error?: string }
   | { type: 'LOGOUT' };
 
 export const createInitialUserState = (overrides: Partial<UserState> = {}): UserState => ({
   isLoading: true,
   isAuthenticated: false,
   user: undefined,
+  authError: undefined,
   ...overrides,
 });
 
 export function userReducer(state: UserState, action: UserAction): UserState {
   switch (action.type) {
     case 'FETCH_START':
-      return { ...state, isLoading: true };
+      return { ...state, isLoading: true, authError: undefined };
 
     case 'FETCH_SUCCESS':
       return {
@@ -37,6 +39,7 @@ export function userReducer(state: UserState, action: UserAction): UserState {
         isLoading: false,
         isAuthenticated: action.payload.isAuthenticated,
         user: action.payload.isAuthenticated ? action.payload.user : undefined,
+        authError: undefined,
       };
 
     case 'FETCH_FAILURE':
@@ -45,6 +48,9 @@ export function userReducer(state: UserState, action: UserAction): UserState {
       return {
         ...state,
         isLoading: false,
+        authError:
+          action.error ||
+          'Unable to check your Yale Labs session. Please try again in a moment.',
       };
 
     case 'LOGOUT':
@@ -52,6 +58,7 @@ export function userReducer(state: UserState, action: UserAction): UserState {
         ...state,
         isAuthenticated: false,
         user: undefined,
+        authError: undefined,
       };
 
     default:

--- a/client/src/utils/listingEmptyState.ts
+++ b/client/src/utils/listingEmptyState.ts
@@ -1,0 +1,20 @@
+export type ListingSearchCriteria = {
+  queryString: string;
+  selectedDepartments: string[];
+  selectedResearchAreas: string[];
+  selectedListingResearchAreas: string[];
+  quickFilter: string | null;
+};
+
+export const hasListingSearchCriteria = (params: ListingSearchCriteria) =>
+  params.queryString.trim() !== '' ||
+  params.selectedDepartments.length > 0 ||
+  params.selectedResearchAreas.length > 0 ||
+  params.selectedListingResearchAreas.length > 0 ||
+  Boolean(params.quickFilter);
+
+export const getListingEmptyMessage = (params: ListingSearchCriteria) => {
+  return hasListingSearchCriteria(params)
+    ? 'No labs match your current search or filters'
+    : 'No research labs are available right now';
+};


### PR DESCRIPTION
## Intent

Recover the useful parts of wrong-base PR #105 onto `origin/beta` without reverting beta's newer Yale Research login and posted-role UI.

## What changed

- Replaced auth-check popups with inline login outage state and a retry action.
- Preserved stale authenticated state during transient `/check` failures instead of logging users out.
- Clarified posted-role empty states so a true empty dataset differs from no search/filter matches.
- Added an empty-state path from legacy posted roles to fellowships.
- Moved the pure empty-state helper to a utility so tests do not import the legacy page module.

## Validation

- `yarn install:all:immutable`
- `yarn --cwd client vitest --run src/pages/__tests__/login.test.tsx src/pages/__tests__/home.test.ts src/reducers/__tests__/userReducer.test.ts` (3 files, 22 tests passed)

Targets `beta`. This is the beta-native recovery for #105.