### PR TITLE
Recover public research SEO metadata on beta

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -5,10 +5,21 @@
     <link rel="icon" type="image/svg+xml" href="/brand/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#00356B" />
-    <meta
-      name="description"
-      content="Find research pathways, labs, programs, and evidence-backed next steps at Yale University"
-    />
+    <!-- Yale Research SEO metadata is replaced server-side for public research share URLs. -->
+    <!--YL_SEO_META_START-->
+    <meta name="description" content="Find research pathways, labs, programs, and evidence-backed next steps at Yale University" />
+    <link rel="canonical" href="/" />
+    <meta property="og:site_name" content="Yale Research" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Yale Research" />
+    <meta property="og:description" content="Find research pathways, labs, programs, and evidence-backed next steps at Yale University" />
+    <meta property="og:url" content="/" />
+    <meta property="og:image" content="/brand/apple-touch-icon.svg" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Yale Research" />
+    <meta name="twitter:description" content="Find research pathways, labs, programs, and evidence-backed next steps at Yale University" />
+    <meta name="twitter:image" content="/brand/apple-touch-icon.svg" />
+    <!--YL_SEO_META_END-->
     <link rel="apple-touch-icon" href="/brand/apple-touch-icon.svg" />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Source+Serif+4:wght@400;500;600;700&display=swap" rel="stylesheet">
     <title>Yale Research</title>

--- a/client/index.html
+++ b/client/index.html
@@ -8,17 +8,17 @@
     <!-- Yale Research SEO metadata is replaced server-side for public research share URLs. -->
     <!--YL_SEO_META_START-->
     <meta name="description" content="Find research pathways, labs, programs, and evidence-backed next steps at Yale University" />
-    <link rel="canonical" href="/" />
+    <link rel="canonical" href="https://yalelabs.io/" />
     <meta property="og:site_name" content="Yale Research" />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Yale Research" />
     <meta property="og:description" content="Find research pathways, labs, programs, and evidence-backed next steps at Yale University" />
     <meta property="og:url" content="/" />
-    <meta property="og:image" content="/brand/apple-touch-icon.svg" />
+    <meta property="og:image" content="https://yalelabs.io/brand/apple-touch-icon.svg" />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Yale Research" />
     <meta name="twitter:description" content="Find research pathways, labs, programs, and evidence-backed next steps at Yale University" />
-    <meta name="twitter:image" content="/brand/apple-touch-icon.svg" />
+    <meta name="twitter:image" content="https://yalelabs.io/brand/apple-touch-icon.svg" />
     <!--YL_SEO_META_END-->
     <link rel="apple-touch-icon" href="/brand/apple-touch-icon.svg" />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Source+Serif+4:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/client/src/utils/__tests__/seo.test.ts
+++ b/client/src/utils/__tests__/seo.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { applySeoMetadata, buildResearchSeoMetadata } from '../seo';
+import { applySeoMetadata, buildDefaultSeoMetadata, buildResearchSeoMetadata } from '../seo';
 
 describe('research SEO client fallback', () => {
   afterEach(() => {
@@ -46,6 +46,40 @@ describe('research SEO client fallback', () => {
     );
     expect(document.querySelector('meta[name="twitter:card"]')?.getAttribute('content')).toBe(
       'summary',
+    );
+  });
+
+  it('restores default Yale Research metadata after research metadata has been applied', () => {
+    applySeoMetadata(
+      buildResearchSeoMetadata({
+        origin: 'https://yalelabs.io',
+        pathname: '/research/evidence-backed-lab',
+        researchEntity: {
+          name: 'Evidence-backed lab',
+          description: 'Study immune signaling in public datasets.',
+        } as any,
+      }),
+    );
+
+    applySeoMetadata(
+      buildDefaultSeoMetadata({
+        origin: 'https://yalelabs.io',
+        pathname: '/fellowships',
+      }),
+    );
+
+    expect(document.title).toBe('Yale Research');
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://yalelabs.io/fellowships',
+    );
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'Find research pathways, labs, programs, and evidence-backed next steps at Yale University.',
+    );
+    expect(document.querySelector('meta[property="og:title"]')?.getAttribute('content')).toBe(
+      'Yale Research',
+    );
+    expect(document.querySelector('meta[name="twitter:title"]')?.getAttribute('content')).toBe(
+      'Yale Research',
     );
   });
 });

