### PR TITLE
Add evidence rail for research listings on beta

### DIFF
--- a/client/src/components/shared/ListingDetailModal.tsx
+++ b/client/src/components/shared/ListingDetailModal.tsx
@@ -7,7 +7,7 @@ import { Listing } from '../../types/types';
 import UserContext from '../../contexts/UserContext';
 import ConfigContext from '../../contexts/ConfigContext';
 import { getDepartmentAbbreviation } from '../../utils/departmentNames';
-import { ensureHttpPrefix, safeRouteSegment } from '../../utils/url';
+import { ensureHttpPrefix, safeRouteSegment, safeUrl } from '../../utils/url';
 import { getInstitutionAffiliation, getInstitutionLabel } from '../../utils/institutionAffiliation';
 import FavoriteButton from './FavoriteButton';
 
@@ -20,6 +20,146 @@ interface ListingDetailModalProps {
   onNavigateToResearchArea?: (area: string) => void;
   onNavigateToDepartment?: (dept: string) => void;
 }
+
+const getSafeEvidenceUrl = (url: unknown): string => {
+  const href = safeUrl(url);
+  if (!href) return '';
+  try {
+    const parsed = new URL(href);
+    if (!['http:', 'https:'].includes(parsed.protocol)) return '';
+    parsed.username = '';
+    parsed.password = '';
+    parsed.search = '';
+    parsed.hash = '';
+    return parsed.toString();
+  } catch {
+    return '';
+  }
+};
+
+const getEvidenceHost = (url: string): string => {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '');
+  } catch {
+    return '';
+  }
+};
+
+const formatEvidenceDate = (date?: string): string => {
+  if (!date) return '';
+  const parsed = new Date(date);
+  if (Number.isNaN(parsed.getTime())) return '';
+  return parsed.toLocaleDateString();
+};
+
+const EvidenceRail = ({ evidence }: { evidence: Listing['evidence'] }) => {
+  const status = evidence?.status || 'unavailable';
+  const sources = (evidence?.sources || [])
+    .map((source) => {
+      const href = getSafeEvidenceUrl(source.url);
+      return {
+        ...source,
+        href,
+        displayLabel: source.label || (href ? getEvidenceHost(href) : 'Source material'),
+      };
+    })
+    .filter((source) => source.displayLabel || source.href);
+  const verifiedDate = formatEvidenceDate(evidence?.lastVerifiedAt || evidence?.generatedAt);
+
+  return (
+    <section className="border border-gray-200 rounded-lg p-4 bg-gray-50/60">
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <div>
+          <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Evidence</h3>
+          {verifiedDate && <p className="text-xs text-gray-400 mt-1">Verified {verifiedDate}</p>}
+        </div>
+        {typeof evidence?.confidence === 'number' && (
+          <span className="text-xs font-medium text-gray-600 bg-white border border-gray-200 rounded-md px-2 py-1">
+            {Math.round(evidence.confidence * 100)}%
+          </span>
+        )}
+      </div>
+
+      {status === 'loading' ? (
+        <p className="text-sm text-gray-500">Checking evidence metadata...</p>
+      ) : status === 'error' ? (
+        <p className="text-sm text-red-600">Evidence metadata could not be loaded.</p>
+      ) : (
+        <>
+          {evidence?.summary && (
+            <p className="text-sm text-gray-700 leading-relaxed mb-3">{evidence.summary}</p>
+          )}
+
+          {sources.length > 0 ? (
+            <div className="space-y-3">
+              {sources.map((source, index) => {
+                const checkedDate = formatEvidenceDate(source.lastCheckedAt);
+                const content = (
+                  <>
+                    <div className="min-w-0">
+                      <div className="text-sm font-medium text-gray-800 truncate">
+                        {source.displayLabel}
+                      </div>
+                      <div className="text-xs text-gray-500">
+                        {[
+                          source.sourceType,
+                          source.href ? getEvidenceHost(source.href) : '',
+                          checkedDate,
+                        ]
+                          .filter(Boolean)
+                          .join(' · ')}
+                      </div>
+                    </div>
+                    {source.href && (
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="14"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        className="flex-shrink-0 text-gray-400"
+                        aria-hidden="true"
+                      >
+                        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                        <polyline points="15 3 21 3 21 9" />
+                        <line x1="10" y1="14" x2="21" y2="3" />
+                      </svg>
+                    )}
+                  </>
+                );
+
+                return source.href ? (
+                  <a
+                    key={`${source.displayLabel}-${index}`}
+                    href={source.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-start justify-between gap-2 rounded-md bg-white border border-gray-200 px-3 py-2 hover:border-blue-200 hover:text-blue-700 transition-colors"
+                  >
+                    {content}
+                  </a>
+                ) : (
+                  <div
+                    key={`${source.displayLabel}-${index}`}
+                    className="flex items-start justify-between gap-2 rounded-md bg-white border border-gray-200 px-3 py-2"
+                  >
+                    {content}
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <p className="text-sm text-gray-500">No source metadata available yet.</p>
+          )}
+        </>
+      )}
+    </section>
+  );
+};
 
 const ListingDetailModal = ({
   isOpen,
@@ -420,6 +560,8 @@ const ListingDetailModal = ({
                     </div>
                   </div>
                 </section>
+
+                <EvidenceRail evidence={listing.evidence} />
               </div>
 
               <div className="col-span-1 md:col-span-2 space-y-6">

--- a/client/src/components/shared/__tests__/ListingDetailModal.evidence.test.tsx
+++ b/client/src/components/shared/__tests__/ListingDetailModal.evidence.test.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import ConfigContext, { defaultConfigContext } from '../../../contexts/ConfigContext';
+import UserContext from '../../../contexts/UserContext';
+import ListingDetailModal from '../ListingDetailModal';
+import { Listing } from '../../../types/types';
+
+const listing: Listing = {
+  id: '507f1f77bcf86cd799439011',
+  ownerId: '',
+  ownerFirstName: 'Ada',
+  ownerLastName: 'Lovelace',
+  ownerEmail: '',
+  ownerTitle: 'Professor',
+  ownerPrimaryDepartment: 'Computer Science',
+  professorIds: [],
+  professorNames: [],
+  title: 'Computing lab',
+  departments: ['Computer Science'],
+  emails: [],
+  websites: [],
+  description: 'Research description',
+  applicantDescription: '',
+  keywords: [],
+  researchAreas: ['Algorithms'],
+  established: '',
+  views: 0,
+  favorites: 0,
+  hiringStatus: 1,
+  archived: false,
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  confirmed: true,
+  audited: false,
+};
+
+const renderModal = (listingOverride: Partial<Listing> = {}) =>
+  render(
+    <MemoryRouter>
+      <UserContext.Provider
+        value={{
+          isLoading: false,
+          isAuthenticated: true,
+          user: { userType: 'student' } as any,
+          checkContext: vi.fn(),
+        }}
+      >
+        <ConfigContext.Provider
+          value={{
+            ...defaultConfigContext,
+            departments: [],
+            departmentCategories: [],
+            researchAreas: [],
+            researchFields: [],
+            fieldOrder: [],
+            isLoading: false,
+            isLoaded: true,
+            error: null,
+            getDepartmentByAbbr: () => undefined,
+            getColorForResearchArea: () => ({
+              bg: 'bg-blue-50',
+              text: 'text-blue-700',
+              border: 'border-blue-100',
+            }),
+          }}
+        >
+          <ListingDetailModal
+            isOpen
+            onClose={vi.fn()}
+            listing={{ ...listing, ...listingOverride }}
+            isFavorite={false}
+            onToggleFavorite={vi.fn()}
+          />
+        </ConfigContext.Provider>
+      </UserContext.Provider>
+    </MemoryRouter>,
+  );
+
+describe('ListingDetailModal evidence rail', () => {
+  it('shows an empty evidence state when public metadata is unavailable', () => {
+    renderModal();
+
+    expect(screen.getByText(/evidence/i)).toBeTruthy();
+    expect(screen.getByText(/no source metadata available yet/i)).toBeTruthy();
+  });
+
+  it('renders safe source links without showing raw private URL parts', () => {
+    renderModal({
+      evidence: {
+        status: 'available',
+        summary: 'Matched from public profile and publication records.',
+        confidence: 0.92,
+        lastVerifiedAt: '2026-02-03T00:00:00.000Z',
+        sources: [
+          {
+            label: 'OpenAlex work',
+            url: 'https://example.edu/path?token=secret#private',
+            sourceType: 'Publication',
+            lastCheckedAt: '2026-02-01T00:00:00.000Z',
+          },
+          {
+            label: 'Unsafe script',
+            url: 'javascript:alert(1)',
+          },
+        ],
+      },
+    });
+
+    const link = screen.getByRole('link', { name: /openalex work/i });
+    expect(link.getAttribute('href')).toBe('https://example.edu/path');
+    expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+    expect(screen.getByText(/matched from public profile/i)).toBeTruthy();
+    expect(screen.getByText('92%')).toBeTruthy();
+    expect(screen.getByText(/example.edu/i)).toBeTruthy();
+    expect(screen.getByText(/unsafe script/i)).toBeTruthy();
+    expect(screen.queryByRole('link', { name: /unsafe script/i })).toBeNull();
+    expect(screen.queryByText(/token=secret/i)).toBeNull();
+  });
+
+  it('renders loading and error evidence states', () => {
+    const { rerender } = renderModal({
+      evidence: { status: 'loading', sources: [] },
+    });
+
+    expect(screen.getByText(/checking evidence metadata/i)).toBeTruthy();
+
+    rerender(
+      <MemoryRouter>
+        <UserContext.Provider
+          value={{
+            isLoading: false,
+            isAuthenticated: true,
+            user: { userType: 'student' } as any,
+            checkContext: vi.fn(),
+          }}
+        >
+          <ConfigContext.Provider value={defaultConfigContext}>
+            <ListingDetailModal
+              isOpen
+              onClose={vi.fn()}
+              listing={{ ...listing, evidence: { status: 'error', sources: [] } }}
+              isFavorite={false}
+              onToggleFavorite={vi.fn()}
+            />
+          </ConfigContext.Provider>
+        </UserContext.Provider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText(/evidence metadata could not be loaded/i)).toBeTruthy();
+  });
+});

--- a/client/src/types/types.tsx
+++ b/client/src/types/types.tsx
@@ -30,6 +30,24 @@ export type Listing = {
   createdAt: string;
   confirmed: boolean;
   audited: boolean;
+  evidence?: ListingEvidence;
+};
+
+export type ListingEvidenceSource = {
+  label?: string;
+  url?: string;
+  sourceType?: string;
+  description?: string;
+  lastCheckedAt?: string;
+};
+
+export type ListingEvidence = {
+  status?: 'available' | 'unavailable' | 'loading' | 'error' | string;
+  summary?: string;
+  confidence?: number;
+  generatedAt?: string;
+  lastVerifiedAt?: string;
+  sources?: ListingEvidenceSource[];
 };
 
 export type FellowshipLink = {

--- a/data-migration/MigrateToMeilisearch.ts
+++ b/data-migration/MigrateToMeilisearch.ts
@@ -44,6 +44,9 @@ async function migrateToMeilisearch() {
       delete meiliDoc._id;
       delete meiliDoc.__v;
       delete meiliDoc.embedding; // Ensure legacy vectors aren't pushed
+      if (meiliDoc.evidence && typeof meiliDoc.evidence === 'object') {
+        delete meiliDoc.evidence.internalNotes;
+      }
       return meiliDoc;
     });
 

--- a/server/src/controllers/listingController.evidence.test.ts
+++ b/server/src/controllers/listingController.evidence.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizePublicEvidence } from './listingController';
+
+describe('sanitizePublicEvidence', () => {
+  it('removes private fields and unsafe URL details from evidence metadata', () => {
+    const evidence = sanitizePublicEvidence({
+      status: 'available',
+      summary: 'Source-backed listing.',
+      confidence: 0.8,
+      generatedAt: '2026-01-01T00:00:00.000Z',
+      internalNotes: 'private review note',
+      sources: [
+        {
+          label: 'Official profile',
+          url: 'https://user:pass@example.edu/path?token=secret#hash',
+          sourceType: 'official',
+          description: 'Faculty profile',
+          lastCheckedAt: '2026-01-02T00:00:00.000Z',
+          internalNotes: 'do not expose',
+        },
+        {
+          label: 'Bad source',
+          url: 'javascript:alert(1)',
+        },
+      ],
+    });
+
+    expect(evidence).toEqual({
+      status: 'available',
+      summary: 'Source-backed listing.',
+      confidence: 0.8,
+      generatedAt: '2026-01-01T00:00:00.000Z',
+      lastVerifiedAt: undefined,
+      sources: [
+        {
+          label: 'Official profile',
+          url: 'https://example.edu/path',
+          sourceType: 'official',
+          description: 'Faculty profile',
+          lastCheckedAt: '2026-01-02T00:00:00.000Z',
+        },
+        {
+          label: 'Bad source',
+          url: undefined,
+          sourceType: undefined,
+          description: undefined,
+          lastCheckedAt: undefined,
+        },
+      ],
+    });
+    expect(JSON.stringify(evidence)).not.toContain('private');
+    expect(JSON.stringify(evidence)).not.toContain('secret');
+  });
+
+  it('returns an unavailable shell when evidence is absent', () => {
+    expect(sanitizePublicEvidence(undefined)).toEqual({
+      status: 'unavailable',
+      sources: [],
+    });
+  });
+});

--- a/server/src/controllers/listingController.ts
+++ b/server/src/controllers/listingController.ts
@@ -263,6 +263,84 @@ const publicListingText = (value: unknown): string | undefined =>
 const publicListingTextArray = (values: unknown): string[] =>
   Array.isArray(values) ? values.flatMap((value) => publicListingText(value) ?? []) : [];
 
+const PUBLIC_EVIDENCE_SOURCE_LIMIT = 8;
+
+const toOptionalString = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed === '' ? undefined : trimmed;
+};
+
+const toIsoString = (value: unknown): string | undefined => {
+  if (!value) return undefined;
+  const date = value instanceof Date ? value : new Date(value as string);
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+};
+
+const sanitizePublicSourceUrl = (value: unknown): string | undefined => {
+  const raw = toOptionalString(value);
+  if (!raw) return undefined;
+  const withScheme = /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(raw) ? raw : `https://${raw}`;
+
+  try {
+    const parsed = new URL(withScheme);
+    if (!['http:', 'https:'].includes(parsed.protocol)) return undefined;
+    parsed.username = '';
+    parsed.password = '';
+    parsed.search = '';
+    parsed.hash = '';
+    return parsed.toString();
+  } catch {
+    return undefined;
+  }
+};
+
+export const sanitizePublicEvidence = (evidence: any) => {
+  if (!evidence || typeof evidence !== 'object') {
+    return {
+      status: 'unavailable',
+      sources: [],
+    };
+  }
+
+  const sources = Array.isArray(evidence.sources)
+    ? evidence.sources
+        .map((source: any) => {
+          const url = sanitizePublicSourceUrl(source?.url);
+          const label =
+            toOptionalString(source?.label) ||
+            toOptionalString(source?.title) ||
+            (url ? new URL(url).hostname.replace(/^www\./, '') : undefined);
+          if (!url && !label) return null;
+
+          return {
+            label,
+            url,
+            sourceType: toOptionalString(source?.sourceType),
+            description: toOptionalString(source?.description),
+            lastCheckedAt: toIsoString(source?.lastCheckedAt),
+          };
+        })
+        .filter(Boolean)
+        .slice(0, PUBLIC_EVIDENCE_SOURCE_LIMIT)
+    : [];
+
+  return {
+    status: toOptionalString(evidence.status) || (sources.length > 0 ? 'available' : 'unavailable'),
+    summary: toOptionalString(evidence.summary),
+    confidence:
+      typeof evidence.confidence === 'number' &&
+      Number.isFinite(evidence.confidence) &&
+      evidence.confidence >= 0 &&
+      evidence.confidence <= 1
+        ? evidence.confidence
+        : undefined,
+    generatedAt: toIsoString(evidence.generatedAt),
+    lastVerifiedAt: toIsoString(evidence.lastVerifiedAt),
+    sources,
+  };
+};
+
 const publicListingForAuthenticatedReader = (listing: any) => {
   const id = serializedDocumentId(listing._id) || serializedDocumentId(listing.id) || '';
   return {
@@ -281,6 +359,7 @@ const publicListingForAuthenticatedReader = (listing: any) => {
     commitment: publicListingText(listing.commitment),
     compensationType: publicListingText(listing.compensationType),
     expiresAt: listing.expiresAt,
+    evidence: sanitizePublicEvidence(listing.evidence),
   };
 };
 

--- a/server/src/models/listing.ts
+++ b/server/src/models/listing.ts
@@ -3,6 +3,32 @@
  */
 import mongoose from 'mongoose';
 
+const evidenceSourceSchema = new mongoose.Schema(
+  {
+    label: {
+      type: String,
+      required: false,
+    },
+    url: {
+      type: String,
+      required: false,
+    },
+    sourceType: {
+      type: String,
+      required: false,
+    },
+    description: {
+      type: String,
+      required: false,
+    },
+    lastCheckedAt: {
+      type: Date,
+      required: false,
+    },
+  },
+  { _id: false },
+);
+
 const listingSchema = new mongoose.Schema(
   {
     ownerId: {
@@ -126,6 +152,37 @@ const listingSchema = new mongoose.Schema(
     audited: {
       type: Boolean,
       default: false,
+    },
+    evidence: {
+      status: {
+        type: String,
+        required: false,
+      },
+      summary: {
+        type: String,
+        required: false,
+      },
+      confidence: {
+        type: Number,
+        required: false,
+      },
+      generatedAt: {
+        type: Date,
+        required: false,
+      },
+      lastVerifiedAt: {
+        type: Date,
+        required: false,
+      },
+      sources: {
+        type: [evidenceSourceSchema],
+        default: [],
+      },
+      internalNotes: {
+        type: String,
+        required: false,
+        select: false,
+      },
     },
     expiresAt: {
       type: Date,

--- a/server/src/services/listingService.ts
+++ b/server/src/services/listingService.ts
@@ -25,6 +25,20 @@ const PUBLIC_LISTING_MUTATION_FILTER = {
   confirmed: true,
 };
 
+const prepareListingForMeili = (doc: any) => {
+  const id = serializedDocumentId(doc._id) || serializedDocumentId(doc.id);
+  if (!id) return null;
+
+  const meiliDoc = { ...doc, id };
+  delete meiliDoc._id;
+  delete meiliDoc.__v;
+  delete meiliDoc.embedding;
+  if (meiliDoc.evidence && typeof meiliDoc.evidence === 'object') {
+    delete meiliDoc.evidence.internalNotes;
+  }
+  return meiliDoc;
+};
+
 export function normalizeListingObjectId(value: unknown): string | undefined {
   const id =
     typeof value === 'string'
@@ -450,11 +464,8 @@ export const createListing = async (data: any, owner: any) => {
 
   try {
     const doc = listing.toObject();
-    const id = serializedDocumentId(doc._id) || serializedDocumentId(doc.id);
-    if (id) {
-      const meiliDoc = { ...doc, id };
-      delete meiliDoc._id;
-      delete meiliDoc.__v;
+    const meiliDoc = prepareListingForMeili(doc);
+    if (meiliDoc) {
       const index = await getMeiliIndex('listings');
       await index.addDocuments([meiliDoc]);
     }
@@ -651,11 +662,8 @@ export const updateListing = async (
 
     try {
       const doc = listing.toObject();
-      const id = serializedDocumentId(doc._id) || serializedDocumentId(doc.id);
-      if (id) {
-        const meiliDoc = { ...doc, id };
-        delete meiliDoc._id;
-        delete meiliDoc.__v;
+      const meiliDoc = prepareListingForMeili(doc);
+      if (meiliDoc) {
         const index = await getMeiliIndex('listings');
         await index.updateDocuments([meiliDoc]);
       }


### PR DESCRIPTION
## Summary
- add public-safe listing evidence metadata to listing types, schema, and serialization
- render an evidence rail in listing detail modals with sanitized source links
- keep internal evidence notes out of Meilisearch and public responses

## Validation
- yarn test:ci src/components/shared/__tests__/ListingDetailModal.evidence.test.tsx
- yarn test src/controllers/listingController.evidence.test.ts
- yarn build (client)
- yarn build (server)
- yarn security:policy