### PR TITLE
Recover Sentry error tracking and boundary on beta

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,6 +9,7 @@
     "@emotion/react": "^11.8.1",
     "@emotion/styled": "^11.8.1",
     "@mui/material": "^7.3.5",
+    "@sentry/react": "^10.63.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.5.2",
     "@types/jest": "^27.4.1",

--- a/client/src/components/ErrorBoundary.tsx
+++ b/client/src/components/ErrorBoundary.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { captureClientError } from '../utils/errorTracking';
+
+type ErrorBoundaryProps = {
+  children: React.ReactNode;
+};
+
+type ErrorBoundaryState = {
+  hasError: boolean;
+};
+
+class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = {
+    hasError: false,
+  };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    captureClientError(error, errorInfo.componentStack ?? undefined);
+  }
+
+  private handleReload = () => {
+    window.location.reload();
+  };
+
+  private handleHome = () => {
+    window.location.assign('/');
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <main className="min-h-screen bg-slate-100 flex items-center justify-center px-4">
+          <section
+            className="w-full max-w-md rounded-lg border border-slate-200 bg-white p-8 text-center shadow-sm"
+            role="alert"
+            aria-labelledby="error-boundary-title"
+          >
+            <h1 id="error-boundary-title" className="text-2xl font-semibold text-slate-900">
+              Something went wrong
+            </h1>
+            <p className="mt-4 text-slate-600">
+              The page hit an unexpected error. Refresh to try again, or return home.
+            </p>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:justify-center">
+              <button
+                type="button"
+                className="rounded-md bg-blue-600 px-5 py-3 font-semibold text-white transition-colors hover:bg-blue-700"
+                onClick={this.handleReload}
+              >
+                Refresh page
+              </button>
+              <button
+                type="button"
+                className="rounded-md border border-slate-300 px-5 py-3 font-semibold text-slate-700 transition-colors hover:bg-slate-50"
+                onClick={this.handleHome}
+              >
+                Go home
+              </button>
+            </div>
+          </section>
+        </main>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/client/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/client/src/components/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import ErrorBoundary from '../ErrorBoundary';
+import { captureClientError } from '../../utils/errorTracking';
+
+vi.mock('../../utils/errorTracking', () => ({
+  captureClientError: vi.fn(),
+}));
+
+const BrokenComponent = () => {
+  throw new Error('render failed');
+};
+
+describe('ErrorBoundary', () => {
+  it('renders recovery UI and captures render errors', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <ErrorBoundary>
+        <BrokenComponent />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /something went wrong/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /refresh page/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /go home/i })).toBeInTheDocument();
+    expect(captureClientError).toHaveBeenCalledWith(expect.any(Error), expect.any(String));
+
+    consoleError.mockRestore();
+  });
+
+  it('reloads the page from the recovery action', async () => {
+    const user = userEvent.setup();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const reload = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, reload },
+    });
+
+    render(
+      <ErrorBoundary>
+        <BrokenComponent />
+      </ErrorBoundary>,
+    );
+
+    await user.click(screen.getByRole('button', { name: /refresh page/i }));
+
+    expect(reload).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+});

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -8,6 +8,10 @@ import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 import UserContextProvider from './providers/UserContextProvider';
+import ErrorBoundary from './components/ErrorBoundary';
+import { initializeErrorTracking } from './utils/errorTracking';
+
+initializeErrorTracking();
 
 const AgentationToolbar = import.meta.env.DEV
   ? React.lazy(async () => {
@@ -26,14 +30,16 @@ const root = createRoot(container);
 
 root.render(
   <React.StrictMode>
-    <UserContextProvider>
-      <App />
-      {AgentationToolbar ? (
-        <Suspense fallback={null}>
-          <AgentationToolbar />
-        </Suspense>
-      ) : null}
-    </UserContextProvider>
+    <ErrorBoundary>
+      <UserContextProvider>
+        <App />
+        {AgentationToolbar ? (
+          <Suspense fallback={null}>
+            <AgentationToolbar />
+          </Suspense>
+        ) : null}
+      </UserContextProvider>
+    </ErrorBoundary>
   </React.StrictMode>,
 );
 

--- a/client/src/setupTests.ts
+++ b/client/src/setupTests.ts
@@ -1,4 +1,10 @@
 /**
- * Test environment setup for Jest.
+ * Test environment setup for Vitest.
  */
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+afterEach(() => {
+  cleanup();
+});

--- a/client/src/types/vite-env.d.ts
+++ b/client/src/types/vite-env.d.ts
@@ -5,6 +5,9 @@ interface ImportMetaEnv {
   readonly DEV: boolean;
   readonly VITE_APP_SERVER: string;
   readonly VITE_GOOGLE_CLIENT_ID?: string;
+  readonly VITE_SENTRY_DSN?: string;
+  readonly VITE_SENTRY_ENVIRONMENT?: string;
+  readonly VITE_SENTRY_RELEASE?: string;
 }
 
 interface ImportMeta {

--- a/client/src/utils/__tests__/errorTracking.test.ts
+++ b/client/src/utils/__tests__/errorTracking.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { initializeErrorTracking } from '../errorTracking';
+import * as Sentry from '@sentry/react';
+
+vi.mock('@sentry/react', () => ({
+  init: vi.fn(),
+  captureException: vi.fn(),
+}));
+
+describe('client errorTracking', () => {
+  it('does not initialize without a DSN', () => {
+    expect(initializeErrorTracking({ environment: 'test' })).toBe(false);
+    expect(Sentry.init).not.toHaveBeenCalled();
+  });
+
+  it('passes configurable environment and release tags to Sentry', () => {
+    expect(
+      initializeErrorTracking({
+        dsn: 'https://public@example.com/1',
+        environment: 'staging',
+        release: 'abc123',
+      }),
+    ).toBe(true);
+
+    expect(Sentry.init).toHaveBeenCalledWith({
+      dsn: 'https://public@example.com/1',
+      environment: 'staging',
+      release: 'abc123',
+    });
+  });
+});

--- a/client/src/utils/errorTracking.ts
+++ b/client/src/utils/errorTracking.ts
@@ -1,0 +1,39 @@
+import * as Sentry from '@sentry/react';
+
+type ErrorTrackingConfig = {
+  dsn?: string;
+  environment: string;
+  release?: string;
+};
+
+const getErrorTrackingConfig = (): ErrorTrackingConfig => ({
+  dsn: import.meta.env.VITE_SENTRY_DSN,
+  environment: import.meta.env.VITE_SENTRY_ENVIRONMENT || import.meta.env.MODE || 'development',
+  release: import.meta.env.VITE_SENTRY_RELEASE,
+});
+
+export const initializeErrorTracking = (config = getErrorTrackingConfig()) => {
+  if (!config.dsn) {
+    return false;
+  }
+
+  Sentry.init({
+    dsn: config.dsn,
+    environment: config.environment,
+    release: config.release,
+  });
+
+  return true;
+};
+
+export const captureClientError = (error: unknown, componentStack?: string) => {
+  Sentry.captureException(error, {
+    contexts: componentStack
+      ? {
+          react: {
+            componentStack,
+          },
+        }
+      : undefined,
+  });
+};

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -13,6 +13,7 @@ export default defineConfig({
   test: {
     globals: false,
     environment: 'jsdom',
+    setupFiles: './src/setupTests.ts',
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
     testTimeout: 10000,
   },

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -847,6 +847,76 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry/browser-utils@npm:10.63.0":
+  version: 10.63.0
+  resolution: "@sentry/browser-utils@npm:10.63.0"
+  dependencies:
+    "@sentry/core": "npm:10.63.0"
+  checksum: 10c0/6a1833833bc0bcbfa9eb4b49df6c6745d958aaf1367e18f24dd01f01dbb17a6fb92c009917ce5eb1f923f4dc7bffe542f281721430588564b0c17b21446e0fd8
+  languageName: node
+  linkType: hard
+
+"@sentry/browser@npm:10.63.0":
+  version: 10.63.0
+  resolution: "@sentry/browser@npm:10.63.0"
+  dependencies:
+    "@sentry/browser-utils": "npm:10.63.0"
+    "@sentry/core": "npm:10.63.0"
+    "@sentry/feedback": "npm:10.63.0"
+    "@sentry/replay": "npm:10.63.0"
+    "@sentry/replay-canvas": "npm:10.63.0"
+  checksum: 10c0/c0c221c1a11ad59c4568601db130673a79738e0f35b282bfde37c49f1dadd7e412b7970a45290ad2aaf8fb1a3534d0bc2fa890c0a91f02110a2177b626b8f97c
+  languageName: node
+  linkType: hard
+
+"@sentry/core@npm:10.63.0":
+  version: 10.63.0
+  resolution: "@sentry/core@npm:10.63.0"
+  checksum: 10c0/1efa658c0708abbc8a3fb8b351fcb16028e54d4eb0f63a99d91a6137cecdcb45f0c0a691ffa7b80b06f5d8715784e2929e34e40fa505ba70c67c4c25834549d0
+  languageName: node
+  linkType: hard
+
+"@sentry/feedback@npm:10.63.0":
+  version: 10.63.0
+  resolution: "@sentry/feedback@npm:10.63.0"
+  dependencies:
+    "@sentry/core": "npm:10.63.0"
+  checksum: 10c0/21eebb96acdd27772061107c1b0d298c237c1bb122b673be2d108b950e150b764e55d740f49dd3e17437f1754a2bd0022b1bd84b4f928df2077fcee2a620af73
+  languageName: node
+  linkType: hard
+
+"@sentry/react@npm:^10.63.0":
+  version: 10.63.0
+  resolution: "@sentry/react@npm:10.63.0"
+  dependencies:
+    "@sentry/browser": "npm:10.63.0"
+    "@sentry/core": "npm:10.63.0"
+  peerDependencies:
+    react: ^16.14.0 || 17.x || 18.x || 19.x
+  checksum: 10c0/51e50a3944b2a8fadec1d574cc9490a3022d5deb6af597f1a1c8fbed1ffe3d6f9c0c19942c82f29baac5af3c6508dfc4d8351e420373ef8a1abe5390b40dd4eb
+  languageName: node
+  linkType: hard
+
+"@sentry/replay-canvas@npm:10.63.0":
+  version: 10.63.0
+  resolution: "@sentry/replay-canvas@npm:10.63.0"
+  dependencies:
+    "@sentry/core": "npm:10.63.0"
+    "@sentry/replay": "npm:10.63.0"
+  checksum: 10c0/9969cf5a5aac75f2e6f3c3863535a26c248b256ba97f5774825fd9238048bae16668e3b327d3fa288b390a709da0211a62113aa922febe48613a31d2f5a55a43
+  languageName: node
+  linkType: hard
+
+"@sentry/replay@npm:10.63.0":
+  version: 10.63.0
+  resolution: "@sentry/replay@npm:10.63.0"
+  dependencies:
+    "@sentry/browser-utils": "npm:10.63.0"
+    "@sentry/core": "npm:10.63.0"
+  checksum: 10c0/c04135b2aec857b195cf64e1c6a9fe9586403b1560c52b77520fb32175419e6fbfcd1850f2d8fe1401cdb262053b05ee06a8a808136207c33a5f2f30aa00629c
+  languageName: node
+  linkType: hard
+
 "@standard-schema/spec@npm:^1.1.0":
   version: 1.1.0
   resolution: "@standard-schema/spec@npm:1.1.0"
@@ -1493,6 +1563,7 @@ __metadata:
     "@emotion/react": "npm:^11.8.1"
     "@emotion/styled": "npm:^11.8.1"
     "@mui/material": "npm:^7.3.5"
+    "@sentry/react": "npm:^10.63.0"
     "@testing-library/dom": "npm:^10.0.0"
     "@testing-library/jest-dom": "npm:^6.9.1"
     "@testing-library/react": "npm:^16.3.0"

--- a/server/package.json
+++ b/server/package.json
@@ -85,6 +85,7 @@
     "prod": "cross-env NODE_ENV=production tsx watch src/index.ts"
   },
   "dependencies": {
+    "@sentry/node": "^10.63.0",
     "axios": "^1.17.0",
     "cheerio": "^1.2.0",
     "cookie-session": "^2.1.0",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -6,8 +6,10 @@ import dotenv from 'dotenv';
 import { initializeConnections, getApiMode } from './db/connections';
 import { startGateRefreshScheduler } from './scripts/gateRefreshScheduler';
 import { sanitizeLogValue } from './utils/logSanitizer';
+import { captureStartupError, initializeErrorTracking } from './utils/errorTracking';
 
 dotenv.config();
+initializeErrorTracking();
 
 const port = process.env.PORT || 4000;
 
@@ -31,6 +33,7 @@ const startApp = async () => {
       }
     });
   } catch (error) {
+    await captureStartupError(error);
     console.error('Failed to start app:', sanitizeLogValue(error));
     process.exit(1);
   }

--- a/server/src/middleware/__tests__/errorHandler.test.ts
+++ b/server/src/middleware/__tests__/errorHandler.test.ts
@@ -2,6 +2,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { NextFunction, Request, Response } from 'express';
 import { errorHandler, notFoundHandler } from '../errorHandler';
 import { NotFoundError, ObjectIdError } from '../../utils/errors';
+import { captureServerError } from '../../utils/errorTracking';
+
+vi.mock('../../utils/errorTracking', () => ({
+  captureServerError: vi.fn(),
+}));
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -28,15 +33,11 @@ describe('errorHandler', () => {
     const response = createResponse();
     const error = Object.assign(new Error('mongodb://user:pass@example.invalid leaked'), { status: 403 });
 
-    errorHandler(
-      error,
-      {} as Request,
-      response,
-      vi.fn() as unknown as NextFunction,
-    );
+    errorHandler(error, {} as Request, response, vi.fn() as unknown as NextFunction);
 
     expect(response.status).toHaveBeenCalledWith(403);
     expect(response.json).toHaveBeenCalledWith({ error: 'Forbidden' });
+    expect(captureServerError).not.toHaveBeenCalled();
     expect(consoleError.mock.calls.flat().join(' ')).not.toContain('user:pass');
   });
 
@@ -47,12 +48,7 @@ describe('errorHandler', () => {
       'Failed mongodb://user:pass@example.invalid/db?api_key=secret-key for ada@example.edu with Bearer abc123 and 203-555-1212',
     );
 
-    errorHandler(
-      error,
-      {} as Request,
-      response,
-      vi.fn() as unknown as NextFunction,
-    );
+    errorHandler(error, {} as Request, response, vi.fn() as unknown as NextFunction);
 
     const logged = consoleError.mock.calls.flat().join(' ');
     expect(logged).not.toContain('user:pass');
@@ -65,6 +61,7 @@ describe('errorHandler', () => {
     expect(logged).toContain('[email redacted]');
     expect(logged).toContain('[token-redacted]');
     expect(logged).toContain('[phone redacted]');
+    expect(captureServerError).toHaveBeenCalledWith(error, {});
   });
 
   it('does not leak object ids from not-found errors', () => {
@@ -80,6 +77,7 @@ describe('errorHandler', () => {
 
     expect(response.status).toHaveBeenCalledWith(404);
     expect(response.json).toHaveBeenCalledWith({ error: 'Not found' });
+    expect(captureServerError).not.toHaveBeenCalled();
   });
 
   it('does not leak cast/object-id details from object-id errors', () => {
@@ -95,6 +93,7 @@ describe('errorHandler', () => {
 
     expect(response.status).toHaveBeenCalledWith(404);
     expect(response.json).toHaveBeenCalledWith({ error: 'Not found' });
+    expect(captureServerError).not.toHaveBeenCalled();
   });
 
   it('hides internal messages for remote development-labelled runtimes', () => {
@@ -105,19 +104,16 @@ describe('errorHandler', () => {
       SERVER_BASE_URL: 'https://yalelabs.io',
     };
     const response = createResponse();
+    const error = new Error('database password appeared in stack context');
 
-    errorHandler(
-      new Error('database password appeared in stack context'),
-      {} as Request,
-      response,
-      vi.fn() as unknown as NextFunction,
-    );
+    errorHandler(error, {} as Request, response, vi.fn() as unknown as NextFunction);
 
     expect(response.status).toHaveBeenCalledWith(500);
     expect(response.json).toHaveBeenCalledWith({
       error: 'Internal server error',
       message: undefined,
     });
+    expect(captureServerError).toHaveBeenCalledWith(error, {});
   });
 
   it('does not leak validation details in local test responses', () => {
@@ -132,18 +128,14 @@ describe('errorHandler', () => {
       { name: 'ValidationError' },
     );
 
-    errorHandler(
-      error,
-      {} as Request,
-      response,
-      vi.fn() as unknown as NextFunction,
-    );
+    errorHandler(error, {} as Request, response, vi.fn() as unknown as NextFunction);
 
     expect(response.status).toHaveBeenCalledWith(400);
     expect(response.json).toHaveBeenCalledWith({
       error: 'Validation error',
       details: undefined,
     });
+    expect(captureServerError).not.toHaveBeenCalled();
   });
 
   it('does not leak internal messages in local test 500 responses', () => {
@@ -153,19 +145,16 @@ describe('errorHandler', () => {
       NODE_ENV: 'test',
     };
     const response = createResponse();
+    const error = new Error('mongodb://user:pass@example.invalid local test context');
 
-    errorHandler(
-      new Error('mongodb://user:pass@example.invalid local test context'),
-      {} as Request,
-      response,
-      vi.fn() as unknown as NextFunction,
-    );
+    errorHandler(error, {} as Request, response, vi.fn() as unknown as NextFunction);
 
     expect(response.status).toHaveBeenCalledWith(500);
     expect(response.json).toHaveBeenCalledWith({
       error: 'Internal server error',
       message: undefined,
     });
+    expect(captureServerError).toHaveBeenCalledWith(error, {});
   });
 
   it('delegates late errors after headers are sent instead of writing another response', () => {
@@ -182,6 +171,7 @@ describe('errorHandler', () => {
     expect(next).toHaveBeenCalledWith(error);
     expect(response.status).not.toHaveBeenCalled();
     expect(response.json).not.toHaveBeenCalled();
+    expect(captureServerError).not.toHaveBeenCalled();
   });
 });
 

--- a/server/src/middleware/__tests__/errorHandler.test.ts
+++ b/server/src/middleware/__tests__/errorHandler.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { NextFunction, Request, Response } from 'express';
 import { errorHandler, notFoundHandler } from '../errorHandler';
 import { NotFoundError, ObjectIdError } from '../../utils/errors';
@@ -23,6 +23,10 @@ const createResponse = () => {
 };
 
 describe('errorHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   afterEach(() => {
     process.env = { ...ORIGINAL_ENV };
     vi.restoreAllMocks();

--- a/server/src/middleware/errorHandler.ts
+++ b/server/src/middleware/errorHandler.ts
@@ -6,6 +6,7 @@ import { NotFoundError, ObjectIdError, IncorrectPermissionsError } from '../util
 import { sanitizeErrorForLog } from '../utils/logSanitizer';
 import { requiresDeployedRuntimeSecurity } from '../utils/environment';
 import { triggerReconnect } from '../db/connections';
+import { captureServerError } from '../utils/errorTracking';
 
 const clientErrorStatus = (error: Error): number | null => {
   const status = (error as any).status ?? (error as any).statusCode;
@@ -80,6 +81,7 @@ export const errorHandler = (error: Error, req: Request, res: Response, next: Ne
     return res.status(503).json({ error: 'Service temporarily unavailable' });
   }
 
+  captureServerError(error, req);
   res.status(500).json({
     error: 'Internal server error',
     message: undefined,

--- a/server/src/utils/__tests__/errorTracking.test.ts
+++ b/server/src/utils/__tests__/errorTracking.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Request } from 'express';
 
-import { initializeErrorTracking } from '../errorTracking';
+import { captureServerError, initializeErrorTracking } from '../errorTracking';
 import * as Sentry from '@sentry/node';
 
 vi.mock('@sentry/node', () => ({
@@ -11,6 +12,7 @@ vi.mock('@sentry/node', () => ({
 describe('server errorTracking', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.SENTRY_DSN;
   });
 
   it('does not initialize without a DSN', () => {
@@ -31,6 +33,34 @@ describe('server errorTracking', () => {
       dsn: 'https://public@example.com/1',
       environment: 'production',
       release: 'abc123',
+    });
+  });
+
+  it('captures request context without raw query strings', () => {
+    process.env.SENTRY_DSN = 'https://public@example.com/1';
+
+    const error = new Error('boom');
+    const req = {
+      method: 'GET',
+      path: '/api/research',
+      originalUrl: '/api/research?query=private-search',
+      user: { netId: 'abc123' },
+    } as unknown as Request;
+
+    captureServerError(error, req);
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(error, {
+      tags: {
+        method: 'GET',
+        path: '/api/research',
+      },
+      user: { id: 'abc123' },
+      contexts: {
+        request: {
+          path: '/api/research',
+          method: 'GET',
+        },
+      },
     });
   });
 });

--- a/server/src/utils/__tests__/errorTracking.test.ts
+++ b/server/src/utils/__tests__/errorTracking.test.ts
@@ -1,12 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Request } from 'express';
 
-import { captureServerError, initializeErrorTracking } from '../errorTracking';
+import { captureServerError, captureStartupError, initializeErrorTracking } from '../errorTracking';
 import * as Sentry from '@sentry/node';
 
 vi.mock('@sentry/node', () => ({
   init: vi.fn(),
   captureException: vi.fn(),
+  flush: vi.fn(),
 }));
 
 describe('server errorTracking', () => {
@@ -62,5 +63,17 @@ describe('server errorTracking', () => {
         },
       },
     });
+  });
+
+  it('captures and flushes startup errors', async () => {
+    process.env.SENTRY_DSN = 'https://public@example.com/1';
+    vi.mocked(Sentry.flush).mockResolvedValue(true);
+
+    const error = new Error('startup failed');
+
+    await captureStartupError(error);
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(error);
+    expect(Sentry.flush).toHaveBeenCalledWith(2000);
   });
 });

--- a/server/src/utils/__tests__/errorTracking.test.ts
+++ b/server/src/utils/__tests__/errorTracking.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { initializeErrorTracking } from '../errorTracking';
+import * as Sentry from '@sentry/node';
+
+vi.mock('@sentry/node', () => ({
+  init: vi.fn(),
+  captureException: vi.fn(),
+}));
+
+describe('server errorTracking', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not initialize without a DSN', () => {
+    expect(initializeErrorTracking({ environment: 'test' })).toBe(false);
+    expect(Sentry.init).not.toHaveBeenCalled();
+  });
+
+  it('passes configurable environment and release tags to Sentry', () => {
+    expect(
+      initializeErrorTracking({
+        dsn: 'https://public@example.com/1',
+        environment: 'production',
+        release: 'abc123',
+      }),
+    ).toBe(true);
+
+    expect(Sentry.init).toHaveBeenCalledWith({
+      dsn: 'https://public@example.com/1',
+      environment: 'production',
+      release: 'abc123',
+    });
+  });
+});

--- a/server/src/utils/errorTracking.ts
+++ b/server/src/utils/errorTracking.ts
@@ -1,0 +1,64 @@
+import * as Sentry from '@sentry/node';
+import { Request } from 'express';
+
+type ErrorTrackingConfig = {
+  dsn?: string;
+  environment: string;
+  release?: string;
+};
+
+let initialized = false;
+
+const getErrorTrackingConfig = (): ErrorTrackingConfig => ({
+  dsn: process.env.SENTRY_DSN,
+  environment: process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV || 'development',
+  release: process.env.SENTRY_RELEASE,
+});
+
+export const initializeErrorTracking = (config = getErrorTrackingConfig()) => {
+  if (!config.dsn) {
+    return false;
+  }
+
+  if (!initialized) {
+    Sentry.init({
+      dsn: config.dsn,
+      environment: config.environment,
+      release: config.release,
+    });
+    initialized = true;
+  }
+
+  return true;
+};
+
+export const captureServerError = (error: Error, req: Request) => {
+  if (!initializeErrorTracking()) {
+    return;
+  }
+
+  const user = req.user as { netId?: string } | undefined;
+
+  Sentry.captureException(error, {
+    tags: {
+      method: req.method,
+      path: req.path,
+    },
+    user: user?.netId ? { id: user.netId } : undefined,
+    contexts: {
+      request: {
+        path: req.path,
+        method: req.method,
+      },
+    },
+  });
+};
+
+export const captureStartupError = async (error: unknown) => {
+  if (!initializeErrorTracking()) {
+    return;
+  }
+
+  Sentry.captureException(error);
+  await Sentry.flush(2000);
+};

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -5,6 +5,45 @@ __metadata:
   version: 10
   cacheKey: 10c0
 
+"@apm-js-collab/code-transformer-bundler-plugins@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "@apm-js-collab/code-transformer-bundler-plugins@npm:0.5.0"
+  dependencies:
+    "@apm-js-collab/code-transformer": "npm:^0.15.0"
+    es-module-lexer: "npm:^2.1.0"
+    magic-string: "npm:^0.30.21"
+    module-details-from-path: "npm:^1.0.4"
+  checksum: 10c0/c3a049ea8d55004708172ba5063ada786f0c5f4f7593b37c8449d44fb77b75b965c236718dc6322b5e7bf623e94e6b4cc3a6bf1454d489341a5347101ebefcce
+  languageName: node
+  linkType: hard
+
+"@apm-js-collab/code-transformer@npm:^0.15.0":
+  version: 0.15.0
+  resolution: "@apm-js-collab/code-transformer@npm:0.15.0"
+  dependencies:
+    "@types/estree": "npm:^1.0.8"
+    astring: "npm:^1.9.0"
+    esquery: "npm:^1.7.0"
+    meriyah: "npm:^6.1.4"
+    semifies: "npm:^1.0.0"
+    source-map: "npm:^0.6.0"
+  bin:
+    code-transformer: cli.js
+  checksum: 10c0/675772aa5f9ed57e64fb26e56a3b2c69dc551421249f955f508817d0c9ba83ecc4a176156e71b427e33f1704fdea6cb60b1126188ec4fa0466651ba8861d7c95
+  languageName: node
+  linkType: hard
+
+"@apm-js-collab/tracing-hooks@npm:^0.10.0":
+  version: 0.10.1
+  resolution: "@apm-js-collab/tracing-hooks@npm:0.10.1"
+  dependencies:
+    "@apm-js-collab/code-transformer": "npm:^0.15.0"
+    debug: "npm:^4.4.1"
+    module-details-from-path: "npm:^1.0.4"
+  checksum: 10c0/4787052784177aa7be18577cd6c2adcf023193986b575b809cb157d0cd5d16865144c7b25bdba96aa131f515d8ac33b783f21e2dc0cc48f6c010c898f9bc89b7
+  languageName: node
+  linkType: hard
+
 "@cspotcode/source-map-support@npm:^0.8.0":
   version: 0.8.1
   resolution: "@cspotcode/source-map-support@npm:0.8.1"
@@ -455,6 +494,92 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/api-logs@npm:0.214.0":
+  version: 0.214.0
+  resolution: "@opentelemetry/api-logs@npm:0.214.0"
+  dependencies:
+    "@opentelemetry/api": "npm:^1.3.0"
+  checksum: 10c0/414f8b824ad52ad2cc358cc2f26b709e64b0748fd7c3e6b7a613cb3b3a1138adf6c0a80d92fad8832ab4b62bbf3e1d1424bf5c707efe2f49bfd15500031ccbf7
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/api@npm:^1.3.0, @opentelemetry/api@npm:^1.9.1":
+  version: 1.9.1
+  resolution: "@opentelemetry/api@npm:1.9.1"
+  checksum: 10c0/c608485fc8b5a91e1f7e05e843b45b509307456b31cd2ad365933d90813e40ebfedf179f1451c762037e82d7c76aa8500e95d2da3609f640a1206cde5322cd14
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/core@npm:2.9.0":
+  version: 2.9.0
+  resolution: "@opentelemetry/core@npm:2.9.0"
+  dependencies:
+    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: 10c0/2b498ed07594e8e8d569832fffb54fe35479f2fe256651b02ed2c834971c2a50750265afb0e15da348515673d84b357d7ffeb75eb7fe7e63a0fbabd34ad01e65
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/instrumentation@npm:^0.214.0":
+  version: 0.214.0
+  resolution: "@opentelemetry/instrumentation@npm:0.214.0"
+  dependencies:
+    "@opentelemetry/api-logs": "npm:0.214.0"
+    import-in-the-middle: "npm:^3.0.0"
+    require-in-the-middle: "npm:^8.0.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/0b0bde772a28c134d8f27c078d9b4a368b64b3b2183ffe1eea3067944f3ee711b8ce820d50b55c59a6218bf5a04722ebf6f04c27850895a7faa423cb56c99653
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/resources@npm:2.9.0":
+  version: 2.9.0
+  resolution: "@opentelemetry/resources@npm:2.9.0"
+  dependencies:
+    "@opentelemetry/core": "npm:2.9.0"
+    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.3.0 <1.10.0"
+  checksum: 10c0/b0fe7a1dc7c4c1ccb0dc905cf2578b15de39d37bd43058c35521a455019dc1eca6fc4a54ad3a3e48bdddbd2d8088514bb52bc333b7652a4957df5088140c2129
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/sdk-trace-base@npm:^2.6.1":
+  version: 2.9.0
+  resolution: "@opentelemetry/sdk-trace-base@npm:2.9.0"
+  dependencies:
+    "@opentelemetry/core": "npm:2.9.0"
+    "@opentelemetry/resources": "npm:2.9.0"
+    "@opentelemetry/sdk-trace": "npm:2.9.0"
+    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.3.0 <1.10.0"
+  checksum: 10c0/b9ca8de6f6b972a924b6e87da3b3b5a042867f7f7433d9058a5b4102d05a5d12dfbc487bf0e95b1d1fd0c4a480bbd8ad7e273f4c3886843fac21326e2cbf574a
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/sdk-trace@npm:2.9.0":
+  version: 2.9.0
+  resolution: "@opentelemetry/sdk-trace@npm:2.9.0"
+  dependencies:
+    "@opentelemetry/core": "npm:2.9.0"
+    "@opentelemetry/resources": "npm:2.9.0"
+    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.3.0 <1.10.0"
+  checksum: 10c0/8a6d2be45c3be8a66b455443edd0f1dcb571fc9e12edc310a87ae87a6cb15303a36d0b91ba5b5595e5f5715adc75316a171097b71e96014584c634c398c09043
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/semantic-conventions@npm:^1.29.0, @opentelemetry/semantic-conventions@npm:^1.40.0":
+  version: 1.41.1
+  resolution: "@opentelemetry/semantic-conventions@npm:1.41.1"
+  checksum: 10c0/c54b1edf845766e93026d30fd95e15da9dba8d7a5b58f8c320c5d36ab542c77b37868f3e8e3d78ec162da8ee2afd24781f0a65934c9bdbc1aea86b47b12f074c
+  languageName: node
+  linkType: hard
+
 "@oxc-project/types@npm:=0.133.0":
   version: 0.133.0
   resolution: "@oxc-project/types@npm:0.133.0"
@@ -753,6 +878,95 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry/conventions@npm:^0.12.0":
+  version: 0.12.0
+  resolution: "@sentry/conventions@npm:0.12.0"
+  checksum: 10c0/d275102c0c9ae925516f36cad6c4333980f9f04a47520c88c63bc80446a804c82f4df7a92b7b105fd2f46c35435a33fbe0ce744cc21856dde3460187bd80111b
+  languageName: node
+  linkType: hard
+
+"@sentry/core@npm:10.63.0":
+  version: 10.63.0
+  resolution: "@sentry/core@npm:10.63.0"
+  checksum: 10c0/1efa658c0708abbc8a3fb8b351fcb16028e54d4eb0f63a99d91a6137cecdcb45f0c0a691ffa7b80b06f5d8715784e2929e34e40fa505ba70c67c4c25834549d0
+  languageName: node
+  linkType: hard
+
+"@sentry/node-core@npm:10.63.0":
+  version: 10.63.0
+  resolution: "@sentry/node-core@npm:10.63.0"
+  dependencies:
+    "@sentry/conventions": "npm:^0.12.0"
+    "@sentry/core": "npm:10.63.0"
+    "@sentry/opentelemetry": "npm:10.63.0"
+    import-in-the-middle: "npm:^3.0.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.9.0
+    "@opentelemetry/core": ^1.30.1 || ^2.1.0
+    "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1"
+    "@opentelemetry/instrumentation": ">=0.57.1 <1"
+    "@opentelemetry/sdk-trace-base": ^1.30.1 || ^2.1.0
+  peerDependenciesMeta:
+    "@opentelemetry/api":
+      optional: true
+    "@opentelemetry/core":
+      optional: true
+    "@opentelemetry/exporter-trace-otlp-http":
+      optional: true
+    "@opentelemetry/instrumentation":
+      optional: true
+    "@opentelemetry/sdk-trace-base":
+      optional: true
+  checksum: 10c0/c0b5db7d0160371b90645ab51af2136f795c6cf2b506c7fb39537e79a7b53014407487229eb4635a944ad965dd30aa4b3e3ba1cff6390dce4fb581a451fecb26
+  languageName: node
+  linkType: hard
+
+"@sentry/node@npm:^10.63.0":
+  version: 10.63.0
+  resolution: "@sentry/node@npm:10.63.0"
+  dependencies:
+    "@opentelemetry/api": "npm:^1.9.1"
+    "@opentelemetry/instrumentation": "npm:^0.214.0"
+    "@opentelemetry/sdk-trace-base": "npm:^2.6.1"
+    "@opentelemetry/semantic-conventions": "npm:^1.40.0"
+    "@sentry/conventions": "npm:^0.12.0"
+    "@sentry/core": "npm:10.63.0"
+    "@sentry/node-core": "npm:10.63.0"
+    "@sentry/opentelemetry": "npm:10.63.0"
+    "@sentry/server-utils": "npm:10.63.0"
+    import-in-the-middle: "npm:^3.0.0"
+  checksum: 10c0/009761a4fc7cfd48b2369b8c8858d488f2a7d94b9e4c984d823ea617d7f35e1e83bcb644a2765beb98b3db489f9b8e2b8c693b07e265b538e6f68340f3da5dc9
+  languageName: node
+  linkType: hard
+
+"@sentry/opentelemetry@npm:10.63.0":
+  version: 10.63.0
+  resolution: "@sentry/opentelemetry@npm:10.63.0"
+  dependencies:
+    "@sentry/conventions": "npm:^0.12.0"
+    "@sentry/core": "npm:10.63.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.9.0
+    "@opentelemetry/core": ^1.30.1 || ^2.1.0
+    "@opentelemetry/sdk-trace-base": ^1.30.1 || ^2.1.0
+  checksum: 10c0/76b811f6ed2849ae554c2807a54da1bfb05af33efa8350aafae0271c42a0265feb684559fdc58a39545a4169d426dd71d9d02d6bcbbe7d4f9aa77b015c50a138
+  languageName: node
+  linkType: hard
+
+"@sentry/server-utils@npm:10.63.0":
+  version: 10.63.0
+  resolution: "@sentry/server-utils@npm:10.63.0"
+  dependencies:
+    "@apm-js-collab/code-transformer": "npm:^0.15.0"
+    "@apm-js-collab/code-transformer-bundler-plugins": "npm:^0.5.0"
+    "@apm-js-collab/tracing-hooks": "npm:^0.10.0"
+    "@sentry/conventions": "npm:^0.12.0"
+    "@sentry/core": "npm:10.63.0"
+    magic-string: "npm:~0.30.0"
+  checksum: 10c0/d2022b288e51a585c1ed8c3009c9afefa9848b69c4b7d02a4d3ef4e34cfea2c6b6ee20956d180f1af36a950e6c0e5adbb3f6cd0167264aa5f6398debe004ec3b
+  languageName: node
+  linkType: hard
+
 "@standard-schema/spec@npm:^1.1.0":
   version: 1.1.0
   resolution: "@standard-schema/spec@npm:1.1.0"
@@ -857,7 +1071,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:^1.0.0":
+"@types/estree@npm:^1.0.0, @types/estree@npm:^1.0.8":
   version: 1.0.9
   resolution: "@types/estree@npm:1.0.9"
   checksum: 10c0/3ad3286ca2988cd550dafb8f2ad599c8474868e954fa601a36655bdfefd8039f7c714b8c1c7f2ae219ffbd58bd4660e66fa7479a0120fc02d4777057d4865387
@@ -1232,6 +1446,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"astring@npm:^1.9.0":
+  version: 1.9.0
+  resolution: "astring@npm:1.9.0"
+  bin:
+    astring: bin/astring
+  checksum: 10c0/e7519544d9824494e80ef0e722bb3a0c543a31440d59691c13aeaceb75b14502af536b23f08db50aa6c632dafaade54caa25f0788aa7550b6b2d6e2df89e0830
+  languageName: node
+  linkType: hard
+
 "async-function@npm:^1.0.0":
   version: 1.0.0
   resolution: "async-function@npm:1.0.0"
@@ -1471,6 +1694,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cjs-module-lexer@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "cjs-module-lexer@npm:2.2.0"
+  checksum: 10c0/aec4ca58f87145fac221386790ecaae8b012f2e2359a45acb61d8c75ea4fa84f6ea869f17abc1a7e91a808eff0fed581209632f03540de16f72f0a28f5fd35ac
+  languageName: node
+  linkType: hard
+
 "combined-stream@npm:^1.0.8":
   version: 1.0.8
   resolution: "combined-stream@npm:1.0.8"
@@ -1666,7 +1896,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4, debug@npm:^4.3.4, debug@npm:^4.4.0":
+"debug@npm:4, debug@npm:^4, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:^4.4.0, debug@npm:^4.4.1":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -1869,6 +2099,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-module-lexer@npm:^2.1.0, es-module-lexer@npm:^2.2.0":
+  version: 2.3.0
+  resolution: "es-module-lexer@npm:2.3.0"
+  checksum: 10c0/14b28d854ec2aec285c481daeea268451e01ab2813f09f98eb1ac432521d8c3b38ce552a49f2e4af3ba188b74acbafe9e8d7271ce912bd98f1651b02bd06717e
+  languageName: node
+  linkType: hard
+
 "es-object-atoms@npm:^1.0.0, es-object-atoms@npm:^1.1.1":
   version: 1.1.1
   resolution: "es-object-atoms@npm:1.1.1"
@@ -1983,6 +2220,22 @@ __metadata:
   version: 1.0.3
   resolution: "escape-html@npm:1.0.3"
   checksum: 10c0/524c739d776b36c3d29fa08a22e03e8824e3b2fd57500e5e44ecf3cc4707c34c60f9ca0781c0e33d191f2991161504c295e98f68c78fe7baa6e57081ec6ac0a3
+  languageName: node
+  linkType: hard
+
+"esquery@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "esquery@npm:1.7.0"
+  dependencies:
+    estraverse: "npm:^5.1.0"
+  checksum: 10c0/77d5173db450b66f3bc685d11af4c90cffeedb340f34a39af96d43509a335ce39c894fd79233df32d38f5e4e219fa0f7076f6ec90bae8320170ba082c0db4793
+  languageName: node
+  linkType: hard
+
+"estraverse@npm:^5.1.0":
+  version: 5.3.0
+  resolution: "estraverse@npm:5.3.0"
+  checksum: 10c0/1ff9447b96263dec95d6d67431c5e0771eb9776427421260a3e2f0fdd5d6bd4f8e37a7338f5ad2880c9f143450c9b1e4fc2069060724570a49cf9cf0312bd107
   languageName: node
   linkType: hard
 
@@ -2436,6 +2689,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"import-in-the-middle@npm:^3.0.0":
+  version: 3.3.0
+  resolution: "import-in-the-middle@npm:3.3.0"
+  dependencies:
+    cjs-module-lexer: "npm:^2.2.0"
+    es-module-lexer: "npm:^2.2.0"
+    module-details-from-path: "npm:^1.0.4"
+  checksum: 10c0/e1dc7f480e1517dfc9931c37dae959876cb026479efcaed2d8d3a3e9b6f7c69632113127cfeb5fb6bcbfc7371e0fed5e7a63118d37472d537160da65a208c7d8
+  languageName: node
+  linkType: hard
+
 "imurmurhash@npm:^0.1.4":
   version: 0.1.4
   resolution: "imurmurhash@npm:0.1.4"
@@ -2688,7 +2952,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"magic-string@npm:^0.30.17, magic-string@npm:^0.30.21":
+"magic-string@npm:^0.30.17, magic-string@npm:^0.30.21, magic-string@npm:~0.30.0":
   version: 0.30.21
   resolution: "magic-string@npm:0.30.21"
   dependencies:
@@ -2755,6 +3019,13 @@ __metadata:
   version: 1.0.3
   resolution: "merge-descriptors@npm:1.0.3"
   checksum: 10c0/866b7094afd9293b5ea5dcd82d71f80e51514bed33b4c4e9f516795dc366612a4cbb4dc94356e943a8a6914889a914530badff27f397191b9b75cda20b6bae93
+  languageName: node
+  linkType: hard
+
+"meriyah@npm:^6.1.4":
+  version: 6.1.4
+  resolution: "meriyah@npm:6.1.4"
+  checksum: 10c0/d792a12df453b9e86c2bb70e73adf41b2d0fa88125381143e4d339d309ddcbb7aeb108e286411dcb19be82539d29b881279c613ae03ce514b7c296c72e9a8d00
   languageName: node
   linkType: hard
 
@@ -2907,6 +3178,13 @@ __metadata:
     pkg-types: "npm:^1.3.1"
     ufo: "npm:^1.6.3"
   checksum: 10c0/aa826683a6daddf2aef65f9c8142e362731cf8e415a5591faf92fd51040a76697e45ab6dbb7a3b38be74e0f8c464825a7eabe827750455c7472421953f5da733
+  languageName: node
+  linkType: hard
+
+"module-details-from-path@npm:^1.0.3, module-details-from-path@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "module-details-from-path@npm:1.0.4"
+  checksum: 10c0/10863413e96dab07dee917eae07afe46f7bf853065cc75a7d2a718adf67574857fb64f8a2c0c9af12ac733a9a8cf652db7ed39b95f7a355d08106cb9cc50c83b
   languageName: node
   linkType: hard
 
@@ -3451,6 +3729,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"require-in-the-middle@npm:^8.0.0":
+  version: 8.0.1
+  resolution: "require-in-the-middle@npm:8.0.1"
+  dependencies:
+    debug: "npm:^4.3.5"
+    module-details-from-path: "npm:^1.0.3"
+  checksum: 10c0/4b3d29adfff873585dceffa9ddb8f33bb6599001ddff758503e0e5ade2ae6d20d691314125bb13679fa75a19893338e11953d4702dd2fea181e95c0f8316b29b
+  languageName: node
+  linkType: hard
+
 "resolve-from@npm:^5.0.0":
   version: 5.0.0
   resolution: "resolve-from@npm:5.0.0"
@@ -3641,6 +3929,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semifies@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "semifies@npm:1.0.0"
+  checksum: 10c0/d93d5e8d2c0b7d5f972b9378736ed5cc1f2ab40d043234b4156665872f08cb0da914ee8c8b35c59dc6b17880a4c5502588c7515c6bb4dbc3ce5565746428d31d
+  languageName: node
+  linkType: hard
+
 "semver@npm:^7.3.5":
   version: 7.7.3
   resolution: "semver@npm:7.7.3"
@@ -3696,6 +3991,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "server@workspace:."
   dependencies:
+    "@sentry/node": "npm:^10.63.0"
     "@types/cookie-session": "npm:^2.0.48"
     "@types/cors": "npm:^2.8.12"
     "@types/express": "npm:4.17.13"
@@ -3853,6 +4149,13 @@ __metadata:
   version: 1.2.1
   resolution: "source-map-js@npm:1.2.1"
   checksum: 10c0/7bda1fc4c197e3c6ff17de1b8b2c20e60af81b63a52cb32ec5a5d67a20a7d42651e2cb34ebe93833c5a2a084377e17455854fee3e21e7925c64a51b6a52b0faf
+  languageName: node
+  linkType: hard
+
+"source-map@npm:^0.6.0":
+  version: 0.6.1
+  resolution: "source-map@npm:0.6.1"
+  checksum: 10c0/ab55398007c5e5532957cb0beee2368529618ac0ab372d789806f5718123cc4367d57de3904b4e6a4170eb5a0b0f41373066d02ca0735a0c4d75c7d328d3e011
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Intent

Recover wrong-base PR #106 onto `origin/beta` with beta-native conflict resolution.

## What changed

- Added client Sentry initialization and a reusable React `ErrorBoundary` fallback.
- Wrapped the beta app in `ErrorBoundary` without removing the existing dev-only Agentation toolbar.
- Added server Sentry initialization and capture for unexpected 500-level handled errors.
- Captures startup failures before the process exits nonzero.
- Preserved beta's existing sanitized error logging, client-error mapping, Mongo reconnect behavior, package scripts, and data-operation scripts.

## Validation

- `yarn --cwd client vitest --run src/components/__tests__/ErrorBoundary.test.tsx src/utils/__tests__/errorTracking.test.ts`
- `yarn --cwd server vitest run src/utils/__tests__/errorTracking.test.ts src/middleware/__tests__/errorHandler.test.ts`
- `node --test scripts/security-preflight.test.mjs`
- `yarn --cwd client build`
- `yarn --cwd server build`

Targets `beta`. This is the beta-native recovery for #106.
