### PR TITLE
Improve planning dashboard cues and export

### DIFF
--- a/client/src/components/accounts/FavoritesManager.tsx
+++ b/client/src/components/accounts/FavoritesManager.tsx
@@ -81,6 +81,13 @@ export const savedProgramDeadlineSummary = (
   const next = upcoming[0];
   if (!next) return {};
 
+  if (next.fellowship.isAcceptingApplications) {
+    return {
+      nextDeadlineDate: next.fellowship.deadline || undefined,
+      nextDeadlineLabel: `${next.fellowship.title}: Now open; due ${dateFormatter.format(next.date)}`,
+    };
+  }
+
   return {
     nextDeadlineDate: next.fellowship.deadline || undefined,
     nextDeadlineLabel: `${next.fellowship.title}: Due ${dateFormatter.format(next.date)}`,

--- a/client/src/components/accounts/SavedPathwaysSection.tsx
+++ b/client/src/components/accounts/SavedPathwaysSection.tsx
@@ -55,6 +55,28 @@ export interface FellowshipFundingMatch {
 
 type FundingMatchesByPathway = Record<string, FellowshipFundingMatch[]>;
 
+interface SavedPlanExportItem {
+  title?: string;
+  researchEntity?: {
+    name?: string;
+  };
+  intent?: string;
+  stage?: string;
+  checklist?: Record<string, boolean>;
+  sourceLinks?: string[];
+  bestNextStepCategory?: string;
+  privateNote?: string;
+}
+
+interface SavedPlanExportPayload {
+  exportedAt?: string;
+  itemCount?: number;
+  privacy?: {
+    includesPrivateNotes?: boolean;
+  };
+  items?: SavedPlanExportItem[];
+}
+
 export interface DeadlineReminder {
   kind: 'posted-opportunity' | 'fellowship';
   label: string;
@@ -266,7 +288,7 @@ export const deadlineReminderForPathway = (
         }
       : null,
     ...matches.map((match) =>
-      match.deadline
+      match.deadline && match.strength !== 'weak_candidate'
         ? {
             kind: 'fellowship' as const,
             label: 'Fellowship deadline',
@@ -289,7 +311,9 @@ export const deadlineReminderForPathway = (
   const future = candidates
     .filter((candidate) => candidate.days >= 0)
     .sort((a, b) => a.days - b.days);
-  const selected = future[0] || candidates.sort((a, b) => b.date.getTime() - a.date.getTime())[0];
+  if (future.length === 0) return null;
+
+  const selected = future[0];
   const urgency = reminderUrgency(selected.days);
   const dueWord = urgency === 'overdue' ? 'Passed' : 'Due';
   const formattedDate = formatDeadline(selected.deadline);
@@ -325,6 +349,51 @@ const normalizePlanChecklist = (value: unknown): Record<string, boolean> => {
     }
   }
   return checklist;
+};
+
+const labelizeExportValue = (value?: string): string =>
+  labelize(value || '').replace(/\b\w/g, (letter) => letter.toUpperCase());
+
+const readableSavedPlanExport = (payload: SavedPlanExportPayload): string => {
+  const lines = [
+    '# Saved Research Plans',
+    '',
+    `Exported: ${payload.exportedAt ? formatDeadline(payload.exportedAt) : formatDeadline(new Date().toISOString())}`,
+    `Private notes: ${payload.privacy?.includesPrivateNotes ? 'included' : 'not included'}`,
+    `Plans: ${payload.itemCount ?? payload.items?.length ?? 0}`,
+    '',
+  ];
+
+  for (const [index, item] of (payload.items || []).entries()) {
+    const checkedItems = Object.entries(item.checklist || {})
+      .filter(([, checked]) => checked)
+      .map(([key]) => labelizeExportValue(key));
+
+    lines.push(
+      `## ${index + 1}. ${item.title || 'Saved research plan'}`,
+      '',
+      `Research home: ${item.researchEntity?.name || 'Unknown'}`,
+      `Intent: ${labelizeExportValue(item.intent)}`,
+      `Stage: ${labelizeExportValue(item.stage)}`,
+      `Next step: ${labelizeExportValue(item.bestNextStepCategory)}`,
+    );
+
+    if (item.privateNote) {
+      lines.push('', 'Private note:', item.privateNote);
+    }
+
+    if (checkedItems.length > 0) {
+      lines.push('', 'Completed checklist:', ...checkedItems.map((label) => `- ${label}`));
+    }
+
+    if ((item.sourceLinks || []).length > 0) {
+      lines.push('', 'Sources:', ...(item.sourceLinks || []).map((source) => `- ${source}`));
+    }
+
+    lines.push('');
+  }
+
+  return lines.join('\n');
 };
 
 const normalizeStoredPlan = (value: unknown): PathwayPlan | null => {
@@ -512,6 +581,7 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
   const [error, setError] = useState('');
   const [exporting, setExporting] = useState(false);
   const [exportError, setExportError] = useState('');
+  const [exportNotice, setExportNotice] = useState('');
   const [includePrivateNotesInExport, setIncludePrivateNotesInExport] = useState(false);
   const [showExportControls, setShowExportControls] = useState(false);
   const [expandedPlanIds, setExpandedPlanIds] = useState<Record<string, boolean>>({});
@@ -706,6 +776,7 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
   const exportSavedPathways = async () => {
     setExporting(true);
     setExportError('');
+    setExportNotice('');
     try {
       const response = includePrivateNotesInExport
         ? await axios.post(
@@ -716,19 +787,21 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
         : await axios.get('/users/savedResearchPlanDetails/export', {
             withCredentials: true,
           });
-      const blob = new Blob([JSON.stringify(response.data, null, 2)], {
-        type: 'application/json',
+      const payload = response.data as SavedPlanExportPayload;
+      const blob = new Blob([readableSavedPlanExport(payload)], {
+        type: 'text/markdown;charset=utf-8',
       });
       const url = window.URL.createObjectURL(blob);
       const link = document.createElement('a');
       link.href = url;
       link.download = includePrivateNotesInExport
-        ? 'saved-research-plan-advising-share.json'
-        : 'saved-research-plans.json';
+        ? 'saved-research-plan-advising-share.md'
+        : 'saved-research-plans.md';
       document.body.appendChild(link);
       link.click();
       link.remove();
       window.URL.revokeObjectURL(url);
+      setExportNotice('Advising export downloaded.');
     } catch {
       console.error('Error exporting saved research plans.');
       setExportError('Saved research plans could not be exported.');
@@ -785,6 +858,12 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
       {exportError && (
         <div className="mb-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">
           {exportError}
+        </div>
+      )}
+
+      {exportNotice && (
+        <div className="mb-4 rounded-md border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800">
+          {exportNotice}
         </div>
       )}
 

--- a/client/src/components/accounts/__tests__/FavoritesManager.test.tsx
+++ b/client/src/components/accounts/__tests__/FavoritesManager.test.tsx
@@ -67,6 +67,26 @@ describe('FavoritesManager', () => {
     });
   });
 
+  it('surfaces open saved programs as now-open planning cues', () => {
+    expect(
+      savedProgramDeadlineSummary(
+        [
+          {
+            _id: 'fellowship-1',
+            id: 'fellowship-1',
+            title: 'Open Research Award',
+            deadline: '2026-05-30T00:00:00.000Z',
+            isAcceptingApplications: true,
+          } as any,
+        ],
+        new Date('2026-05-22T15:00:00.000Z'),
+      ),
+    ).toMatchObject({
+      nextDeadlineDate: '2026-05-30T00:00:00.000Z',
+      nextDeadlineLabel: 'Open Research Award: Now open; due May 30, 2026',
+    });
+  });
+
   it('reports saved program count to the planning overview', async () => {
     const onSummaryChange = vi.fn();
     mockedAxios.get.mockImplementation((url: string) => {
@@ -79,6 +99,7 @@ describe('FavoritesManager', () => {
                 id: 'fellowship-1',
                 title: 'Summer Research Grant',
                 deadline: '2099-06-30T00:00:00.000Z',
+                isAcceptingApplications: true,
               },
             ],
           },
@@ -99,7 +120,7 @@ describe('FavoritesManager', () => {
       expect(onSummaryChange).toHaveBeenCalledWith({
         count: 1,
         nextDeadlineDate: '2099-06-30T00:00:00.000Z',
-        nextDeadlineLabel: 'Summer Research Grant: Due Jun 30, 2099',
+        nextDeadlineLabel: 'Summer Research Grant: Now open; due Jun 30, 2099',
       });
     });
   });

--- a/client/src/components/accounts/__tests__/SavedPathwaysSection.test.ts
+++ b/client/src/components/accounts/__tests__/SavedPathwaysSection.test.ts
@@ -269,6 +269,22 @@ describe('saved research planning helpers', () => {
       sourceUrl: 'https://example.edu/fellowship/apply',
     });
   });
+
+  it('does not promote expired weak fellowship candidates into next-up reminders', () => {
+    const result = deadlineReminderForPathway(
+      pathway(),
+      [
+        fellowshipMatch({
+          title: 'Expired Weak Award',
+          strength: 'weak_candidate',
+          deadline: '2026-02-12T00:00:00.000Z',
+        }),
+      ],
+      new Date('2026-05-01T12:00:00.000Z'),
+    );
+
+    expect(result).toBeNull();
+  });
 });
 
 describe('SavedPathwaysSection advising export', () => {
@@ -343,7 +359,7 @@ describe('SavedPathwaysSection advising export', () => {
                 activePostedOpportunity: {
                   _id: 'posted-1',
                   title: 'Archive assistant',
-                  deadline: '2026-05-20T00:00:00.000Z',
+                  deadline: '2099-05-20T00:00:00.000Z',
                   applicationUrl: 'https://example.edu/apply',
                   status: 'OPEN',
                 },
@@ -406,10 +422,22 @@ describe('SavedPathwaysSection advising export', () => {
       if (url === '/users/savedResearchPlanDetails/export') {
         return Promise.resolve({
           data: {
+            exportedAt: '2026-05-13T12:00:00.000Z',
+            itemCount: 1,
             privacy: {
               includesPrivateNotes: false,
             },
-            items: [],
+            items: [
+              {
+                title: 'Explore archival climate records',
+                researchEntity: { name: 'Climate Archive' },
+                intent: 'outreach',
+                stage: 'researching',
+                checklist: { 'outreach-route': true },
+                sourceLinks: ['https://example.edu/pathway'],
+                bestNextStepCategory: 'plan-outreach',
+              },
+            ],
           },
         });
       }
@@ -419,10 +447,23 @@ describe('SavedPathwaysSection advising export', () => {
       if (url === '/users/savedResearchPlanDetails/export') {
         return Promise.resolve({
           data: {
+            exportedAt: '2026-05-13T12:00:00.000Z',
+            itemCount: 1,
             privacy: {
               includesPrivateNotes: data?.includePrivateNotes === true,
             },
-            items: [],
+            items: [
+              {
+                title: 'Explore archival climate records',
+                researchEntity: { name: 'Climate Archive' },
+                intent: 'outreach',
+                stage: 'researching',
+                checklist: { 'outreach-route': true },
+                sourceLinks: ['https://example.edu/pathway'],
+                bestNextStepCategory: 'plan-outreach',
+                privateNote: data?.includePrivateNotes ? 'Discuss with my advisor.' : undefined,
+              },
+            ],
           },
         });
       }
@@ -446,5 +487,62 @@ describe('SavedPathwaysSection advising export', () => {
         }),
       );
     });
+    expect(screen.getByText('Advising export downloaded.')).toBeTruthy();
+  });
+
+  it('downloads a readable advising markdown export instead of raw JSON', async () => {
+    const user = userEvent.setup();
+    let exportedBlob: Blob | null = null;
+    vi.mocked(window.URL.createObjectURL).mockImplementation((blob) => {
+      exportedBlob = blob as Blob;
+      return 'blob:saved-pathways';
+    });
+
+    mockedAxios.get.mockImplementation((url) => {
+      if (url === '/users/savedResearchPlans') {
+        return Promise.resolve({ data: { savedResearchPlans: [pathway()] } });
+      }
+      if (url === '/users/savedResearchPlanDetails') {
+        return Promise.resolve({ data: { savedResearchPlanDetails: {} } });
+      }
+      if (url === '/users/savedResearchPlanFundingMatches') {
+        return Promise.resolve({ data: { matchesByPathwayId: {} } });
+      }
+      if (url === '/users/savedResearchPlanDetails/export') {
+        return Promise.resolve({
+          data: {
+            exportedAt: '2026-05-13T12:00:00.000Z',
+            itemCount: 1,
+            privacy: { includesPrivateNotes: false },
+            items: [
+              {
+                title: 'Explore archival climate records',
+                researchEntity: { name: 'Climate Archive' },
+                intent: 'outreach',
+                stage: 'researching',
+                checklist: { 'outreach-route': true },
+                sourceLinks: ['https://example.edu/pathway'],
+                bestNextStepCategory: 'plan-outreach',
+              },
+            ],
+          },
+        });
+      }
+      return Promise.reject(new Error(`Unexpected URL: ${url}`));
+    });
+
+    render(createElement(MemoryRouter, null, createElement(SavedPathwaysSection)));
+
+    await screen.findByText('Explore archival climate records');
+    await user.click(screen.getByRole('button', { name: 'Advising export' }));
+    await user.click(screen.getByRole('button', { name: 'Export for advising' }));
+
+    await waitFor(() => expect(exportedBlob).not.toBeNull());
+    const text = await exportedBlob!.text();
+    expect(text).toContain('# Saved Research Plans');
+    expect(text).toContain('## 1. Explore archival climate records');
+    expect(text).toContain('Research home: Climate Archive');
+    expect(text).toContain('- https://example.edu/pathway');
+    expect(text.trim()).not.toMatch(/^{/);
   });
 });


### PR DESCRIPTION
## Summary
- show open saved programs as now-open dashboard cues
- stop expired weak fellowship matches from driving saved-plan Next up reminders
- export saved research plans as readable Markdown with success feedback instead of raw JSON

## Validation
- yarn --cwd /tmp/ylabs-beta-planning/client vitest --run src/components/accounts/__tests__/SavedPathwaysSection.test.ts src/components/accounts/__tests__/FavoritesManager.test.tsx src/pages/__tests__/account.test.tsx
- yarn --cwd /tmp/ylabs-beta-planning/client build