--- a/client/src/utils/__tests__/seo.test.ts
+++ b/client/src/utils/__tests__/seo.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { applySeoMetadata, buildResearchSeoMetadata } from '../seo';
+
+describe('research SEO client fallback', () => {
+  afterEach(() => {
+    document.title = '';
+    document.head.innerHTML = '';
+  });
+
+  it('builds useful listing metadata without exposing private contact fields', () => {
+    const metadata = buildResearchSeoMetadata({
+      origin: 'https://yalelabs.io',
+      pathname: '/research/evidence-backed-lab',
+      researchEntity: {
+        name: 'Evidence-backed lab',
+        description: 'Study immune signaling in public datasets.',
+        researchAreas: ['Computational Biology'],
+        ownerEmail: 'private@yale.edu',
+        emails: ['private-list@yale.edu'],
+      } as any,
+    });
+
+    expect(metadata.title).toBe('Evidence-backed lab | Yale Research');
+    expect(metadata.description).toBe('Study immune signaling in public datasets.');
+    expect(JSON.stringify(metadata)).not.toContain('private@yale.edu');
+    expect(JSON.stringify(metadata)).not.toContain('private-list@yale.edu');
+  });
+
+  it('updates canonical and social tags after React loads when server injection is unavailable', () => {
+    const metadata = buildResearchSeoMetadata({
+      origin: 'https://yalelabs.io',
+      pathname: '/research',
+    });
+
+    applySeoMetadata(metadata);
+
+    expect(document.title).toBe('Yale Research');
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://yalelabs.io/research',
+    );
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'Find research pathways, labs, programs, and evidence-backed next steps at Yale University.',
+    );
+    expect(document.querySelector('meta[property="og:title"]')?.getAttribute('content')).toBe(
+      'Yale Research',
+    );
+    expect(document.querySelector('meta[name="twitter:card"]')?.getAttribute('content')).toBe(
+      'summary',
+    );
+  });
+});

--- a/client/src/utils/__tests__/seo.test.ts
+++ b/client/src/utils/__tests__/seo.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
 import { applySeoMetadata, buildDefaultSeoMetadata, buildResearchSeoMetadata } from '../seo';
 
 describe('research SEO client fallback', () => {
@@ -80,6 +81,23 @@ describe('research SEO client fallback', () => {
     );
     expect(document.querySelector('meta[name="twitter:title"]')?.getAttribute('content')).toBe(
       'Yale Research',
+    );
+  });
+
+  it('keeps the static SPA shell metadata generic for non-research routes', () => {
+    const html = readFileSync('index.html', 'utf8');
+
+    expect(html).toContain('<title>Yale Research</title>');
+    expect(html).toContain(
+      '<meta name="description" content="Find research pathways, labs, programs, and evidence-backed next steps at Yale University" />',
+    );
+    expect(html).toContain('<meta property="og:title" content="Yale Research" />');
+    expect(html).toContain(
+      '<meta property="og:description" content="Find research pathways, labs, programs, and evidence-backed next steps at Yale University" />',
+    );
+    expect(html).toContain('<meta name="twitter:title" content="Yale Research" />');
+    expect(html).toContain(
+      '<meta name="twitter:description" content="Find research pathways, labs, programs, and evidence-backed next steps at Yale University" />',
     );
   });
 });

--- a/client/src/utils/seo.ts
+++ b/client/src/utils/seo.ts
@@ -17,6 +17,9 @@ export type SeoMetadata = {
 
 const SITE_NAME = 'Yale Research';
 const DEFAULT_RESEARCH_TITLE = 'Yale Research';
+const DEFAULT_SITE_TITLE = 'Yale Research';
+const DEFAULT_SITE_DESCRIPTION =
+  'Find research pathways, labs, programs, and evidence-backed next steps at Yale University.';
 const DEFAULT_RESEARCH_DESCRIPTION =
   'Find research pathways, labs, programs, and evidence-backed next steps at Yale University.';
 
@@ -95,6 +98,22 @@ export const buildResearchSeoMetadata = (params: {
     canonicalUrl,
     imageUrl,
     type: 'article',
+  };
+};
+
+export const buildDefaultSeoMetadata = (params: {
+  origin: string;
+  pathname: string;
+}): SeoMetadata => {
+  const origin = params.origin.replace(/\/+$/, '');
+  const canonicalUrl = `${origin}${params.pathname.startsWith('/') ? params.pathname : `/${params.pathname}`}`;
+
+  return {
+    title: DEFAULT_SITE_TITLE,
+    description: DEFAULT_SITE_DESCRIPTION,
+    canonicalUrl,
+    imageUrl: `${origin}/brand/apple-touch-icon.svg`,
+    type: 'website',
   };
 };
 

--- a/client/src/utils/seo.ts
+++ b/client/src/utils/seo.ts
@@ -1,0 +1,149 @@
+/**
+ * Client-side SEO fallback for the SPA.
+ *
+ * Express injects crawler-visible metadata for built public research routes.
+ * During Vite development or static-only hosting, this updater provides the
+ * strongest practical fallback after React loads.
+ */
+import type { ResearchEntity } from '../types/researchEntity';
+
+export type SeoMetadata = {
+  title: string;
+  description: string;
+  canonicalUrl: string;
+  imageUrl: string;
+  type: 'website' | 'article';
+};
+
+const SITE_NAME = 'Yale Research';
+const DEFAULT_RESEARCH_TITLE = 'Yale Research';
+const DEFAULT_RESEARCH_DESCRIPTION =
+  'Find research pathways, labs, programs, and evidence-backed next steps at Yale University.';
+
+const compact = (value: string): string => value.replace(/\s+/g, ' ').trim();
+
+const stripHtml = (value: string): string => compact(value.replace(/<[^>]*>/g, ' '));
+
+const truncate = (value: string, maxLength: number): string => {
+  const clean = compact(value);
+  if (clean.length <= maxLength) return clean;
+  const truncated = clean.slice(0, maxLength - 1).trimEnd();
+  const lastSpace = truncated.lastIndexOf(' ');
+  return `${(lastSpace > 80 ? truncated.slice(0, lastSpace) : truncated).trimEnd()}...`;
+};
+
+const firstNonEmpty = (...values: Array<string | undefined>): string | undefined =>
+  values.map((value) => (value ? stripHtml(value) : '')).find(Boolean);
+
+const joinList = (values: unknown): string | undefined => {
+  if (!Array.isArray(values)) return undefined;
+  const clean = values.filter((value): value is string => typeof value === 'string').map(compact);
+  return clean.filter(Boolean).slice(0, 3).join(', ') || undefined;
+};
+
+export const buildResearchSeoMetadata = (params: {
+  origin: string;
+  pathname: string;
+  researchEntity?: Partial<ResearchEntity> | null;
+}): SeoMetadata => {
+  const origin = params.origin.replace(/\/+$/, '');
+  const canonicalUrl = `${origin}${params.pathname.startsWith('/') ? params.pathname : `/${params.pathname}`}`;
+  const imageUrl = `${origin}/brand/apple-touch-icon.svg`;
+
+  if (!params.researchEntity) {
+    return {
+      title: DEFAULT_RESEARCH_TITLE,
+      description: DEFAULT_RESEARCH_DESCRIPTION,
+      canonicalUrl,
+      imageUrl,
+      type: 'website',
+    };
+  }
+
+  const researchEntity = params.researchEntity;
+  const name = firstNonEmpty(researchEntity.name, researchEntity.displayName) || 'Research profile';
+  const title = truncate(`${name} | ${SITE_NAME}`, 65);
+  const topicalContext =
+    joinList(researchEntity.researchAreas) ||
+    joinList(researchEntity.profileResearchAreas) ||
+    joinList(researchEntity.keywords) ||
+    joinList(researchEntity.departments);
+  const departmentContext = joinList(researchEntity.departments);
+  const fallbackDescription = compact(
+    [
+      name,
+      departmentContext ? `at ${departmentContext}` : undefined,
+      topicalContext ? `Research areas include ${topicalContext}.` : undefined,
+    ]
+      .filter(Boolean)
+      .join(' '),
+  );
+
+  return {
+    title,
+    description: truncate(
+      firstNonEmpty(
+        researchEntity.shortDescription,
+        researchEntity.description,
+        researchEntity.fullDescription,
+        researchEntity.profileSynthesisDescription,
+        fallbackDescription,
+      ) ||
+        DEFAULT_RESEARCH_DESCRIPTION,
+      160,
+    ),
+    canonicalUrl,
+    imageUrl,
+    type: 'article',
+  };
+};
+
+const upsertMeta = (selector: string, attrs: Record<string, string>) => {
+  let element = document.head.querySelector<HTMLMetaElement>(selector);
+  if (!element) {
+    element = document.createElement('meta');
+    document.head.appendChild(element);
+  }
+
+  Object.entries(attrs).forEach(([name, value]) => {
+    element!.setAttribute(name, value);
+  });
+};
+
+const upsertCanonical = (href: string) => {
+  let element = document.head.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+  if (!element) {
+    element = document.createElement('link');
+    element.setAttribute('rel', 'canonical');
+    document.head.appendChild(element);
+  }
+  element.setAttribute('href', href);
+};
+
+export const applySeoMetadata = (metadata: SeoMetadata) => {
+  document.title = metadata.title;
+  upsertCanonical(metadata.canonicalUrl);
+  upsertMeta('meta[name="description"]', {
+    name: 'description',
+    content: metadata.description,
+  });
+  upsertMeta('meta[property="og:site_name"]', {
+    property: 'og:site_name',
+    content: SITE_NAME,
+  });
+  upsertMeta('meta[property="og:type"]', { property: 'og:type', content: metadata.type });
+  upsertMeta('meta[property="og:title"]', { property: 'og:title', content: metadata.title });
+  upsertMeta('meta[property="og:description"]', {
+    property: 'og:description',
+    content: metadata.description,
+  });
+  upsertMeta('meta[property="og:url"]', { property: 'og:url', content: metadata.canonicalUrl });
+  upsertMeta('meta[property="og:image"]', { property: 'og:image', content: metadata.imageUrl });
+  upsertMeta('meta[name="twitter:card"]', { name: 'twitter:card', content: 'summary' });
+  upsertMeta('meta[name="twitter:title"]', { name: 'twitter:title', content: metadata.title });
+  upsertMeta('meta[name="twitter:description"]', {
+    name: 'twitter:description',
+    content: metadata.description,
+  });
+  upsertMeta('meta[name="twitter:image"]', { name: 'twitter:image', content: metadata.imageUrl });
+};

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -10,6 +10,7 @@ import passport, { passportRoutes } from './passport';
 import routes from './routes/index';
 import cookieSession from 'cookie-session';
 import dotenv from 'dotenv';
+import { readFile } from 'fs/promises';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 import { errorHandler, notFoundHandler } from './middleware/errorHandler';
@@ -19,8 +20,16 @@ import { csrfOriginGuard } from './middleware/csrfOriginGuard';
 import { createCorsOriginHandler } from './middleware/corsOrigin';
 import { sessionCookieName } from './utils/sessionCookie';
 import { createRateLimitHandler } from './middleware/rateLimitResponse';
+import { getResearchGroupBySlug } from './services/researchGroupService';
+import {
+  buildPublicResearchSeoMetadata,
+  injectSeoMetadata,
+  resolvePublicBaseUrl,
+} from './utils/publicResearchSeo';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const clientDistPath = path.join(__dirname, '../../client/dist');
+const clientIndexPath = path.join(clientDistPath, 'index.html');
 const API_BODY_LIMIT = '64kb';
 const API_URLENCODED_PARAMETER_LIMIT = 100;
 const SAFE_RATE_LIMIT_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
@@ -308,22 +317,54 @@ const app = express()
 
 app.use('/api', notFoundHandler);
 
+const sendPublicResearchIndex = async (
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction,
+) => {
+  try {
+    const indexHtml = await readFile(clientIndexPath, 'utf8');
+    let researchEntity = null;
+
+    if (req.params.slug) {
+      try {
+        researchEntity = await getResearchGroupBySlug(req.params.slug);
+      } catch (error) {
+        console.error('Unable to load public research SEO metadata:', error);
+      }
+    }
+
+    const metadata = buildPublicResearchSeoMetadata({
+      baseUrl: resolvePublicBaseUrl(req),
+      path: req.path,
+      researchEntity,
+    });
+
+    res.type('html').send(injectSeoMetadata(indexHtml, metadata));
+  } catch (error) {
+    next(error);
+  }
+};
+
 app.use(blockSourceMapAssetRequests);
 app.use(setOAuthCallbackAssetCacheHeaders);
 app.use(
-  express.static(path.join(__dirname, '../../client/dist'), {
+  express.static(clientDistPath, {
     dotfiles: 'ignore',
     fallthrough: true,
     index: false,
   }),
 );
 
+app.get('/research', sendPublicResearchIndex);
+app.get('/research/:slug', sendPublicResearchIndex);
+
 app.get('*', (req, res) => {
   if (!shouldServeSpaFallback(req)) {
     return sendStaticNotFound(res);
   }
 
-  res.sendFile(path.join(__dirname, '../../client/dist/index.html'));
+  res.sendFile(clientIndexPath);
 });
 
 app.use(errorHandler);

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -349,7 +349,7 @@ const sendPublicResearchIndex = async (
 app.use(blockSourceMapAssetRequests);
 app.use(setOAuthCallbackAssetCacheHeaders);
 app.use(
-  express.static(clientDistPath, {
+  express.static(path.join(__dirname, '../../client/dist'), {
     dotfiles: 'ignore',
     fallthrough: true,
     index: false,

--- a/server/src/utils/__tests__/publicResearchSeo.test.ts
+++ b/server/src/utils/__tests__/publicResearchSeo.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildPublicResearchSeoMetadata,
+  injectSeoMetadata,
+  renderSeoTags,
+} from '../publicResearchSeo';
+
+describe('public research SEO metadata', () => {
+  it('builds share metadata from public-safe listing fields only', () => {
+    const metadata = buildPublicResearchSeoMetadata({
+      baseUrl: 'https://yalelabs.io/',
+      path: '/research/evidence-backed-lab',
+      researchEntity: {
+        name: 'Evidence-backed lab',
+        description: 'Study immune signaling in public datasets.',
+        departments: ['Computer Science'],
+        researchAreas: ['Computational Biology'],
+        ownerEmail: 'private@yale.edu',
+        emails: ['private-list@yale.edu'],
+      } as any,
+    });
+    const tags = renderSeoTags(metadata);
+
+    expect(metadata.title).toBe('Evidence-backed lab | Yale Research');
+    expect(metadata.description).toBe('Study immune signaling in public datasets.');
+    expect(metadata.canonicalUrl).toBe('https://yalelabs.io/research/evidence-backed-lab');
+    expect(tags).toContain('property="og:title" content="Evidence-backed lab | Yale Research"');
+    expect(tags).not.toContain('private@yale.edu');
+    expect(tags).not.toContain('private-list@yale.edu');
+  });
+
+  it('injects crawler-visible public research metadata into the SPA shell', () => {
+    const html = `<!doctype html><html><head><title>Yale Research</title><!--YL_SEO_META_START--><meta name="description" content="old" /><!--YL_SEO_META_END--></head><body></body></html>`;
+    const metadata = buildPublicResearchSeoMetadata({
+      baseUrl: 'https://yalelabs.io',
+      path: '/research',
+    });
+
+    const injected = injectSeoMetadata(html, metadata);
+
+    expect(injected).toContain('<title>Yale Research</title>');
+    expect(injected).toContain('rel="canonical" href="https://yalelabs.io/research"');
+    expect(injected).toContain('property="og:type" content="website"');
+    expect(injected).toContain('name="twitter:card" content="summary"');
+    expect(injected).not.toContain('content="old"');
+  });
+});

--- a/server/src/utils/publicResearchSeo.ts
+++ b/server/src/utils/publicResearchSeo.ts
@@ -1,0 +1,169 @@
+/**
+ * SEO helpers for public research pages.
+ *
+ * The app is still a client-rendered SPA. These helpers let the production
+ * Express server replace the built index.html metadata for public research
+ * share URLs; Vite-only/static hosts fall back to the client head updater.
+ */
+
+export type PublicResearchSeoEntity = {
+  id?: string;
+  name?: string;
+  displayName?: string;
+  shortDescription?: string;
+  description?: string;
+  fullDescription?: string;
+  profileSynthesisDescription?: string;
+  departments?: string[];
+  researchAreas?: string[];
+  profileResearchAreas?: string[];
+  keywords?: string[];
+};
+
+export type SeoMetadata = {
+  title: string;
+  description: string;
+  canonicalUrl: string;
+  imageUrl: string;
+  type: 'website' | 'article';
+};
+
+const SITE_NAME = 'Yale Research';
+const DEFAULT_RESEARCH_TITLE = 'Yale Research';
+const DEFAULT_RESEARCH_DESCRIPTION =
+  'Find research pathways, labs, programs, and evidence-backed next steps at Yale University.';
+const SEO_START = '<!--YL_SEO_META_START-->';
+const SEO_END = '<!--YL_SEO_META_END-->';
+
+const compact = (value: string): string => value.replace(/\s+/g, ' ').trim();
+
+const stripHtml = (value: string): string => compact(value.replace(/<[^>]*>/g, ' '));
+
+const truncate = (value: string, maxLength: number): string => {
+  const clean = compact(value);
+  if (clean.length <= maxLength) return clean;
+  const truncated = clean.slice(0, maxLength - 1).trimEnd();
+  const lastSpace = truncated.lastIndexOf(' ');
+  return `${(lastSpace > 80 ? truncated.slice(0, lastSpace) : truncated).trimEnd()}...`;
+};
+
+const firstNonEmpty = (...values: Array<string | undefined>): string | undefined =>
+  values.map((value) => (value ? stripHtml(value) : '')).find(Boolean);
+
+const joinList = (values: unknown): string | undefined => {
+  if (!Array.isArray(values)) return undefined;
+  const clean = values.filter((value): value is string => typeof value === 'string').map(compact);
+  return clean.filter(Boolean).slice(0, 3).join(', ') || undefined;
+};
+
+export const buildPublicResearchSeoMetadata = (params: {
+  baseUrl: string;
+  path: string;
+  researchEntity?: PublicResearchSeoEntity | null;
+}): SeoMetadata => {
+  const baseUrl = params.baseUrl.replace(/\/+$/, '');
+  const path = params.path.startsWith('/') ? params.path : `/${params.path}`;
+  const canonicalUrl = `${baseUrl}${path}`;
+  const imageUrl = `${baseUrl}/brand/apple-touch-icon.svg`;
+
+  if (!params.researchEntity) {
+    return {
+      title: DEFAULT_RESEARCH_TITLE,
+      description: DEFAULT_RESEARCH_DESCRIPTION,
+      canonicalUrl,
+      imageUrl,
+      type: 'website',
+    };
+  }
+
+  const researchEntity = params.researchEntity;
+  const name = firstNonEmpty(researchEntity.name, researchEntity.displayName) || 'Research profile';
+  const title = truncate(`${name} | ${SITE_NAME}`, 65);
+  const topicalContext =
+    joinList(researchEntity.researchAreas) ||
+    joinList(researchEntity.profileResearchAreas) ||
+    joinList(researchEntity.keywords) ||
+    joinList(researchEntity.departments);
+  const departmentContext = joinList(researchEntity.departments);
+  const fallbackDescription = compact(
+    [
+      name,
+      departmentContext ? `at ${departmentContext}` : undefined,
+      topicalContext ? `Research areas include ${topicalContext}.` : undefined,
+    ]
+      .filter(Boolean)
+      .join(' '),
+  );
+
+  return {
+    title,
+    description: truncate(
+      firstNonEmpty(
+        researchEntity.shortDescription,
+        researchEntity.description,
+        researchEntity.fullDescription,
+        researchEntity.profileSynthesisDescription,
+        fallbackDescription,
+      ) ||
+        DEFAULT_RESEARCH_DESCRIPTION,
+      160,
+    ),
+    canonicalUrl,
+    imageUrl,
+    type: 'article',
+  };
+};
+
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+export const renderSeoTags = (metadata: SeoMetadata): string => {
+  const title = escapeHtml(metadata.title);
+  const description = escapeHtml(metadata.description);
+  const canonicalUrl = escapeHtml(metadata.canonicalUrl);
+  const imageUrl = escapeHtml(metadata.imageUrl);
+
+  return [
+    SEO_START,
+    `<meta name="description" content="${description}" />`,
+    `<link rel="canonical" href="${canonicalUrl}" />`,
+    `<meta property="og:site_name" content="${SITE_NAME}" />`,
+    `<meta property="og:type" content="${metadata.type}" />`,
+    `<meta property="og:title" content="${title}" />`,
+    `<meta property="og:description" content="${description}" />`,
+    `<meta property="og:url" content="${canonicalUrl}" />`,
+    `<meta property="og:image" content="${imageUrl}" />`,
+    `<meta name="twitter:card" content="summary" />`,
+    `<meta name="twitter:title" content="${title}" />`,
+    `<meta name="twitter:description" content="${description}" />`,
+    `<meta name="twitter:image" content="${imageUrl}" />`,
+    SEO_END,
+  ].join('\n    ');
+};
+
+export const injectSeoMetadata = (html: string, metadata: SeoMetadata): string => {
+  const withTitle = html.replace(/<title>.*?<\/title>/i, `<title>${escapeHtml(metadata.title)}</title>`);
+  const startIndex = withTitle.indexOf(SEO_START);
+  const endIndex = withTitle.indexOf(SEO_END);
+
+  if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
+    return withTitle.replace('</head>', `    ${renderSeoTags(metadata)}\n  </head>`);
+  }
+
+  return `${withTitle.slice(0, startIndex)}${renderSeoTags(metadata)}${withTitle.slice(
+    endIndex + SEO_END.length,
+  )}`;
+};
+
+export const resolvePublicBaseUrl = (req: {
+  protocol: string;
+  get(name: string): string | undefined;
+}): string => {
+  const host = req.get('host') || 'localhost:4000';
+  return `${req.protocol}://${host}`;
+};


### PR DESCRIPTION
## Summary
- recover public research SEO/share metadata against beta's ResearchEntity detail model
- inject crawler-visible metadata for `/research` and `/research/:slug` while preserving beta static-file hardening
- add client-side SEO fallback/reset helpers for SPA/static development paths

## Validation
- `yarn --cwd server vitest run src/utils/__tests__/publicResearchSeo.test.ts`
- `yarn --cwd client vitest --run src/utils/__tests__/seo.test.ts`
- `node scripts/security-preflight.test.mjs`
- `yarn --cwd server build`
- `yarn --cwd client build`

## Recovery notes
- Recovered from original PR #115 onto `origin/beta`.
- Skipped stale documentation and lint-only replay commits that conflicted with beta-era docs/branding; PR body records the beta-adapted behavior.
