### PR TITLE
feat(research): add student search facets

### DIFF
--- a/client/src/pages/__tests__/research.test.tsx
+++ b/client/src/pages/__tests__/research.test.tsx
@@ -36,7 +36,10 @@ const originalIntersectionObserver = window.IntersectionObserver;
 const originalGlobalIntersectionObserver = globalThis.IntersectionObserver;
 const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
 
-const researchSearchResponse = (researchEntities: unknown[] = [], overrides: Record<string, unknown> = {}) => ({
+const researchSearchResponse = (
+  researchEntities: unknown[] = [],
+  overrides: Record<string, unknown> = {},
+) => ({
   data: {
     researchEntities,
     estimatedTotalHits: researchEntities.length,
@@ -72,8 +75,7 @@ const mockSearchResponses = (
         browseQuality?: string;
         qualityFilters?: string[];
       },
-    ) =>
-      Promise.resolve(resolver(url, body)),
+    ) => Promise.resolve(resolver(url, body)),
   );
 };
 
@@ -356,7 +358,9 @@ describe('Research page', () => {
     expect(container.textContent).not.toContain('Official Yale source found');
     expect(container.textContent).not.toContain('Source-backed profile context');
     const browseSection = screen.getByLabelText('Research homes to explore');
-    const browseHeadingRow = within(browseSection).getByText('Research homes to explore').parentElement;
+    const browseHeadingRow = within(browseSection).getByText(
+      'Research homes to explore',
+    ).parentElement;
     expect(browseHeadingRow?.parentElement?.className).toContain('w-full');
     expect(browseHeadingRow?.className).toContain('justify-between');
     expect(within(browseSection).queryByText('1 profile')).toBeNull();
@@ -364,8 +368,7 @@ describe('Research page', () => {
     expect(container.textContent).not.toContain('indexed profiles');
     const browseLayout = Array.from(browseSection.querySelectorAll('.grid')).find(
       (element) =>
-        element.className.includes('grid gap-5') &&
-        !element.className.includes('xl:grid-cols'),
+        element.className.includes('grid gap-5') && !element.className.includes('xl:grid-cols'),
     );
     const browseGrid = browseSection.querySelector('.grid.gap-3');
     expect(browseLayout?.className).toContain('grid gap-5');
@@ -409,7 +412,9 @@ describe('Research page', () => {
     expect(container.textContent).not.toContain('Grouped Search Results');
     expect(container.textContent).not.toContain('V1 fallback');
     expect(container.textContent).not.toContain('0 profiles');
-    expect((screen.getByRole('button', { name: 'Search' }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole('button', { name: 'Search' }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
   });
 
   it('submits quick-start prompts as research searches', async () => {
@@ -523,6 +528,77 @@ describe('Research page', () => {
 
     await screen.findByRole('heading', { name: 'Quantum Materials Example' });
     expect(screen.getByTestId('location').textContent).toBe('/research?q=quantum+materials');
+  });
+
+  it('filters search results by school, department, and undergraduate evidence in the URL', async () => {
+    mockSearchResponses((url) => {
+      if (url !== '/research/search') return unexpectedSearchEndpoint(url);
+      return researchSearchResponse([researchEntity], {
+        facetDistribution: {
+          school: { 'Yale College': 8, 'School of Medicine': 4 },
+          departments: { 'Computer Science': 5, Neuroscience: 3 },
+        },
+      });
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/research?q=machine+learning']}>
+        <ConfigContext.Provider
+          value={{
+            ...defaultConfigContext,
+            isLoading: false,
+            isLoaded: true,
+            departments,
+            departmentCategories: ['Computing & AI', 'Humanities & Arts', 'Life Sciences'],
+          }}
+        >
+          <LocationDisplay />
+          <Research />
+        </ConfigContext.Provider>
+      </MemoryRouter>,
+    );
+
+    await screen.findByRole('heading', { name: 'AI Safety Lab' });
+    fireEvent.change(screen.getByLabelText('Filter by school'), {
+      target: { value: 'Yale College' },
+    });
+    await waitFor(() => {
+      expect(mockedAxios.post.mock.calls.at(-1)?.[1]).toEqual(
+        expect.objectContaining({ filters: { school: ['Yale College'] }, page: 1 }),
+      );
+    });
+
+    fireEvent.change(screen.getByLabelText('Filter by department'), {
+      target: { value: 'Computer Science' },
+    });
+    await waitFor(() => {
+      expect(mockedAxios.post.mock.calls.at(-1)?.[1]).toEqual(
+        expect.objectContaining({
+          filters: {
+            school: ['Yale College'],
+            departments: ['Computer Science'],
+          },
+          page: 1,
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByLabelText('Has undergraduate evidence'));
+    await waitFor(() => {
+      expect(mockedAxios.post.mock.calls.at(-1)?.[1]).toEqual(
+        expect.objectContaining({
+          filters: {
+            school: ['Yale College'],
+            departments: ['Computer Science'],
+            acceptanceLevel: 'verified-or-likely',
+          },
+          page: 1,
+        }),
+      );
+      expect(screen.getByTestId('location').textContent).toBe(
+        '/research?q=machine+learning&school=Yale+College&department=Computer+Science&undergrad=1',
+      );
+    });
   });
 
   it('returns to default research homes when clearing a quick-start search', async () => {
@@ -802,10 +878,10 @@ describe('Research page', () => {
 
     mockSearchResponses((url, body) => {
       if (url !== '/research/search') return unexpectedSearchEndpoint(url);
-      return researchSearchResponse(
-        body.page === 2 ? [nextResearchEntity] : [researchEntity],
-        { estimatedTotalHits: 25, page: body.page || 1 },
-      );
+      return researchSearchResponse(body.page === 2 ? [nextResearchEntity] : [researchEntity], {
+        estimatedTotalHits: 25,
+        page: body.page || 1,
+      });
     });
 
     renderResearch();
@@ -868,17 +944,15 @@ describe('Research page', () => {
       };
     }>();
 
-    mockedAxios.post.mockImplementation(
-      (url: string, body: { page?: number }) => {
-        if (url !== '/research/search') {
-          return Promise.reject(new Error(`Unexpected retired or unknown search endpoint: ${url}`));
-        }
-        if (body.page === 2) return nextPage.promise;
-        return Promise.resolve(
-          researchSearchResponse([researchEntity], { estimatedTotalHits: 25, page: 1 }),
-        );
-      },
-    );
+    mockedAxios.post.mockImplementation((url: string, body: { page?: number }) => {
+      if (url !== '/research/search') {
+        return Promise.reject(new Error(`Unexpected retired or unknown search endpoint: ${url}`));
+      }
+      if (body.page === 2) return nextPage.promise;
+      return Promise.resolve(
+        researchSearchResponse([researchEntity], { estimatedTotalHits: 25, page: 1 }),
+      );
+    });
 
     renderResearch();
 
@@ -957,10 +1031,10 @@ describe('Research page', () => {
 
     mockSearchResponses((url, body) => {
       if (url !== '/research/search') return unexpectedSearchEndpoint(url);
-      return researchSearchResponse(
-        body.page === 2 ? [nextResearchEntity] : firstPage,
-        { estimatedTotalHits: 24, page: body.page || 1 },
-      );
+      return researchSearchResponse(body.page === 2 ? [nextResearchEntity] : firstPage, {
+        estimatedTotalHits: 24,
+        page: body.page || 1,
+      });
     });
 
     renderResearch();
@@ -1023,10 +1097,10 @@ describe('Research page', () => {
 
     mockSearchResponses((url, body) => {
       if (url !== '/research/search') return unexpectedSearchEndpoint(url);
-      return researchSearchResponse(
-        body.page === 2 ? [nextResearchEntity] : [researchEntity],
-        { estimatedTotalHits: 25, page: body.page || 1 },
-      );
+      return researchSearchResponse(body.page === 2 ? [nextResearchEntity] : [researchEntity], {
+        estimatedTotalHits: 25,
+        page: body.page || 1,
+      });
     });
 
     renderResearch(departments, ['/research?q=protein+folding']);
@@ -1156,9 +1230,7 @@ describe('Research page', () => {
     await screen.findByText("Showing research matches for 'protein folding'");
 
     await waitFor(() => {
-      expect(screen.getByRole('status').textContent).toContain(
-        '1 research home, 1 contact',
-      );
+      expect(screen.getByRole('status').textContent).toContain('1 research home, 1 contact');
     });
     expect(screen.getByRole('status').textContent).not.toContain('way in');
     expect(screen.queryByRole('link', { name: /Compare .*pathway/i })).toBeNull();
@@ -1188,7 +1260,7 @@ describe('Research page', () => {
     expect(
       screen
         .getAllByRole('link', { name: 'AI Safety Lab' })
-      .some((link) => link.getAttribute('href') === '/research/ai-safety-lab'),
+        .some((link) => link.getAttribute('href') === '/research/ai-safety-lab'),
     ).toBe(true);
     expect(container.textContent).toContain('Review source context');
     expect(container.textContent).toContain('Source route');
@@ -1296,12 +1368,12 @@ describe('Research page', () => {
       if (body.q === 'machine learning') {
         return url === '/research/search'
           ? researchSearchResponse([
-            {
-              ...researchEntity,
-              contactName: '',
-              contactRole: '',
-            },
-          ])
+              {
+                ...researchEntity,
+                contactName: '',
+                contactRole: '',
+              },
+            ])
           : unexpectedSearchEndpoint(url);
       }
 
@@ -1330,25 +1402,25 @@ describe('Research page', () => {
       if (body.q === 'digital humanities') {
         return url === '/research/search'
           ? researchSearchResponse([
-            {
-              ...researchEntity,
-              _id: 'entity-2',
-              id: 'entity-2',
-              slug: 'digital-humanities-lab',
-              name: 'Yale Digital Humanities Lab',
-              displayName: 'Yale Digital Humanities Lab',
-              description: 'Computational text analysis and archive-centered research.',
-              departments: ['English'],
-              researchAreas: ['digital humanities'],
-              sourceUrls: ['https://example.yale.edu'],
-              searchMatch: {
-                mode: 'hybrid',
-                concepts: ['digital humanities'],
-                methods: ['computational text analysis'],
-                reason: 'Matches computational text analysis, digital humanities.',
+              {
+                ...researchEntity,
+                _id: 'entity-2',
+                id: 'entity-2',
+                slug: 'digital-humanities-lab',
+                name: 'Yale Digital Humanities Lab',
+                displayName: 'Yale Digital Humanities Lab',
+                description: 'Computational text analysis and archive-centered research.',
+                departments: ['English'],
+                researchAreas: ['digital humanities'],
+                sourceUrls: ['https://example.yale.edu'],
+                searchMatch: {
+                  mode: 'hybrid',
+                  concepts: ['digital humanities'],
+                  methods: ['computational text analysis'],
+                  reason: 'Matches computational text analysis, digital humanities.',
+                },
               },
-            },
-          ])
+            ])
           : unexpectedSearchEndpoint(url);
       }
 
@@ -1365,8 +1437,14 @@ describe('Research page', () => {
     expect(
       await screen.findByRole('heading', { name: 'Yale Digital Humanities Lab' }),
     ).toBeTruthy();
-    expect(screen.queryByText('Why this matches: Matches computational text analysis, digital humanities.')).toBeNull();
-    expect(screen.queryByText('Matches computational text analysis, digital humanities.')).toBeNull();
+    expect(
+      screen.queryByText(
+        'Why this matches: Matches computational text analysis, digital humanities.',
+      ),
+    ).toBeNull();
+    expect(
+      screen.queryByText('Matches computational text analysis, digital humanities.'),
+    ).toBeNull();
     expect(screen.getByRole('link', { name: 'Yale Digital Humanities Lab' })).toBeTruthy();
     expect(screen.getByRole('link', { name: 'View profile →' }).getAttribute('href')).toBe(
       '/research/digital-humanities-lab',
@@ -1417,5 +1495,4 @@ describe('Research page', () => {
     expect(await screen.findByRole('heading', { name: 'AI Safety Lab' })).toBeTruthy();
     expect(mockedAxios.post).toHaveBeenCalledTimes(initialSearchCalls);
   });
-
 });

--- a/client/src/pages/research.tsx
+++ b/client/src/pages/research.tsx
@@ -21,10 +21,7 @@ import {
 } from '../types/researchEntity';
 import { getUniqueDepartmentLabels } from '../utils/departmentNames';
 import useDocumentTitle from '../hooks/useDocumentTitle';
-import type {
-  PathwaySearchFilters,
-  PathwaySearchHit,
-} from '../types/pathway';
+import type { PathwaySearchFilters, PathwaySearchHit } from '../types/pathway';
 
 interface DepartmentResearchHomeConfig {
   abbreviation?: string;
@@ -99,6 +96,7 @@ interface ResearchEntitySearchPage {
   estimatedTotalHits: number;
   page: number;
   pageSize: number;
+  facetDistribution: Record<string, Record<string, number>>;
 }
 
 interface ActiveResearchSearchRequest {
@@ -116,6 +114,10 @@ interface ResearchPageSnapshot {
   showWeakestProfilesFirst: boolean;
   qualityFilters: ResearchQualityFilter[];
   trustTierFilters: ResearchTrustTierFilter[];
+  selectedSchool: string;
+  selectedDepartment: string;
+  requireUndergradEvidence: boolean;
+  facetDistribution: Record<string, Record<string, number>>;
   groupedResults: GroupedResearchResults;
   searchResultResearchEntities: ResearchEntity[];
   searchPage: number;
@@ -171,6 +173,7 @@ const searchResearchEntities = async (
     estimatedTotalHits: normalized.estimatedTotalHits || 0,
     page: normalized.page || page,
     pageSize: normalized.pageSize || pageSize,
+    facetDistribution: normalized.facetDistribution || {},
   };
 };
 
@@ -184,9 +187,7 @@ const isResearchEntitySearchExhausted = (page: ResearchEntitySearchPage) =>
 
 const SectionHeading = ({ children }: { children: string }) => (
   <div className="mb-3 flex w-full items-center justify-between gap-3">
-    <h2 className="yr-kicker min-w-0 flex-1">
-      {children}
-    </h2>
+    <h2 className="yr-kicker min-w-0 flex-1">{children}</h2>
   </div>
 );
 
@@ -305,9 +306,7 @@ const Research = () => {
     researchPageSnapshot?.key === pageSnapshotKey && researchPageSnapshot.isAdmin === isAdmin
       ? researchPageSnapshot
       : null;
-  const restoredSnapshotRef = useRef<ResearchPageSnapshot | null>(
-    restorableSnapshot,
-  );
+  const restoredSnapshotRef = useRef<ResearchPageSnapshot | null>(restorableSnapshot);
   const [query, setQuery] = useState(
     () => restoredSnapshotRef.current?.query ?? searchParams.get('q') ?? '',
   );
@@ -344,14 +343,30 @@ const Research = () => {
           )
         : []),
   );
-  const [groupedResults, setGroupedResults] = useState<GroupedResearchResults>(() =>
-    restoredSnapshotRef.current?.groupedResults ?? emptyGroupedResults(''),
+  const [selectedSchool, setSelectedSchool] = useState(
+    () => restoredSnapshotRef.current?.selectedSchool ?? searchParams.get('school') ?? '',
   );
-  const [searchResultResearchEntities, setSearchResultResearchEntities] = useState<ResearchEntity[]>(
-    () => restoredSnapshotRef.current?.searchResultResearchEntities ?? [],
+  const [selectedDepartment, setSelectedDepartment] = useState(
+    () => restoredSnapshotRef.current?.selectedDepartment ?? searchParams.get('department') ?? '',
   );
+  const [requireUndergradEvidence, setRequireUndergradEvidence] = useState(
+    () =>
+      restoredSnapshotRef.current?.requireUndergradEvidence ??
+      searchParams.get('undergrad') === '1',
+  );
+  const [facetDistribution, setFacetDistribution] = useState<
+    Record<string, Record<string, number>>
+  >(() => restoredSnapshotRef.current?.facetDistribution ?? {});
+  const [groupedResults, setGroupedResults] = useState<GroupedResearchResults>(
+    () => restoredSnapshotRef.current?.groupedResults ?? emptyGroupedResults(''),
+  );
+  const [searchResultResearchEntities, setSearchResultResearchEntities] = useState<
+    ResearchEntity[]
+  >(() => restoredSnapshotRef.current?.searchResultResearchEntities ?? []);
   const [searchPage, setSearchPage] = useState(() => restoredSnapshotRef.current?.searchPage ?? 1);
-  const [searchTotal, setSearchTotal] = useState(() => restoredSnapshotRef.current?.searchTotal ?? 0);
+  const [searchTotal, setSearchTotal] = useState(
+    () => restoredSnapshotRef.current?.searchTotal ?? 0,
+  );
   const [searchExhausted, setSearchExhausted] = useState(
     () => restoredSnapshotRef.current?.searchExhausted ?? true,
   );
@@ -394,10 +409,7 @@ const Research = () => {
     [departments],
   );
   const departmentSearchTargetByLabel = useMemo(
-    () =>
-      new Map(
-        departmentSearchTargets.map((target) => [target.label.toLowerCase(), target]),
-      ),
+    () => new Map(departmentSearchTargets.map((target) => [target.label.toLowerCase(), target])),
     [departmentSearchTargets],
   );
 
@@ -410,6 +422,9 @@ const Research = () => {
       showWeakest?: boolean;
       quality?: ResearchQualityFilter[];
       trustTiers?: ResearchTrustTierFilter[];
+      school?: string;
+      department?: string;
+      requireUndergradEvidence?: boolean;
     },
     options: { replace?: boolean } = {},
   ) => {
@@ -418,6 +433,9 @@ const Research = () => {
     if (nextQuery) params.set('q', nextQuery);
     const departmentLabel = (nextState.departmentLabel || '').trim();
     if (departmentLabel) params.set('dept', departmentLabel);
+    if (nextState.school?.trim()) params.set('school', nextState.school.trim());
+    if (nextState.department?.trim()) params.set('department', nextState.department.trim());
+    if (nextState.requireUndergradEvidence) params.set('undergrad', '1');
 
     if (isAdmin) {
       if (nextState.showWeakest) params.set('weak', '1');
@@ -428,10 +446,13 @@ const Research = () => {
     setSearchParams(params, { replace: Boolean(options.replace) });
   };
 
-  useEffect(() => () => {
-    searchAbortRef.current?.abort();
-    defaultSearchAbortRef.current?.abort();
-  }, []);
+  useEffect(
+    () => () => {
+      searchAbortRef.current?.abort();
+      defaultSearchAbortRef.current?.abort();
+    },
+    [],
+  );
 
   useEffect(() => {
     if (isAdmin) return;
@@ -539,6 +560,9 @@ const Research = () => {
       writeResearchSearchParams({
         query: trimmed,
         departmentLabel: options.departmentSearch?.label,
+        school: filters.school?.[0],
+        department: filters.departments?.[0],
+        requireUndergradEvidence: filters.acceptanceLevel === 'verified-or-likely',
         showWeakest: showWeakestProfilesFirst,
         quality: qualityFilters,
         trustTiers: trustTierFilters,
@@ -566,6 +590,7 @@ const Research = () => {
       setSearchError('');
       setSearchResultResearchEntities(researchEntities);
       setSearchTotal(researchEntitiesPage.estimatedTotalHits);
+      setFacetDistribution(researchEntitiesPage.facetDistribution);
       setSearchExhausted(isResearchEntitySearchExhausted(researchEntitiesPage));
 
       setGroupedResults(
@@ -647,9 +672,23 @@ const Research = () => {
     }
   };
 
+  const studentSearchFilters = (
+    school = selectedSchool,
+    department = selectedDepartment,
+    undergradEvidence = requireUndergradEvidence,
+  ): ResearchSearchFilters => ({
+    ...(school ? { school: [school] } : {}),
+    ...(department ? { departments: [department] } : {}),
+    ...(undergradEvidence ? { acceptanceLevel: 'verified-or-likely' as const } : {}),
+  });
+
   const onSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    runSearch(query.trim());
+    const filters = studentSearchFilters();
+    runSearch(query.trim(), {
+      filters,
+      hasFilterSelections: hasStructuredFilters(filters),
+    });
   };
 
   const resetSearch = () => {
@@ -658,6 +697,10 @@ const Research = () => {
     setQuery('');
     setSubmittedQuery('');
     setDepartmentSearch(null);
+    setSelectedSchool('');
+    setSelectedDepartment('');
+    setRequireUndergradEvidence(false);
+    setFacetDistribution({});
     setGroupedResults(emptyGroupedResults(''));
     setSearchResultResearchEntities([]);
     setSearchPage(1);
@@ -687,6 +730,9 @@ const Research = () => {
   useEffect(() => {
     const urlQuery = searchParams.get('q') || '';
     const urlDepartmentLabel = searchParams.get('dept') || '';
+    const urlSchool = searchParams.get('school') || '';
+    const urlDepartment = searchParams.get('department') || '';
+    const urlRequiresUndergradEvidence = searchParams.get('undergrad') === '1';
     const urlWeakestFirst = isAdmin && searchParams.get('weak') === '1';
     const urlQualityFilters = isAdmin
       ? readSearchParamList(
@@ -721,9 +767,27 @@ const Research = () => {
       setTrustTierFilters(urlTrustTierFilters);
       return;
     }
+    if (selectedSchool !== urlSchool) {
+      setSelectedSchool(urlSchool);
+      return;
+    }
+    if (selectedDepartment !== urlDepartment) {
+      setSelectedDepartment(urlDepartment);
+      return;
+    }
+    if (requireUndergradEvidence !== urlRequiresUndergradEvidence) {
+      setRequireUndergradEvidence(urlRequiresUndergradEvidence);
+      return;
+    }
+
+    const studentFilters: ResearchSearchFilters = {
+      ...(urlSchool ? { school: [urlSchool] } : {}),
+      ...(urlDepartment ? { departments: [urlDepartment] } : {}),
+      ...(urlRequiresUndergradEvidence ? { acceptanceLevel: 'verified-or-likely' as const } : {}),
+    };
 
     const urlDepartmentSearch = urlDepartmentLabel
-      ? departmentSearchTargetByLabel.get(urlDepartmentLabel.toLowerCase()) ?? null
+      ? (departmentSearchTargetByLabel.get(urlDepartmentLabel.toLowerCase()) ?? null)
       : null;
 
     if (urlDepartmentSearch) {
@@ -741,10 +805,29 @@ const Research = () => {
     }
 
     if (urlQuery.trim()) {
-      if (!urlDepartmentLabel && submittedQuery === urlQuery.trim()) {
+      if (
+        !urlDepartmentLabel &&
+        submittedQuery === urlQuery.trim() &&
+        JSON.stringify(activeSearchRequest?.filters || {}) === JSON.stringify(studentFilters)
+      ) {
         return;
       }
-      runSearch(urlQuery, { syncUrl: false });
+      runSearch(urlQuery, { filters: studentFilters, syncUrl: false });
+      return;
+    }
+
+    if (hasStructuredFilters(studentFilters)) {
+      if (
+        submittedQuery === 'filtered research' &&
+        JSON.stringify(activeSearchRequest?.filters || {}) === JSON.stringify(studentFilters)
+      ) {
+        return;
+      }
+      runSearch('', {
+        filters: studentFilters,
+        hasFilterSelections: true,
+        syncUrl: false,
+      });
       return;
     }
 
@@ -771,10 +854,14 @@ const Research = () => {
     showWeakestProfilesFirst,
     qualityFilters,
     trustTierFilters,
+    selectedSchool,
+    selectedDepartment,
+    requireUndergradEvidence,
     departmentSearchTargetByLabel,
     departmentSearch,
     hasSubmittedSearch,
     submittedQuery,
+    activeSearchRequest,
   ]);
 
   useEffect(() => {
@@ -787,6 +874,10 @@ const Research = () => {
       showWeakestProfilesFirst,
       qualityFilters,
       trustTierFilters,
+      selectedSchool,
+      selectedDepartment,
+      requireUndergradEvidence,
+      facetDistribution,
       groupedResults,
       searchResultResearchEntities,
       searchPage,
@@ -808,6 +899,10 @@ const Research = () => {
     showWeakestProfilesFirst,
     qualityFilters,
     trustTierFilters,
+    selectedSchool,
+    selectedDepartment,
+    requireUndergradEvidence,
+    facetDistribution,
     groupedResults,
     searchResultResearchEntities,
     searchPage,
@@ -832,10 +927,7 @@ const Research = () => {
     runSearchResultsPage(searchPage);
   }, [activeSearchRequest, hasSubmittedSearch, searchPage]);
 
-  const activeResults = useMemo(
-    () => groupedResults,
-    [groupedResults],
-  );
+  const activeResults = useMemo(() => groupedResults, [groupedResults]);
   const defaultGroupedResults = useMemo(
     () =>
       buildGroupedSearchResults({
@@ -860,10 +952,49 @@ const Research = () => {
     totalRawCount: searchTotal,
     filteredCount: searchResultResearchEntities.length,
   });
-  const searchDisabled = searchLoading || query.trim().length === 0;
+  const hasStudentFacetSelection = Boolean(
+    selectedSchool || selectedDepartment || requireUndergradEvidence,
+  );
+  const searchDisabled = searchLoading || (query.trim().length === 0 && !hasStudentFacetSelection);
   const searchHelpText = query.trim()
     ? 'Press Enter or Search to see matching research homes.'
-    : 'Enter a topic or name to enable Search.';
+    : hasStudentFacetSelection
+      ? 'Search with the selected filters.'
+      : 'Enter a topic or name to enable Search.';
+  const schoolOptions = useMemo(
+    () =>
+      Array.from(
+        new Set([
+          ...Object.keys(facetDistribution.school || {}),
+          ...(selectedSchool ? [selectedSchool] : []),
+        ]),
+      ).sort((a, b) => a.localeCompare(b)),
+    [facetDistribution.school, selectedSchool],
+  );
+  const departmentOptions = useMemo(
+    () =>
+      Array.from(
+        new Set([
+          ...Object.keys(facetDistribution.departments || {}),
+          ...(selectedDepartment ? [selectedDepartment] : []),
+        ]),
+      ).sort((a, b) => a.localeCompare(b)),
+    [facetDistribution.departments, selectedDepartment],
+  );
+  const applyStudentFacets = (school: string, department: string, undergradEvidence: boolean) => {
+    setSelectedSchool(school);
+    setSelectedDepartment(department);
+    setRequireUndergradEvidence(undergradEvidence);
+    const filters = studentSearchFilters(school, department, undergradEvidence);
+    if (!query.trim() && !hasStructuredFilters(filters)) {
+      resetSearch();
+      return;
+    }
+    runSearch(query.trim(), {
+      filters,
+      hasFilterSelections: hasStructuredFilters(filters),
+    });
+  };
   const runDepartmentSearch = (target: DepartmentSearchTarget) =>
     runSearch(target.label, {
       searchQuery: '',
@@ -931,273 +1062,350 @@ const Research = () => {
     <div className="yr-page min-h-[calc(100vh-8rem)]">
       <div className="mx-auto w-full max-w-screen-2xl px-5 py-5 sm:py-8 lg:px-8">
         <div className="grid gap-5 sm:gap-6 2xl:grid-cols-[22rem_minmax(0,1fr)] 2xl:items-start 2xl:gap-8">
-        <header className="yr-panel rounded-md p-4 sm:p-6 2xl:sticky 2xl:top-6">
-          <p className="yr-kicker mb-3">Yale Research</p>
-          <h1 className="max-w-3xl text-2xl font-semibold leading-tight tracking-normal text-slate-950 sm:text-4xl">
-            Find a Yale lab that fits you.
-          </h1>
-          <p
-            id="research-search-context"
-            className="mt-2 max-w-2xl text-sm leading-relaxed text-slate-600 sm:mt-3 sm:text-base"
-          >
-            Search by interest, professor, course topic, method, or question. We&apos;ll help you
-            find relevant research profiles and possible next steps.
-          </p>
-
-          <form onSubmit={onSubmit} className="mt-4 sm:mt-7">
-            <label htmlFor="research-search" className="mb-2 block text-sm font-semibold text-slate-950">
-              Search Yale research
-            </label>
-            <div className="flex flex-col gap-2 sm:flex-row 2xl:flex-col">
-              <input
-                id="research-search"
-                ref={searchInputRef}
-                type="search"
-                value={query}
-                onChange={(event) => {
-                  const nextQuery = event.target.value;
-                  setQuery(nextQuery);
-                  if (!nextQuery.trim() && hasSubmittedSearch) {
-                    resetSearch();
-                  }
-                }}
-                aria-describedby="research-search-context research-search-help"
-                placeholder="Type a topic, professor, lab, method, or research question"
-                className="min-h-12 min-w-0 flex-1 rounded-md border border-[var(--yr-line-strong)] bg-[var(--yr-panel)] px-4 text-base text-slate-950 placeholder:text-slate-400 focus:border-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200 sm:min-h-14"
-              />
-              <button
-                type="submit"
-                className="min-h-12 rounded-md bg-[var(--yr-blue)] px-6 text-sm font-semibold text-white hover:bg-blue-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200 disabled:bg-slate-200 disabled:text-slate-700 sm:min-h-14"
-                disabled={searchDisabled}
-              >
-                {searchLoading ? 'Searching...' : 'Search'}
-              </button>
-            </div>
-            <p id="research-search-help" className="mt-2 text-sm text-slate-600">
-              {searchHelpText}
-            </p>
-            <div
-              className="mt-4 flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center"
-              aria-label="Suggested research searches"
+          <header className="yr-panel rounded-md p-4 sm:p-6 2xl:sticky 2xl:top-6">
+            <p className="yr-kicker mb-3">Yale Research</p>
+            <h1 className="max-w-3xl text-2xl font-semibold leading-tight tracking-normal text-slate-950 sm:text-4xl">
+              Find a Yale lab that fits you.
+            </h1>
+            <p
+              id="research-search-context"
+              className="mt-2 max-w-2xl text-sm leading-relaxed text-slate-600 sm:mt-3 sm:text-base"
             >
-              <span className="yr-kicker text-[0.7rem]">
-                Try a starting point
-              </span>
-              <div className="flex flex-wrap gap-2">
-                {QUICK_START_PROMPTS.map((prompt) => (
-                  <button
-                    key={prompt.query}
-                    type="button"
-                    onClick={() => {
-                      setQuery(prompt.query);
-                      runSearch(prompt.query);
-                    }}
-                    className="yr-pill yr-pill-blue min-h-[44px] rounded-md px-3 py-2 transition-colors hover:border-blue-300 hover:bg-[var(--yr-panel)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
-                  >
-                    {prompt.label}
-                  </button>
-                ))}
-              </div>
-            </div>
-          </form>
+              Search by interest, professor, course topic, method, or question. We&apos;ll help you
+              find relevant research profiles and possible next steps.
+            </p>
 
-        </header>
-
-        <div className="min-w-0">
-        {!hasSubmittedSearch && (
-          <section aria-busy={defaultSearchLoading} aria-label="Research homes to explore">
-            <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-              <div className="w-full">
-                <SectionHeading>Research homes to explore</SectionHeading>
-                <p className="text-sm text-gray-600">
-                  Open a profile to review people, evidence, sources, and planning context.
-                </p>
-              </div>
-              {isAdmin && (
-                <label className="yr-card inline-flex min-h-11 shrink-0 items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-slate-700">
-                  <input
-                    type="checkbox"
-                    checked={showWeakestProfilesFirst}
-                    onChange={(event) => setWeakestProfilesFirst(event.target.checked)}
-                    className="h-4 w-4 rounded border-[var(--yr-line-strong)] text-blue-700 focus:ring-blue-200"
-                  />
-                  <span>Show weakest profiles first</span>
-                </label>
-              )}
-            </div>
-            {defaultSearchError && (
-              <div
-                role="alert"
-                className="mb-4 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900"
+            <form onSubmit={onSubmit} className="mt-4 sm:mt-7">
+              <label
+                htmlFor="research-search"
+                className="mb-2 block text-sm font-semibold text-slate-950"
               >
-                {defaultSearchError}
-              </div>
-            )}
-            {isAdmin && showWeakestProfilesFirst && (
-              <div
-                className="yr-muted-surface mb-4 flex flex-wrap gap-2 rounded-md p-2"
-                aria-label="Quality filters"
-              >
-                {QUALITY_FILTER_OPTIONS.map((option) => {
-                  const isActive = qualityFilters.includes(option.value);
-                  return (
-                    <button
-                      key={option.value}
-                      type="button"
-                      aria-pressed={isActive}
-                      onClick={() => toggleQualityFilter(option.value)}
-                      className={`min-h-10 rounded-md border px-3 py-1.5 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200 ${
-                        isActive
-                          ? 'border-blue-700 bg-[var(--yr-panel)] text-blue-900'
-                          : 'border-[var(--yr-border-warm)] bg-transparent text-slate-700 hover:bg-[var(--yr-panel)]'
-                      }`}
-                    >
-                      {option.label}
-                    </button>
-                  );
-                })}
-              </div>
-            )}
-            {isAdmin && (
-              <div
-                className="mb-4 flex flex-wrap gap-2 rounded-md border border-[var(--yr-line)] bg-[var(--yr-panel)] p-2"
-                aria-label="Trust tier filters"
-              >
-                {TRUST_TIER_FILTER_OPTIONS.map((option) => {
-                  const isActive = trustTierFilters.includes(option.value);
-                  return (
-                    <button
-                      key={option.value}
-                      type="button"
-                      aria-pressed={isActive}
-                      onClick={() => toggleTrustTierFilter(option.value)}
-                      className={`min-h-10 rounded-md border px-3 py-1.5 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200 ${
-                        isActive
-                          ? 'border-slate-900 bg-slate-900 text-white'
-                          : 'border-[var(--yr-line)] bg-[var(--yr-panel)] text-slate-700 hover:bg-[var(--yr-panel-muted)]'
-                      }`}
-                    >
-                      {option.label}
-                    </button>
-                  );
-                })}
-              </div>
-            )}
-            {defaultSearchLoading && defaultGroupedResults.clusters.length === 0 ? (
-              <div className="grid gap-3">
-                {Array.from({ length: 3 }).map((_, index) => (
-                  <ClusterLoadingCard key={index} />
-                ))}
-              </div>
-            ) : defaultGroupedResults.clusters.length > 0 ? (
-              <div className="grid gap-5">
-                <div>
-                  <div className="grid gap-3 lg:grid-cols-2 2xl:grid-cols-[repeat(3,minmax(0,1fr))]">
-                    {defaultGroupedResults.clusters.map((cluster) => (
-                      <ResearchHomeCard
-                        key={cluster.id}
-                        home={cluster}
-                        onSelect={exploreHome}
-                        variant="compact"
-                        showAdminQuality={isAdmin && showWeakestProfilesFirst}
-                      />
-                    ))}
-                  </div>
-                  {defaultSearchLoading && defaultGroupedResults.clusters.length > 0 && (
-                    <InfiniteScrollLoadingDots label="Loading more research homes" />
-                  )}
-                  {!defaultSearchExhausted && <div ref={defaultSentinelRef} className="h-10 w-full" />}
-                </div>
-              </div>
-            ) : (
-              <EmptyGroup>
-                No research homes match these filters. Try a broader topic, professor name, lab,
-                method, or research question.
-              </EmptyGroup>
-            )}
-          </section>
-        )}
-
-        {hasSubmittedSearch && (
-          <section aria-busy={searchLoading} aria-label="Search results">
-            <div className="yr-card rounded-md p-4 md:flex md:items-center md:justify-between md:gap-3">
-              <div>
-                <h2 className="text-lg font-semibold text-slate-950">
-                  Showing research matches for &apos;{submittedQuery}&apos;
-                </h2>
-                <p
-                  role="status"
-                  aria-live="polite"
-                  aria-atomic="true"
-                  className="mt-1 text-sm text-slate-600"
+                Search Yale research
+              </label>
+              <div className="flex flex-col gap-2 sm:flex-row 2xl:flex-col">
+                <input
+                  id="research-search"
+                  ref={searchInputRef}
+                  type="search"
+                  value={query}
+                  onChange={(event) => {
+                    const nextQuery = event.target.value;
+                    setQuery(nextQuery);
+                    if (!nextQuery.trim() && hasSubmittedSearch) {
+                      resetSearch();
+                    }
+                  }}
+                  aria-describedby="research-search-context research-search-help"
+                  placeholder="Type a topic, professor, lab, method, or research question"
+                  className="min-h-12 min-w-0 flex-1 rounded-md border border-[var(--yr-line-strong)] bg-[var(--yr-panel)] px-4 text-base text-slate-950 placeholder:text-slate-400 focus:border-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200 sm:min-h-14"
+                />
+                <button
+                  type="submit"
+                  className="min-h-12 rounded-md bg-[var(--yr-blue)] px-6 text-sm font-semibold text-white hover:bg-blue-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200 disabled:bg-slate-200 disabled:text-slate-700 sm:min-h-14"
+                  disabled={searchDisabled}
                 >
-                  {resultSummary(
-                    activeResults,
-                    submittedQuery,
-                    searchLoading,
-                    departmentSearch?.label,
-                  )}
-                </p>
+                  {searchLoading ? 'Searching...' : 'Search'}
+                </button>
               </div>
-            </div>
-
-            {searchError && (
+              <p id="research-search-help" className="mt-2 text-sm text-slate-600">
+                {searchHelpText}
+              </p>
               <div
-                role="alert"
-                className="mt-4 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900"
+                className="mt-4 flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center"
+                aria-label="Suggested research searches"
               >
-                {searchError}
-              </div>
-            )}
-
-            <section className="mt-5">
-              <SectionHeading>Research homes</SectionHeading>
-              {searchLoading && activeResults.clusters.length === 0 ? (
-                <div className="grid gap-3">
-                  {Array.from({ length: 3 }).map((_, index) => (
-                    <ClusterLoadingCard key={index} />
+                <span className="yr-kicker text-[0.7rem]">Try a starting point</span>
+                <div className="flex flex-wrap gap-2">
+                  {QUICK_START_PROMPTS.map((prompt) => (
+                    <button
+                      key={prompt.query}
+                      type="button"
+                      onClick={() => {
+                        setQuery(prompt.query);
+                        runSearch(prompt.query);
+                      }}
+                      className="yr-pill yr-pill-blue min-h-[44px] rounded-md px-3 py-2 transition-colors hover:border-blue-300 hover:bg-[var(--yr-panel)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+                    >
+                      {prompt.label}
+                    </button>
                   ))}
                 </div>
-              ) : activeResults.clusters.length > 0 ? (
-                <>
+              </div>
+            </form>
+          </header>
+
+          <div className="min-w-0">
+            {!hasSubmittedSearch && (
+              <section aria-busy={defaultSearchLoading} aria-label="Research homes to explore">
+                <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+                  <div className="w-full">
+                    <SectionHeading>Research homes to explore</SectionHeading>
+                    <p className="text-sm text-gray-600">
+                      Open a profile to review people, evidence, sources, and planning context.
+                    </p>
+                  </div>
+                  {isAdmin && (
+                    <label className="yr-card inline-flex min-h-11 shrink-0 items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-slate-700">
+                      <input
+                        type="checkbox"
+                        checked={showWeakestProfilesFirst}
+                        onChange={(event) => setWeakestProfilesFirst(event.target.checked)}
+                        className="h-4 w-4 rounded border-[var(--yr-line-strong)] text-blue-700 focus:ring-blue-200"
+                      />
+                      <span>Show weakest profiles first</span>
+                    </label>
+                  )}
+                </div>
+                {defaultSearchError && (
+                  <div
+                    role="alert"
+                    className="mb-4 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900"
+                  >
+                    {defaultSearchError}
+                  </div>
+                )}
+                {isAdmin && showWeakestProfilesFirst && (
+                  <div
+                    className="yr-muted-surface mb-4 flex flex-wrap gap-2 rounded-md p-2"
+                    aria-label="Quality filters"
+                  >
+                    {QUALITY_FILTER_OPTIONS.map((option) => {
+                      const isActive = qualityFilters.includes(option.value);
+                      return (
+                        <button
+                          key={option.value}
+                          type="button"
+                          aria-pressed={isActive}
+                          onClick={() => toggleQualityFilter(option.value)}
+                          className={`min-h-10 rounded-md border px-3 py-1.5 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200 ${
+                            isActive
+                              ? 'border-blue-700 bg-[var(--yr-panel)] text-blue-900'
+                              : 'border-[var(--yr-border-warm)] bg-transparent text-slate-700 hover:bg-[var(--yr-panel)]'
+                          }`}
+                        >
+                          {option.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+                {isAdmin && (
+                  <div
+                    className="mb-4 flex flex-wrap gap-2 rounded-md border border-[var(--yr-line)] bg-[var(--yr-panel)] p-2"
+                    aria-label="Trust tier filters"
+                  >
+                    {TRUST_TIER_FILTER_OPTIONS.map((option) => {
+                      const isActive = trustTierFilters.includes(option.value);
+                      return (
+                        <button
+                          key={option.value}
+                          type="button"
+                          aria-pressed={isActive}
+                          onClick={() => toggleTrustTierFilter(option.value)}
+                          className={`min-h-10 rounded-md border px-3 py-1.5 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200 ${
+                            isActive
+                              ? 'border-slate-900 bg-slate-900 text-white'
+                              : 'border-[var(--yr-line)] bg-[var(--yr-panel)] text-slate-700 hover:bg-[var(--yr-panel-muted)]'
+                          }`}
+                        >
+                          {option.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+                {defaultSearchLoading && defaultGroupedResults.clusters.length === 0 ? (
+                  <div className="grid gap-3">
+                    {Array.from({ length: 3 }).map((_, index) => (
+                      <ClusterLoadingCard key={index} />
+                    ))}
+                  </div>
+                ) : defaultGroupedResults.clusters.length > 0 ? (
                   <div className="grid gap-5">
-                    <div className="grid gap-3 lg:grid-cols-2 2xl:grid-cols-[repeat(3,minmax(0,1fr))]">
-                      {activeResults.clusters.map((cluster) => (
-                        <ResearchHomeCard
-                          key={cluster.id}
-                          home={cluster}
-                          onSelect={exploreHome}
-                          variant="compact"
-                        />
-                      ))}
+                    <div>
+                      <div className="grid gap-3 lg:grid-cols-2 2xl:grid-cols-[repeat(3,minmax(0,1fr))]">
+                        {defaultGroupedResults.clusters.map((cluster) => (
+                          <ResearchHomeCard
+                            key={cluster.id}
+                            home={cluster}
+                            onSelect={exploreHome}
+                            variant="compact"
+                            showAdminQuality={isAdmin && showWeakestProfilesFirst}
+                          />
+                        ))}
+                      </div>
+                      {defaultSearchLoading && defaultGroupedResults.clusters.length > 0 && (
+                        <InfiniteScrollLoadingDots label="Loading more research homes" />
+                      )}
+                      {!defaultSearchExhausted && (
+                        <div ref={defaultSentinelRef} className="h-10 w-full" />
+                      )}
                     </div>
                   </div>
-                  {searchLoading && activeResults.clusters.length > 0 && (
-                    <InfiniteScrollLoadingDots label="Loading more research homes" />
-                  )}
-                  {!searchExhausted && <div ref={searchSentinelRef} className="h-10 w-full" />}
-                </>
-              ) : (
-                <EmptyGroup>
-                  {departmentSearch
-                    ? 'This is a data coverage gap, not proof that the department has no undergraduate research. Try a topic, method, professor, or adjacent department while this department is being seeded.'
-                    : 'No indexed research homes matched this search yet. Try a broader topic, related method, professor, or adjacent department while coverage improves.'}
-                </EmptyGroup>
-              )}
-            </section>
-
-            {activeResults.papers.length > 0 && (
-              <section className="mt-5">
-                <SectionHeading>Papers via profiles</SectionHeading>
-                <LabPapersList
-                  papers={activeResults.papers}
-                  emptyText="No related profile papers matched this search yet."
-                />
+                ) : (
+                  <EmptyGroup>
+                    No research homes match these filters. Try a broader topic, professor name, lab,
+                    method, or research question.
+                  </EmptyGroup>
+                )}
               </section>
             )}
-          </section>
-        )}
-        </div>
+
+            {hasSubmittedSearch && (
+              <section aria-busy={searchLoading} aria-label="Search results">
+                <div className="yr-card rounded-md p-4 md:flex md:items-center md:justify-between md:gap-3">
+                  <div>
+                    <h2 className="text-lg font-semibold text-slate-950">
+                      Showing research matches for &apos;{submittedQuery}&apos;
+                    </h2>
+                    <p
+                      role="status"
+                      aria-live="polite"
+                      aria-atomic="true"
+                      className="mt-1 text-sm text-slate-600"
+                    >
+                      {resultSummary(
+                        activeResults,
+                        submittedQuery,
+                        searchLoading,
+                        departmentSearch?.label,
+                      )}
+                    </p>
+                  </div>
+                </div>
+
+                <fieldset className="mt-3 border-0 p-0">
+                  <legend className="sr-only">Narrow research results</legend>
+                  <div className="grid gap-4 rounded-md border border-[var(--yr-line)] bg-[var(--yr-panel)] p-3 sm:grid-cols-2 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto_auto] xl:items-end">
+                    <label className="block text-sm font-medium text-slate-800">
+                      School
+                      <select
+                        aria-label="Filter by school"
+                        value={selectedSchool}
+                        onChange={(event) =>
+                          applyStudentFacets(
+                            event.target.value,
+                            selectedDepartment,
+                            requireUndergradEvidence,
+                          )
+                        }
+                        className="mt-1 min-h-11 w-full rounded-md border border-[var(--yr-line-strong)] bg-white px-3 text-sm text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+                      >
+                        <option value="">All schools</option>
+                        {schoolOptions.map((school) => (
+                          <option key={school} value={school}>
+                            {school} ({facetDistribution.school?.[school] ?? searchTotal})
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                    <label className="block text-sm font-medium text-slate-800">
+                      Department
+                      <select
+                        aria-label="Filter by department"
+                        value={selectedDepartment}
+                        onChange={(event) =>
+                          applyStudentFacets(
+                            selectedSchool,
+                            event.target.value,
+                            requireUndergradEvidence,
+                          )
+                        }
+                        className="mt-1 min-h-11 w-full rounded-md border border-[var(--yr-line-strong)] bg-white px-3 text-sm text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+                      >
+                        <option value="">All departments</option>
+                        {departmentOptions.map((department) => (
+                          <option key={department} value={department}>
+                            {getUniqueDepartmentLabels([department], departments)[0] || department}{' '}
+                            ({facetDistribution.departments?.[department] ?? searchTotal})
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                    <label className="inline-flex min-h-11 items-center gap-2 rounded-md border border-[var(--yr-line)] bg-white px-3 py-2 text-sm font-medium text-slate-800">
+                      <input
+                        type="checkbox"
+                        checked={requireUndergradEvidence}
+                        onChange={(event) =>
+                          applyStudentFacets(
+                            selectedSchool,
+                            selectedDepartment,
+                            event.target.checked,
+                          )
+                        }
+                        className="h-4 w-4 rounded border-[var(--yr-line-strong)] text-blue-700 focus:ring-blue-200"
+                      />
+                      Has undergraduate evidence
+                    </label>
+                    {hasStudentFacetSelection && (
+                      <button
+                        type="button"
+                        onClick={() => applyStudentFacets('', '', false)}
+                        className="min-h-11 rounded-md border border-[var(--yr-line-strong)] bg-white px-3 text-sm font-semibold text-slate-700 hover:bg-[var(--yr-panel-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+                      >
+                        Clear filters
+                      </button>
+                    )}
+                  </div>
+                </fieldset>
+
+                {searchError && (
+                  <div
+                    role="alert"
+                    className="mt-4 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900"
+                  >
+                    {searchError}
+                  </div>
+                )}
+
+                <section className="mt-5">
+                  <SectionHeading>Research homes</SectionHeading>
+                  {searchLoading && activeResults.clusters.length === 0 ? (
+                    <div className="grid gap-3">
+                      {Array.from({ length: 3 }).map((_, index) => (
+                        <ClusterLoadingCard key={index} />
+                      ))}
+                    </div>
+                  ) : activeResults.clusters.length > 0 ? (
+                    <>
+                      <div className="grid gap-5">
+                        <div className="grid gap-3 lg:grid-cols-2 2xl:grid-cols-[repeat(3,minmax(0,1fr))]">
+                          {activeResults.clusters.map((cluster) => (
+                            <ResearchHomeCard
+                              key={cluster.id}
+                              home={cluster}
+                              onSelect={exploreHome}
+                              variant="compact"
+                            />
+                          ))}
+                        </div>
+                      </div>
+                      {searchLoading && activeResults.clusters.length > 0 && (
+                        <InfiniteScrollLoadingDots label="Loading more research homes" />
+                      )}
+                      {!searchExhausted && <div ref={searchSentinelRef} className="h-10 w-full" />}
+                    </>
+                  ) : (
+                    <EmptyGroup>
+                      {departmentSearch
+                        ? 'This is a data coverage gap, not proof that the department has no undergraduate research. Try a topic, method, professor, or adjacent department while this department is being seeded.'
+                        : 'No indexed research homes matched this search yet. Try a broader topic, related method, professor, or adjacent department while coverage improves.'}
+                    </EmptyGroup>
+                  )}
+                </section>
+
+                {activeResults.papers.length > 0 && (
+                  <section className="mt-5">
+                    <SectionHeading>Papers via profiles</SectionHeading>
+                    <LabPapersList
+                      papers={activeResults.papers}
+                      emptyText="No related profile papers matched this search yet."
+                    />
+                  </section>
+                )}
+              </section>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/client/src/types/researchEntity.ts
+++ b/client/src/types/researchEntity.ts
@@ -59,29 +59,36 @@ export interface ResearchEntity extends ResearchEntityBacking {
   studentVisibilityReviewNote?: string;
 }
 
-export interface ResearchEntitySearchResponse
-  extends Partial<Omit<ResearchGroupSearchResponse, 'hits' | 'researchEntities'>> {
+export interface ResearchEntitySearchResponse extends Partial<
+  Omit<ResearchGroupSearchResponse, 'hits' | 'researchEntities'>
+> {
   researchEntities?: ResearchEntity[];
   hits?: ResearchEntity[];
+  facetDistribution?: Record<string, Record<string, number>>;
 }
 
-export interface NormalizedResearchEntitySearchResponse
-  extends Omit<ResearchGroupSearchResponse, 'hits' | 'researchEntities'> {
+export interface NormalizedResearchEntitySearchResponse extends Omit<
+  ResearchGroupSearchResponse,
+  'hits' | 'researchEntities'
+> {
   researchEntities: ResearchEntity[];
   hits: ResearchEntity[];
 }
 
-export interface ResearchEntityDetailPayload
-  extends Omit<LabDetailPayload, 'group' | 'researchEntity'> {
+export interface ResearchEntityDetailPayload extends Omit<
+  LabDetailPayload,
+  'group' | 'researchEntity'
+> {
   researchEntity: ResearchEntity;
   group?: ResearchEntity;
 }
 
-type MaybeResearchEntityDetailPayload =
-  Partial<Omit<LabDetailPayload, 'group' | 'researchEntity'>> & {
-    researchEntity?: ResearchEntity | null;
-    group?: ResearchEntity | null;
-  };
+type MaybeResearchEntityDetailPayload = Partial<
+  Omit<LabDetailPayload, 'group' | 'researchEntity'>
+> & {
+  researchEntity?: ResearchEntity | null;
+  group?: ResearchEntity | null;
+};
 
 const normalizeSearchMatch = (
   value: ResearchEntitySearchMatch | undefined,
@@ -107,7 +114,10 @@ const normalizeStudentDecisionExplanation = (
     headline: value.headline.trim(),
     explanation: value.explanation.trim(),
     why: Array.isArray(value.why)
-      ? value.why.map((item) => String(item).trim()).filter(Boolean).slice(0, 3)
+      ? value.why
+          .map((item) => String(item).trim())
+          .filter(Boolean)
+          .slice(0, 3)
       : [],
     sourceUrls: Array.isArray(value.sourceUrls)
       ? value.sourceUrls.map((item) => String(item).trim()).filter(Boolean)

--- a/client/src/types/researchGroup.ts
+++ b/client/src/types/researchGroup.ts
@@ -193,4 +193,5 @@ export interface ResearchGroupSearchResponse {
   estimatedTotalHits: number;
   page: number;
   pageSize: number;
+  facetDistribution?: Record<string, Record<string, number>>;
 }

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,348 +1,346 @@
-# Graph Report - ylabs  (2026-07-10)
+# Graph Report - ylabs-fr5  (2026-07-10)
 
 ## Corpus Check
-- 846 files · ~1,319,391 words
+- 846 files · ~1,320,280 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8498 nodes · 21686 edges · 338 communities (300 shown, 38 thin omitted)
+- 8499 nodes · 21689 edges · 336 communities (298 shown, 38 thin omitted)
 - Extraction: 98% EXTRACTED · 2% INFERRED · 0% AMBIGUOUS · INFERRED: 479 edges (avg confidence: 0.63)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `0cb191c2`
+- Built from commit: `606a5151`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
 ## Community Hubs (Navigation)
-- [[_COMMUNITY_Decisions|Decisions]]
-- [[_COMMUNITY_labDetail.tsx|labDetail.tsx]]
-- [[_COMMUNITY_browsable.ts|browsable.ts]]
-- [[_COMMUNITY_security-preflight.test.mjs|security-preflight.test.mjs]]
-- [[_COMMUNITY_departmentRosterScraper.ts|departmentRosterScraper.ts]]
-- [[_COMMUNITY_labDetail.ts|labDetail.ts]]
-- [[_COMMUNITY_App.tsx|App.tsx]]
-- [[_COMMUNITY_logSanitizer.ts|logSanitizer.ts]]
-- [[_COMMUNITY_adminListingsTableReducer.ts|adminListingsTableReducer.ts]]
-- [[_COMMUNITY_profileService.ts|profileService.ts]]
-- [[_COMMUNITY_labMicrositeDescriptionLLMExtractor.ts|labMicrositeDescriptionLLMExtractor.ts]]
-- [[_COMMUNITY_AdminAccessReview.tsx|AdminAccessReview.tsx]]
-- [[_COMMUNITY_materializeEntity|materializeEntity]]
-- [[_COMMUNITY_researchGroupService.ts|researchGroupService.ts]]
-- [[_COMMUNITY_researchEntitySearchIndexService.ts|researchEntitySearchIndexService.ts]]
-- [[_COMMUNITY_accessMaterializer.ts|accessMaterializer.ts]]
+- [[_COMMUNITY_types.tsx|types.tsx]]
+- [[_COMMUNITY_types.ts|types.ts]]
 - [[_COMMUNITY_UserContext.ts|UserContext.ts]]
-- [[_COMMUNITY_index.ts|index.ts]]
 - [[_COMMUNITY_sanitizeLogValue|sanitizeLogValue]]
-- [[_COMMUNITY_integrityGate.ts|integrityGate.ts]]
-- [[_COMMUNITY_passport.ts|passport.ts]]
-- [[_COMMUNITY_Navbar.tsx|Navbar.tsx]]
-- [[_COMMUNITY_undergradFellowshipRecipientScraper.ts|undergradFellowshipRecipientScraper.ts]]
-- [[_COMMUNITY_duplicateEntityNameReview.ts|duplicateEntityNameReview.ts]]
-- [[_COMMUNITY_app.ts|app.ts]]
-- [[_COMMUNITY_dedupeResearchEntitiesByPi.ts|dedupeResearchEntitiesByPi.ts]]
-- [[_COMMUNITY_admin.ts|admin.ts]]
+- [[_COMMUNITY_departmentRosterScraper.ts|departmentRosterScraper.ts]]
+- [[_COMMUNITY_labMicrositeUndergradLLMExtractor.ts|labMicrositeUndergradLLMExtractor.ts]]
+- [[_COMMUNITY_scripts|scripts]]
+- [[_COMMUNITY_researchEntityDescriptionQuality.ts|researchEntityDescriptionQuality.ts]]
+- [[_COMMUNITY_App.tsx|App.tsx]]
 - [[_COMMUNITY_safeHttpUrl|safeHttpUrl]]
 - [[_COMMUNITY_researchDiscoveryAdapters.ts|researchDiscoveryAdapters.ts]]
-- [[_COMMUNITY_ysmAtoZScraper.ts|ysmAtoZScraper.ts]]
-- [[_COMMUNITY_advisees|advisees]]
-- [[_COMMUNITY_launchAcquisitionReportService.ts|launchAcquisitionReportService.ts]]
-- [[_COMMUNITY_profileDataQualityAudit.ts|profileDataQualityAudit.ts]]
-- [[_COMMUNITY_centersInstitutesScraper.ts|centersInstitutesScraper.ts]]
-- [[_COMMUNITY_types.tsx|types.tsx]]
-- [[_COMMUNITY_ScraperContext|ScraperContext]]
-- [[_COMMUNITY_studentVisibilityGateService.ts|studentVisibilityGateService.ts]]
-- [[_COMMUNITY_buildUserBioObservationScore|buildUserBioObservationScore]]
-- [[_COMMUNITY_User|User]]
-- [[_COMMUNITY_userService.ts|userService.ts]]
-- [[_COMMUNITY_backfillStudentVisibilityTiers.ts|backfillStudentVisibilityTiers.ts]]
-- [[_COMMUNITY_AdminDepartments.tsx|AdminDepartments.tsx]]
-- [[_COMMUNITY_getUniqueDepartmentLabels|getUniqueDepartmentLabels]]
-- [[_COMMUNITY_researchEntityCoverageAudit.ts|researchEntityCoverageAudit.ts]]
-- [[_COMMUNITY_researchAnalytics.ts|researchAnalytics.ts]]
-- [[_COMMUNITY_sourceHealth.ts|sourceHealth.ts]]
-- [[_COMMUNITY_researchEntity.ts|researchEntity.ts]]
-- [[_COMMUNITY_textValue|textValue]]
-- [[_COMMUNITY_ResearchGroupMember|ResearchGroupMember]]
-- [[_COMMUNITY_listingService.ts|listingService.ts]]
-- [[_COMMUNITY_redactDirectContactInfo|redactDirectContactInfo]]
-- [[_COMMUNITY_betaDataQualityCore.ts|betaDataQualityCore.ts]]
-- [[_COMMUNITY_scripts|scripts]]
-- [[_COMMUNITY_productionPromotionSmoke.mjs|productionPromotionSmoke.mjs]]
-- [[_COMMUNITY_research.tsx|research.tsx]]
-- [[_COMMUNITY_runReport.ts|runReport.ts]]
-- [[_COMMUNITY_opportunityDetailService.ts|opportunityDetailService.ts]]
-- [[_COMMUNITY_staleObservationConflictReview.ts|staleObservationConflictReview.ts]]
-- [[_COMMUNITY_researchEntityDescriptionQuality.ts|researchEntityDescriptionQuality.ts]]
-- [[_COMMUNITY_betaDataQuality.ts|betaDataQuality.ts]]
-- [[_COMMUNITY_studentVisibilityTier.ts|studentVisibilityTier.ts]]
+- [[_COMMUNITY_index.ts|index.ts]]
+- [[_COMMUNITY_client|client]]
+- [[_COMMUNITY_duplicateEntityNameReview.ts|duplicateEntityNameReview.ts]]
+- [[_COMMUNITY_labDetail.tsx|labDetail.tsx]]
+- [[_COMMUNITY_Observation|Observation]]
 - [[_COMMUNITY_listingController.ts|listingController.ts]]
-- [[_COMMUNITY_researchGroup.ts|researchGroup.ts]]
-- [[_COMMUNITY_analyticsService.ts|analyticsService.ts]]
-- [[_COMMUNITY_BOOLEAN_FLAGS|BOOLEAN_FLAGS]]
+- [[_COMMUNITY_betaDataQuality.ts|betaDataQuality.ts]]
+- [[_COMMUNITY_resolveSafeJsonReportOutputPath|resolveSafeJsonReportOutputPath]]
 - [[_COMMUNITY_acceptedInputsCore.ts|acceptedInputsCore.ts]]
-- [[_COMMUNITY_serializedDocumentId|serializedDocumentId]]
-- [[_COMMUNITY_researchEntityEvidenceCoverage.ts|researchEntityEvidenceCoverage.ts]]
-- [[_COMMUNITY_fellowshipMatchingService.ts|fellowshipMatchingService.ts]]
-- [[_COMMUNITY_AdminOperatorBoard.tsx|AdminOperatorBoard.tsx]]
-- [[_COMMUNITY_nsfAwardScraper.ts|nsfAwardScraper.ts]]
-- [[_COMMUNITY_fellowshipInputs.ts|fellowshipInputs.ts]]
-- [[_COMMUNITY_repairOfficialProfilePublicationPointers.ts|repairOfficialProfilePublicationPointers.ts]]
-- [[_COMMUNITY_postedOpportunityService.ts|postedOpportunityService.ts]]
-- [[_COMMUNITY_profileController.ts|profileController.ts]]
-- [[_COMMUNITY_analytics.ts|analytics.ts]]
-- [[_COMMUNITY_openAlexPaperScraper.ts|openAlexPaperScraper.ts]]
-- [[_COMMUNITY_labMicrositeUndergradLLMExtractor.ts|labMicrositeUndergradLLMExtractor.ts]]
-- [[_COMMUNITY_researchEntityMemberReferenceAudit.ts|researchEntityMemberReferenceAudit.ts]]
+- [[_COMMUNITY_dedupeResearchEntitiesByPi.ts|dedupeResearchEntitiesByPi.ts]]
+- [[_COMMUNITY_listingService.ts|listingService.ts]]
+- [[_COMMUNITY_profileDataQualityAudit.ts|profileDataQualityAudit.ts]]
+- [[_COMMUNITY_researchGroupService.ts|researchGroupService.ts]]
+- [[_COMMUNITY_researchQualitySearchReview.ts|researchQualitySearchReview.ts]]
+- [[_COMMUNITY_browsable.ts|browsable.ts]]
+- [[_COMMUNITY_passport.ts|passport.ts]]
+- [[_COMMUNITY_launchAcquisitionReportService.ts|launchAcquisitionReportService.ts]]
+- [[_COMMUNITY_labMicrositeDescriptionLLMExtractor.ts|labMicrositeDescriptionLLMExtractor.ts]]
+- [[_COMMUNITY_betaDataQualityCore.ts|betaDataQualityCore.ts]]
+- [[_COMMUNITY_sourceHealth.ts|sourceHealth.ts]]
+- [[_COMMUNITY_ysmAtoZScraper.ts|ysmAtoZScraper.ts]]
+- [[_COMMUNITY_integrityGate.ts|integrityGate.ts]]
+- [[_COMMUNITY_analyticsService.ts|analyticsService.ts]]
+- [[_COMMUNITY_userService.ts|userService.ts]]
+- [[_COMMUNITY_studentVisibilityGateService.ts|studentVisibilityGateService.ts]]
+- [[_COMMUNITY_AdminDepartments.tsx|AdminDepartments.tsx]]
+- [[_COMMUNITY_runReport.ts|runReport.ts]]
+- [[_COMMUNITY_accessMaterializer.ts|accessMaterializer.ts]]
+- [[_COMMUNITY_User|User]]
+- [[_COMMUNITY_profileService.ts|profileService.ts]]
+- [[_COMMUNITY_researchGroup.ts|researchGroup.ts]]
 - [[_COMMUNITY_SavedPathwaysSection.tsx|SavedPathwaysSection.tsx]]
-- [[_COMMUNITY_departmentUndergradResearchScraper.ts|departmentUndergradResearchScraper.ts]]
+- [[_COMMUNITY_ImportRootDataFiles.ts|ImportRootDataFiles.ts]]
+- [[_COMMUNITY_scholarlyLinkSuppressionAudit.ts|scholarlyLinkSuppressionAudit.ts]]
 - [[_COMMUNITY_pathwaySearchIndexService.ts|pathwaySearchIndexService.ts]]
-- [[_COMMUNITY_researchEntity.ts|researchEntity.ts]]
+- [[_COMMUNITY_studentVisibilityTier.ts|studentVisibilityTier.ts]]
+- [[_COMMUNITY_dataOps.ts|dataOps.ts]]
+- [[_COMMUNITY_fellowshipInputs.ts|fellowshipInputs.ts]]
 - [[_COMMUNITY_adminOperatorBoardService.ts|adminOperatorBoardService.ts]]
 - [[_COMMUNITY_Listing|Listing]]
-- [[_COMMUNITY_promoteAcceptedBetaCopy.ts|promoteAcceptedBetaCopy.ts]]
-- [[_COMMUNITY_Yale Research - Developer Guide|Yale Research - Developer Guide]]
-- [[_COMMUNITY_paperAuthorshipAudit.ts|paperAuthorshipAudit.ts]]
-- [[_COMMUNITY_Observation|Observation]]
-- [[_COMMUNITY_Environment Progression|Environment Progression]]
-- [[_COMMUNITY_devDependencies|devDependencies]]
-- [[_COMMUNITY_Per-Source Audit Playbooks|Per-Source Audit Playbooks]]
-- [[_COMMUNITY_assertPublicHttpUrl|assertPublicHttpUrl]]
-- [[_COMMUNITY_studentDecisionLLMExtractor.ts|studentDecisionLLMExtractor.ts]]
-- [[_COMMUNITY_adminFellowshipFormReducer.ts|adminFellowshipFormReducer.ts]]
-- [[_COMMUNITY_ResearchHomeCard.tsx|ResearchHomeCard.tsx]]
-- [[_COMMUNITY_applyProfileResearchAreaFallback|applyProfileResearchAreaFallback]]
-- [[_COMMUNITY_backfillProfileBiosFromOfficialUrls.ts|backfillProfileBiosFromOfficialUrls.ts]]
-- [[_COMMUNITY_rebuildPathwaySearchIndex.ts|rebuildPathwaySearchIndex.ts]]
-- [[_COMMUNITY_claimGate.ts|claimGate.ts]]
-- [[_COMMUNITY_dedupeUsersByIdentityCore.ts|dedupeUsersByIdentityCore.ts]]
-- [[_COMMUNITY_longText.ts|longText.ts]]
-- [[_COMMUNITY_attempt|attempt]]
-- [[_COMMUNITY_launchTrustContractService.ts|launchTrustContractService.ts]]
-- [[_COMMUNITY_buildAdminOperatorBoard|buildAdminOperatorBoard]]
-- [[_COMMUNITY_analytics.tsx|analytics.tsx]]
+- [[_COMMUNITY_admin.ts|admin.ts]]
 - [[_COMMUNITY_officialProfilePiBackfillScraper.ts|officialProfilePiBackfillScraper.ts]]
-- [[_COMMUNITY_pathwaySearchService.ts|pathwaySearchService.ts]]
-- [[_COMMUNITY_renderedFetch.ts|renderedFetch.ts]]
-- [[_COMMUNITY_BackfillV4FacultyMembers.ts|BackfillV4FacultyMembers.ts]]
-- [[_COMMUNITY_repairArchivedEntityArtifacts.ts|repairArchivedEntityArtifacts.ts]]
-- [[_COMMUNITY_listingClaimRequestService.ts|listingClaimRequestService.ts]]
-- [[_COMMUNITY_brianFeed|brianFeed]]
-- [[_COMMUNITY_betaRepairQueue.ts|betaRepairQueue.ts]]
-- [[_COMMUNITY_assessment|assessment]]
 - [[_COMMUNITY_yaleCollegeFellowshipsOfficeScraper.ts|yaleCollegeFellowshipsOfficeScraper.ts]]
-- [[_COMMUNITY_scripts|scripts]]
-- [[_COMMUNITY_pathwayQualityAudit.ts|pathwayQualityAudit.ts]]
-- [[_COMMUNITY_base|base]]
-- [[_COMMUNITY_isNonBiographicalPublicBio|isNonBiographicalPublicBio]]
-- [[_COMMUNITY_cronRunner.ts|cronRunner.ts]]
-- [[_COMMUNITY_normalizeProfileUpdateForStorage|normalizeProfileUpdateForStorage]]
-- [[_COMMUNITY_yaleResearchOfficialScraper.ts|yaleResearchOfficialScraper.ts]]
-- [[_COMMUNITY_Adding a New Endpoint|Adding a New Endpoint]]
-- [[_COMMUNITY_yaleDirectoryScraper.ts|yaleDirectoryScraper.ts]]
-- [[_COMMUNITY_fellowshipController.ts|fellowshipController.ts]]
-- [[_COMMUNITY_ListingDetailModal.tsx|ListingDetailModal.tsx]]
-- [[_COMMUNITY_scholarlyLinkSuppressionAudit.ts|scholarlyLinkSuppressionAudit.ts]]
-- [[_COMMUNITY_pathwayController.ts|pathwayController.ts]]
-- [[_COMMUNITY_researchEntityDescriptionText.ts|researchEntityDescriptionText.ts]]
-- [[_COMMUNITY_dir|dir]]
-- [[_COMMUNITY_launchReviewExceptions.ts|launchReviewExceptions.ts]]
-- [[_COMMUNITY_adminRender|adminRender]]
-- [[_COMMUNITY_Session Notes|Session Notes]]
-- [[_COMMUNITY_acceptedInputs.ts|acceptedInputs.ts]]
-- [[_COMMUNITY_scraperIntegrityGate.ts|scraperIntegrityGate.ts]]
-- [[_COMMUNITY_research-detail-professor-audit.mjs|research-detail-professor-audit.mjs]]
-- [[_COMMUNITY_dedupeUsersByIdentity.ts|dedupeUsersByIdentity.ts]]
-- [[_COMMUNITY_ImportRootDataFiles.ts|ImportRootDataFiles.ts]]
-- [[_COMMUNITY_candidateDescriptionCrawlUrls|candidateDescriptionCrawlUrls]]
-- [[_COMMUNITY_getResearchGroupDetail|getResearchGroupDetail]]
+- [[_COMMUNITY_Navbar.tsx|Navbar.tsx]]
+- [[_COMMUNITY_pathwaySearchService.ts|pathwaySearchService.ts]]
+- [[_COMMUNITY_paperAuthorshipAudit.ts|paperAuthorshipAudit.ts]]
+- [[_COMMUNITY_entryPathwayService.ts|entryPathwayService.ts]]
+- [[_COMMUNITY_devDependencies|devDependencies]]
 - [[_COMMUNITY_applicationRoutePathwayBackfillCore.ts|applicationRoutePathwayBackfillCore.ts]]
-- [[_COMMUNITY_generateKeywords.ts|generateKeywords.ts]]
-- [[_COMMUNITY_scriptWriteGuards.ts|scriptWriteGuards.ts]]
-- [[_COMMUNITY_types.ts|types.ts]]
-- [[_COMMUNITY_client|client]]
-- [[_COMMUNITY_departmentGroundTruth.ts|departmentGroundTruth.ts]]
-- [[_COMMUNITY_profileBioCoverageAudit.ts|profileBioCoverageAudit.ts]]
-- [[_COMMUNITY_Research Model|Research Model]]
-- [[_COMMUNITY_cli.ts|cli.ts]]
-- [[_COMMUNITY_AdminFellowshipsTable.tsx|AdminFellowshipsTable.tsx]]
-- [[_COMMUNITY_smartTitle.ts|smartTitle.ts]]
-- [[_COMMUNITY_crossSourceObservationConflictReview.ts|crossSourceObservationConflictReview.ts]]
-- [[_COMMUNITY_migrateResearchEntities.ts|migrateResearchEntities.ts]]
-- [[_COMMUNITY_visibilityRepairQueueService.ts|visibilityRepairQueueService.ts]]
-- [[_COMMUNITY_abstractBios|abstractBios]]
+- [[_COMMUNITY_serializedDocumentId|serializedDocumentId]]
+- [[_COMMUNITY_entityMaterializer.ts|entityMaterializer.ts]]
+- [[_COMMUNITY_AdminOperatorBoard.tsx|AdminOperatorBoard.tsx]]
 - [[_COMMUNITY_researchEntity.ts|researchEntity.ts]]
-- [[_COMMUNITY_researchQualitySearchReview.ts|researchQualitySearchReview.ts]]
-- [[_COMMUNITY_{ container }|{ container }]]
+- [[_COMMUNITY_scripts|scripts]]
+- [[_COMMUNITY_officialProfilePiBackfillScraper.test.ts|officialProfilePiBackfillScraper.test.ts]]
+- [[_COMMUNITY_undergradFellowshipRecipientScraper.ts|undergradFellowshipRecipientScraper.ts]]
+- [[_COMMUNITY_crossSourceObservationConflictReview.ts|crossSourceObservationConflictReview.ts]]
+- [[_COMMUNITY_researchEntityMemberReferenceAudit.ts|researchEntityMemberReferenceAudit.ts]]
+- [[_COMMUNITY_productionPromotionSmoke.mjs|productionPromotionSmoke.mjs]]
+- [[_COMMUNITY_ListingDetailModal.tsx|ListingDetailModal.tsx]]
+- [[_COMMUNITY_seedSources.ts|seedSources.ts]]
+- [[_COMMUNITY_repairOfficialProfilePublicationPointers.ts|repairOfficialProfilePublicationPointers.ts]]
+- [[_COMMUNITY_fellowshipService.ts|fellowshipService.ts]]
+- [[_COMMUNITY_opportunityDetail.tsx|opportunityDetail.tsx]]
+- [[_COMMUNITY_index.ts|index.ts]]
+- [[_COMMUNITY_researchAnalytics.ts|researchAnalytics.ts]]
+- [[_COMMUNITY_analytics.tsx|analytics.tsx]]
+- [[_COMMUNITY_scripts|scripts]]
+- [[_COMMUNITY_configService.ts|configService.ts]]
+- [[_COMMUNITY_backfillProfileBiosFromOfficialUrls.ts|backfillProfileBiosFromOfficialUrls.ts]]
+- [[_COMMUNITY_departmentLeadRepairPlanCore.ts|departmentLeadRepairPlanCore.ts]]
+- [[_COMMUNITY_researchEntityEvidenceCoverage.ts|researchEntityEvidenceCoverage.ts]]
+- [[_COMMUNITY_cli.ts|cli.ts]]
+- [[_COMMUNITY_ScraperContext|ScraperContext]]
+- [[_COMMUNITY_studentVisibilityRepairTargets.ts|studentVisibilityRepairTargets.ts]]
+- [[_COMMUNITY_researchEntitySearchIndexService.ts|researchEntitySearchIndexService.ts]]
+- [[_COMMUNITY_opportunityDetailService.ts|opportunityDetailService.ts]]
+- [[_COMMUNITY_programController.ts|programController.ts]]
+- [[_COMMUNITY_departmentUndergradResearchScraper.ts|departmentUndergradResearchScraper.ts]]
+- [[_COMMUNITY_centersInstitutesScraper.ts|centersInstitutesScraper.ts]]
+- [[_COMMUNITY_studentDecisionLLMExtractor.ts|studentDecisionLLMExtractor.ts]]
+- [[_COMMUNITY_field|field]]
+- [[_COMMUNITY_researchEntityCoverageAudit.ts|researchEntityCoverageAudit.ts]]
+- [[_COMMUNITY_research.tsx|research.tsx]]
+- [[_COMMUNITY_isLikelyPersonUrl|isLikelyPersonUrl]]
+- [[_COMMUNITY_research-detail-professor-audit.mjs|research-detail-professor-audit.mjs]]
+- [[_COMMUNITY_AdminAccessReview.tsx|AdminAccessReview.tsx]]
+- [[_COMMUNITY_analytics.ts|analytics.ts]]
+- [[_COMMUNITY_dedupeUsersByIdentityCore.ts|dedupeUsersByIdentityCore.ts]]
+- [[_COMMUNITY_openAlexPaperScraper.ts|openAlexPaperScraper.ts]]
+- [[_COMMUNITY_dependencies|dependencies]]
+- [[_COMMUNITY_ProfileEditor.tsx|ProfileEditor.tsx]]
+- [[_COMMUNITY_apiBaseUrl.ts|apiBaseUrl.ts]]
+- [[_COMMUNITY_postedOpportunityService.ts|postedOpportunityService.ts]]
+- [[_COMMUNITY_assertPublicHttpUrl|assertPublicHttpUrl]]
+- [[_COMMUNITY_arxivPreprintScraper.ts|arxivPreprintScraper.ts]]
+- [[_COMMUNITY_launchTrustContractService.ts|launchTrustContractService.ts]]
+- [[_COMMUNITY_pathwayQualityAudit.ts|pathwayQualityAudit.ts]]
+- [[_COMMUNITY_promoteAcceptedBetaCopy.ts|promoteAcceptedBetaCopy.ts]]
+- [[_COMMUNITY_textValue|textValue]]
+- [[_COMMUNITY_departmentGroundTruth.ts|departmentGroundTruth.ts]]
+- [[_COMMUNITY_app.ts|app.ts]]
+- [[_COMMUNITY_listingClaimRequestService.ts|listingClaimRequestService.ts]]
+- [[_COMMUNITY_profileController.ts|profileController.ts]]
+- [[_COMMUNITY_logSanitizer.ts|logSanitizer.ts]]
+- [[_COMMUNITY_adminAccessReviewService.ts|adminAccessReviewService.ts]]
 - [[_COMMUNITY_migrateResearchEntityCollections.ts|migrateResearchEntityCollections.ts]]
-- [[_COMMUNITY_researchGroupController.ts|researchGroupController.ts]]
-- [[_COMMUNITY_migrateSmartTitles.ts|migrateSmartTitles.ts]]
-- [[_COMMUNITY_externalIdsSchema|externalIdsSchema]]
-- [[_COMMUNITY_studentDecisionExplanationService.ts|studentDecisionExplanationService.ts]]
+- [[_COMMUNITY_scholarlyLinkToPublicLink|scholarlyLinkToPublicLink]]
+- [[_COMMUNITY_UserContextProvider.tsx|UserContextProvider.tsx]]
+- [[_COMMUNITY_safeRouteSegment|safeRouteSegment]]
+- [[_COMMUNITY_betaDataQualityCore.test.ts|betaDataQualityCore.test.ts]]
+- [[_COMMUNITY_migrateResearchEntities.ts|migrateResearchEntities.ts]]
+- [[_COMMUNITY_buildAdminOperatorBoard|buildAdminOperatorBoard]]
+- [[_COMMUNITY_axios.ts|axios.ts]]
 - [[_COMMUNITY_disambiguateSurnameLabNames.ts|disambiguateSurnameLabNames.ts]]
 - [[_COMMUNITY_repairDuplicateAccessSignals.ts|repairDuplicateAccessSignals.ts]]
-- [[_COMMUNITY_arxivPreprintScraper.ts|arxivPreprintScraper.ts]]
-- [[_COMMUNITY_EvidenceQualitySection|EvidenceQualitySection]]
-- [[_COMMUNITY_LIVE|LIVE]]
-- [[_COMMUNITY_dependencies|dependencies]]
-- [[_COMMUNITY_normalizeOfficialProfileUrl|normalizeOfficialProfileUrl]]
-- [[_COMMUNITY_axios.ts|axios.ts]]
-- [[_COMMUNITY_programController.ts|programController.ts]]
-- [[_COMMUNITY_seedDepartments.ts|seedDepartments.ts]]
-- [[_COMMUNITY_Active Detail Docs|Active Detail Docs]]
+- [[_COMMUNITY_fellowshipMatchingService.ts|fellowshipMatchingService.ts]]
+- [[_COMMUNITY_fellowshipController.ts|fellowshipController.ts]]
+- [[_COMMUNITY_environment.ts|environment.ts]]
+- [[_COMMUNITY_repairArchivedEntityArtifacts.ts|repairArchivedEntityArtifacts.ts]]
 - [[_COMMUNITY_repairMismatchedPersonEmailsCore.ts|repairMismatchedPersonEmailsCore.ts]]
-- [[_COMMUNITY_betaReadinessGate.ts|betaReadinessGate.ts]]
-- [[_COMMUNITY_buildDescriptionLLMPrompt|buildDescriptionLLMPrompt]]
-- [[_COMMUNITY_index.tsx|index.tsx]]
-- [[_COMMUNITY_callLLM|callLLM]]
-- [[_COMMUNITY_adminAccessReviewService.ts|adminAccessReviewService.ts]]
-- [[_COMMUNITY_studentVisibilityRepairTargets.ts|studentVisibilityRepairTargets.ts]]
-- [[_COMMUNITY_scripts|scripts]]
-- [[_COMMUNITY_v4MigrationUtils.ts|v4MigrationUtils.ts]]
-- [[_COMMUNITY_source.ts|source.ts]]
-- [[_COMMUNITY_cleanupLegacyMongoCollections.ts|cleanupLegacyMongoCollections.ts]]
-- [[_COMMUNITY_seedSources.ts|seedSources.ts]]
-- [[_COMMUNITY_AdminProfileEditModal.tsx|AdminProfileEditModal.tsx]]
-- [[_COMMUNITY_configService.ts|configService.ts]]
-- [[_COMMUNITY_publicResearchSeo.ts|publicResearchSeo.ts]]
-- [[_COMMUNITY_migrateMongoNaming.ts|migrateMongoNaming.ts]]
+- [[_COMMUNITY_errorHandler.ts|errorHandler.ts]]
 - [[_COMMUNITY_researchEntityPiDedupeCore.ts|researchEntityPiDedupeCore.ts]]
-- [[_COMMUNITY_staleObservationConflictReview.test.ts|staleObservationConflictReview.test.ts]]
-- [[_COMMUNITY_launchTrustContract.ts|launchTrustContract.ts]]
-- [[_COMMUNITY_EvidenceSourceRow.tsx|EvidenceSourceRow.tsx]]
-- [[_COMMUNITY_adminGrantService.ts|adminGrantService.ts]]
-- [[_COMMUNITY_resolveSafeJsonReportOutputPath|resolveSafeJsonReportOutputPath]]
-- [[_COMMUNITY_dependencies|dependencies]]
-- [[_COMMUNITY_users.ts|users.ts]]
-- [[_COMMUNITY_unified-research-search-audit.mjs|unified-research-search-audit.mjs]]
-- [[_COMMUNITY_index.ts|index.ts]]
+- [[_COMMUNITY_listingResearchEntityProfile.ts|listingResearchEntityProfile.ts]]
+- [[_COMMUNITY_researchEntityQuality.ts|researchEntityQuality.ts]]
+- [[_COMMUNITY_cronRunner.ts|cronRunner.ts]]
+- [[_COMMUNITY_entityMaterializer.test.ts|entityMaterializer.test.ts]]
 - [[_COMMUNITY_userEmailHygiene.ts|userEmailHygiene.ts]]
-- [[_COMMUNITY_orcidWorksScraper.ts|orcidWorksScraper.ts]]
-- [[_COMMUNITY_backfillResearchHomeOfficialUrls.ts|backfillResearchHomeOfficialUrls.ts]]
-- [[_COMMUNITY_backfillFacultyWaysIn.ts|backfillFacultyWaysIn.ts]]
-- [[_COMMUNITY_publicationsTableReducer.ts|publicationsTableReducer.ts]]
-- [[_COMMUNITY_AdminFacultyProfilesTable.tsx|AdminFacultyProfilesTable.tsx]]
-- [[_COMMUNITY_meiliSyncService.ts|meiliSyncService.ts]]
-- [[_COMMUNITY_AdminOperatorBoard|AdminOperatorBoard]]
-- [[_COMMUNITY_departmentResolver.ts|departmentResolver.ts]]
-- [[_COMMUNITY_isPublicHttpUrl|isPublicHttpUrl]]
-- [[_COMMUNITY_repairProfileDescriptionBackfillConflicts.ts|repairProfileDescriptionBackfillConflicts.ts]]
-- [[_COMMUNITY_clearBetaStudentAnalytics.ts|clearBetaStudentAnalytics.ts]]
-- [[_COMMUNITY_scraperIntegrityDuplicateReview.ts|scraperIntegrityDuplicateReview.ts]]
-- [[_COMMUNITY_normalizePublicProfile|normalizePublicProfile]]
-- [[_COMMUNITY_departmentLeadRepairPlanCore.ts|departmentLeadRepairPlanCore.ts]]
-- [[_COMMUNITY_auditResearchEntityRename.ts|auditResearchEntityRename.ts]]
-- [[_COMMUNITY_normalizeName|normalizeName]]
-- [[_COMMUNITY_authorshipEvidence|authorshipEvidence]]
-- [[_COMMUNITY_actor|actor]]
-- [[_COMMUNITY_compilerOptions|compilerOptions]]
-- [[_COMMUNITY_backfillPostedOpportunitiesFromListings.ts|backfillPostedOpportunitiesFromListings.ts]]
-- [[_COMMUNITY_acronymExpansion|acronymExpansion]]
 - [[_COMMUNITY_paperQualityService.ts|paperQualityService.ts]]
-- [[_COMMUNITY_dataOps.ts|dataOps.ts]]
-- [[_COMMUNITY_actionabilityMatch|actionabilityMatch]]
-- [[_COMMUNITY_pathwayRelevanceReview.ts|pathwayRelevanceReview.ts]]
-- [[_COMMUNITY_profileImageQualityAudit.ts|profileImageQualityAudit.ts]]
-- [[_COMMUNITY_researchGroupService.test.ts|researchGroupService.test.ts]]
-- [[_COMMUNITY_programs.ts|programs.ts]]
-- [[_COMMUNITY_bare|bare]]
-- [[_COMMUNITY_crossrefFreeFullText|crossrefFreeFullText]]
+- [[_COMMUNITY_profileBioCoverageAudit.ts|profileBioCoverageAudit.ts]]
+- [[_COMMUNITY_initializeConnections|initializeConnections]]
+- [[_COMMUNITY_staleObservationConflictReview.ts|staleObservationConflictReview.ts]]
+- [[_COMMUNITY_visibilityRepairQueueService.test.ts|visibilityRepairQueueService.test.ts]]
+- [[_COMMUNITY_AdminProfileEditModal.tsx|AdminProfileEditModal.tsx]]
+- [[_COMMUNITY_seedDepartments.ts|seedDepartments.ts]]
+- [[_COMMUNITY_unified-research-search-audit.mjs|unified-research-search-audit.mjs]]
+- [[_COMMUNITY_researchGroupController.ts|researchGroupController.ts]]
+- [[_COMMUNITY_yaleResearchOfficialScraper.ts|yaleResearchOfficialScraper.ts]]
+- [[_COMMUNITY_cleanupLegacyMongoCollections.ts|cleanupLegacyMongoCollections.ts]]
+- [[_COMMUNITY_launchReviewExceptions.ts|launchReviewExceptions.ts]]
+- [[_COMMUNITY_profile.tsx|profile.tsx]]
+- [[_COMMUNITY_ResearchGroupMember|ResearchGroupMember]]
+- [[_COMMUNITY_materializePaperObservationsFromRun|materializePaperObservationsFromRun]]
+- [[_COMMUNITY_Yale Research - Developer Guide|Yale Research - Developer Guide]]
+- [[_COMMUNITY_migrateMongoNaming.ts|migrateMongoNaming.ts]]
+- [[_COMMUNITY_repairProfileDescriptionBackfillConflicts.ts|repairProfileDescriptionBackfillConflicts.ts]]
+- [[_COMMUNITY_cleanPublicHttpUrl|cleanPublicHttpUrl]]
+- [[_COMMUNITY_migrateSmartTitles.ts|migrateSmartTitles.ts]]
+- [[_COMMUNITY_redactDirectContactInfo|redactDirectContactInfo]]
+- [[_COMMUNITY_betaSeedEnvironment.ts|betaSeedEnvironment.ts]]
+- [[_COMMUNITY_agent-workflow|agent-workflow.md]]
+- [[_COMMUNITY_betaReadinessGate.ts|betaReadinessGate.ts]]
+- [[_COMMUNITY_textValue|textValue]]
+- [[_COMMUNITY_auditResearchEntityRename.ts|auditResearchEntityRename.ts]]
+- [[_COMMUNITY_backfillPostedOpportunitiesFromListings.ts|backfillPostedOpportunitiesFromListings.ts]]
+- [[_COMMUNITY_Session Notes|Session Notes]]
+- [[_COMMUNITY_devDependencies|devDependencies]]
+- [[_COMMUNITY_acceptedInputs.ts|acceptedInputs.ts]]
+- [[_COMMUNITY_claimGate.ts|claimGate.ts]]
+- [[_COMMUNITY_scraperIntegrityDuplicateReview.ts|scraperIntegrityDuplicateReview.ts]]
+- [[_COMMUNITY_clearBetaStudentAnalytics.ts|clearBetaStudentAnalytics.ts]]
+- [[_COMMUNITY_visibilityRepairQueueService.ts|visibilityRepairQueueService.ts]]
+- [[_COMMUNITY_Yale Research|Yale Research]]
+- [[_COMMUNITY_adminListingsTableReducer.ts|adminListingsTableReducer.ts]]
 - [[_COMMUNITY_compilerOptions|compilerOptions]]
-- [[_COMMUNITY_seo.ts|seo.ts]]
-- [[_COMMUNITY_MigratePublicationsToPapers.ts|MigratePublicationsToPapers.ts]]
+- [[_COMMUNITY_seedResearchAreas.ts|seedResearchAreas.ts]]
+- [[_COMMUNITY_Decisions|Decisions]]
+- [[_COMMUNITY_Research Data Pipeline|Research Data Pipeline]]
+- [[_COMMUNITY_Research Model|Research Model]]
+- [[_COMMUNITY_index.ts|index.ts]]
+- [[_COMMUNITY_adminGrantService.ts|adminGrantService.ts]]
+- [[_COMMUNITY_profileImageQualityAuditCore.ts|profileImageQualityAuditCore.ts]]
+- [[_COMMUNITY_assertScriptApplyAllowed|assertScriptApplyAllowed]]
+- [[_COMMUNITY_updateOwnProfile|updateOwnProfile]]
+- [[_COMMUNITY_studentDecisionExplanationService.ts|studentDecisionExplanationService.ts]]
+- [[_COMMUNITY_compilerOptions|compilerOptions]]
+- [[_COMMUNITY_AdminFacultyProfilesTable.tsx|AdminFacultyProfilesTable.tsx]]
+- [[_COMMUNITY_generateKeywords.ts|generateKeywords.ts]]
+- [[_COMMUNITY_Per-Source Audit Playbooks|Per-Source Audit Playbooks]]
+- [[_COMMUNITY_fellowship.ts|fellowship.ts]]
+- [[_COMMUNITY_materializeEntity|materializeEntity]]
+- [[_COMMUNITY_backfillResearchDescriptions.ts|backfillResearchDescriptions.ts]]
+- [[_COMMUNITY_backfillResearchHomeOfficialUrls.ts|backfillResearchHomeOfficialUrls.ts]]
+- [[_COMMUNITY_smartTitle.ts|smartTitle.ts]]
+- [[_COMMUNITY_researchEntityDto.ts|researchEntityDto.ts]]
+- [[_COMMUNITY_backfillCenterDirectors.ts|backfillCenterDirectors.ts]]
+- [[_COMMUNITY_normalizeOfficialProfileUrl|normalizeOfficialProfileUrl]]
+- [[_COMMUNITY_betaRepairQueue.ts|betaRepairQueue.ts]]
+- [[_COMMUNITY_sanitizeProfileResearchTerms|sanitizeProfileResearchTerms]]
+- [[_COMMUNITY_pathwayRelevanceReview.ts|pathwayRelevanceReview.ts]]
+- [[_COMMUNITY_accessSummaryService.ts|accessSummaryService.ts]]
 - [[_COMMUNITY_sourceHealthService.ts|sourceHealthService.ts]]
+- [[_COMMUNITY_adminFellowshipsTableReducer.ts|adminFellowshipsTableReducer.ts]]
+- [[_COMMUNITY_resolutions|resolutions]]
+- [[_COMMUNITY_publicResearchSeo.ts|publicResearchSeo.ts]]
+- [[_COMMUNITY_researchEntity.ts|researchEntity.ts]]
+- [[_COMMUNITY_visibilityReleaseQueueItem.ts|visibilityReleaseQueueItem.ts]]
+- [[_COMMUNITY_users.ts|users.ts]]
+- [[_COMMUNITY_extractOfficialProfileResearchHomes|extractOfficialProfileResearchHomes]]
+- [[_COMMUNITY_dependencies|dependencies]]
+- [[_COMMUNITY_dedupeExploratoryContactPathways.ts|dedupeExploratoryContactPathways.ts]]
+- [[_COMMUNITY_repairListingResearchEntityProfiles.ts|repairListingResearchEntityProfiles.ts]]
+- [[_COMMUNITY_scraperIntegrityGate.ts|scraperIntegrityGate.ts]]
+- [[_COMMUNITY_isPublicHttpUrl|isPublicHttpUrl]]
+- [[_COMMUNITY_MigrateDepartments.ts|MigrateDepartments.ts]]
+- [[_COMMUNITY_compilerOptions|compilerOptions]]
+- [[_COMMUNITY_Environment Progression|Environment Progression]]
+- [[_COMMUNITY_ScrapeRun|ScrapeRun]]
+- [[_COMMUNITY_programs.ts|programs.ts]]
+- [[_COMMUNITY_csrfOriginGuard.ts|csrfOriginGuard.ts]]
+- [[_COMMUNITY_main|main]]
+- [[_COMMUNITY_AdminFellowshipsTable.tsx|AdminFellowshipsTable.tsx]]
+- [[_COMMUNITY_seo.ts|seo.ts]]
+- [[_COMMUNITY_BackfillV4StudentProfiles.ts|BackfillV4StudentProfiles.ts]]
+- [[_COMMUNITY_backfillProgramClassifications.ts|backfillProgramClassifications.ts]]
+- [[_COMMUNITY_Graphify repo memory|Graphify repo memory]]
+- [[_COMMUNITY_securityHeaders.ts|securityHeaders.ts]]
+- [[_COMMUNITY_package.json|package.json]]
 - [[_COMMUNITY_listings.ts|listings.ts]]
 - [[_COMMUNITY_confidenceResolver.ts|confidenceResolver.ts]]
-- [[_COMMUNITY_facultyResearch|facultyResearch]]
-- [[_COMMUNITY_filterDuplicateRunObservations|filterDuplicateRunObservations]]
-- [[_COMMUNITY_authenticatedRouteDoc|authenticatedRouteDoc]]
-- [[_COMMUNITY_normalizeAcceptedDecisionValidation|normalizeAcceptedDecisionValidation]]
-- [[_COMMUNITY_isLocalHostValue|isLocalHostValue]]
-- [[_COMMUNITY_UIUX Direction|UI/UX Direction]]
-- [[_COMMUNITY_LEGACY_EXPLORATORY_CONTACT_PATHWAY_DERIVATION_KEYS|LEGACY_EXPLORATORY_CONTACT_PATHWAY_DERIVATION_KEYS]]
-- [[_COMMUNITY_firstSentence|firstSentence]]
-- [[_COMMUNITY_loadCandidateCollisions|loadCandidateCollisions]]
-- [[_COMMUNITY_entityMaterializer.test.ts|entityMaterializer.test.ts]]
-- [[_COMMUNITY_backfillCenterDirectors.ts|backfillCenterDirectors.ts]]
-- [[_COMMUNITY_programClassifier.ts|programClassifier.ts]]
-- [[_COMMUNITY_seed.ts|seed.ts]]
-- [[_COMMUNITY_index.ts|index.ts]]
-- [[_COMMUNITY_seedResearchAreas.ts|seedResearchAreas.ts]]
-- [[_COMMUNITY_fellowships.tsx|fellowships.tsx]]
-- [[_COMMUNITY_securityHeaders.ts|securityHeaders.ts]]
-- [[_COMMUNITY_dir|dir]]
-- [[_COMMUNITY_leadMemberDisplayName|leadMemberDisplayName]]
-- [[_COMMUNITY_environment.ts|environment.ts]]
-- [[_COMMUNITY_sourceReviewDecisionHandoffs|sourceReviewDecisionHandoffs]]
-- [[_COMMUNITY_dependencies|dependencies]]
-- [[_COMMUNITY_sourceReviewDecisionValidationProbeCommands|sourceReviewDecisionValidationProbeCommands]]
-- [[_COMMUNITY_departmentGroundTruth.test.ts|departmentGroundTruth.test.ts]]
-- [[_COMMUNITY_applyProfileResearchAreasForIndexDocument|applyProfileResearchAreasForIndexDocument]]
-- [[_COMMUNITY_csv|csv]]
-- [[_COMMUNITY_entryToMemberObservations|entryToMemberObservations]]
-- [[_COMMUNITY_dir|dir]]
-- [[_COMMUNITY_repairListingResearchEntityProfiles.ts|repairListingResearchEntityProfiles.ts]]
-- [[_COMMUNITY_CanonicalDepartmentListResult|CanonicalDepartmentListResult]]
-- [[_COMMUNITY_ArtifactFreshnessStrip|ArtifactFreshnessStrip]]
-- [[_COMMUNITY_MockBroadcastChannel|MockBroadcastChannel]]
-- [[_COMMUNITY_Product Context|Product Context]]
-- [[_COMMUNITY_1. Admin And Search Gates|1. Admin And Search Gates]]
-- [[_COMMUNITY_apiBaseUrl.ts|apiBaseUrl.ts]]
-- [[_COMMUNITY_resolutions|resolutions]]
-- [[_COMMUNITY_sourceReviewDecisionValidationLines|sourceReviewDecisionValidationLines]]
-- [[_COMMUNITY_spreadsheetSafety.ts|spreadsheetSafety.ts]]
-- [[_COMMUNITY_summary|summary]]
-- [[_COMMUNITY_trustedLeadResearchHomeBioFallback|trustedLeadResearchHomeBioFallback]]
-- [[_COMMUNITY_README|README.md]]
-- [[_COMMUNITY_paragraphs|paragraphs]]
-- [[_COMMUNITY_opportunity.ts|opportunity.ts]]
-- [[_COMMUNITY_README|README.md]]
-- [[_COMMUNITY_BackfillV4Grants.ts|BackfillV4Grants.ts]]
-- [[_COMMUNITY_isLikelyPersonUrl|isLikelyPersonUrl]]
-- [[_COMMUNITY_sanitizeMongo.ts|sanitizeMongo.ts]]
-- [[_COMMUNITY_index.ts|index.ts]]
 - [[_COMMUNITY_OfficialProfilePublicationValue|OfficialProfilePublicationValue]]
-- [[_COMMUNITY_.run|.run]]
-- [[_COMMUNITY_researchEntityRelationship.ts|researchEntityRelationship.ts]]
-- [[_COMMUNITY_corsOrigin.ts|corsOrigin.ts]]
-- [[_COMMUNITY_Codex Guide|Codex Guide]]
-- [[_COMMUNITY_dataMigrationV4GrantBackfill.test.ts|dataMigrationV4GrantBackfill.test.ts]]
+- [[_COMMUNITY_AdminOperatorBoard|AdminOperatorBoard]]
+- [[_COMMUNITY_labDetail.ts|labDetail.ts]]
+- [[_COMMUNITY_BackfillV4FacultyMembers.ts|BackfillV4FacultyMembers.ts]]
 - [[_COMMUNITY_refreshGateScorecards.ts|refreshGateScorecards.ts]]
-- [[_COMMUNITY_createInitialAdminTableState|createInitialAdminTableState]]
-- [[_COMMUNITY_dedupeExploratoryContactPathways.ts|dedupeExploratoryContactPathways.ts]]
-- [[_COMMUNITY_args|args]]
-- [[_COMMUNITY_compilerOptions|compilerOptions]]
+- [[_COMMUNITY_fellowships.ts|fellowships.ts]]
+- [[_COMMUNITY_Auth and Security|Auth and Security]]
+- [[_COMMUNITY_Yale Research Product Context|Yale Research Product Context]]
+- [[_COMMUNITY_adminFellowshipFormReducer.ts|adminFellowshipFormReducer.ts]]
+- [[_COMMUNITY_MigrateUsers.ts|MigrateUsers.ts]]
+- [[_COMMUNITY_Local Development Setup|Local Development Setup]]
+- [[_COMMUNITY_Product Context|Product Context]]
+- [[_COMMUNITY_UIUX Direction|UI/UX Direction]]
+- [[_COMMUNITY_ensure-server-build-fresh.mjs|ensure-server-build-fresh.mjs]]
+- [[_COMMUNITY_corsOrigin.ts|corsOrigin.ts]]
+- [[_COMMUNITY_sanitizeMongo.ts|sanitizeMongo.ts]]
+- [[_COMMUNITY_staleObservationConflictReview.test.ts|staleObservationConflictReview.test.ts]]
+- [[_COMMUNITY_Architecture|Architecture]]
+- [[_COMMUNITY_listingFormReducer.ts|listingFormReducer.ts]]
+- [[_COMMUNITY_Scraper Deployment Runbook|Scraper Deployment Runbook]]
 - [[_COMMUNITY_devDependencies|devDependencies]]
-- [[_COMMUNITY_CliOptions|CliOptions]]
+- [[_COMMUNITY_resolutions|resolutions]]
+- [[_COMMUNITY_paperAuthorshipPolicy.ts|paperAuthorshipPolicy.ts]]
+- [[_COMMUNITY_importFaculty.ts|importFaculty.ts]]
+- [[_COMMUNITY_launchAcquisitionReport.ts|launchAcquisitionReport.ts]]
+- [[_COMMUNITY_departmentResolver.ts|departmentResolver.ts]]
+- [[_COMMUNITY_researchAreaResolver.ts|researchAreaResolver.ts]]
+- [[_COMMUNITY_EvidenceSourceRow.tsx|EvidenceSourceRow.tsx]]
+- [[_COMMUNITY_buildCandidateSample|buildCandidateSample]]
+- [[_COMMUNITY_buildStaleObservationConflictSummary|buildStaleObservationConflictSummary]]
 - [[_COMMUNITY_testFixturePrivacy.test.ts|testFixturePrivacy.test.ts]]
-- [[_COMMUNITY_{ ctx }|{ ctx }]]
-- [[_COMMUNITY_itemOperations.ts|itemOperations.ts]]
+- [[_COMMUNITY_manifest.json|manifest.json]]
+- [[_COMMUNITY_Available Scripts|Available Scripts]]
+- [[_COMMUNITY_departmentGroundTruth.test.ts|departmentGroundTruth.test.ts]]
+- [[_COMMUNITY_package.json|package.json]]
+- [[_COMMUNITY_observation|observation]]
+- [[_COMMUNITY_researchGroupFilters.ts|researchGroupFilters.ts]]
 - [[_COMMUNITY_useFavorites.ts|useFavorites.ts]]
+- [[_COMMUNITY_check-no-secrets-core.mjs|check-no-secrets-core.mjs]]
+- [[_COMMUNITY_security-preflight.test.mjs|security-preflight.test.mjs]]
+- [[_COMMUNITY_contactEmail.ts|contactEmail.ts]]
+- [[_COMMUNITY_adminTableReducer.test.ts|adminTableReducer.test.ts]]
+- [[_COMMUNITY_MockBroadcastChannel|MockBroadcastChannel]]
+- [[_COMMUNITY_copyBetaToProd.ts|copyBetaToProd.ts]]
+- [[_COMMUNITY_main|main]]
+- [[_COMMUNITY_parseStaleObservationConflictReviewArgs|parseStaleObservationConflictReviewArgs]]
+- [[_COMMUNITY_normalizeAcceptedDecisionValidation|normalizeAcceptedDecisionValidation]]
+- [[_COMMUNITY_researchAreas.ts|researchAreas.ts]]
+- [[_COMMUNITY_Contributing endpoints, pages, schema|Contributing: endpoints, pages, schema]]
+- [[_COMMUNITY_Scrapers|Scrapers]]
+- [[_COMMUNITY_Search and Data|Search and Data]]
+- [[_COMMUNITY_checker.py|checker.py]]
+- [[_COMMUNITY_dependencies|dependencies]]
+- [[_COMMUNITY_normalizeCrossSourceReviewDecision|normalizeCrossSourceReviewDecision]]
+- [[_COMMUNITY_loadCrossSourceConflictGroups|loadCrossSourceConflictGroups]]
+- [[_COMMUNITY_normalizeStaleObservationReviewDecision|normalizeStaleObservationReviewDecision]]
+- [[_COMMUNITY_with-playwright-libs.sh|with-playwright-libs.sh]]
+- [[_COMMUNITY_runStaleObservationConflictReview|runStaleObservationConflictReview]]
+- [[_COMMUNITY_dataMigrationPackageScripts.test.ts|dataMigrationPackageScripts.test.ts]]
+- [[_COMMUNITY_dataMigrationV4GrantBackfill.test.ts|dataMigrationV4GrantBackfill.test.ts]]
+- [[_COMMUNITY_departmentMigrationCliSafety.test.ts|departmentMigrationCliSafety.test.ts]]
+- [[_COMMUNITY_publicationMigrationCliSafety.test.ts|publicationMigrationCliSafety.test.ts]]
+- [[_COMMUNITY_rootDataImportCliSafety.test.ts|rootDataImportCliSafety.test.ts]]
+- [[_COMMUNITY_userMigrationCliSafety.test.ts|userMigrationCliSafety.test.ts]]
+- [[_COMMUNITY_useDebouncedLocalStorage.test.tsx|useDebouncedLocalStorage.test.tsx]]
+- [[_COMMUNITY_vite-env.d.ts|vite-env.d.ts]]
+- [[_COMMUNITY_README|README.md]]
+- [[_COMMUNITY_dataMigrationV4DeprecatedBackfills.test.ts|dataMigrationV4DeprecatedBackfills.test.ts]]
+- [[_COMMUNITY_dataMigrationV4IdentityBackfills.test.ts|dataMigrationV4IdentityBackfills.test.ts]]
+- [[_COMMUNITY_yaliesService.test.ts|yaliesService.test.ts]]
 - [[_COMMUNITY_appSecurityRuntime.test.ts|appSecurityRuntime.test.ts]]
-- [[_COMMUNITY_entityMaterializer.ts|entityMaterializer.ts]]
+- [[_COMMUNITY_postcss.config.js|postcss.config.js]]
 - [[_COMMUNITY_ArtifactFreshnessStrip|ArtifactFreshnessStrip]]
 - [[_COMMUNITY_sourceReviewDecisionHandoffs|sourceReviewDecisionHandoffs]]
-- [[_COMMUNITY_astronomyConfig|astronomyConfig]]
-- [[_COMMUNITY_runStaleObservationConflictReview|runStaleObservationConflictReview]]
+- [[_COMMUNITY_sourceReviewDecisionValidationLines|sourceReviewDecisionValidationLines]]
+- [[_COMMUNITY_sourceReviewDecisionValidationProbeCommands|sourceReviewDecisionValidationProbeCommands]]
 - [[_COMMUNITY_diffDepartmentRows|diffDepartmentRows]]
 - [[_COMMUNITY_README|README.md]]
-- [[_COMMUNITY_safeSpreadsheetCell|safeSpreadsheetCell]]
-- [[_COMMUNITY_10. P2 Fellowship, Course, And Contact Materialization|10. P2 Fellowship, Course, And Contact Materialization]]
-- [[_COMMUNITY_Research Data Pipeline|Research Data Pipeline]]
+- [[_COMMUNITY_update_rdb.py|update_rdb.py]]
+- [[_COMMUNITY_getSavedResearchPlanFundingMatches|getSavedResearchPlanFundingMatches]]
+- [[_COMMUNITY_buildFetchMetric|buildFetchMetric]]
 - [[_COMMUNITY_BETA_REPAIR_QUEUE_REPORT_MAX_AGE_HOURS|BETA_REPAIR_QUEUE_REPORT_MAX_AGE_HOURS]]
 - [[_COMMUNITY_DATA_QUALITY_SCORECARD_MAX_AGE_HOURS|DATA_QUALITY_SCORECARD_MAX_AGE_HOURS]]
 - [[_COMMUNITY_LAUNCH_ACQUISITION_REPORT_MAX_AGE_HOURS|LAUNCH_ACQUISITION_REPORT_MAX_AGE_HOURS]]
 - [[_COMMUNITY_LAUNCH_REVIEW_EXCEPTIONS_REPORT_MAX_AGE_HOURS|LAUNCH_REVIEW_EXCEPTIONS_REPORT_MAX_AGE_HOURS]]
 - [[_COMMUNITY_LAUNCH_TRUST_SCORECARD_MAX_AGE_HOURS|LAUNCH_TRUST_SCORECARD_MAX_AGE_HOURS]]
-- [[_COMMUNITY_courseTableService.ts|courseTableService.ts]]
-- [[_COMMUNITY_importFaculty.ts|importFaculty.ts]]
-- [[_COMMUNITY_1. M1.2 Client API-Boundary Vocabulary|1. M1.2 Client API-Boundary Vocabulary]]
+- [[_COMMUNITY_PROMOTION_COPY_DRY_RUN_REPORT_MAX_AGE_HOURS|PROMOTION_COPY_DRY_RUN_REPORT_MAX_AGE_HOURS]]
+- [[_COMMUNITY_SCRAPER_INTEGRITY_SCORECARD_MAX_AGE_HOURS|SCRAPER_INTEGRITY_SCORECARD_MAX_AGE_HOURS]]
+- [[_COMMUNITY_archiveProgram|archiveProgram]]
 - [[_COMMUNITY_bulkCreatePrograms|bulkCreatePrograms]]
-- [[_COMMUNITY_AdminListingsTable.tsx|AdminListingsTable.tsx]]
+- [[_COMMUNITY_createProgram|createProgram]]
 - [[_COMMUNITY_deleteProgram|deleteProgram]]
-- [[_COMMUNITY_devDependencies|devDependencies]]
-- [[_COMMUNITY_errorHandler.ts|errorHandler.ts]]
-- [[_COMMUNITY_next|next]]
+- [[_COMMUNITY_readAllPrograms|readAllPrograms]]
+- [[_COMMUNITY_unarchiveProgram|unarchiveProgram]]
+- [[_COMMUNITY_updateProgram|updateProgram]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `sanitizeLogValue()` - 251 edges
@@ -371,293 +369,293 @@
 ## Import Cycles
 - None detected.
 
-## Communities (338 total, 38 thin omitted)
+## Communities (336 total, 38 thin omitted)
 
-### Community 0 - "Decisions"
-Cohesion: 0.04
-Nodes (73): AdminFellowshipEditModal(), Props, FellowshipModal(), FellowshipModalProps, trackFellowshipApplyClick(), fellowship, renderModal(), sortOptions (+65 more)
-
-### Community 1 - "labDetail.tsx"
+### Community 0 - "types.tsx"
 Cohesion: 0.05
-Nodes (57): ScraperOrchestrator, CallCenterDirectorLLMFn, CandidateCenter, CenterDirector, CenterDirectorExtraction, CenterDirectorLLMExtractor, CenterDirectorLLMExtractorDeps, CenterFinderFn (+49 more)
+Nodes (49): AdminFellowshipEditModal(), Props, fellowship, renderModal(), sortOptions, defaultFellowshipSearchContext, FellowshipSearchContextType, dateValue() (+41 more)
 
-### Community 2 - "browsable.ts"
+### Community 1 - "types.ts"
+Cohesion: 0.05
+Nodes (53): ScrapeSnapshot, scrapeSnapshotSchema, ScraperOrchestrator, getCached(), invalidateCache(), CrossrefFetcher, CrossrefMessage, crossrefMessageToObservations() (+45 more)
+
+### Community 2 - "UserContext.ts"
 Cohesion: 0.04
-Nodes (56): baseProfile, renderProfileHeader(), fellowship, item, renderAdmin(), listing, renderModal(), listing (+48 more)
+Nodes (53): baseProfile, renderProfileHeader(), fellowship, item, renderAdmin(), listing, renderModal(), listing (+45 more)
 
-### Community 3 - "security-preflight.test.mjs"
-Cohesion: 0.08
-Nodes (77): mocks, privateProgram, addFavFellowships(), addFavListings(), addFavPathways(), addSavedPrograms(), addSavedResearchPlans(), ALLOWED_SELF_USER_TYPES (+69 more)
+### Community 3 - "sanitizeLogValue"
+Cohesion: 0.09
+Nodes (74): mocks, privateProgram, addFavFellowships(), addFavListings(), addFavPathways(), addSavedPrograms(), addSavedResearchPlans(), ALLOWED_SELF_USER_TYPES (+66 more)
 
 ### Community 4 - "departmentRosterScraper.ts"
-Cohesion: 0.07
-Nodes (72): memberObservationsForEntityKey(), absolutize(), canonicalProfileUrlFromHtml(), cleanProfileSectionText(), cleanText(), csFacultyDataExtractor(), csJsRenderedStub(), csRenderedExtractor() (+64 more)
+Cohesion: 0.09
+Nodes (60): absolutize(), canonicalProfileUrlFromHtml(), cleanProfileSectionText(), cleanText(), csFacultyDataExtractor(), csJsRenderedStub(), csRenderedExtractor(), decodeHtmlEntities() (+52 more)
 
-### Community 5 - "labDetail.ts"
+### Community 5 - "labMicrositeUndergradLLMExtractor.ts"
 Cohesion: 0.05
-Nodes (66): average(), boundedRenderedFetchTimeout(), buildFetchAttemptMetrics(), createScraplingRenderedFetcher(), currentMemoryBytes(), DEFAULT_BRIDGE_PATH, defaultRenderedSeedRedirectCheck(), execFileAsync (+58 more)
+Nodes (68): average(), boundedRenderedFetchTimeout(), buildFetchAttemptMetrics(), createScraplingRenderedFetcher(), currentMemoryBytes(), DEFAULT_BRIDGE_PATH, defaultRenderedSeedRedirectCheck(), execFileAsync (+60 more)
 
-### Community 6 - "App.tsx"
+### Community 6 - "scripts"
 Cohesion: 0.03
 Nodes (75): scripts, accepted-inputs, access-signals:repair-duplicates, application-routes:backfill-pathways, beta:clear-student-analytics, beta:data-quality, beta:readiness, beta:repair-queue (+67 more)
 
-### Community 7 - "logSanitizer.ts"
+### Community 7 - "researchEntityDescriptionQuality.ts"
 Cohesion: 0.08
 Nodes (71): activeAreasOfResearchSummary(), assessResearchEntityDescriptionQuality(), deriveShortDescriptionFromFullDescription(), DescriptionQualityFlag, FieldQuality, fullDescriptionQuality(), hasBrokenTemplate(), hasDuplicatedLongFragment() (+63 more)
 
-### Community 8 - "adminListingsTableReducer.ts"
-Cohesion: 0.04
-Nodes (38): PlanningOverview(), PlanningOverviewProps, pluralize(), HttpStatusNotifier(), scrollPositions, ScrollToTop(), normalizeReturnPath(), SignInButton() (+30 more)
-
-### Community 9 - "profileService.ts"
+### Community 8 - "App.tsx"
 Cohesion: 0.05
-Nodes (62): AccessReviewCounts, AccessReviewDetail, AccessReviewEntitySummary, AccessSignal, AdminAccessReview(), ContactRoute, EntryPathway, evidenceIds() (+54 more)
+Nodes (35): PlanningOverview(), PlanningOverviewProps, pluralize(), scrollPositions, ScrollToTop(), normalizeReturnPath(), SignInButton(), SignInButtonProps (+27 more)
 
-### Community 10 - "labMicrositeDescriptionLLMExtractor.ts"
-Cohesion: 0.05
-Nodes (67): directoryFirstNextStep(), directoryFirstPathwayLabel(), formatDate(), PathwayActionCard(), PathwayActionCardProps, LabPaper, PathwayActionability, PathwayBestNextStepCategory (+59 more)
-
-### Community 11 - "AdminAccessReview.tsx"
+### Community 9 - "safeHttpUrl"
 Cohesion: 0.06
-Nodes (50): AccessSignal, accessSignalSchema, ContactRoute, contactRouteSchema, categoryColorKeys, Department, DepartmentCodeSystem, departmentSchema (+42 more)
+Nodes (54): SourceLinks(), DeveloperCard(), DeveloperCardProps, FellowshipModal(), FellowshipModalProps, RichText(), trackFellowshipApplyClick(), LabInquireModal() (+46 more)
 
-### Community 12 - "materializeEntity"
+### Community 10 - "researchDiscoveryAdapters.ts"
+Cohesion: 0.07
+Nodes (55): directoryFirstNextStep(), directoryFirstPathwayLabel(), formatDate(), PathwayActionCard(), buildCompleteContextSummary(), buildGroupedSearchResults(), buildIdentityConfidenceRecords(), buildPathwayEvidenceRows() (+47 more)
+
+### Community 11 - "index.ts"
+Cohesion: 0.06
+Nodes (44): AccessSignal, accessSignalSchema, ContactRoute, contactRouteSchema, categoryColorKeys, Department, DepartmentCodeSystem, departmentSchema (+36 more)
+
+### Community 12 - "client"
 Cohesion: 0.06
 Nodes (58): csvCell(), dateFormatter, deadlineEndOfUtcDay(), FavoritesManager(), FavoritesManagerProps, fellowshipToBrowsable(), savedProgramDeadlineSummary(), validDeadlineDate() (+50 more)
 
-### Community 13 - "researchGroupService.ts"
+### Community 13 - "duplicateEntityNameReview.ts"
 Cohesion: 0.06
 Nodes (67): DuplicateEntityReviewCategory, DuplicateEntityReviewEntity, DuplicateEntityReviewSummary, applyResearchEntityDedupeGroupsSequentially, ResearchEntityDedupeMergeGroup, ACTIVE_FILTER, assertDuplicateEntityNameReviewApplyAllowed(), asString() (+59 more)
 
-### Community 14 - "researchEntitySearchIndexService.ts"
+### Community 14 - "labDetail.tsx"
 Cohesion: 0.06
-Nodes (57): copy, FirstSaveCallout(), FirstSaveCalloutProps, mockedAxios, mockedSwal, Endpoints, FavoritesKind, useFavorites() (+49 more)
+Nodes (66): copy, FirstSaveCallout(), FirstSaveCalloutProps, adminQualityNotes(), AffiliatedResearchEntitiesSection(), compactDepartmentLabels(), decisionNextStep(), DecisionSummary() (+58 more)
 
-### Community 15 - "accessMaterializer.ts"
+### Community 15 - "Observation"
 Cohesion: 0.07
 Nodes (53): backfillV4Grants(), buildV4GrantBackfillOutput(), __dirname, __filename, normalizeAgency(), V4GrantBackfillResult, writeV4GrantBackfillOutput(), backfillV4PaperGraph() (+45 more)
 
-### Community 16 - "UserContext.ts"
+### Community 16 - "listingController.ts"
 Cohesion: 0.07
-Nodes (58): addViewToListing(), archiveListingForCurrentUser(), boundedListingSearchQuery(), buildListingOutreachEvent(), buildMongoFilterMatch(), buildRobustFilterMatch(), createListingForCurrentUser(), deleteListingForCurrentUser() (+50 more)
+Nodes (58): addViewToListing(), archiveListingForCurrentUser(), boundedListingSearchQuery(), buildListingOutreachEvent(), buildMongoFilterMatch(), buildRobustFilterMatch(), createListingForCurrentUser(), escapeMeiliFilterValue() (+50 more)
 
-### Community 17 - "index.ts"
-Cohesion: 0.08
-Nodes (61): ACTIVE_FILTER, asString(), asStringArray(), buildBetaDataQualityScorecard(), buildCollectionCounts(), buildDescriptionQuality(), buildDuplicateEntityNames(), buildLiveLinkCheck() (+53 more)
+### Community 17 - "betaDataQuality.ts"
+Cohesion: 0.09
+Nodes (50): ACTIVE_FILTER, asString(), asStringArray(), buildCollectionCounts(), buildDescriptionQuality(), buildDuplicateEntityNames(), buildEmailHygiene(), buildOpportunityState() (+42 more)
 
-### Community 18 - "sanitizeLogValue"
-Cohesion: 0.08
-Nodes (49): initializeConnections(), CliOptions, FILTER, main(), parseArgs(), CliOptions, main(), parseArgs() (+41 more)
+### Community 18 - "resolveSafeJsonReportOutputPath"
+Cohesion: 0.19
+Nodes (20): CliOptions, main(), parseArgs(), BackfillEntry, CliOptions, DEFAULT_INPUT, isCommunityForcePortal(), isHttpUrl() (+12 more)
 
-### Community 19 - "integrityGate.ts"
+### Community 19 - "acceptedInputsCore.ts"
 Cohesion: 0.07
-Nodes (58): AcceptedInputIssue, AcceptedInputUser, applyOrcidCrosswalkCsv(), ArxivResolvedTarget, ArxivValidationResult, buildAcceptedInputsStatus(), buildArxivCandidateRows(), buildScholarCandidateRows() (+50 more)
+Nodes (60): AcceptedInputIssue, AcceptedInputUser, applyOrcidCrosswalkCsv(), applyScholarAcceptedCsv(), ArxivResolvedTarget, ArxivValidationResult, asString(), asStringArray() (+52 more)
 
-### Community 20 - "passport.ts"
+### Community 20 - "dedupeResearchEntitiesByPi.ts"
 Cohesion: 0.07
 Nodes (60): applyDeleteModeArtifactPlan(), applyResearchEntityDedupeMergeGroup(), applyResearchEntityPiDedupeGroupsSequentially(), archiveOrDeleteDuplicateDocument(), ARRAY_REFERENCE_SPECS, ARTIFACT_SPECS, assertResearchEntityPiDedupeApplyAllowed(), assertResearchEntityPiDedupeApplyBounded() (+52 more)
 
-### Community 21 - "Navbar.tsx"
-Cohesion: 0.08
-Nodes (55): getListingModel(), addFavorite(), archiveListing(), boundedListingDate(), boundedListingNetid(), boundedListingNetidArray(), boundedListingNumber(), boundedListingString() (+47 more)
+### Community 21 - "listingService.ts"
+Cohesion: 0.11
+Nodes (38): deleteListingForCurrentUser(), getListingModel(), addFavorite(), boundedListingDate(), boundedListingNetid(), boundedListingNetidArray(), boundedListingNumber(), boundedListingString() (+30 more)
 
-### Community 22 - "undergradFellowshipRecipientScraper.ts"
+### Community 22 - "profileDataQualityAudit.ts"
 Cohesion: 0.10
 Nodes (58): auditProfileRecord(), candidateOfficialProfileUrls(), candidateProfileFactsMatchUser(), classifyStoredBioIssue(), classifyStoredTitleIssue(), collectObjects(), compareOfficialProfileFacts(), corpusForProfile() (+50 more)
 
-### Community 23 - "duplicateEntityNameReview.ts"
-Cohesion: 0.07
-Nodes (58): mapResearchGroupKindToEntityType(), PublicResearchEntityDto, addPublicMemberField(), addPublicMemberInternalProfilePath(), addPublicMemberProfileUrls(), boundedResearchFilterValues(), boundedResearchSearchQuery(), escapedRegExp() (+50 more)
+### Community 23 - "researchGroupService.ts"
+Cohesion: 0.04
+Nodes (112): getResearchGroupBySlug(), addPublicMemberField(), addPublicMemberInternalProfilePath(), addPublicMemberProfileUrls(), addPublicPaperField(), boundedResearchFilterValues(), boundedResearchSearchQuery(), buildLeadPiOutreachContactRoute() (+104 more)
 
-### Community 24 - "app.ts"
+### Community 24 - "researchQualitySearchReview.ts"
 Cohesion: 0.07
 Nodes (54): addMapSet(), aggregateCountAndTypes(), aggregateCountMap(), buildLexicalReasons(), buildResearchQualitySearchReviewOutput(), buildReview(), collectSearchCandidates(), countMap() (+46 more)
 
-### Community 25 - "dedupeResearchEntitiesByPi.ts"
-Cohesion: 0.07
-Nodes (39): ArchivedBadge(), BrowseCard, BrowseCardProps, BrowseGrid(), BrowseGridProps, BrowseListItem, BrowseListItemProps, FavoriteButton (+31 more)
+### Community 25 - "browsable.ts"
+Cohesion: 0.06
+Nodes (56): ArchivedBadge(), BrowseCard, BrowseCardProps, BrowseGrid(), BrowseGridProps, BrowseListItem, BrowseListItemProps, FavoriteButton (+48 more)
 
-### Community 26 - "admin.ts"
-Cohesion: 0.07
-Nodes (49): authConfig, authDebug(), AuthenticatedSessionUser, buildDirectoryUpdate(), casLogin(), DEV_LOGIN_PROFILES, ensureDevLoginUser(), findOrCreateUser() (+41 more)
+### Community 26 - "passport.ts"
+Cohesion: 0.06
+Nodes (51): authConfig, authDebug(), AuthenticatedSessionUser, buildAuthenticatedSessionUser(), buildDirectoryUpdate(), casLogin(), DEV_LOGIN_PROFILES, ensureDevLoginUser() (+43 more)
 
-### Community 27 - "safeHttpUrl"
+### Community 27 - "launchAcquisitionReportService.ts"
 Cohesion: 0.09
 Nodes (54): AccessRecordCounts, ActionEvidenceGroups, addGroup(), buildActionGroups(), buildActionManifestRow(), buildLaunchAcquisitionReport(), buildManifestRow(), buildPiGroups() (+46 more)
 
-### Community 28 - "researchDiscoveryAdapters.ts"
+### Community 28 - "labMicrositeDescriptionLLMExtractor.ts"
 Cohesion: 0.08
-Nodes (51): ObservedEntityType, CallDescriptionLLMFn, CandidateDescriptionLab, CandidateDescriptionLabDoc, candidateDescriptionLabsFromDocs(), candidateKeyMatches(), candidateUrlsForDoc(), defaultCallLLM() (+43 more)
+Nodes (50): ObservedEntityType, CallDescriptionLLMFn, CandidateDescriptionLab, CandidateDescriptionLabDoc, candidateDescriptionLabsFromDocs(), candidateKeyMatches(), candidateUrlsForDoc(), defaultCallLLM() (+42 more)
 
-### Community 29 - "ysmAtoZScraper.ts"
+### Community 29 - "betaDataQualityCore.ts"
 Cohesion: 0.06
-Nodes (56): DuplicateEntityCluster, BETA_CHECK_OPERATOR_METADATA, betaCommand(), BetaDataQualityCheck, BetaDataQualityDiagnostics, BetaDataQualityProgressEvent, BetaDataQualitySeverity, BetaDataQualitySummary (+48 more)
+Nodes (53): DuplicateEntityCluster, BETA_CHECK_OPERATOR_METADATA, betaCommand(), BetaDataQualityCheck, BetaDataQualityDiagnostics, BetaDataQualityProgressEvent, BetaDataQualitySeverity, BetaDataQualitySummary (+45 more)
 
-### Community 30 - "advisees"
+### Community 30 - "sourceHealth.ts"
 Cohesion: 0.07
 Nodes (55): AcceptedDecisionValidationCommandInput, attachAcceptedDecisionValidationSummary(), attachReviewArtifactSummary(), buildCrossSourceObservationReviewCommand(), buildReviewArtifactRollups(), buildReviewArtifactStatus(), buildReviewDecisionValidationStatus(), buildReviewQueues() (+47 more)
 
-### Community 31 - "launchAcquisitionReportService.ts"
-Cohesion: 0.08
-Nodes (47): defaultFetchUrl(), defaultFetchPage(), fetchHtml(), defaultFetchHtml(), defaultFetchPage(), defaultFetchPage(), fetchHtml(), defaultFetcher() (+39 more)
+### Community 31 - "ysmAtoZScraper.ts"
+Cohesion: 0.12
+Nodes (31): absoluteUrl(), cleanDescription(), cleanProfileTitle(), clippedDescription(), decodeHtmlEntities(), escapeRegex(), extractLabHomepageDescription(), extractProfileContactWidgetProfile() (+23 more)
 
-### Community 32 - "profileDataQualityAudit.ts"
+### Community 32 - "integrityGate.ts"
+Cohesion: 0.09
+Nodes (35): ActiveArtifactOnArchivedEntity, BuildPostMaterializationIntegrityInput, buildPostMaterializationIntegritySummary(), buildSamePiNameDuplicateGroupsFromDedupeRows(), CurrentMemberOnArchivedEntity, DuplicateCurrentMemberGroup, DuplicateExploratoryContactPathwayGroup, enrichIntegrityWarnings() (+27 more)
+
+### Community 33 - "analyticsService.ts"
 Cohesion: 0.07
-Nodes (50): ActiveArtifactOnArchivedEntity, buildDuplicateAccessSignalGroupsFromRows(), buildDuplicateResearchPaperGroupsFromRows(), BuildPostMaterializationIntegrityInput, buildPostMaterializationIntegritySummary(), buildSamePiNameDuplicateGroupsFromDedupeRows(), CurrentMemberOnArchivedEntity, DuplicateCurrentMemberGroup (+42 more)
+Nodes (62): AnalyticsEvent, ActionNeededAnalytics, ANALYTICS_EVENT_TYPES, ANALYTICS_NON_USER_NETIDS, ANALYTICS_RESEARCH_ENTITY_TYPES, AnalyticsUserDrilldownQuery, AnalyticsUserDrilldownResult, AnalyticsUsersQuery (+54 more)
 
-### Community 33 - "centersInstitutesScraper.ts"
+### Community 34 - "userService.ts"
 Cohesion: 0.07
-Nodes (53): ActionNeededAnalytics, ANALYTICS_EVENT_TYPES, ANALYTICS_NON_USER_NETIDS, ANALYTICS_RESEARCH_ENTITY_TYPES, AnalyticsUserDrilldownQuery, AnalyticsUserDrilldownResult, AnalyticsUsersQuery, AnalyticsUsersResult (+45 more)
+Nodes (60): escapeCsvCell(), confirmListing(), readListing(), unconfirmListing(), updateListing(), addDepartments(), addOwnListings(), assertSafeUserUpdateDocument() (+52 more)
 
-### Community 34 - "types.tsx"
-Cohesion: 0.08
-Nodes (50): confirmListing(), readListing(), unconfirmListing(), addDepartments(), assertSafeUserUpdateDocument(), badRequestError(), buildCaseInsensitiveNetidFilter(), buildSavedPathwayPlansExport() (+42 more)
-
-### Community 35 - "ScraperContext"
+### Community 35 - "studentVisibilityGateService.ts"
 Cohesion: 0.07
-Nodes (50): actionRepairReasons, buildNameOnlyVisibilityDedupeRows(), buildSamePiVisibilityDedupeRows(), countByEntityId(), defaultGateDeps, entityDuplicateUrls(), evidenceReasons, exactDuplicateCanonicalScore() (+42 more)
+Nodes (52): actionRepairReasons, applyStudentVisibilityGatePlans(), buildNameOnlyVisibilityDedupeRows(), buildSamePiVisibilityDedupeRows(), countByEntityId(), defaultGateDeps, entityDuplicateUrls(), evidenceReasons (+44 more)
 
-### Community 36 - "studentVisibilityGateService.ts"
+### Community 36 - "AdminDepartments.tsx"
 Cohesion: 0.06
 Nodes (42): AdminDepartments(), CATEGORY_COLORS, DEPARTMENT_CATEGORIES, DepartmentAction, DepartmentDoc, DepartmentState, EditDraft, INITIAL_NEW_DRAFT (+34 more)
 
-### Community 37 - "buildUserBioObservationScore"
+### Community 37 - "runReport.ts"
 Cohesion: 0.07
 Nodes (51): ACCESS_ARTIFACT_TYPES, ACCESS_EVIDENCE_CONFLICT_FIELDS, ADDITIVE_METADATA_CONFLICT_FIELDS, buildCoverageFetchSummary(), buildCoverageSourceSummary(), buildMaterializationConflictEntityClauses(), buildMaterializationConflictReview(), buildPostMaterializationSummary() (+43 more)
 
-### Community 38 - "User"
+### Community 38 - "accessMaterializer.ts"
+Cohesion: 0.08
+Nodes (54): AccessSignalConfidence, ContactPolicy, ContactRouteVisibility, accessArtifactCandidatesFromDerived(), AccessMaterializationResult, AccessObservation, bestObservation(), confidenceLabel() (+46 more)
+
+### Community 39 - "User"
+Cohesion: 0.06
+Nodes (37): publicationSchema, User, userSchema, ArxivPreprintScraperOptions, entityKeyForResult(), EUROPE_PMC_SOURCE_CONFIG, EuropePmcFetcher, EuropePmcPaperScraper (+29 more)
+
+### Community 40 - "profileService.ts"
 Cohesion: 0.09
-Nodes (50): AccessSignalConfidence, ContactPolicy, ContactRouteVisibility, accessArtifactCandidatesFromDerived(), AccessMaterializationResult, AccessObservation, bestObservation(), confidenceLabel() (+42 more)
+Nodes (50): ADMIN_UPDATE_FIELDS, ALLOWED_SELF_UPDATE_FIELDS, appointmentTitleCount(), capitalizeSentenceStart(), cleanPublicProfileBio(), cleanResearchHomeSummaryForBio(), clipPublicProfileBio(), dedupeProfileResearchEntities() (+42 more)
 
-### Community 39 - "userService.ts"
+### Community 41 - "researchGroup.ts"
 Cohesion: 0.07
-Nodes (36): publicationSchema, User, userSchema, summarizeFetchMetrics, arxivEntryToObservations(), ArxivFetcher, ArxivPreprintScraper, ArxivPreprintScraperOptions (+28 more)
+Nodes (41): LabHeader(), LabHeaderProps, normalizeActionUrl(), LabInquireModalProps, baseGroup, baseGroup, LabContactRoute, AccessSummary (+33 more)
 
-### Community 40 - "backfillStudentVisibilityTiers.ts"
-Cohesion: 0.09
-Nodes (51): ADMIN_UPDATE_FIELDS, ALLOWED_SELF_UPDATE_FIELDS, appointmentTitleCount(), capitalizeSentenceStart(), cleanPublicProfileBio(), cleanResearchHomeSummaryForBio(), clipPublicProfileBio(), dedupeProfileResearchEntities() (+43 more)
-
-### Community 41 - "AdminDepartments.tsx"
-Cohesion: 0.07
-Nodes (42): LabInquireModalProps, LabMembersList(), LabMembersListProps, ROLE_LABELS, ROLE_ORDER, ROLE_PILL_CLASSES, baseGroup, baseGroup (+34 more)
-
-### Community 42 - "getUniqueDepartmentLabels"
+### Community 42 - "SavedPathwaysSection.tsx"
 Cohesion: 0.09
 Nodes (44): CHECKLIST_TEMPLATES, daysUntil(), DeadlineReminder, deadlineReminderForPathway(), defaultIntentForPathway(), FellowshipFundingMatch, filterStoredPlansForSavedPathways(), formatDeadline() (+36 more)
 
-### Community 43 - "researchEntityCoverageAudit.ts"
+### Community 43 - "ImportRootDataFiles.ts"
 Cohesion: 0.09
-Nodes (47): asPlainObject(), assertRootDataImportApplyAllowed(), buildDepartmentMap(), buildRootDataImportOutput(), cleanText(), confidenceFor(), countCsvRows(), DEFAULT_OPTIONS (+39 more)
+Nodes (46): asPlainObject(), assertRootDataImportApplyAllowed(), buildDepartmentMap(), buildRootDataImportOutput(), cleanText(), confidenceFor(), countCsvRows(), DEFAULT_OPTIONS (+38 more)
 
-### Community 44 - "researchAnalytics.ts"
-Cohesion: 0.08
-Nodes (40): researchScholarlyAttributionSchema, researchScholarlyLinkSchema, assertScholarlyLinkProvenanceAuditApplyAllowed(), buildScholarlyLinkProvenanceAuditOutput(), __filename, main(), nullTargetAttributionFilter, orphanAttributionIds() (+32 more)
+### Community 44 - "scholarlyLinkSuppressionAudit.ts"
+Cohesion: 0.11
+Nodes (32): assertScholarlyLinkProvenanceAuditApplyAllowed(), buildScholarlyLinkProvenanceAuditOutput(), __filename, main(), nullTargetAttributionFilter, orphanAttributionIds(), ownerlessLinkFilter, parseNonNegativeInteger() (+24 more)
 
-### Community 45 - "sourceHealth.ts"
+### Community 45 - "pathwaySearchIndexService.ts"
 Cohesion: 0.10
-Nodes (45): anyFilter(), boundedFilterValues(), boundedSearchQuery(), buildPathwayMeiliFilter(), buildPathwayMeiliSort(), buildPathwaySearchIndexDocument(), buildPathwaySearchIndexDocuments(), configurePathwaySearchIndex() (+37 more)
+Nodes (43): anyFilter(), boundedFilterValues(), boundedSearchQuery(), buildPathwayMeiliFilter(), buildPathwayMeiliSort(), buildPathwaySearchIndexDocument(), buildPathwaySearchIndexDocuments(), configurePathwaySearchIndex() (+35 more)
 
-### Community 46 - "researchEntity.ts"
+### Community 46 - "studentVisibilityTier.ts"
 Cohesion: 0.09
 Nodes (41): classifyProgramResearchRelevance(), ProgramResearchRelevanceInput, ProgramResearchRelevanceResult, RESEARCH_PROGRAM_KINDS, RESEARCH_PURPOSES, text(), computeProgramStudentVisibility(), computeResearchEntityStudentVisibility() (+33 more)
 
-### Community 47 - "textValue"
+### Community 47 - "dataOps.ts"
 Cohesion: 0.11
 Nodes (41): assertDestinationMatchesTarget(), assertExplicitCsvForExecute(), assertMeilisearchTargetMatches(), assertMongoTargetMatches(), assertSafeWrite(), DataOpsDestinations, DataOpsOptions, DataOpsTarget (+33 more)
 
-### Community 48 - "ResearchGroupMember"
+### Community 48 - "fellowshipInputs.ts"
 Cohesion: 0.09
-Nodes (41): ACCEPTED_INPUT_FILE_EXTENSIONS, acceptedPath(), AdvisorResolution, AdvisorResolver, assertAcceptedInputPathRoot(), assertSafeAcceptedInputPathText(), candidateRowsFromText(), coerceReviewRow() (+33 more)
+Nodes (42): ACCEPTED_INPUT_FILE_EXTENSIONS, acceptedPath(), AdvisorResolution, AdvisorResolver, assertAcceptedInputPathRoot(), assertSafeAcceptedInputPathText(), candidateRowsFromText(), coerceReviewRow() (+34 more)
 
-### Community 49 - "listingService.ts"
+### Community 49 - "adminOperatorBoardService.ts"
 Cohesion: 0.06
-Nodes (44): BetaRepairQueueGateArtifact, buildQueueSummaries(), buildReleaseQueueSummary(), buildRepairQueueSummary(), buildSourceFreshness(), classifyOperatorQueueReason(), compactProgramSample(), compactResearchSample() (+36 more)
+Nodes (42): BetaRepairQueueGateArtifact, buildQueueSummaries(), buildReleaseQueueSummary(), buildSourceFreshness(), classifyOperatorQueueReason(), compactProgramSample(), compactResearchSample(), countByTier() (+34 more)
 
-### Community 50 - "redactDirectContactInfo"
+### Community 50 - "Listing"
 Cohesion: 0.09
 Nodes (29): ListingEditor(), DepartmentInput(), DepartmentInputProps, VennDiagramToggle(), VennDiagramToggleProps, CombinedFilterDropdown(), CombinedFilterDropdownProps, FilterTabConfig (+21 more)
 
-### Community 51 - "betaDataQualityCore.ts"
-Cohesion: 0.08
-Nodes (38): ACCESS_REVIEW_RECORD_TYPES, ADMIN_FELLOWSHIP_SORT_FIELDS, ADMIN_LISTING_SORT_FIELDS, ADMIN_PROFILE_SORT_FIELDS, ADMIN_SEARCH_ERROR_MESSAGES, adminAccessReviewLockedFields(), adminAccessReviewRecordUpdateDto(), adminActorNetid() (+30 more)
+### Community 51 - "admin.ts"
+Cohesion: 0.06
+Nodes (52): ACCESS_REVIEW_RECORD_TYPES, ADMIN_FELLOWSHIP_SORT_FIELDS, ADMIN_LISTING_SORT_FIELDS, ADMIN_PROFILE_SORT_FIELDS, ADMIN_SEARCH_ERROR_MESSAGES, ADMIN_URL_CHECK_ALLOWED_PORTS, adminAccessReviewLockedFields(), adminAccessReviewRecordUpdateDto() (+44 more)
 
-### Community 52 - "scripts"
+### Community 52 - "officialProfilePiBackfillScraper.ts"
 Cohesion: 0.08
 Nodes (43): absolutize(), canonicalLegacyResearchHomeUrl(), canonicalUrlFromHtml(), cleanInterestForBio(), derivedBioFromOfficialProfile(), derivedBioFromOfficialProfileInterests(), entityExpectedPeople(), entityLeadDirectWebsiteToObservations() (+35 more)
 
-### Community 53 - "productionPromotionSmoke.mjs"
+### Community 53 - "yaleCollegeFellowshipsOfficeScraper.ts"
 Cohesion: 0.11
 Nodes (41): absoluteUrl(), bestDeadlineText(), candidateFromDetailPage(), candidateFromLink(), candidateToObservations(), compactTitleIdentity(), DEFAULT_PAGE_URLS, existingKeyForCandidate() (+33 more)
 
-### Community 54 - "research.tsx"
+### Community 54 - "Navbar.tsx"
 Cohesion: 0.06
 Nodes (22): AboutButton(), AnalyticsButton(), FeedbackButton(), getAcademicDisciplineColor(), getResearchAreaChipColor(), listingQuickFilters, Navbar(), NavbarSearchBar() (+14 more)
 
-### Community 55 - "runReport.ts"
-Cohesion: 0.08
-Nodes (40): EntryPathwayStatus, EntryPathwayType, EvidenceStrength, DerivedEntryPathway, RouteClassification, UpsertEntryPathwayInput, BestNextStepSnapshot, boundedFilterValues() (+32 more)
+### Community 55 - "pathwaySearchService.ts"
+Cohesion: 0.10
+Nodes (33): BestNextStepSnapshot, boundedFilterValues(), boundedSearchQuery(), buildBestNextStepCategoryExpression(), buildEntityMatch(), buildPathwayMatch(), buildSort(), buildTextMatch() (+25 more)
 
-### Community 56 - "opportunityDetailService.ts"
+### Community 56 - "paperAuthorshipAudit.ts"
 Cohesion: 0.11
 Nodes (41): Paper, PaperAuthor, CrossrefPaperScraperOptions, applyCleanup(), applyIntegrityCleanup(), assertPaperAuthorshipAuditApplyAllowed(), AUTHORSHIP_METHODS, AUTHORSHIP_SOURCES (+33 more)
 
-### Community 57 - "staleObservationConflictReview.ts"
-Cohesion: 0.11
-Nodes (32): AccessSignalServiceDeps, AccessSignalUpsertResult, compactObject(), getAccessSignalModel(), toStoredId(), toStoredObjectId(), upsertAccessSignal(), compactObject() (+24 more)
+### Community 57 - "entryPathwayService.ts"
+Cohesion: 0.12
+Nodes (31): AccessSignalServiceDeps, AccessSignalUpsertResult, compactObject(), getAccessSignalModel(), toStoredId(), toStoredObjectId(), upsertAccessSignal(), compactObject() (+23 more)
 
-### Community 58 - "researchEntityDescriptionQuality.ts"
+### Community 58 - "devDependencies"
 Cohesion: 0.05
 Nodes (41): browserslist, development, production, devDependencies, agentation, autoprefixer, jsdom, postcss (+33 more)
 
-### Community 59 - "betaDataQuality.ts"
+### Community 59 - "applicationRoutePathwayBackfillCore.ts"
 Cohesion: 0.11
-Nodes (39): ContactRouteType, materializeAccessForResearchGroup(), pathwayDerivationKeyForRoute(), pathwayDerivationKeyForSignal(), applicationRouteBackfillDerivationKey(), ApplicationRoutePathwayBackfillDeps, ApplicationRoutePathwayBackfillEntity, ApplicationRoutePathwayBackfillOptions (+31 more)
+Nodes (37): applicationRouteBackfillDerivationKey(), ApplicationRoutePathwayBackfillDeps, ApplicationRoutePathwayBackfillEntity, ApplicationRoutePathwayBackfillOptions, ApplicationRoutePathwayBackfillResult, ApplicationRoutePathwayBackfillRoute, backfillApplicationRoutePathways(), classifyApplicationRoutePathway() (+29 more)
 
-### Community 60 - "studentVisibilityTier.ts"
-Cohesion: 0.10
-Nodes (38): publicSafeStudentVisibilityTiers, publicStudentVisibilityTiers, StudentVisibilityTier, studentVisibilityTiers, applyProgramUpdates(), applyResearchUpdates(), assertStudentVisibilityBackfillApplyAllowed(), buildNameOnlyVisibilityDedupeRows() (+30 more)
+### Community 60 - "serializedDocumentId"
+Cohesion: 0.08
+Nodes (43): StudentVisibilityTier, normalizeSeedNetid(), requireSeedToken(), SEED_USER_FIELDS, seedListingSummary(), seedUserPayload(), seedUserSummary(), tokensMatch() (+35 more)
 
-### Community 61 - "listingController.ts"
-Cohesion: 0.09
-Nodes (41): normalizeUserType(), ResolvedField, buildOfficialProfileScholarlyLinkUpserts(), cleanScholarlyHttpUrl(), cleanScholarlyText(), compactPersonName(), comparableObservationValue(), deptUserNameFilters() (+33 more)
+### Community 61 - "entityMaterializer.ts"
+Cohesion: 0.11
+Nodes (35): ResolvedField, buildOfficialProfileScholarlyLinkUpserts(), cleanScholarlyHttpUrl(), cleanScholarlyText(), DEPARTMENT_IDENTITY_STOPWORDS, departmentIdentityTokens(), findUserDocByOfficialProfileObservations(), identityTokens() (+27 more)
 
-### Community 62 - "researchGroup.ts"
+### Community 62 - "AdminOperatorBoard.tsx"
 Cohesion: 0.05
 Nodes (33): DataQualityDuplicateNamePreflight, DataQualitySamePiDedupeReview, DataQualitySuspiciousUserEmailCopy, decisionLaneCopy, evidenceReasons, GATE_LABELS, GateArtifactFreshness, LaunchReviewExceptionDecisionValidation (+25 more)
 
-### Community 63 - "analyticsService.ts"
+### Community 63 - "researchEntity.ts"
 Cohesion: 0.09
-Nodes (36): LabDetailAction, LabDetailState, otherPayload, sampleGroup, sampleListing, samplePayload, MaybeResearchEntityDetailPayload, NormalizedResearchEntitySearchResponse (+28 more)
+Nodes (38): createInitialLabDetailState(), LabDetailAction, labDetailReducer(), LabDetailState, otherPayload, sampleGroup, sampleListing, samplePayload (+30 more)
 
-### Community 64 - "BOOLEAN_FLAGS"
+### Community 64 - "scripts"
 Cohesion: 0.05
 Nodes (40): dependencies, csv-parse, dotenv, meilisearch, mongoose, openai, description, devDependencies (+32 more)
 
-### Community 65 - "acceptedInputsCore.ts"
+### Community 65 - "officialProfilePiBackfillScraper.test.ts"
 Cohesion: 0.12
 Nodes (38): annotateEntitiesWithLeadUsers(), annotateEntitiesWithSourceObservationUrls(), annotateProfileDescriptionPreferredSourceEvidence(), entityResearchHomeToObservations(), firstNonDuplicateLeadDirectWebsiteUrl(), generatedOfficialProfileUrlCandidatesForPerson(), identityToResearchEntityDescriptionObservations(), identityToResearchEntityPiKeyObservations() (+30 more)
 
-### Community 66 - "serializedDocumentId"
-Cohesion: 0.10
-Nodes (34): AdvisorAggregateRow, buildObservationsForAdvisor(), DEFAULT_ACCEPTED_FELLOWSHIP_RECIPIENT_PDF_DIR, DEFAULT_PROGRAM_CONFIGS, defaultOwnerToGroupSlug(), drupalRecipientRowExtractor(), escapeRegex(), ExtractorCtx (+26 more)
+### Community 66 - "undergradFellowshipRecipientScraper.ts"
+Cohesion: 0.06
+Nodes (66): memberObservationsForEntityKey(), entryToUserObservations(), awardToRecord(), buildCoPiObservations(), buildPiUserObservations(), buildResearchGroupObservations(), defaultDateStart(), findUserForPi() (+58 more)
 
-### Community 67 - "researchEntityEvidenceCoverage.ts"
+### Community 67 - "crossSourceObservationConflictReview.ts"
 Cohesion: 0.07
 Nodes (40): ACCESS_EVIDENCE_CONFLICT_FIELDS, ADDITIVE_METADATA_CONFLICT_FIELDS, AggregatedCrossSourceObservationConflictGroup, buildCategoryCounts(), buildConflictPlan(), buildCrossSourceObservationConflictSummary(), buildFieldCounts(), buildPolicyBucketCounts() (+32 more)
 
-### Community 68 - "fellowshipMatchingService.ts"
+### Community 68 - "researchEntityMemberReferenceAudit.ts"
 Cohesion: 0.12
 Nodes (38): applyMemberReferenceRepairs(), buildCurrentMemberOnArchivedEntityPipeline(), buildExistingMemberMatchQuery(), buildOrphanMemberUserReferencePipeline(), CURRENT_MEMBER_ON_ARCHIVED_ENTITY_STAGES, escapeRegExp(), exactCaseInsensitive(), loadCandidateUsers() (+30 more)
 
-### Community 69 - "AdminOperatorBoard.tsx"
+### Community 69 - "productionPromotionSmoke.mjs"
 Cohesion: 0.13
 Nodes (37): addCheck(), checkOpportunityDetail(), checkProgramApis(), config, discoverResearch(), failOnInternalLabels(), installRoutes(), main() (+29 more)
 
-### Community 70 - "nsfAwardScraper.ts"
+### Community 70 - "ListingDetailModal.tsx"
 Cohesion: 0.09
 Nodes (30): EvidenceRail(), formatEvidenceDate(), getEvidenceHost(), getSafeEvidenceUrl(), ListingDetailModal(), ListingDetailModalProps, MockIntersectionObserver, TestScroller() (+22 more)
 
-### Community 71 - "fellowshipInputs.ts"
+### Community 71 - "seedSources.ts"
 Cohesion: 0.08
 Nodes (31): sourceSchema, SourceCoverageArtifactType, sourceCoverageArtifactTypes, sourceCoverageEvidenceCategories, SourceCoverageEvidenceCategory, SourceCoverageMetadata, SourceCoverageTier, sourceCoverageTiers (+23 more)
 
@@ -665,683 +663,683 @@ Nodes (31): sourceSchema, SourceCoverageArtifactType, sourceCoverageArtifactType
 Cohesion: 0.15
 Nodes (37): absolutize(), archivePointerRow(), assertOfficialProfilePublicationPointerRepairApplyAllowed(), candidateRepairUrls(), cleanText(), crawlFeaturedPublications(), createRepairPageReader(), ExtractedFeaturedPublication (+29 more)
 
-### Community 73 - "postedOpportunityService.ts"
+### Community 73 - "fellowshipService.ts"
 Cohesion: 0.10
-Nodes (36): adminFellowshipDate(), adminFellowshipLinks(), adminFellowshipNumber(), adminFellowshipStringArray(), adminFellowshipText(), archiveFellowship(), boundedPublicText(), boundedSearchFilterValues() (+28 more)
+Nodes (42): addFavorite(), addView(), adminFellowshipDate(), adminFellowshipLinks(), adminFellowshipNumber(), adminFellowshipStringArray(), adminFellowshipText(), archiveFellowship() (+34 more)
 
-### Community 74 - "profileController.ts"
-Cohesion: 0.11
-Nodes (32): LabHeader(), LabHeaderProps, normalizeActionUrl(), WaysToApproachSection(), approachHeadingLabel(), decisionHeadingLabel(), entityKindLabel(), facultyResearchLabelBase() (+24 more)
-
-### Community 75 - "analytics.ts"
+### Community 74 - "opportunityDetail.tsx"
 Cohesion: 0.09
-Nodes (17): asyncHandler(), compactPositiveInteger(), requireBody(), requireFields(), validateNetid(), validateObjectId(), validatePagination(), validateQuery() (+9 more)
+Nodes (23): PrivateRoute(), PrivateRouteProps, InfiniteScrollLoadingDots(), InfiniteScrollLoadingDotsProps, LoadingSpinner(), LoadingSpinnerProps, sizeMap, applicationStateTone() (+15 more)
 
-### Community 76 - "openAlexPaperScraper.ts"
+### Community 75 - "index.ts"
+Cohesion: 0.14
+Nodes (6): asyncHandler(), router, router, router, router, router
+
+### Community 76 - "researchAnalytics.ts"
 Cohesion: 0.09
 Nodes (33): analyticsEventSchema, AnalyticsEventType, RESEARCH_ENTITY_TYPES, ResearchEntityType, AnalyticsUserEvent, LogEventParams, AnalyticsUser, buildResearchEvent() (+25 more)
 
-### Community 77 - "labMicrositeUndergradLLMExtractor.ts"
+### Community 77 - "analytics.tsx"
 Cohesion: 0.09
 Nodes (32): Analytics(), analyticsRanges, defaultAdminAccess, defaultUserActivity, SortOrder, UserActivitySort, analyticsData, mockedAxios (+24 more)
 
-### Community 78 - "researchEntityMemberReferenceAudit.ts"
+### Community 78 - "scripts"
 Cohesion: 0.06
 Nodes (36): scripts, audit:research-detail-professors, audit:unified-research, build, build:client, build:server, clean:all, dev:client (+28 more)
 
-### Community 79 - "SavedPathwaysSection.tsx"
-Cohesion: 0.10
-Nodes (24): DepartmentCategory, fieldColorKeys, ResearchArea, researchAreaSchema, ResearchField, router, invokeRouteHandler(), mocks (+16 more)
+### Community 79 - "configService.ts"
+Cohesion: 0.15
+Nodes (17): ResearchField, router, routeHandlerNames(), routesByPath(), buildDeploymentFingerprint(), ConfigData, DeploymentEnv, DeploymentEnvKey (+9 more)
 
-### Community 80 - "departmentUndergradResearchScraper.ts"
+### Community 80 - "backfillProfileBiosFromOfficialUrls.ts"
 Cohesion: 0.13
 Nodes (34): articleForFacultyTitle(), BioBackfillCandidate, BioBackfillDecision, buildCandidates(), composeTitleLedBio(), decideBioBackfill(), detectFieldMismatch(), __dirname (+26 more)
 
-### Community 81 - "pathwaySearchIndexService.ts"
+### Community 81 - "departmentLeadRepairPlanCore.ts"
 Cohesion: 0.11
 Nodes (32): escapeRegExp(), main(), normalizeEmail(), parseDepartmentLeadRepairPlanArgs(), valuesForArg(), buildDepartmentLeadRepairApplyOperations(), buildDepartmentLeadRepairPlan(), compareDepartmentLeadRepairPlans() (+24 more)
 
-### Community 82 - "researchEntity.ts"
+### Community 82 - "researchEntityEvidenceCoverage.ts"
 Cohesion: 0.11
 Nodes (32): assessResearchEntityEvidenceCoverage(), buildEvidenceCoverageImpact(), buildEvidenceCoverageImpactReportForObservations(), descriptionObservationSources(), descriptionState(), entityIdentifierKey(), EvidenceClaimState, EvidenceCoverageAssessment (+24 more)
 
-### Community 83 - "adminOperatorBoardService.ts"
+### Community 83 - "cli.ts"
 Cohesion: 0.14
 Nodes (28): __dirname, __filename, main(), BOOLEAN_FLAGS, buildCronOutputPayload(), buildMaterializeOutputPayload(), buildScraperCliOutputPayload(), buildScraperCliPreflight() (+20 more)
 
-### Community 84 - "Listing"
+### Community 84 - "ScraperContext"
 Cohesion: 0.11
 Nodes (30): canonicalPiName(), DEFAULT_FISCAL_YEARS, escapeRegex(), fetchPage(), FetchPageOpts, findUserForPi(), grantToRecord(), groupGrantsByPi() (+22 more)
 
-### Community 85 - "promoteAcceptedBetaCopy.ts"
+### Community 85 - "studentVisibilityRepairTargets.ts"
 Cohesion: 0.12
 Nodes (31): buildBucket(), buildStudentVisibilityRepairTargetReport(), compactSample(), compareByLabel(), compareDepartmentCandidates(), compareLlmCandidates(), DEPARTMENT_REPAIR_REASONS, DEPARTMENT_UNDERGRAD_RESEARCH_DEPARTMENTS (+23 more)
 
-### Community 86 - "Yale Research - Developer Guide"
+### Community 86 - "researchEntitySearchIndexService.ts"
 Cohesion: 0.11
 Nodes (32): addUniqueSearchTerm(), buildResearchEntitySearchIndexDocument(), buildResearchEntitySearchIndexDocuments(), buildResearchEntitySearchIndexDocumentsWithMemberNames(), buildStudentSearchTerms(), cleanPersonName(), emptyMemberNameFields(), facultyDisplayName() (+24 more)
 
-### Community 87 - "paperAuthorshipAudit.ts"
+### Community 87 - "opportunityDetailService.ts"
 Cohesion: 0.11
 Nodes (27): getOpportunityById(), normalizeOpportunityIdParam(), mocks, compactStrings(), evidenceExcerpt(), firstEvidenceText(), getOpportunityApplicationLabel(), getOpportunityApplicationState() (+19 more)
 
-### Community 88 - "Observation"
-Cohesion: 0.11
-Nodes (27): addFavoriteToProgram(), addViewToProgram(), boundedSearchQuery(), getProgramById(), numericSearchParam(), OPERATOR_PROGRAM_SORT_FIELDS, parseFilter(), parseStudentVisibilityFilter() (+19 more)
-
-### Community 89 - "Environment Progression"
-Cohesion: 0.14
-Nodes (30): ResearchGroupKind, absoluteUrl(), bestApplicationUrl(), conciseText(), DEFAULT_DEPARTMENT_UNDERGRAD_RESEARCH_PAGES, departmentEntityKey(), departmentGuidanceDescription(), DepartmentUndergradResearchPageConfig (+22 more)
-
-### Community 90 - "devDependencies"
+### Community 88 - "programController.ts"
 Cohesion: 0.12
-Nodes (30): absolutize(), CenterConfig, CenterExtractor, CenterKind, CenterMember, centerMemberRelationshipObservations(), centerMemberRelationshipObservationsForEntityKey(), CentersInstitutesScraper (+22 more)
+Nodes (29): getFellowshipById(), addFavoriteToProgram(), addViewToProgram(), boundedSearchQuery(), getProgramById(), numericSearchParam(), OPERATOR_PROGRAM_SORT_FIELDS, parseFilter() (+21 more)
 
-### Community 91 - "Per-Source Audit Playbooks"
+### Community 89 - "departmentUndergradResearchScraper.ts"
+Cohesion: 0.16
+Nodes (28): absoluteUrl(), bestApplicationUrl(), conciseText(), DEFAULT_DEPARTMENT_UNDERGRAD_RESEARCH_PAGES, departmentEntityKey(), departmentGuidanceDescription(), DepartmentUndergradResearchPageConfig, DepartmentUndergradResearchParser (+20 more)
+
+### Community 90 - "centersInstitutesScraper.ts"
+Cohesion: 0.07
+Nodes (45): affiliationExtractionToObservations(), CallCenterAffiliationLLMFn, CandidateCenter, CenterAffiliationExtraction, CenterAffiliationLLMExtractor, CenterAffiliationLLMExtractorDeps, CenterAffiliationPerson, CenterFinderFn (+37 more)
+
+### Community 91 - "studentDecisionLLMExtractor.ts"
+Cohesion: 0.17
+Nodes (22): buildStudentDecisionPrompt(), candidateMatchesOnly(), clean(), compactSourceUrls(), DecisionCandidateLoader, DecisionCandidateSelectionOptions, decisionExtractionToObservation(), defaultCandidateLoader() (+14 more)
+
+### Community 92 - "field"
 Cohesion: 0.11
-Nodes (30): buildStudentDecisionPrompt(), candidateMatchesOnly(), clean(), compactSourceUrls(), DecisionCandidate, DecisionCandidateLoader, DecisionCandidateSelectionOptions, decisionExtractionToObservation() (+22 more)
+Nodes (35): buildDuplicateAccessSignalGroupsFromRows(), loadDuplicateAccessSignalGroups(), field(), normalizedHeader(), applyUserIdentityDedupeGroups(), archiveDuplicateUniqueUserReferences(), assertDedupeUsersByIdentityApplyAllowed(), buildDedupeUsersByIdentityOutput() (+27 more)
 
-### Community 92 - "assertPublicHttpUrl"
-Cohesion: 0.12
-Nodes (31): field(), normalizedHeader(), applyUserIdentityDedupeGroups(), archiveDuplicateUniqueUserReferences(), assertDedupeUsersByIdentityApplyAllowed(), buildDedupeUsersByIdentityOutput(), buildUserIdentityCollisionPipeline(), IDENTITY_FIELDS (+23 more)
-
-### Community 93 - "studentDecisionLLMExtractor.ts"
+### Community 93 - "researchEntityCoverageAudit.ts"
 Cohesion: 0.13
 Nodes (29): aggregateCountMap(), AuditEntityRecord, buildBulkAudit(), buildObservationFlags(), buildResearchEntityCoverageAuditOutput(), buildSlugAudit(), countMap(), __dirname (+21 more)
 
-### Community 94 - "adminFellowshipFormReducer.ts"
-Cohesion: 0.09
-Nodes (27): ActiveResearchSearchRequest, buildDepartmentSearchTargets(), DepartmentResearchHomeConfig, DepartmentSearchTarget, emptyGroupedResults(), hasStructuredFilters(), isResearchEntitySearchExhausted(), pluralize() (+19 more)
+### Community 94 - "research.tsx"
+Cohesion: 0.06
+Nodes (38): PathwayActionCardProps, ActiveResearchSearchRequest, buildDepartmentSearchTargets(), DepartmentResearchHomeConfig, DepartmentSearchTarget, emptyGroupedResults(), hasStructuredFilters(), isResearchEntitySearchExhausted() (+30 more)
 
-### Community 95 - "ResearchHomeCard.tsx"
-Cohesion: 0.11
-Nodes (33): initial(), allNameTokens(), allowsLastNameOnlyPersonUrl(), cleanProfileUrlsForPerson(), cleanPublicHttpUrl(), compoundLastNameMatchedTokens(), expandedResearchAreasPublicBio(), formatPublicBioList() (+25 more)
+### Community 95 - "isLikelyPersonUrl"
+Cohesion: 0.25
+Nodes (16): initial(), allNameTokens(), allowsLastNameOnlyPersonUrl(), compoundLastNameMatchedTokens(), entityNameMatchesUser(), givenNameAliasMatches(), hasPartialCompoundLastNameProfilePath(), hasSurnameOnlyProfilePath() (+8 more)
 
-### Community 96 - "applyProfileResearchAreaFallback"
+### Community 96 - "research-detail-professor-audit.mjs"
 Cohesion: 0.11
 Nodes (27): absoluteApiUrl(), absoluteClientUrl(), addFinding(), artifacts, auditEntity(), auditProfileLink(), clientBase, collectResearchEntities() (+19 more)
 
-### Community 97 - "backfillProfileBiosFromOfficialUrls.ts"
+### Community 97 - "AdminAccessReview.tsx"
 Cohesion: 0.11
-Nodes (33): getResearchGroupBySlug(), route(), addPublicPaperField(), buildLeadPiOutreachContactRoute(), buildResearchActivityLinkPayload(), contactRouteDedupeKey(), contactRouteRank(), dedupePublicContactRoutes() (+25 more)
+Nodes (23): AccessReviewCounts, AccessReviewDetail, AccessReviewEntitySummary, AccessSignal, AdminAccessReview(), ContactRoute, EntryPathway, evidenceIds() (+15 more)
 
-### Community 98 - "rebuildPathwaySearchIndex.ts"
-Cohesion: 0.09
-Nodes (21): AnalyticsEvent, ANALYTICS_SORT_DIRECTIONS, ANALYTICS_USER_SORTS, AnalyticsRequestError, parseAnalyticsSortDirection(), parseAnalyticsUserSort(), router, invokeRouteHandler() (+13 more)
+### Community 98 - "analytics.ts"
+Cohesion: 0.10
+Nodes (12): ANALYTICS_SORT_DIRECTIONS, ANALYTICS_USER_SORTS, AnalyticsRequestError, parseAnalyticsSortDirection(), parseAnalyticsUserSort(), router, invokeRouteHandler(), mocks (+4 more)
 
-### Community 99 - "claimGate.ts"
+### Community 99 - "dedupeUsersByIdentityCore.ts"
 Cohesion: 0.12
 Nodes (31): DuplicatePersonGroup, buildUserIdentityDedupePlan(), buildUserIdentityDedupeSummary(), canonicalScore(), chooseCanonicalUser(), clusterUsersByCompatibleName(), comparePlannedGroups(), compareStrings() (+23 more)
 
-### Community 100 - "dedupeUsersByIdentityCore.ts"
-Cohesion: 0.13
-Nodes (29): arxivIdFromUrl(), buildExternalIds(), buildOpenAlexAuthorshipEvidence(), extractArxivId(), FacultyRecord, fetchPage(), HttpFetcher, isExactNameMatch() (+21 more)
+### Community 100 - "openAlexPaperScraper.ts"
+Cohesion: 0.12
+Nodes (30): arxivIdFromUrl(), buildExternalIds(), buildOpenAlexAuthorshipEvidence(), extractArxivId(), FacultyRecord, fetchPage(), HttpFetcher, isExactNameMatch() (+22 more)
 
-### Community 101 - "longText.ts"
+### Community 101 - "dependencies"
 Cohesion: 0.08
 Nodes (28): dependencies, axios, @emotion/react, @emotion/styled, @mui/material, react, react-dom, react-router-dom (+20 more)
 
-### Community 102 - "attempt"
-Cohesion: 0.13
-Nodes (25): ProfileEditor(), ProfileEditorProps, orcidHref(), ProfileHeader(), ProfileHeaderProps, profileLinkDedupeKey(), profileUrlLinks(), shouldHideBroadSchoolLabel() (+17 more)
+### Community 102 - "ProfileEditor.tsx"
+Cohesion: 0.23
+Nodes (12): ProfileEditor(), ProfileEditorProps, ProfileHeaderProps, createInitialProfileEditorState(), hydrateFromProfile(), ProfileEditorAction, profileEditorReducer(), ProfileEditorState (+4 more)
 
-### Community 103 - "launchTrustContractService.ts"
-Cohesion: 0.11
-Nodes (23): AdminRoute(), AdminRouteProps, getLocalAdminDevLoginUrl(), getSafeLocalAdminRedirectTarget(), PrivateRoute(), PrivateRouteProps, InfiniteScrollLoadingDots(), InfiniteScrollLoadingDotsProps (+15 more)
+### Community 103 - "apiBaseUrl.ts"
+Cohesion: 0.22
+Nodes (13): AdminRoute(), AdminRouteProps, getLocalAdminDevLoginUrl(), getSafeLocalAdminRedirectTarget(), SignOutButton(), storeLogoutReturnPath(), buildApiUrl(), getApiBaseUrl() (+5 more)
 
-### Community 104 - "buildAdminOperatorBoard"
-Cohesion: 0.13
-Nodes (30): CompensationType, PostedOpportunityStatus, activeListingBackfillFilter(), backfillPostedOpportunitiesFromListings(), BackfillPostedOpportunitiesFromListingsOptions, BackfillPostedOpportunitiesFromListingsResult, compactObject(), firstUrl() (+22 more)
+### Community 104 - "postedOpportunityService.ts"
+Cohesion: 0.14
+Nodes (27): activeListingBackfillFilter(), backfillPostedOpportunitiesFromListings(), BackfillPostedOpportunitiesFromListingsOptions, BackfillPostedOpportunitiesFromListingsResult, compactObject(), firstUrl(), getEntryPathwayModel(), getEntryPathwayStatusForPostedOpportunity() (+19 more)
 
-### Community 105 - "analytics.tsx"
-Cohesion: 0.13
-Nodes (25): ScrapeSnapshot, scrapeSnapshotSchema, getCached(), invalidateCache(), setCached(), StudentDecisionLLMExtractor, ACCESS_DETAIL_CONFIGS, accessObservationsForEntity() (+17 more)
-
-### Community 106 - "officialProfilePiBackfillScraper.ts"
+### Community 105 - "assertPublicHttpUrl"
 Cohesion: 0.08
-Nodes (28): affiliationExtractionToObservations(), CallCenterAffiliationLLMFn, CandidateCenter, CenterAffiliationExtraction, CenterAffiliationLLMExtractor, CenterAffiliationLLMExtractorDeps, CenterAffiliationPerson, CenterFinderFn (+20 more)
+Nodes (45): defaultFetchUrl(), setCached(), defaultFetchPage(), CallCenterDirectorLLMFn, CandidateCenter, CenterDirector, CenterDirectorExtraction, CenterDirectorLLMExtractor (+37 more)
 
-### Community 107 - "pathwaySearchService.ts"
-Cohesion: 0.12
-Nodes (27): LaunchReviewExceptionCliOptions, buildLaunchTrustContractOutput(), CliOptions, __filename, main(), parseLaunchTrustContractArgs(), parsePositiveInteger(), parseRequiredValue() (+19 more)
+### Community 106 - "arxivPreprintScraper.ts"
+Cohesion: 0.11
+Nodes (22): arxivEntryToObservations(), ArxivFetcher, ArxivPreprintScraper, buildAuthorSearchQuery(), normalizeArxivId(), normalizeArxivText(), parseArxivFeed(), ParsedArxivEntry (+14 more)
 
-### Community 108 - "renderedFetch.ts"
+### Community 107 - "launchTrustContractService.ts"
+Cohesion: 0.10
+Nodes (30): LaunchReviewExceptionCliOptions, buildLaunchTrustContractOutput(), CliOptions, __filename, main(), parseLaunchTrustContractArgs(), parsePositiveInteger(), parseRequiredValue() (+22 more)
+
+### Community 108 - "pathwayQualityAudit.ts"
 Cohesion: 0.13
 Nodes (28): activeListingFilter(), aggregateCountMap(), buildEntityContexts(), buildPathwayQualityAuditOutput(), countMap(), __dirname, __filename, main() (+20 more)
 
-### Community 109 - "BackfillV4FacultyMembers.ts"
+### Community 109 - "promoteAcceptedBetaCopy.ts"
 Cohesion: 0.11
 Nodes (30): applyCopy(), assertPromotionSummaryCanApply(), assertSafeOptions(), buildApplyBlockers(), buildPlan(), buildPromotionSummary(), COLLECTION_CATEGORY_ORDER, CollectionCategorySummary (+22 more)
 
-### Community 110 - "repairArchivedEntityArtifacts.ts"
-Cohesion: 0.19
-Nodes (31): member(), attemptProgramRepair(), buildResearchSourceDescriptionPatch(), cleanResearchInterest(), entityPersonDisplayName(), hasHttpUrl(), isDescriptionEligibleSourceUrl(), isLeadMember() (+23 more)
+### Community 110 - "textValue"
+Cohesion: 0.15
+Nodes (36): member(), buildResearchSourceDescriptionPatch(), cleanResearchInterest(), entityPersonDisplayName(), hasHttpUrl(), interestCorroboratedByBio(), isDescriptionEligibleSourceUrl(), isLeadMember() (+28 more)
 
-### Community 111 - "listingClaimRequestService.ts"
+### Community 111 - "departmentGroundTruth.ts"
 Cohesion: 0.14
 Nodes (29): addSourceRecord(), buildDepartmentGroundTruth(), buildResolverKeys(), buildRowsFromSources(), categoryColorKeys, chooseCodeSystem(), CuratedDepartment, curatedDepartments (+21 more)
 
-### Community 112 - "brianFeed"
+### Community 112 - "app.ts"
 Cohesion: 0.08
 Nodes (21): allowList, apiLimiter, bypassRuntimeSecurity, clientDistPath, clientIndexPath, corsOptions, deployedBrowserOrigins, __dirname (+13 more)
 
-### Community 113 - "betaRepairQueue.ts"
+### Community 113 - "listingClaimRequestService.ts"
 Cohesion: 0.14
-Nodes (27): getAdminListingClaimRequest(), listAdminListingClaimRequests(), reviewAdminListingClaimRequest(), submitListingClaimRequest(), ListingClaimRequest, listingClaimRequestSchema, ListingClaimRequestStatus, ListingClaimRequestType (+19 more)
+Nodes (26): getAdminListingClaimRequest(), listAdminListingClaimRequests(), reviewAdminListingClaimRequest(), submitListingClaimRequest(), ListingClaimRequest, listingClaimRequestSchema, ListingClaimRequestStatus, ListingClaimRequestType (+18 more)
 
-### Community 114 - "assessment"
-Cohesion: 0.13
-Nodes (23): addIfDefined(), getProfile(), getProfileCourses(), getProfileListings(), getPublications(), normalizePublicationPagination(), PUBLICATION_SORT_FIELDS, publicationSortValue() (+15 more)
+### Community 114 - "profileController.ts"
+Cohesion: 0.12
+Nodes (26): addIfDefined(), getProfile(), getProfileCourses(), getProfileListings(), getPublications(), normalizePublicationPagination(), PUBLICATION_SORT_FIELDS, publicationSortValue() (+18 more)
 
-### Community 115 - "yaleCollegeFellowshipsOfficeScraper.ts"
+### Community 115 - "logSanitizer.ts"
 Cohesion: 0.09
-Nodes (25): ApiMode, mongoOptions, BrowseRankBackfillCliOptions, BrowseRankBackfillResult, __dirname, __filename, main(), parseBrowseRankBackfillArgs() (+17 more)
+Nodes (26): BrowseRankBackfillCliOptions, BrowseRankBackfillResult, __dirname, __filename, main(), parseBrowseRankBackfillArgs(), parsePositiveInt(), runBrowseRankBackfill() (+18 more)
 
-### Community 116 - "scripts"
-Cohesion: 0.13
-Nodes (28): recordReviewStatuses, AccessReviewCountSummary, accessReviewDocumentId(), AccessReviewEntitySummary, AccessReviewListInput, AccessReviewRecordType, AccessReviewRequestError, attachEvidenceItems() (+20 more)
+### Community 116 - "adminAccessReviewService.ts"
+Cohesion: 0.14
+Nodes (27): recordReviewStatuses, AccessReviewCountSummary, accessReviewDocumentId(), AccessReviewEntitySummary, AccessReviewListInput, AccessReviewRecordType, attachEvidenceItems(), buildReviewSummary() (+19 more)
 
-### Community 117 - "pathwayQualityAudit.ts"
+### Community 117 - "migrateResearchEntityCollections.ts"
 Cohesion: 0.14
 Nodes (30): assertResearchEntityCollectionMigrationWriteAllowed(), buildCollectionMigrationLiveFilter(), buildCollectionMigrationTargetReferenceFilter(), buildResearchEntityCollectionMigrationOutput(), COLLECTION_MIGRATIONS, collectionExists(), CollectionMigration, collectionMigrationModeWrites() (+22 more)
 
-### Community 118 - "base"
-Cohesion: 0.10
-Nodes (28): buildProfileResearchMembershipFilter(), cleanScholarlyTitle(), cleanUrl(), dateToIso(), hasInspectableOpenAlexDestination(), isDatasetLikeScholarlyLink(), isGeneratedOfficialProfilePublicationAnchor(), isOfficialProfileScholarlyLink() (+20 more)
+### Community 118 - "scholarlyLinkToPublicLink"
+Cohesion: 0.09
+Nodes (30): buildProfileResearchMembershipFilter(), cleanPublicSourceLabel(), cleanScholarlyTitle(), cleanUrl(), dateToIso(), hasInspectableOpenAlexDestination(), isDatasetLikeScholarlyLink(), isGeneratedOfficialProfilePublicationAnchor() (+22 more)
 
-### Community 119 - "isNonBiographicalPublicBio"
+### Community 119 - "UserContextProvider.tsx"
 Cohesion: 0.11
 Nodes (16): ListingEditorProps, ErrorBoundary, ErrorBoundaryProps, ErrorBoundaryState, container, root, UserContextProvider(), sampleUser (+8 more)
 
-### Community 120 - "cronRunner.ts"
-Cohesion: 0.12
-Nodes (24): adminQualityLabels(), contextLabelClass(), countLabel(), directoryFirstBadgeLabel(), directoryFirstPathwayLabel(), evidenceStatusClass(), isInteractiveElement(), ResearchHomeCard() (+16 more)
+### Community 120 - "safeRouteSegment"
+Cohesion: 0.09
+Nodes (32): cleanResearchInterest(), ResearchInterests(), ResearchInterestsProps, SOURCE_CHROME_PATTERNS, splitCleanResearchInterest(), adminQualityLabels(), contextLabelClass(), countLabel() (+24 more)
 
-### Community 121 - "normalizeProfileUpdateForStorage"
-Cohesion: 0.13
-Nodes (24): awardToRecord(), buildCoPiObservations(), buildResearchGroupObservations(), defaultDateStart(), fetchPage(), findUserForPi(), groupAwardsByPi(), maxStartDate() (+16 more)
+### Community 121 - "betaDataQualityCore.test.ts"
+Cohesion: 0.15
+Nodes (20): buildBetaDataQualityScorecard(), buildLiveLinkCheck(), buildUrlHygiene(), collectLinkCandidateInputs(), describeMongoTarget(), main(), BetaDataQualityScorecard, buildBetaDataQualityDiagnostics() (+12 more)
 
-### Community 122 - "yaleResearchOfficialScraper.ts"
+### Community 122 - "migrateResearchEntities.ts"
 Cohesion: 0.13
 Nodes (29): assertResearchEntityMigrationWriteAllowed(), BACKFILL_ARRAY_FIELD_PAIRS, BACKFILL_FIELD_PAIRS, backfillReferences(), buildResearchEntityMigrationOutput(), buildResearchEntityMigrationReferenceMatch(), collectionExists(), copyResearchEntities() (+21 more)
 
-### Community 123 - "Adding a New Endpoint"
+### Community 123 - "buildAdminOperatorBoard"
 Cohesion: 0.16
 Nodes (27): betaTargetCommand(), buildAdminOperatorBoard(), buildGateArtifactFreshness(), buildRecommendedNextActions(), deriveDataQualityGate(), deriveLaunchAcquisitionGate(), deriveLaunchTrustGate(), derivePromotionCopyGate() (+19 more)
 
-### Community 124 - "yaleDirectoryScraper.ts"
-Cohesion: 0.08
-Nodes (18): mockedAxios, CourseTableCourse, CourseTableSection(), CourseTableSectionProps, formatSeason(), ProfileListingsProps, SearchResponse, useSearchCore() (+10 more)
+### Community 124 - "axios.ts"
+Cohesion: 0.07
+Nodes (20): mockedAxios, HttpStatusNotifier(), CourseTableCourse, CourseTableSection(), CourseTableSectionProps, formatSeason(), ProfileListingsProps, SearchResponse (+12 more)
 
-### Community 125 - "fellowshipController.ts"
+### Community 125 - "disambiguateSurnameLabNames.ts"
 Cohesion: 0.12
 Nodes (27): ACTIVE_FILTER, applyPlans(), ApplyResult, assertDisambiguateSurnameLabApplyAllowed(), buildSurnameLabDisambiguationPlans(), cleanNamePart(), consumeValue(), __dirname (+19 more)
 
-### Community 126 - "ListingDetailModal.tsx"
+### Community 126 - "repairDuplicateAccessSignals.ts"
 Cohesion: 0.14
 Nodes (27): applyPlans(), assertDuplicateAccessSignalRepairApplyAllowed(), BlockedDuplicateAccessSignalRepairGroup, buildDuplicateAccessSignalRepairPlans(), __dirname, DuplicateAccessSignalPathwayContext, DuplicateAccessSignalRecord, DuplicateAccessSignalRepairPlanResult (+19 more)
 
-### Community 127 - "scholarlyLinkSuppressionAudit.ts"
+### Community 127 - "fellowshipMatchingService.ts"
 Cohesion: 0.14
 Nodes (24): buildFellowshipApplicationCycleEvidence(), cleanHttpUrl(), cleanString(), dateStatus(), FellowshipApplicationCycleEvidence, hasApplicationRoute(), looksRecurring(), publicFellowshipApplicationCycleEvidence (+16 more)
 
-### Community 128 - "pathwayController.ts"
-Cohesion: 0.15
-Nodes (24): addFavoriteToFellowship(), addViewToFellowship(), boundedSearchQuery(), getFellowshipById(), getFellowshipFilterOptions(), numericSearchParam(), parseFilter(), PUBLIC_FELLOWSHIP_SORT_FIELDS (+16 more)
+### Community 128 - "fellowshipController.ts"
+Cohesion: 0.18
+Nodes (17): addFavoriteToFellowship(), addViewToFellowship(), boundedSearchQuery(), getFellowshipFilterOptions(), numericSearchParam(), parseFilter(), PUBLIC_FELLOWSHIP_SORT_FIELDS, publicFellowshipPage() (+9 more)
 
-### Community 129 - "researchEntityDescriptionText.ts"
-Cohesion: 0.16
-Nodes (20): csrfOriginGuard(), isTrustedUnsafeRequestOrigin(), originFromUrl(), SAFE_METHODS, allowedOrigins, ORIGINAL_ENV, requireLocalSeedRuntime(), allowsNonProductionSecurityBypass() (+12 more)
+### Community 129 - "environment.ts"
+Cohesion: 0.28
+Nodes (14): requireLocalSeedRuntime(), allowsNonProductionSecurityBypass(), isCI(), isDevelopment(), isLocalDevelopmentRuntime(), isLocalHostValue(), isProduction(), isTest() (+6 more)
 
-### Community 130 - "dir"
+### Community 130 - "repairArchivedEntityArtifacts.ts"
 Cohesion: 0.15
 Nodes (24): applyRepairPlan(), archiveArtifact(), ARTIFACT_SPECS, ArtifactSpec, assertArchivedEntityArtifactRepairApplyAllowed(), buildRepairArchivedEntityArtifactsOutput(), collectionExists(), __filename (+16 more)
 
-### Community 131 - "launchReviewExceptions.ts"
+### Community 131 - "repairMismatchedPersonEmailsCore.ts"
 Cohesion: 0.15
 Nodes (25): applyRepairs(), assertRepairMismatchedPersonEmailsApplyAllowed(), loadUsers(), main(), runRepairMismatchedPersonEmails(), writeOutput(), buildMismatchedExternalIdentityRepairs(), buildMismatchedPersonEmailRepairPlan() (+17 more)
 
-### Community 132 - "adminRender"
-Cohesion: 0.14
-Nodes (16): triggerReconnect(), AsyncRequestHandler, clientErrorStatus(), errorHandler(), notFoundHandler(), publicClientErrorMessage(), ORIGINAL_ENV, BadRequestError (+8 more)
+### Community 132 - "errorHandler.ts"
+Cohesion: 0.08
+Nodes (29): app, getApiMode(), triggerReconnect(), startApp(), AsyncRequestHandler, clientErrorStatus(), errorHandler(), notFoundHandler() (+21 more)
 
-### Community 133 - "Session Notes"
+### Community 133 - "researchEntityPiDedupeCore.ts"
 Cohesion: 0.19
 Nodes (26): buildFundingGroupFromCluster(), buildFundingResearchEntityDedupePlan(), buildGroupFromCluster(), buildOfficialLabUrlResearchEntityDedupePlan(), buildProfileAreaShellDuplicateGroup(), buildResearchEntityPiDedupePlan(), canonicalScore(), cleanMergedResearchAreas() (+18 more)
 
-### Community 134 - "acceptedInputs.ts"
-Cohesion: 0.16
-Nodes (23): buildListingResearchEntityProfilePatch(), hasText(), isHttpUrl(), ListingResearchEntityProfileInput, looksLikeOwnerTitle(), looksLikePublicationBlurb(), missingArray(), missingText() (+15 more)
+### Community 134 - "listingResearchEntityProfile.ts"
+Cohesion: 0.28
+Nodes (14): buildListingResearchEntityProfilePatch(), hasText(), isHttpUrl(), ListingResearchEntityProfileInput, looksLikeOwnerTitle(), looksLikePublicationBlurb(), missingArray(), missingText() (+6 more)
 
-### Community 135 - "scraperIntegrityGate.ts"
+### Community 135 - "researchEntityQuality.ts"
 Cohesion: 0.14
 Nodes (21): ACCESS_SIGNAL_POINTS, accessPoints(), computeResearchEntityBrowseRank(), descriptionPoints(), leadPoints(), ResearchEntityBrowseRankInput, __testing, buildResearchEntityQualitySummary() (+13 more)
 
-### Community 136 - "research-detail-professor-audit.mjs"
+### Community 136 - "cronRunner.ts"
 Cohesion: 0.17
 Nodes (20): ScrapeJobLock, scrapeJobLockSchema, createCronOwnerId(), createCronRunnerDependencies(), CronRunnerDependencies, loadCronSource(), runScraperCron(), RunScraperCronResult (+12 more)
 
-### Community 137 - "dedupeUsersByIdentity.ts"
-Cohesion: 0.14
-Nodes (26): buildResearchGroupMemberUpsert(), centerRelationshipTypeForResolvedTarget(), findExistingResearchEntityByFacultyResearchAreaIdentity(), findUniqueUserForResearchGroupMember(), findUniqueUserIdByPersonName(), idValue(), isFacultyResearchAreaKey(), isInitialOnlyNameValue() (+18 more)
+### Community 137 - "entityMaterializer.test.ts"
+Cohesion: 0.13
+Nodes (31): addPostMaterializationMetrics(), buildInferredPiMemberUpsert(), buildResearchGroupMemberUpsert(), centerRelationshipTypeForResolvedTarget(), countListingBackedPostedOpportunitiesForRun(), emptyPostMaterializationMetrics(), findExistingResearchEntityByFacultyResearchAreaIdentity(), findUniqueUserIdByPersonName() (+23 more)
 
-### Community 138 - "ImportRootDataFiles.ts"
-Cohesion: 0.18
-Nodes (23): buildEmailHygiene(), buildSuspiciousUserEmailScorecardSummary(), isInvalidOptionalEmail(), assertUserEmailHygieneApplyAllowed(), buildSuspiciousUserEmailFilter(), buildUserEmailHygieneOutput(), loadSuspiciousUsers(), main() (+15 more)
+### Community 138 - "userEmailHygiene.ts"
+Cohesion: 0.22
+Nodes (17): assertUserEmailHygieneApplyAllowed(), buildSuspiciousUserEmailFilter(), buildUserEmailHygieneOutput(), loadSuspiciousUsers(), main(), runUserEmailHygiene(), writeUserEmailHygieneOutput(), buildUserEmailHygieneSummary() (+9 more)
 
-### Community 139 - "candidateDescriptionCrawlUrls"
+### Community 139 - "paperQualityService.ts"
 Cohesion: 0.14
 Nodes (22): buildPaperQualityAuditOutput(), __filename, main(), PaperQualityAuditCliOptions, parseNonNegativeInteger(), parsePaperQualityAuditArgs(), writePaperQualityAuditOutput(), activeScholarlyLinkFilter (+14 more)
 
-### Community 140 - "getResearchGroupDetail"
-Cohesion: 0.17
-Nodes (25): buildProfessorBioCoverageAudit(), emptySourceBuckets(), hasUsefulResearchSummary(), homeFallbackBucketForProfile(), isIndividualResearchHome(), isLeadRole(), isOrcidUrl(), isTrustedResearchHomeWebsite() (+17 more)
-
-### Community 141 - "applicationRoutePathwayBackfillCore.ts"
+### Community 140 - "profileBioCoverageAudit.ts"
 Cohesion: 0.10
-Nodes (21): argValue(), Feeder, FeederResult, FEEDERS, __filenameLocal, runFeeder(), runGateRefresh(), SERVER_ROOT (+13 more)
+Nodes (40): buildProfessorBioCoverageAuditOutput(), buildProfessorBioCoverageInputs(), idValue(), main(), parseInteger(), parseProfessorBioCoverageAuditArgs(), parseRequiredOutputPath(), ProfessorBioCoverageAuditCliOptions (+32 more)
 
-### Community 142 - "generateKeywords.ts"
-Cohesion: 0.08
-Nodes (25): ACCESS_EVIDENCE_CONFLICT_FIELDS, ADDITIVE_METADATA_CONFLICT_FIELDS, AggregatedObservationConflictGroup, ALL_KNOWN_CONFLICT_FIELDS, CONTENT_CONFLICT_FIELDS, __filename, FUNDING_CONTEXT_CONFLICT_FIELDS, IDENTITY_OR_ROUTING_CONFLICT_FIELDS (+17 more)
+### Community 141 - "initializeConnections"
+Cohesion: 0.11
+Nodes (23): ApiMode, initializeConnections(), mongoOptions, CliOptions, FILTER, main(), parseArgs(), buildProfileImageQualityAuditOutput() (+15 more)
 
-### Community 143 - "scriptWriteGuards.ts"
-Cohesion: 0.12
-Nodes (23): actionReasons, attemptVisibilityRepair(), buildVisibilityRepairPiMemberUpsert(), buildVisibilityRepairPlan(), buildVisibilityRepairPlans(), classifyVisibilityRepairStage(), defaultRepairDeps, interestCorroboratedByBio() (+15 more)
+### Community 142 - "staleObservationConflictReview.ts"
+Cohesion: 0.07
+Nodes (29): ACCESS_EVIDENCE_CONFLICT_FIELDS, ADDITIVE_METADATA_CONFLICT_FIELDS, AggregatedObservationConflictGroup, ALL_KNOWN_CONFLICT_FIELDS, buildMongoFieldFilter(), CONTENT_CONFLICT_FIELDS, __filename, FUNDING_CONTEXT_CONFLICT_FIELDS (+21 more)
 
-### Community 144 - "types.ts"
-Cohesion: 0.13
-Nodes (19): AdminProfile, AdminProfileEditModal(), AdminProfileEditModalProps, PublicationsTable(), PublicationsTableProps, SortField, AdminProfileEditAction, adminProfileEditReducer() (+11 more)
+### Community 143 - "visibilityRepairQueueService.test.ts"
+Cohesion: 0.36
+Nodes (7): buildRepairQueueSummary(), buildVisibilityRepairPiMemberUpsert(), buildVisibilityRepairPlan(), buildVisibilityRepairPlans(), classifyVisibilityRepairStage(), repairActionForStage(), runVisibilityRepairQueue()
 
-### Community 145 - "client"
+### Community 144 - "AdminProfileEditModal.tsx"
+Cohesion: 0.25
+Nodes (12): AdminProfile, AdminProfileEditModal(), AdminProfileEditModalProps, AdminProfileEditAction, adminProfileEditReducer(), AdminProfileEditState, AdminProfileShape, createInitialAdminProfileEditState() (+4 more)
+
+### Community 145 - "seedDepartments.ts"
 Cohesion: 0.12
 Nodes (24): DepartmentSeedRow, applyDepartmentRows(), assertDepartmentSeedApplyAllowed(), auditUnresolvedDepartmentStrings(), buildDepartmentSeedOutput(), classifyUnresolvedDepartmentString(), Department, DepartmentDiffSummary (+16 more)
 
-### Community 146 - "departmentGroundTruth.ts"
+### Community 146 - "unified-research-search-audit.mjs"
 Cohesion: 0.12
 Nodes (22): artifacts, assert(), assertTextExcludes(), assertTextIncludes(), assertTextMatches(), audit(), bodyText(), clientBase (+14 more)
 
-### Community 147 - "profileBioCoverageAudit.ts"
-Cohesion: 0.13
-Nodes (20): hasOversizedStringList(), isOversizedSearchRequest(), OPERATOR_ALLOWED_SORT_FIELDS, parseFilters(), parsePositiveIntegerParam(), parseQualityFilters(), parseStudentVisibilityTiers(), PUBLIC_ALLOWED_SORT_FIELDS (+12 more)
+### Community 147 - "researchGroupController.ts"
+Cohesion: 0.15
+Nodes (19): hasOversizedStringList(), isOversizedSearchRequest(), OPERATOR_ALLOWED_SORT_FIELDS, parseFilters(), parsePositiveIntegerParam(), parseQualityFilters(), parseStudentVisibilityTiers(), PUBLIC_ALLOWED_SORT_FIELDS (+11 more)
 
-### Community 148 - "Research Model"
-Cohesion: 0.16
-Nodes (21): ResearchEntityType, absoluteUrl(), cleanText(), DEFAULT_YALE_RESEARCH_DIRECTORY_CONFIGS, entityFromRecord(), entityToObservations(), inferResearchYaleKind(), pageUrlForIndex() (+13 more)
+### Community 148 - "yaleResearchOfficialScraper.ts"
+Cohesion: 0.18
+Nodes (19): absoluteUrl(), cleanText(), DEFAULT_YALE_RESEARCH_DIRECTORY_CONFIGS, entityFromRecord(), entityToObservations(), inferResearchYaleKind(), pageUrlForIndex(), parseDirectory() (+11 more)
 
-### Community 149 - "cli.ts"
+### Community 149 - "cleanupLegacyMongoCollections.ts"
 Cohesion: 0.17
 Nodes (23): assertLegacyCleanupWriteAllowed(), buildLegacyCleanupOutput(), collectionExists(), copyApplications(), countCollection(), countMissingStudentApplications(), createStudentApplicationIndexes(), dropLegacyCollections() (+15 more)
 
-### Community 150 - "AdminFellowshipsTable.tsx"
-Cohesion: 0.15
-Nodes (21): buildLaunchReviewExceptionCandidates(), buildLaunchReviewExceptionDecisionTemplate(), buildLaunchReviewExceptionOutput(), buildLaunchReviewExceptionPlan(), buildLaunchReviewExceptionReview(), __filename, isStudentReadyLaunchViolation(), LAUNCH_REVIEW_EXCEPTION_DECISION_VALUES (+13 more)
-
-### Community 151 - "smartTitle.ts"
+### Community 150 - "launchReviewExceptions.ts"
 Cohesion: 0.14
-Nodes (17): cleanResearchInterest(), ResearchInterests(), ResearchInterestsProps, SOURCE_CHROME_PATTERNS, splitCleanResearchInterest(), formatRoleLabel(), Profile(), ROLE_LABELS (+9 more)
+Nodes (23): buildLaunchReviewExceptionCandidates(), buildLaunchReviewExceptionDecisionTemplate(), buildLaunchReviewExceptionOutput(), buildLaunchReviewExceptionPlan(), buildLaunchReviewExceptionReview(), __filename, isStudentReadyLaunchViolation(), LAUNCH_REVIEW_EXCEPTION_DECISION_VALUES (+15 more)
 
-### Community 152 - "crossSourceObservationConflictReview.ts"
+### Community 151 - "profile.tsx"
+Cohesion: 0.13
+Nodes (22): LongText(), LongTextProps, formatRoleLabel(), Profile(), ROLE_LABELS, Tab, VALID_TABS, createInitialProfilePageState() (+14 more)
+
+### Community 152 - "ResearchGroupMember"
 Cohesion: 0.14
 Nodes (21): ResearchGroupMember, ProfileBackedFacultyResearchAreaMemberDeps, ResolvedRelationshipMaterializationDeps, deleteFromIndex(), ENTITY_REGISTRY, EntityIndexConfig, getConfig(), isSyncableEntityType() (+13 more)
 
-### Community 153 - "migrateResearchEntities.ts"
-Cohesion: 0.18
-Nodes (24): resolveAllFields(), addUniqueValuesToSet(), authorshipEvidenceFromPaperObservations(), buildPaperUpdateFromObservations(), entityModelFor(), findEntityDocByIdentifier(), findPaperForObservationGroup(), isArxivPaperKey() (+16 more)
+### Community 153 - "materializePaperObservationsFromRun"
+Cohesion: 0.35
+Nodes (13): findEntityDocByIdentifier(), findPaperForObservationGroup(), isArxivPaperKey(), isDoiPaperKey(), mapExistingPapers(), materializePaperAuthorEvidenceFromGroups(), materializePaperObservationsFromRun(), normalizeDoiForMaterialization() (+5 more)
 
-### Community 154 - "visibilityRepairQueueService.ts"
+### Community 154 - "Yale Research - Developer Guide"
 Cohesion: 0.09
 Nodes (23): Adding Things, Analytics, API Routes, Architecture, Auth Middleware (`server/src/middleware/auth.ts`), Authentication, CI, Common Commands (+15 more)
 
-### Community 155 - "abstractBios"
+### Community 155 - "migrateMongoNaming.ts"
 Cohesion: 0.15
 Nodes (21): assertMongoNamingMigrationWriteAllowed(), buildMongoNamingMigrationOutput(), buildUserFieldSetStage(), COLLECTION_RENAMES, collectionExists(), CollectionRenameResult, main(), migrateMongoNaming() (+13 more)
 
-### Community 156 - "researchEntity.ts"
+### Community 156 - "repairProfileDescriptionBackfillConflicts.ts"
 Cohesion: 0.16
 Nodes (21): applyPlans(), assertRepairProfileDescriptionBackfillConflictsApplyAllowed(), buildProfileDescriptionConflictRepairPlan(), buildProfileDescriptionConflictRepairPlans(), chooseKeepObservation(), consumePath(), DESCRIPTION_FIELDS, __dirname (+13 more)
 
-### Community 157 - "researchQualitySearchReview.ts"
-Cohesion: 0.15
-Nodes (21): getProfileByNetid(), hasProfileDirectoryLabelContamination(), normalizePublicProfile(), PUBLIC_PROFILE_BASE_ARRAY_FIELDS, PUBLIC_PROFILE_BASE_TEXT_FIELDS, publicProfileBase(), publicProfileImageUrl(), publicProfileResearchEntity() (+13 more)
+### Community 157 - "cleanPublicHttpUrl"
+Cohesion: 0.13
+Nodes (22): cleanProfileUrlsForPerson(), cleanPublicHttpUrl(), hasPersonScopedYaleDirectoryPath(), hasProfileDirectoryLabelContamination(), isLabOrResearchGroupUrl(), isOfficialYaleProfileUrlForUser(), isYaleHost(), officialYaleProfileUrlForUser() (+14 more)
 
-### Community 158 - "{ container }"
+### Community 158 - "migrateSmartTitles.ts"
 Cohesion: 0.13
 Nodes (18): args, ARTS_DEPARTMENT_ABBRS, CATEGORY_PRIORITY, CATEGORY_SUFFIXES, DepartmentCategory, DepartmentDoc, determineSuffix(), escapeRegex() (+10 more)
 
-### Community 159 - "migrateResearchEntityCollections.ts"
-Cohesion: 0.16
-Nodes (20): publicProgramForReader(), publicProgramLinks(), publicProgramText(), publicProgramTextArray(), hasDirectContactInfo(), defaultRewriter(), cache, CourseTableCourse (+12 more)
+### Community 159 - "redactDirectContactInfo"
+Cohesion: 0.20
+Nodes (16): publicProgramLinks(), publicProgramText(), publicProgramTextArray(), defaultRewriter(), cache, CourseTableCourse, fetchAllSeasonCourses(), fetchCourseTableData() (+8 more)
 
-### Community 160 - "researchGroupController.ts"
-Cohesion: 0.16
-Nodes (20): ScrapeJobLockInput, ScraperEnvironment, BetaSeedEnvironmentCliOptions, BetaSeedPlan, BetaSeedPlanStep, BetaSeedRunResult, BetaSeedTargetMetadata, buildBetaSeedPlan() (+12 more)
+### Community 160 - "betaSeedEnvironment.ts"
+Cohesion: 0.18
+Nodes (19): ScrapeJobLockInput, ScraperEnvironment, BetaSeedEnvironmentCliOptions, BetaSeedPlan, BetaSeedPlanStep, BetaSeedRunResult, BetaSeedTargetMetadata, buildBetaSeedPlan() (+11 more)
 
-### Community 161 - "migrateSmartTitles.ts"
+### Community 161 - "agent-workflow.md"
 Cohesion: 0.10
 Nodes (15): Agent Workflow, Durable Notes, Read Order, Skill Index, Finishing work, Fold durable changes into docs, Refresh Graphify, Review the final diff (+7 more)
 
-### Community 162 - "externalIdsSchema"
-Cohesion: 0.16
-Nodes (19): Source, BETA_ROLLOUT_ORDER, BetaReadinessGateCliOptions, buildBetaReadinessCommands(), buildBetaReadinessGateOutput(), collectionCount(), describeMongoTarget(), __dirname (+11 more)
+### Community 162 - "betaReadinessGate.ts"
+Cohesion: 0.17
+Nodes (18): BETA_ROLLOUT_ORDER, BetaReadinessGateCliOptions, buildBetaReadinessCommands(), buildBetaReadinessGateOutput(), collectionCount(), describeMongoTarget(), __dirname, EXPECTED_SOURCE_NAMES (+10 more)
 
-### Community 163 - "studentDecisionExplanationService.ts"
+### Community 163 - "textValue"
 Cohesion: 0.16
 Nodes (21): cleanOfficialProfileDisplayName(), cleanOfficialProfileTitle(), clipOfficialProfileBio(), extractBio(), extractDepartments(), extractEmail(), extractImageUrl(), extractOfficialProfileIdentity() (+13 more)
 
-### Community 164 - "disambiguateSurnameLabNames.ts"
+### Community 164 - "auditResearchEntityRename.ts"
 Cohesion: 0.18
 Nodes (19): buildLegacyResidueSummary(), buildResearchEntityRenameAuditOutput(), collectionExists(), countCollection(), countDanglingReferences(), countLegacyResidue(), LEGACY_RESIDUE_CHECKS, LegacyResidueCheck (+11 more)
 
-### Community 165 - "repairDuplicateAccessSignals.ts"
+### Community 165 - "backfillPostedOpportunitiesFromListings.ts"
 Cohesion: 0.18
 Nodes (18): assertPostedOpportunityBackfillApplyAllowed(), buildPostedOpportunityBackfillOutput(), __dirname, __filename, main(), parsePositiveInteger(), parsePostedOpportunityBackfillArgs(), PostedOpportunityBackfillCliOptions (+10 more)
 
-### Community 166 - "arxivPreprintScraper.ts"
+### Community 166 - "Session Notes"
 Cohesion: 0.10
 Nodes (19): 10) `/research` cluster profile links should avoid broken routes on malformed data, 11) Playwright interaction pass for research flows could not run in this environment, 12) `/research` was blocked by an unrelated Listings error modal, 13) `/research/:slug` repeated the same official source link across pathways, evidence, and CTAs, 14) Listings load failure used a blocking modal instead of inline recovery, 15) `/research` showed duplicate Neuroscience concepts and undersized touch targets, 16) `/research` hierarchy exposed clusters before student decisions, 1) `/research` search request ordering and cancellation (+11 more)
 
-### Community 167 - "EvidenceQualitySection"
-Cohesion: 0.10
-Nodes (19): devDependencies, ts-node, tsup, tsx, @types/cookie-session, @types/cors, @types/express, @types/node (+11 more)
+### Community 167 - "devDependencies"
+Cohesion: 0.18
+Nodes (11): devDependencies, ts-node, tsup, tsx, @types/cookie-session, @types/cors, @types/express, @types/node (+3 more)
 
-### Community 168 - "LIVE"
-Cohesion: 0.21
-Nodes (18): defaultAdvisorResolver(), resolveSafeAcceptedInputRoot(), assertAcceptedInputsApplyAllowed(), buildAcceptedInputsOutput(), CliOptions, COMMANDS_REQUIRING_DB, COMMANDS_SUPPORTING_APPLY, main() (+10 more)
+### Community 168 - "acceptedInputs.ts"
+Cohesion: 0.22
+Nodes (17): defaultAdvisorResolver(), assertAcceptedInputsApplyAllowed(), buildAcceptedInputsOutput(), CliOptions, COMMANDS_REQUIRING_DB, COMMANDS_SUPPORTING_APPLY, main(), parseAcceptedInputsArgs() (+9 more)
 
-### Community 169 - "dependencies"
+### Community 169 - "claimGate.ts"
+Cohesion: 0.09
+Nodes (37): AccessSignalType, ContactRouteType, PostedOpportunityStatus, buildClaimGateOutput(), ClaimGateCliOptions, ClaimGateCollection, consumeValue(), __dirname (+29 more)
+
+### Community 170 - "scraperIntegrityDuplicateReview.ts"
 Cohesion: 0.17
-Nodes (18): AccessSignalType, AccessArtifactCandidate, AccessArtifactType, buildClaimGateReport(), ClaimGateReport, ClaimGateStatus, ClaimValidationBundleResult, ClaimValidationResult (+10 more)
+Nodes (18): buildDuplicateResearchPaperGroupsFromRows(), DuplicateAccessSignalGroup, DuplicateResearchPaperGroup, DuplicateAccessSignalRepairPlan, buildScraperIntegrityDuplicateReviewReport(), consumeValue(), __dirname, __filename (+10 more)
 
-### Community 170 - "normalizeOfficialProfileUrl"
-Cohesion: 0.17
-Nodes (18): DuplicateAccessSignalGroup, DuplicateResearchPaperGroup, DuplicateAccessSignalRepairPlan, buildScraperIntegrityDuplicateReviewReport(), consumeValue(), __dirname, __filename, loadDuplicateAccessSignalReviewGroups() (+10 more)
-
-### Community 171 - "axios.ts"
+### Community 171 - "clearBetaStudentAnalytics.ts"
 Cohesion: 0.24
 Nodes (17): assertClearBetaStudentAnalyticsApplyAllowed(), buildBetaStudentAnalyticsEventFilter(), buildClearBetaStudentAnalyticsOutput(), loadCandidateSummary(), main(), runClearBetaStudentAnalytics(), writeClearBetaStudentAnalyticsOutput(), BETA_STUDENT_ANALYTICS_USER_TYPES (+9 more)
 
-### Community 172 - "programController.ts"
-Cohesion: 0.24
-Nodes (20): archivedResearchEntityRepairBlock(), attemptResearchActionEvidenceRepair(), attemptResearchRepair(), createEntitySourceActionEvidenceRepair(), createOfficialProfileActionEvidenceRepair(), entityActionEvidenceSourceUrl(), entityActionEvidenceSourceUrls(), findOfficialProfileUserMatch() (+12 more)
+### Community 172 - "visibilityRepairQueueService.ts"
+Cohesion: 0.15
+Nodes (32): actionReasons, archivedResearchEntityRepairBlock(), attemptProgramRepair(), attemptResearchActionEvidenceRepair(), attemptResearchRepair(), attemptVisibilityRepair(), createEntitySourceActionEvidenceRepair(), createOfficialProfileActionEvidenceRepair() (+24 more)
 
-### Community 173 - "seedDepartments.ts"
+### Community 173 - "Yale Research"
 Cohesion: 0.11
 Nodes (15): Core Rules, Default Task Loop, Implementation Rules, On-Demand Skills, Parallel Work, Yale Research - Agent Guide, Yale Research, Acknowledgements (+7 more)
 
-### Community 174 - "Active Detail Docs"
+### Community 174 - "adminListingsTableReducer.ts"
 Cohesion: 0.14
 Nodes (15): AdminListing, AdminListingsTable(), PAGE_SIZES, SORT_OPTIONS, SortField, TABLE_COLUMNS, AdminListingsFilter, AdminListingsSortField (+7 more)
 
-### Community 175 - "repairMismatchedPersonEmailsCore.ts"
+### Community 175 - "compilerOptions"
 Cohesion: 0.11
 Nodes (18): compilerOptions, allowJs, allowSyntheticDefaultImports, esModuleInterop, forceConsistentCasingInFileNames, isolatedModules, jsx, lib (+10 more)
 
-### Community 176 - "betaReadinessGate.ts"
+### Community 176 - "seedResearchAreas.ts"
 Cohesion: 0.14
 Nodes (18): assertResearchAreaSeedApplyAllowed(), buildResearchAreaSeedOutput(), buildResearchAreaSeedRows(), defaultResearchAreas, __dirname, fieldColorKeys, __filename, main() (+10 more)
 
-### Community 177 - "buildDescriptionLLMPrompt"
+### Community 177 - "Decisions"
 Cohesion: 0.11
 Nodes (19): 2026-05-07: Evolve Legacy ResearchGroup Conservatively, 2026-05-07: North Star Is Research Navigation, 2026-05-07: Replace Binary Acceptance With Access Signals, 2026-05-07: Separate EntryPathway From PostedOpportunity, 2026-05-07: Use Two Main Product Surfaces, 2026-05-11: Use Pathways As The Student Action Layer, 2026-05-14: Student-Facing Routes Should Not Use URL Versioning, 2026-05-25: Beta Operator Review Is An Automatic Repair State (+11 more)
 
-### Community 178 - "index.tsx"
+### Community 178 - "Research Data Pipeline"
 Cohesion: 0.13
 Nodes (14): Canonical Collections, Pipeline Shape, Promotion Invariants, Read-Only Control Plane, Research Data Pipeline, Retention Posture, Rollback Drill Expectations, Active Priority Queue (+6 more)
 
-### Community 179 - "callLLM"
+### Community 179 - "Research Model"
 Cohesion: 0.11
 Nodes (19): 2026-05-13 External Yale Validation, 2026-05-13 Model Audit, AccessSignal, Admin Review, ContactRoute, Current Implementation Context, EntryPathway, Migration Guidance (+11 more)
 
-### Community 180 - "adminAccessReviewService.ts"
-Cohesion: 0.28
-Nodes (15): AuthenticatedUser, canCreateListing(), canSubmitListingClaimRequest(), hasAdminAuthority(), hasAuthenticatedPrincipal(), isAdmin(), isAuthenticated(), isConfirmed() (+7 more)
+### Community 180 - "index.ts"
+Cohesion: 0.16
+Nodes (24): AuthenticatedUser, canCreateListing(), canSubmitListingClaimRequest(), hasAdminAuthority(), hasAuthenticatedPrincipal(), isAdmin(), isAuthenticated(), isConfirmed() (+16 more)
 
-### Community 181 - "studentVisibilityRepairTargets.ts"
-Cohesion: 0.25
-Nodes (15): AdminGrant, adminGrantSchema, buildAuthenticatedSessionUser(), adminGrantCache, AdminGrantResponse, allowsLegacyAdminUserType(), assertValidNetid(), grantAdminAccess() (+7 more)
+### Community 181 - "adminGrantService.ts"
+Cohesion: 0.29
+Nodes (12): AdminGrant, adminGrantSchema, adminGrantCache, AdminGrantResponse, assertValidNetid(), grantAdminAccess(), hasActiveAdminGrant(), listAdminGrants() (+4 more)
 
-### Community 182 - "scripts"
+### Community 182 - "profileImageQualityAuditCore.ts"
 Cohesion: 0.26
 Nodes (17): buildProfileImageQualitySummary(), DuplicateProfileImageFinding, isLikelyPublicProfileImageUrl(), isNonPersonProfileImageUrl(), isSharedProfileImageAcrossDifferentNames(), isTrustedPublicProfileImageHost(), normalizedIdentityKey(), normalizedName() (+9 more)
 
-### Community 183 - "v4MigrationUtils.ts"
-Cohesion: 0.22
-Nodes (16): assertRebuildPathwaySearchIndexAllowed(), buildRebuildPathwaySearchIndexOutput(), main(), parsePositiveInteger(), parseRebuildPathwaySearchIndexArgs(), parseRequiredOutputPath(), RebuildPathwaySearchIndexCliOptions, writeRebuildPathwaySearchIndexOutput() (+8 more)
+### Community 183 - "assertScriptApplyAllowed"
+Cohesion: 0.09
+Nodes (36): assertPublicationMigrationApplyAllowed(), buildPublicationMigrationOutput(), dedupeKey(), __dirname, EmbeddedPub, __filename, migratePublicationsToPapers(), parsePositiveInteger() (+28 more)
 
-### Community 184 - "source.ts"
+### Community 184 - "updateOwnProfile"
 Cohesion: 0.15
 Nodes (19): ADMIN_PROFILE_USER_TYPES, adminUpdateProfile(), boundedAdminProfileEmail(), boundedAdminProfileNumber(), boundedAdminProfileText(), boundedProfileString(), boundedProfileStringArray(), boundedProfileUrlKey() (+11 more)
 
-### Community 185 - "cleanupLegacyMongoCollections.ts"
+### Community 185 - "studentDecisionExplanationService.ts"
 Cohesion: 0.23
 Nodes (17): actionSet, cleanHttpUrl(), cleanText(), containsDirectEmail(), hasActivePostedOpportunity(), hasPublicOfficialApplicationRoute(), hasPublicRoute(), hasUndergraduateAccessEvidence() (+9 more)
 
-### Community 186 - "seedSources.ts"
+### Community 186 - "compilerOptions"
 Cohesion: 0.11
 Nodes (18): compilerOptions, esModuleInterop, forceConsistentCasingInFileNames, lib, module, moduleResolution, noImplicitAny, outDir (+10 more)
 
-### Community 187 - "AdminProfileEditModal.tsx"
+### Community 187 - "AdminFacultyProfilesTable.tsx"
 Cohesion: 0.16
 Nodes (14): AdminFacultyProfilesTable(), AdminProfile, getHIndex(), getPrimaryDepartment(), PAGE_SIZES, SortField, TABLE_COLUMNS, AdminFacultyProfilesFilter (+6 more)
 
-### Community 188 - "configService.ts"
+### Community 188 - "generateKeywords.ts"
 Cohesion: 0.16
 Nodes (17): ALIAS_MAP, args, buildSystemPrompt(), buildUserPrompt(), callOpenAI(), classifyExistingAreas(), classifyNovelAreas(), classifyOnly (+9 more)
 
-### Community 189 - "publicResearchSeo.ts"
+### Community 189 - "Per-Source Audit Playbooks"
 Cohesion: 0.11
 Nodes (18): Audit Checklist, `department-undergrad-research`, `dept-faculty-roster`, Entity Discovery Sources, Funding And Publication Enrichment, `lab-microsite-description-llm`, `lab-microsite-undergrad-llm`, Mental Model (+10 more)
 
-### Community 190 - "migrateMongoNaming.ts"
+### Community 190 - "fellowship.ts"
 Cohesion: 0.20
 Nodes (15): fellowshipSchema, programCategories, ProgramCategory, ProgramEntryMode, programEntryModes, ProgramKind, programKinds, archiveReviewClassification() (+7 more)
 
-### Community 191 - "researchEntityPiDedupeCore.ts"
-Cohesion: 0.13
-Nodes (8): normalizeSeedNetid(), requireSeedToken(), router, SEED_USER_FIELDS, seedListingSummary(), seedUserPayload(), seedUserSummary(), tokensMatch()
+### Community 191 - "materializeEntity"
+Cohesion: 0.16
+Nodes (20): normalizeUserType(), addUniqueValuesToSet(), buildPaperUpdateFromObservations(), DISCOVERY_ONLY_ACCESS_FIELD_SOURCES, entityModelFor(), hasRequiredFieldsForCreate(), isOfficialProfileBioChromeObservation(), isResearchEntityObservationType() (+12 more)
 
-### Community 192 - "staleObservationConflictReview.test.ts"
+### Community 192 - "backfillResearchDescriptions.ts"
 Cohesion: 0.16
 Nodes (17): getSourceByName(), defaultRewriter(), DESC_BLOCK_REASONS, DescriptionRewriter, __dirname, entityHttpUrls(), fetchGrantAbstract(), __filename (+9 more)
 
-### Community 193 - "launchTrustContract.ts"
+### Community 193 - "backfillResearchHomeOfficialUrls.ts"
 Cohesion: 0.18
 Nodes (16): candidateProfileUrls(), defaultVerifier(), DESC_BLOCK_REASONS, __dirname, __filename, isTrustedYaleProfileUrl(), LEAD_ROLES, main() (+8 more)
 
-### Community 194 - "EvidenceSourceRow.tsx"
+### Community 194 - "smartTitle.ts"
+Cohesion: 0.18
+Nodes (16): DepartmentCategory, ARTS_DEPARTMENT_ABBRS, buildDepartmentLookup(), CATEGORY_PRIORITY, CATEGORY_SUFFIXES, DepartmentDoc, determineSuffix(), escapeRegex() (+8 more)
+
+### Community 195 - "researchEntityDto.ts"
 Cohesion: 0.21
-Nodes (15): buildProfessorBioCoverageAuditOutput(), buildProfessorBioCoverageInputs(), idValue(), main(), parseInteger(), parseProfessorBioCoverageAuditArgs(), parseRequiredOutputPath(), ProfessorBioCoverageAuditCliOptions (+7 more)
+Nodes (18): addResearchEntityDetailAlias(), addResearchEntitySearchAliases(), departmentDisplayLabel(), normalizedDepartmentLabel(), OPERATOR_PUBLIC_RESEARCH_ENTITY_FIELDS, OPTIONAL_PUBLIC_RESEARCH_ENTITY_FIELDS, publicDepartmentArray(), publicHttpUrl() (+10 more)
 
-### Community 195 - "adminGrantService.ts"
-Cohesion: 0.25
-Nodes (16): addResearchEntityDetailAlias(), addResearchEntitySearchAliases(), departmentDisplayLabel(), normalizedDepartmentLabel(), OPERATOR_PUBLIC_RESEARCH_ENTITY_FIELDS, OPTIONAL_PUBLIC_RESEARCH_ENTITY_FIELDS, publicDepartmentArray(), publicHttpUrl() (+8 more)
-
-### Community 196 - "resolveSafeJsonReportOutputPath"
+### Community 196 - "backfillCenterDirectors.ts"
 Cohesion: 0.18
 Nodes (15): MaterializerObservationLike, CenterDirectorsBackfillCliOptions, CenterDirectorsBackfillResult, __dirname, __filename, findCenterDirectorCandidates(), LEAD_ROLES, main() (+7 more)
 
-### Community 197 - "dependencies"
+### Community 197 - "normalizeOfficialProfileUrl"
 Cohesion: 0.22
 Nodes (17): isOfficialYalePersonPageUrl(), isOfficialYaleProfileUrl(), isPotentialDirectYalePersonPageUrl(), normalizeOfficialProfileUrl(), officialPersonUrlMatchesEntity(), officialProfileSlugMatchesGivenNameVariant(), officialProfileUrlsForUser(), personPageUrlMatchesUser() (+9 more)
 
-### Community 198 - "users.ts"
+### Community 198 - "betaRepairQueue.ts"
 Cohesion: 0.26
 Nodes (15): arrayValue(), assertBetaRepairQueueApplyReviewedArtifact(), BetaRepairQueueApplyArtifactValidation, blockedReasonsForAttempt(), buildApplyFromArtifactOptions(), buildBetaRepairQueueOutput(), main(), objectValue() (+7 more)
 
-### Community 199 - "unified-research-search-audit.mjs"
-Cohesion: 0.22
-Nodes (15): buildClaimGateOutput(), ClaimGateCliOptions, ClaimGateCollection, consumeValue(), __dirname, __filename, loadResearchAccessArtifacts(), main() (+7 more)
+### Community 199 - "sanitizeProfileResearchTerms"
+Cohesion: 0.23
+Nodes (12): expandedResearchAreasPublicBio(), formatPublicBioList(), hasOfficialYaleProfileUrl(), officialProfileResearchInterestTermsBio(), publicProfileDisplayName(), supportedPublicProfileTopics(), cleanResearchTerm(), extractExplicitResearchInterestPhrases() (+4 more)
 
-### Community 200 - "index.ts"
+### Community 200 - "pathwayRelevanceReview.ts"
 Cohesion: 0.21
 Nodes (15): buildPathwayRelevanceReviewOutput(), DEFAULT_REVIEW_CASES, __dirname, errorMessage(), __filename, main(), overlap(), parsePathwayRelevanceReviewArgs() (+7 more)
 
-### Community 201 - "userEmailHygiene.ts"
+### Community 201 - "accessSummaryService.ts"
 Cohesion: 0.21
 Nodes (14): AccessSummary, accessSummaryEntityId(), AccessSummaryStatus, bestNextStepFor(), boundedString(), computeStatus(), confidenceScore(), EMPTY_SUMMARY (+6 more)
 
-### Community 202 - "orcidWorksScraper.ts"
+### Community 202 - "sourceHealthService.ts"
 Cohesion: 0.24
 Nodes (15): betaCommand(), buildSourceHealthRows(), commandArg(), iso(), noRecentRunCommand(), reportCommand(), reportOutputPath(), reviewArtifactForRun() (+7 more)
 
-### Community 203 - "backfillResearchHomeOfficialUrls.ts"
+### Community 203 - "adminFellowshipsTableReducer.ts"
 Cohesion: 0.18
 Nodes (13): AdminFellowshipsFilter, AdminFellowshipsSortField, AdminFellowshipsTableAction, adminFellowshipsTableReducer(), AdminFellowshipsTableState, AdminTableAction, AdminTableDefaults, adminTableReducer() (+5 more)
 
-### Community 204 - "backfillFacultyWaysIn.ts"
+### Community 204 - "resolutions"
 Cohesion: 0.12
 Nodes (16): resolutions, axios, brace-expansion, braces, encoding-sniffer, form-data, glob, ip-address (+8 more)
 
-### Community 205 - "publicationsTableReducer.ts"
+### Community 205 - "publicResearchSeo.ts"
 Cohesion: 0.26
 Nodes (14): sendPublicResearchIndex(), getResearchGroupBySlug(), buildPublicResearchSeoMetadata(), compact(), escapeHtml(), firstNonEmpty(), injectSeoMetadata(), joinList() (+6 more)
 
-### Community 206 - "AdminFacultyProfilesTable.tsx"
-Cohesion: 0.23
-Nodes (13): allowedValues(), hasOversizedStringList(), isOversizedSearchRequest(), parseFilters(), parseSearchInput(), parseSort(), publicPathwayResearchEntity(), publicPathwaySearchResult() (+5 more)
+### Community 206 - "researchEntity.ts"
+Cohesion: 0.08
+Nodes (38): allowedValues(), hasOversizedStringList(), isOversizedSearchRequest(), parseFilters(), parseSearchInput(), parseSort(), publicPathwayResearchEntity(), publicPathwaySearchResult() (+30 more)
 
-### Community 207 - "meiliSyncService.ts"
+### Community 207 - "visibilityReleaseQueueItem.ts"
 Cohesion: 0.18
 Nodes (15): VisibilityReleaseQueueCollection, visibilityReleaseQueueCollections, visibilityReleaseQueueItemSchema, VisibilityReleaseQueueStatus, visibilityReleaseQueueStatuses, VisibilityRepairStage, visibilityRepairStages, VisibilityRepairStatus (+7 more)
 
-### Community 208 - "AdminOperatorBoard"
+### Community 208 - "users.ts"
 Cohesion: 0.19
 Nodes (8): getFavoriteIds(), logFavoriteEvent(), logProfileUpdateEvent(), normalizeFavoriteAnalyticsIds(), parseFavoriteAnalyticsResponse(), profileUpdateAnalyticsFields(), router, visibleFavoriteAnalyticsIdsFromResponse()
 
-### Community 209 - "departmentResolver.ts"
+### Community 209 - "extractOfficialProfileResearchHomes"
 Cohesion: 0.25
 Nodes (16): affiliationValuesFromProfiles(), canonicalResearchHomeName(), classifyResearchHome(), cleanProfileCardLabWebsiteLabel(), dedupeRepeatedProfileCardLabel(), disallowedProfileLinkedResearchHome(), extractOfficialProfileResearchHomes(), genericOrganizationName() (+8 more)
 
-### Community 210 - "isPublicHttpUrl"
+### Community 210 - "dependencies"
 Cohesion: 0.13
 Nodes (15): dependencies, axios, cheerio, cookie-session, cors, cross-env, dotenv, express (+7 more)
 
-### Community 211 - "repairProfileDescriptionBackfillConflicts.ts"
+### Community 211 - "dedupeExploratoryContactPathways.ts"
 Cohesion: 0.30
 Nodes (13): applyPlans(), assertDedupeExploratoryContactPathwaysApplyConfirmed(), buildDedupeExploratoryContactPathwaysOutput(), buildPlans(), countDedupeExploratoryContactPathwaysPlannedChanges(), DedupeExploratoryContactPathwaysCliOptions, idString(), main() (+5 more)
 
-### Community 212 - "clearBetaStudentAnalytics.ts"
+### Community 212 - "repairListingResearchEntityProfiles.ts"
 Cohesion: 0.30
 Nodes (13): applyRepairs(), assertRepairListingResearchEntityProfilesApplyAllowed(), buildRepairListingResearchEntityProfilesOutput(), main(), normalizeListingProfileRepairObjectId(), normalizeListingProfileRepairObjectIdString(), parsePositiveInteger(), parseRepairListingResearchEntityProfilesArgs() (+5 more)
 
-### Community 213 - "scraperIntegrityDuplicateReview.ts"
-Cohesion: 0.20
-Nodes (14): currentResearchEntityMemberFilter(), getResearchGroupById(), idEquals(), listMembersOfGroup(), listResearchEntityRelationshipPayload(), normalizeResearchGroupObjectId(), publicRelationshipForResearchDetail(), leanResult() (+6 more)
+### Community 213 - "scraperIntegrityGate.ts"
+Cohesion: 0.27
+Nodes (11): isIntegrityGateFailure(), PostMaterializationIntegritySummary, buildScraperIntegrityGateOutput(), consumeValue(), __dirname, __filename, main(), parseScraperIntegrityGateArgs() (+3 more)
 
-### Community 214 - "normalizePublicProfile"
-Cohesion: 0.30
-Nodes (11): LongText(), LongTextProps, LongTextOptions, longTextParagraphs(), normalizeCommonAcademicAbbreviations(), normalizeInlineWhitespace(), protectDots(), protectSentenceAbbreviations() (+3 more)
+### Community 214 - "isPublicHttpUrl"
+Cohesion: 0.33
+Nodes (9): ipv4ToNumber(), isAllowedPublicHttpPort(), isIpv4InCidr(), isPrivateOrLocalHostname(), isPublicHttpUrl(), PRIVATE_HOSTNAME_SUFFIXES, PRIVATE_IPV4_CIDRS, publicHttpUrl() (+1 more)
 
-### Community 215 - "departmentLeadRepairPlanCore.ts"
+### Community 215 - "MigrateDepartments.ts"
 Cohesion: 0.18
 Nodes (12): assertDepartmentMigrationApplyAllowed(), buildDepartmentMigrationOutput(), ChangeLog, DepartmentDoc, DepartmentMigrationCliOptions, DepartmentMigrationResult, __dirname, __filename (+4 more)
 
-### Community 216 - "auditResearchEntityRename.ts"
+### Community 216 - "compilerOptions"
 Cohesion: 0.14
 Nodes (13): compilerOptions, esModuleInterop, forceConsistentCasingInFileNames, lib, module, outDir, resolveJsonModule, rootDir (+5 more)
 
-### Community 217 - "normalizeName"
+### Community 217 - "Environment Progression"
 Cohesion: 0.14
 Nodes (14): 1. Development Testing, 2. Beta Seeding, 3. Production Seeding, Environment Progression, Known Accepted Warnings To Recheck, Lane A: Accepted Beta Copy, Lane B: Guarded Production Delta, Local, VPN, And Render Constraints (+6 more)
 
-### Community 218 - "authorshipEvidence"
+### Community 218 - "ScrapeRun"
 Cohesion: 0.25
 Nodes (11): ScrapeRun, scrapeRunSchema, buildSupersededObservationPruneFilter(), findKeptRunIds(), nonNegativeInteger(), positiveInteger(), pruneSupersededObservations(), SupersededObservationPruneOptions (+3 more)
 
-### Community 219 - "actor"
+### Community 219 - "programs.ts"
 Cohesion: 0.22
 Nodes (9): buildProgramSearchFilters(), getStringParam(), hasProgramSearchFilters(), logProgramEvent(), logProgramSearchEvent(), parseFilterParam(), router, routeByPath() (+1 more)
 
-### Community 220 - "compilerOptions"
-Cohesion: 0.25
-Nodes (14): DEPARTMENT_IDENTITY_STOPWORDS, departmentIdentityTokens(), findUserDocByOfficialProfileObservations(), identityTokens(), isLikelyYaleEmailLocalPart(), normalizeIdentityText(), observationValueForField(), observedUserDepartmentLabels() (+6 more)
+### Community 220 - "csrfOriginGuard.ts"
+Cohesion: 0.31
+Nodes (6): csrfOriginGuard(), isTrustedUnsafeRequestOrigin(), originFromUrl(), SAFE_METHODS, allowedOrigins, ORIGINAL_ENV
 
-### Community 221 - "backfillPostedOpportunitiesFromListings.ts"
+### Community 221 - "main"
 Cohesion: 0.20
 Nodes (13): buildCrossSourceObservationConflictReviewOutput(), buildCrossSourceObservationDecisionTemplate(), CrossSourceObservationConflictSample, main(), normalizedObservationIdRows(), readCrossSourceObservationReviewDecisions(), runCrossSourceObservationConflictReview(), sameObservationIdsBySource() (+5 more)
 
-### Community 222 - "acronymExpansion"
+### Community 222 - "AdminFellowshipsTable.tsx"
 Cohesion: 0.17
 Nodes (8): AdminFellowship, AdminFellowshipsTable(), FellowshipLink, PAGE_SIZES, SortField, TABLE_COLUMNS, createInitialAdminFellowshipsTableState(), TestFellowship
 
-### Community 223 - "paperQualityService.ts"
+### Community 223 - "seo.ts"
 Cohesion: 0.32
 Nodes (11): applySeoMetadata(), buildDefaultSeoMetadata(), buildResearchSeoMetadata(), compact(), firstNonEmpty(), joinList(), SeoMetadata, stripHtml() (+3 more)
 
-### Community 224 - "dataOps.ts"
+### Community 224 - "BackfillV4StudentProfiles.ts"
 Cohesion: 0.27
 Nodes (11): backfillV4StudentProfiles(), buildDepartmentMap(), compact(), departmentIdsFor(), __filename, graduationYear(), norm(), V4StudentProfileBackfillResult (+3 more)
 
-### Community 225 - "actionabilityMatch"
-Cohesion: 0.22
-Nodes (12): assertPublicationMigrationApplyAllowed(), buildPublicationMigrationOutput(), dedupeKey(), __dirname, EmbeddedPub, __filename, migratePublicationsToPapers(), parsePositiveInteger() (+4 more)
+### Community 225 - "backfillProgramClassifications.ts"
+Cohesion: 0.42
+Nodes (8): assertBackfillProgramClassificationsApplyAllowed(), BackfillProgramClassificationsCliOptions, buildBackfillProgramClassificationsOutput(), main(), parseBackfillProgramClassificationsArgs(), parsePositiveInteger(), parseRequiredOutputPath(), writeBackfillProgramClassificationsOutput()
 
-### Community 226 - "pathwayRelevanceReview.ts"
+### Community 226 - "Graphify repo memory"
 Cohesion: 0.15
 Nodes (11): Canonical Sources, Graphify Onboarding, Refresh Policy, Setup Tasks, Shared Output Policy, Committed vs ignored outputs, Graphify repo memory, Installation (+3 more)
 
-### Community 227 - "profileImageQualityAudit.ts"
+### Community 227 - "securityHeaders.ts"
 Cohesion: 0.27
 Nodes (11): buildContentSecurityPolicy(), CONNECT_SRC_ORIGINS, connectSrcDirective(), CONTENT_SECURITY_POLICY, IMG_SRC_ORIGINS, imgSrcDirective(), PERMISSIONS_POLICY, securityHeaders() (+3 more)
 
-### Community 228 - "researchGroupService.test.ts"
+### Community 228 - "package.json"
 Cohesion: 0.22
-Nodes (13): ADMIN_URL_CHECK_ALLOWED_PORTS, adminUrlCheckDisplayText(), adminUrlCheckDisplayUrl(), checkAdminUrlReachability(), requestHead(), ipv4ToNumber(), isIpv4InCidr(), isIpv6InCidr() (+5 more)
+Nodes (8): engines, node, license, main, name, proxy, type, version
 
-### Community 229 - "programs.ts"
+### Community 229 - "listings.ts"
 Cohesion: 0.24
 Nodes (8): buildListingSearchFilters(), getStringParam(), hasListingSearchFilters(), logListingCreateEvent(), logListingEvent(), logSearchEvent(), parseFilterParam(), router
 
-### Community 230 - "bare"
+### Community 230 - "confidenceResolver.ts"
 Cohesion: 0.24
-Nodes (10): applyProseCompletenessBonus(), DEFAULTS, normalizedProse(), PROSE_COMPLETENESS_FIELDS, recencyDecay(), resolveField(), ResolverObservation, ResolverOptions (+2 more)
+Nodes (11): applyProseCompletenessBonus(), DEFAULTS, normalizedProse(), PROSE_COMPLETENESS_FIELDS, recencyDecay(), resolveAllFields(), resolveField(), ResolverObservation (+3 more)
 
-### Community 231 - "crossrefFreeFullText"
-Cohesion: 0.27
-Nodes (12): addPostMaterializationMetrics(), buildInferredPiMemberUpsert(), countListingBackedPostedOpportunitiesForRun(), departmentValuesForInferredPiLookup(), emptyPostMaterializationMetrics(), materializeFromRun(), materializeInferredPiMembership(), normalizeMaterializerObjectId() (+4 more)
+### Community 231 - "OfficialProfilePublicationValue"
+Cohesion: 0.15
+Nodes (16): compactPersonName(), comparableObservationValue(), departmentValuesForInferredPiLookup(), deptUserNameFilters(), escapeRegex(), escapeRegExp(), fieldProvenanceForResolvedObservation(), findUniqueUserByPersonName() (+8 more)
 
-### Community 232 - "compilerOptions"
+### Community 232 - "AdminOperatorBoard"
 Cohesion: 0.20
 Nodes (12): AdminOperatorBoard(), classifyReason(), formatCountList(), formatDate(), queueDecisionPrompt(), sourceConflictScopeText(), sourceReviewArtifactRollupLines(), sourceReviewCategoryText() (+4 more)
 
-### Community 233 - "seo.ts"
-Cohesion: 0.35
-Nodes (11): decodeHtmlEntities(), decodeNumericEntity(), isScholarlyLink(), LabPapersList(), LabPapersListProps, normalizeResearchActivityTitle(), ResearchActivityLink, resolveDisplayDate() (+3 more)
+### Community 233 - "labDetail.ts"
+Cohesion: 0.09
+Nodes (31): LabMembersList(), LabMembersListProps, ROLE_LABELS, ROLE_ORDER, ROLE_PILL_CLASSES, decodeHtmlEntities(), decodeNumericEntity(), isScholarlyLink() (+23 more)
 
-### Community 234 - "MigratePublicationsToPapers.ts"
+### Community 234 - "BackfillV4FacultyMembers.ts"
 Cohesion: 0.32
 Nodes (11): backfillV4FacultyMembers(), buildDepartmentMap(), compact(), departmentIdsFor(), __filename, isFacultyTitle(), norm(), slugify() (+3 more)
 
-### Community 235 - "sourceHealthService.ts"
-Cohesion: 0.27
-Nodes (8): app, getApiMode(), startApp(), __filenameLocal, gateRefreshIntervalMs(), SERVER_ROOT, startGateRefreshScheduler(), triggerRefresh()
+### Community 235 - "refreshGateScorecards.ts"
+Cohesion: 0.28
+Nodes (8): argValue(), Feeder, FeederResult, FEEDERS, __filenameLocal, runFeeder(), runGateRefresh(), SERVER_ROOT
 
-### Community 236 - "listings.ts"
+### Community 236 - "fellowships.ts"
 Cohesion: 0.26
 Nodes (7): buildFellowshipSearchFilters(), getStringParam(), hasFellowshipSearchFilters(), logFellowshipEvent(), logFellowshipSearchEvent(), parseFilterParam(), router
 
-### Community 237 - "confidenceResolver.ts"
+### Community 237 - "Auth and Security"
 Cohesion: 0.17
 Nodes (11): Auth and Security, Auth middleware, Authentication flow, Client, Environment variables, Error handling, Rate limits, Security middleware (+3 more)
 
-### Community 238 - "facultyResearch"
+### Community 238 - "Yale Research Product Context"
 Cohesion: 0.18
 Nodes (10): Author-Disambiguation Rules, Core Flows, Data-Quality Caveats, Not Optimizing For, Primary User Jobs, Product Thesis, Target User, Trust Constraints (+2 more)
 
-### Community 239 - "filterDuplicateRunObservations"
+### Community 239 - "adminFellowshipFormReducer.ts"
 Cohesion: 0.29
 Nodes (9): FellowshipEditModal(), AdminFellowshipFormAction, adminFellowshipFormReducer(), AdminFellowshipFormSource, AdminFellowshipFormState, createInitialAdminFellowshipFormState(), FellowshipLink, toDatetimeLocal() (+1 more)
 
-### Community 240 - "authenticatedRouteDoc"
+### Community 240 - "MigrateUsers.ts"
 Cohesion: 0.25
 Nodes (9): assertUserMigrationApplyAllowed(), assertUserMigrationReplacementAllowed(), buildUserMigrationOutput(), __dirname, __filename, migrateUsers(), UserMigrationCliOptions, UserMigrationResult (+1 more)
 
-### Community 241 - "normalizeAcceptedDecisionValidation"
+### Community 241 - "Local Development Setup"
 Cohesion: 0.18
 Nodes (11): 1. Fresh machine setup, 2. Install dependencies, 3. Configure environment, 4. Start local Meilisearch, 5. Seed Meilisearch, 6. Start dev servers, 7. Verify setup, Dev login bypass (+3 more)
 
-### Community 242 - "isLocalHostValue"
+### Community 242 - "Product Context"
 Cohesion: 0.18
 Nodes (11): CTA Vocabulary, Entity Page Questions, Explore Research, Navigation Shape, North Star, Planning Context, Primary Surfaces, Product Context (+3 more)
 
@@ -1349,189 +1347,181 @@ Nodes (11): CTA Vocabulary, Entity Page Questions, Explore Research, Navigation 
 Cohesion: 0.18
 Nodes (11): Canonical Product Frame, Current Interface Shape, Graphify Grounding, `/listings`, Near-Term UX Moves, Open UX Questions, `/research`, `/research/:slug` (+3 more)
 
-### Community 244 - "LEGACY_EXPLORATORY_CONTACT_PATHWAY_DERIVATION_KEYS"
+### Community 244 - "ensure-server-build-fresh.mjs"
 Cohesion: 0.18
 Nodes (8): buildDir, buildEntrypoint, forbiddenBuildArtifacts, freshnessInputs, repoRoot, serverRoot, sourceFileExtensions, sourceMtimeMs
 
-### Community 245 - "firstSentence"
+### Community 245 - "corsOrigin.ts"
 Cohesion: 0.29
 Nodes (8): CorsOriginCallback, CorsOriginError, createCorsOriginHandler(), isAllowedCorsOrigin(), normalizeCorsOrigin(), allowedOrigins, HandlerResult, runOriginHandler()
 
-### Community 246 - "loadCandidateCollisions"
+### Community 246 - "sanitizeMongo.ts"
 Cohesion: 0.40
 Nodes (9): hasUnsafeMongoShape(), isPlainObject(), isUnsafeMongoKey(), PROTOTYPE_POLLUTION_KEYS, sanitizeMongo(), scrub(), invokeRejected(), invokeSanitize() (+1 more)
 
-### Community 247 - "entityMaterializer.test.ts"
+### Community 247 - "staleObservationConflictReview.test.ts"
 Cohesion: 0.25
 Nodes (8): assertStaleObservationConflictReviewApplyAllowed(), buildStaleObservationConflictReviewOutput(), buildStaleObservationDecisionTemplate(), main(), normalizeStaleObservationObjectId(), toObjectId(), writeStaleObservationConflictReviewOutput(), writeStaleObservationDecisionTemplate()
 
-### Community 248 - "backfillCenterDirectors.ts"
+### Community 248 - "Architecture"
 Cohesion: 0.18
 Nodes (10): Architecture, Commands, Environments, External integrations, Key services, Naming conventions, Repo map, Routes (+2 more)
 
-### Community 249 - "programClassifier.ts"
+### Community 249 - "listingFormReducer.ts"
 Cohesion: 0.31
 Nodes (7): createInitialListingFormState(), ListingFormAction, ListingFormErrors, listingFormReducer(), ListingFormState, researchAreasFromListing(), resolve()
 
-### Community 250 - "seed.ts"
+### Community 250 - "Scraper Deployment Runbook"
 Cohesion: 0.20
 Nodes (10): Compact Observation Retention, Cost Controls, Data Flow, Goal, Operating Model, Recurring Refresh, Report Checklist, Rollback (+2 more)
 
-### Community 251 - "index.ts"
+### Community 251 - "devDependencies"
 Cohesion: 0.20
 Nodes (10): devDependencies, eslint, eslint-config-prettier, eslint-plugin-react, eslint-plugin-react-hooks, globals, playwright, prettier (+2 more)
 
-### Community 252 - "seedResearchAreas.ts"
+### Community 252 - "resolutions"
 Cohesion: 0.20
 Nodes (10): resolutions, axios, brace-expansion, form-data, path-to-regexp, shell-quote, underscore, undici (+2 more)
 
-### Community 253 - "fellowships.tsx"
-Cohesion: 0.31
-Nodes (9): isPaperAuthorshipEvidence(), isPaperAuthorshipSource(), isPaperMetadataOnlySource(), normalizePaperAuthorshipEvidence(), PAPER_AUTHORSHIP_METHODS, PAPER_AUTHORSHIP_SOURCE_NAMES, PAPER_METADATA_ONLY_SOURCE_NAMES, PaperAuthorshipEvidence (+1 more)
+### Community 253 - "paperAuthorshipPolicy.ts"
+Cohesion: 0.27
+Nodes (10): authorshipEvidenceFromPaperObservations(), isPaperAuthorshipEvidence(), isPaperAuthorshipSource(), isPaperMetadataOnlySource(), normalizePaperAuthorshipEvidence(), PAPER_AUTHORSHIP_METHODS, PAPER_AUTHORSHIP_SOURCE_NAMES, PAPER_METADATA_ONLY_SOURCE_NAMES (+2 more)
 
-### Community 254 - "securityHeaders.ts"
+### Community 254 - "importFaculty.ts"
 Cohesion: 0.31
 Nodes (9): cleanPrimaryDepartment(), cleanSecondaryDepartments(), hasPathPrefix(), importFaculty(), KNOWN_DEPARTMENTS, RawFacultyEntry, resolveSafeFacultyImportJsonPath(), SORTED_KNOWN_DEPTS (+1 more)
 
-### Community 255 - "dir"
+### Community 255 - "launchAcquisitionReport.ts"
 Cohesion: 0.38
 Nodes (7): buildLaunchAcquisitionReportOutput(), LaunchAcquisitionReportCliOptions, main(), parseLaunchAcquisitionReportArgs(), parsePositiveInteger(), writeLaunchAcquisitionReportOutput(), LaunchAcquisitionReportOptions
 
-### Community 256 - "leadMemberDisplayName"
+### Community 256 - "departmentResolver.ts"
 Cohesion: 0.31
 Nodes (8): cache, canonicalizeDepartment(), CanonicalizeResult, DepartmentRow, loadCache(), normalize(), registerDepartmentAlias(), tokenJaccard()
 
-### Community 257 - "environment.ts"
+### Community 257 - "researchAreaResolver.ts"
 Cohesion: 0.31
 Nodes (8): cache, canonicalizeResearchArea(), CanonicalizeResult, loadCache(), normalize(), registerResearchAreaAlias(), ResearchAreaRow, tokenJaccard()
 
-### Community 258 - "sourceReviewDecisionHandoffs"
+### Community 258 - "EvidenceSourceRow.tsx"
 Cohesion: 0.39
 Nodes (7): EvidenceSourceRow(), EvidenceSourceRowProps, formatConfidence(), formatDate(), formatSourceType(), labelize(), EvidenceSourceRowData
 
-### Community 259 - "dependencies"
+### Community 259 - "buildCandidateSample"
 Cohesion: 0.22
 Nodes (9): buildCandidateSample(), buildReviewQueues(), compareObservationsByNewest(), formatOptionalDate(), observedAtMs(), previewValue(), reviewCategoryForField(), reviewQueueForCategory() (+1 more)
 
-### Community 260 - "sourceReviewDecisionValidationProbeCommands"
+### Community 260 - "buildStaleObservationConflictSummary"
 Cohesion: 0.22
 Nodes (9): buildCategoryCounts(), buildFieldCounts(), buildPolicyBucketCounts(), buildStaleObservationConflictSummary(), buildSupersessionPlan(), compareSamplesForReview(), matchesReviewFilters(), policyBucketForCategory() (+1 more)
 
-### Community 261 - "departmentGroundTruth.test.ts"
+### Community 261 - "testFixturePrivacy.test.ts"
 Cohesion: 0.31
 Nodes (8): localPartIsSynthetic(), REAL_FIXTURE_PATTERNS, ROOT, SELF, SOURCE_ROOTS, SYNTHETIC_YALE_TOKENS, testFiles(), walk()
 
-### Community 262 - "applyProfileResearchAreasForIndexDocument"
+### Community 262 - "manifest.json"
 Cohesion: 0.25
 Nodes (7): background_color, display, icons, name, short_name, start_url, theme_color
 
-### Community 263 - "csv"
+### Community 263 - "Available Scripts"
 Cohesion: 0.25
 Nodes (7): Available Scripts, Getting Started with Create React App, Learn More, `npm run build`, `npm run eject`, `npm start`, `npm test`
 
-### Community 264 - "entryToMemberObservations"
+### Community 264 - "departmentGroundTruth.test.ts"
 Cohesion: 0.32
 Nodes (6): DepartmentCategory, DepartmentCodeSystem, departmentSourceUrls, validateDepartmentRows(), __dirname, fixtureByUrl
 
-### Community 265 - "dir"
+### Community 265 - "package.json"
 Cohesion: 0.25
 Nodes (7): author, license, main, name, packageManager, repository, version
 
-### Community 266 - "repairListingResearchEntityProfiles.ts"
+### Community 266 - "observation"
 Cohesion: 0.32
 Nodes (8): observation(), buildCandidateSample(), buildValuePreviewsBySource(), observedAtForResolver(), policyBucketForConflict(), previewValue(), reviewCategoryForField(), toResolverObservation()
 
-### Community 267 - "CanonicalDepartmentListResult"
-Cohesion: 0.46
-Nodes (5): addFavorite(), addView(), ItemMutationFilter, normalizeItemObjectId(), removeFavorite()
+### Community 267 - "researchGroupFilters.ts"
+Cohesion: 0.33
+Nodes (6): acceptanceLevelClauses(), AcceptanceLevelInput, buildResearchGroupFilterString(), escapeMeiliFilterValue(), orEqualsClause(), ResearchGroupFilterInput
 
-### Community 268 - "ArtifactFreshnessStrip"
-Cohesion: 0.32
-Nodes (8): dedupeSameNameLeadMembers(), departmentMatchScore(), memberEvidenceScore(), normalizedMemberName(), normalizedWordsForMatch(), SAME_PERSON_LEAD_ROLE_PRIORITY, samePersonLeadRoleKey(), shouldCollapseSamePersonLeadRoles()
+### Community 268 - "useFavorites.ts"
+Cohesion: 0.38
+Nodes (5): mockedAxios, mockedSwal, Endpoints, FavoritesKind, useFavorites()
 
-### Community 269 - "MockBroadcastChannel"
+### Community 269 - "check-no-secrets-core.mjs"
 Cohesion: 0.43
 Nodes (5): findSecretFindings(), isAllowedPlaceholder(), lineNumberForIndex(), PLACEHOLDER_PATTERNS, SECRET_RULES
 
-### Community 270 - "Product Context"
+### Community 270 - "security-preflight.test.mjs"
 Cohesion: 0.29
 Nodes (6): ciWorkflow, keepAliveWorkflow, packageJson, productionSecuritySmokeWorkflow, renderBlueprint, yarnrc
 
-### Community 271 - "1. Admin And Search Gates"
-Cohesion: 0.29
-Nodes (7): applyStaleObservationSupersessions(), buildMongoFieldFilter(), defaultStaleObservationApplyDeps(), loadSameSourceConflictGroups(), mongoFieldFilterForCategory(), runStaleObservationConflictReview(), stringifyId()
+### Community 271 - "contactEmail.ts"
+Cohesion: 0.70
+Nodes (3): isPublicInstitutionalEmailDomain(), PUBLIC_CONTACT_EMAIL_DOMAINS, publicContactEmail()
 
-### Community 272 - "apiBaseUrl.ts"
+### Community 272 - "adminTableReducer.test.ts"
 Cohesion: 0.33
 Nodes (4): Filter, makeState(), Row, Sort
 
-### Community 274 - "sourceReviewDecisionValidationLines"
+### Community 274 - "copyBetaToProd.ts"
 Cohesion: 0.53
 Nodes (5): closeAll(), DEFAULT_EXCLUDED, flush(), main(), parseList()
 
-### Community 275 - "spreadsheetSafety.ts"
+### Community 275 - "main"
 Cohesion: 0.60
 Nodes (5): status(), blocked_reason(), fail(), is_blocked(), main()
 
-### Community 276 - "summary"
+### Community 276 - "parseStaleObservationConflictReviewArgs"
 Cohesion: 0.47
 Nodes (6): consumeValue(), parsePositiveIntegerValue(), parseRequiredString(), parseReviewCategory(), parseReviewQueue(), parseStaleObservationConflictReviewArgs()
 
-### Community 277 - "trustedLeadResearchHomeBioFallback"
+### Community 277 - "normalizeAcceptedDecisionValidation"
 Cohesion: 0.53
 Nodes (6): copyFiniteNumber(), normalizeAcceptedDecisionValidation(), normalizeDecisionHandoff(), normalizeDuplicateNamePreflight(), normalizeSamePiDedupeReview(), normalizeSamePiDedupeReviewBreakdown()
 
-### Community 278 - "README.md"
-Cohesion: 0.67
-Nodes (4): buildSafeSearchRegex(), escapeRegex(), normalizeRegexOptions(), SAFE_REGEX_OPTIONS
+### Community 278 - "researchAreas.ts"
+Cohesion: 0.17
+Nodes (9): hasDirectContactInfo(), router, invokeRouteHandler(), mocks, routesByPath(), buildSafeSearchRegex(), escapeRegex(), normalizeRegexOptions() (+1 more)
 
-### Community 279 - "paragraphs"
+### Community 279 - "Contributing: endpoints, pages, schema"
 Cohesion: 0.33
 Nodes (5): Adding a new endpoint, Adding a new page, Contributing: endpoints, pages, schema, General implementation rules, Modifying a schema
 
-### Community 280 - "opportunity.ts"
+### Community 280 - "Scrapers"
 Cohesion: 0.33
 Nodes (5): Active source scrapers (`server/src/scrapers/sources/`), Core rule: evidence-first, Infrastructure files, Safety rules (write guards), Scrapers
 
-### Community 281 - "README.md"
+### Community 281 - "Search and Data"
 Cohesion: 0.33
 Nodes (5): Data shape rules, Default `/research` ordering, Meilisearch indexes, Rebuild commands, Search and Data
 
-### Community 282 - "BackfillV4Grants.ts"
+### Community 282 - "checker.py"
 Cohesion: 0.60
 Nodes (4): load_env(), main(), normalize(), Lowercase, strip whitespace and punctuation for fuzzy matching.
 
-### Community 283 - "isLikelyPersonUrl"
+### Community 283 - "dependencies"
 Cohesion: 0.40
 Nodes (5): dependencies, concurrently, dotenv, mongoose, openai
 
-### Community 284 - "sanitizeMongo.ts"
+### Community 284 - "normalizeCrossSourceReviewDecision"
 Cohesion: 0.70
 Nodes (5): asString(), asStringArray(), normalizeCrossSourceReviewDecision(), normalizeObservationIdsBySource(), optionalString()
 
-### Community 285 - "index.ts"
+### Community 285 - "loadCrossSourceConflictGroups"
 Cohesion: 0.60
 Nodes (5): loadCrossSourceConflictGroups(), loadObservationsForGroupKey(), observationCollection(), serializeValue(), stringifyId()
 
-### Community 286 - "OfficialProfilePublicationValue"
+### Community 286 - "normalizeStaleObservationReviewDecision"
 Cohesion: 0.50
 Nodes (5): asString(), asStringArray(), normalizeStaleObservationReviewDecision(), optionalString(), readStaleObservationReviewDecisions()
 
-### Community 288 - ".run"
+### Community 288 - "with-playwright-libs.sh"
 Cohesion: 0.67
 Nodes (3): install_libs(), LD_LIBRARY_PATH, with-playwright-libs.sh script
 
-### Community 289 - "researchEntityRelationship.ts"
-Cohesion: 0.50
-Nodes (3): researchEntityRelationshipSchema, ResearchEntityRelationshipType, researchEntityRelationshipTypes
-
-### Community 290 - "corsOrigin.ts"
-Cohesion: 0.50
-Nodes (4): sameStringSet(), StaleObservationConflictObservation, validateStaleObservationReviewDecision(), validateStaleObservationReviewDecisions()
-
-### Community 300 - "testFixturePrivacy.test.ts"
-Cohesion: 0.67
-Nodes (3): asString(), asStringArray(), normalizeLoadedUser()
+### Community 290 - "runStaleObservationConflictReview"
+Cohesion: 0.29
+Nodes (7): applyStaleObservationSupersessions(), defaultStaleObservationApplyDeps(), runStaleObservationConflictReview(), sameStringSet(), StaleObservationConflictObservation, validateStaleObservationReviewDecision(), validateStaleObservationReviewDecisions()
 
 ## Knowledge Gaps
 - **2205 isolated node(s):** `name`, `version`, `private`, `node`, `@emotion/react` (+2200 more)
@@ -1541,17 +1531,17 @@ Nodes (3): asString(), asStringArray(), normalizeLoadedUser()
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `sanitizeLogValue()` connect `security-preflight.test.mjs` to `labDetail.tsx`, `departmentRosterScraper.ts`, `labDetail.ts`, `researchGroupService.ts`, `UserContext.ts`, `index.ts`, `sanitizeLogValue`, `passport.ts`, `Navbar.tsx`, `undergradFellowshipRecipientScraper.ts`, `app.ts`, `admin.ts`, `researchDiscoveryAdapters.ts`, `advisees`, `launchAcquisitionReportService.ts`, `profileDataQualityAudit.ts`, `centersInstitutesScraper.ts`, `types.tsx`, `buildUserBioObservationScore`, `userService.ts`, `researchAnalytics.ts`, `betaDataQualityCore.ts`, `scripts`, `productionPromotionSmoke.mjs`, `opportunityDetailService.ts`, `staleObservationConflictReview.ts`, `betaDataQuality.ts`, `studentVisibilityTier.ts`, `listingController.ts`, `acceptedInputsCore.ts`, `serializedDocumentId`, `researchEntityEvidenceCoverage.ts`, `fellowshipMatchingService.ts`, `fellowshipInputs.ts`, `repairOfficialProfilePublicationPointers.ts`, `analytics.ts`, `SavedPathwaysSection.tsx`, `departmentUndergradResearchScraper.ts`, `pathwaySearchIndexService.ts`, `adminOperatorBoardService.ts`, `Listing`, `promoteAcceptedBetaCopy.ts`, `paperAuthorshipAudit.ts`, `Observation`, `devDependencies`, `Per-Source Audit Playbooks`, `assertPublicHttpUrl`, `studentDecisionLLMExtractor.ts`, `backfillProfileBiosFromOfficialUrls.ts`, `rebuildPathwaySearchIndex.ts`, `dedupeUsersByIdentityCore.ts`, `buildAdminOperatorBoard`, `analytics.tsx`, `officialProfilePiBackfillScraper.ts`, `pathwaySearchService.ts`, `renderedFetch.ts`, `BackfillV4FacultyMembers.ts`, `assessment`, `yaleCollegeFellowshipsOfficeScraper.ts`, `pathwayQualityAudit.ts`, `normalizeProfileUpdateForStorage`, `yaleResearchOfficialScraper.ts`, `fellowshipController.ts`, `ListingDetailModal.tsx`, `pathwayController.ts`, `dir`, `launchReviewExceptions.ts`, `adminRender`, `research-detail-professor-audit.mjs`, `ImportRootDataFiles.ts`, `candidateDescriptionCrawlUrls`, `applicationRoutePathwayBackfillCore.ts`, `generateKeywords.ts`, `profileBioCoverageAudit.ts`, `cli.ts`, `AdminFellowshipsTable.tsx`, `crossSourceObservationConflictReview.ts`, `migrateResearchEntities.ts`, `abstractBios`, `researchEntity.ts`, `migrateResearchEntityCollections.ts`, `researchGroupController.ts`, `externalIdsSchema`, `disambiguateSurnameLabNames.ts`, `repairDuplicateAccessSignals.ts`, `LIVE`, `normalizeOfficialProfileUrl`, `axios.ts`, `v4MigrationUtils.ts`, `researchEntityPiDedupeCore.ts`, `staleObservationConflictReview.test.ts`, `launchTrustContract.ts`, `EvidenceSourceRow.tsx`, `resolveSafeJsonReportOutputPath`, `users.ts`, `unified-research-search-audit.mjs`, `index.ts`, `AdminOperatorBoard`, `repairProfileDescriptionBackfillConflicts.ts`, `clearBetaStudentAnalytics.ts`, `actor`, `programs.ts`, `crossrefFreeFullText`, `sourceHealthService.ts`, `listings.ts`, `securityHeaders.ts`, `dir`?**
-  _High betweenness centrality (0.128) - this node is a cross-community bridge._
-- **Why does `field()` connect `assertPublicHttpUrl` to `labDetail.tsx`, `sourceReviewDecisionValidationProbeCommands`, `labDetail.ts`, `applicationRoutePathwayBackfillCore.ts`, `types.ts`, `index.ts`, `integrityGate.ts`, `migrateResearchEntities.ts`, `researchDiscoveryAdapters.ts`, `researchQualitySearchReview.ts`, `advisees`, `profileDataQualityAudit.ts`, `centersInstitutesScraper.ts`, `buildUserBioObservationScore`, `userService.ts`, `normalizeOfficialProfileUrl`, `researchEntityCoverageAudit.ts`, `programController.ts`, `Active Detail Docs`, `scripts`, `staleObservationConflictReview.ts`, `AdminProfileEditModal.tsx`, `researchEntityEvidenceCoverage.ts`, `postedOpportunityService.ts`, `analytics.ts`, `acronymExpansion`, `dedupeUsersByIdentityCore.ts`, `BackfillV4FacultyMembers.ts`, `betaRepairQueue.ts`?**
-  _High betweenness centrality (0.080) - this node is a cross-community bridge._
-- **Why does `member()` connect `repairArchivedEntityArtifacts.ts` to `applyProfileResearchAreaFallback`, `backfillProfileBiosFromOfficialUrls.ts`, `EvidenceSourceRow.tsx`, `departmentRosterScraper.ts`, `AdminDepartments.tsx`, `ArtifactFreshnessStrip`, `researchEntitySearchIndexService.ts`, `accessMaterializer.ts`, `researchEntity.ts`, `crossSourceObservationConflictReview.ts`, `Yale Research - Developer Guide`, `app.ts`, `devDependencies`, `fellowshipController.ts`?**
-  _High betweenness centrality (0.076) - this node is a cross-community bridge._
+- **Why does `sanitizeLogValue()` connect `sanitizeLogValue` to `types.ts`, `departmentRosterScraper.ts`, `labMicrositeUndergradLLMExtractor.ts`, `duplicateEntityNameReview.ts`, `listingController.ts`, `betaDataQuality.ts`, `resolveSafeJsonReportOutputPath`, `dedupeResearchEntitiesByPi.ts`, `listingService.ts`, `profileDataQualityAudit.ts`, `researchGroupService.ts`, `researchQualitySearchReview.ts`, `passport.ts`, `labMicrositeDescriptionLLMExtractor.ts`, `sourceHealth.ts`, `analyticsService.ts`, `userService.ts`, `runReport.ts`, `User`, `scholarlyLinkSuppressionAudit.ts`, `admin.ts`, `officialProfilePiBackfillScraper.ts`, `yaleCollegeFellowshipsOfficeScraper.ts`, `paperAuthorshipAudit.ts`, `entryPathwayService.ts`, `applicationRoutePathwayBackfillCore.ts`, `serializedDocumentId`, `entityMaterializer.ts`, `officialProfilePiBackfillScraper.test.ts`, `undergradFellowshipRecipientScraper.ts`, `crossSourceObservationConflictReview.ts`, `researchEntityMemberReferenceAudit.ts`, `seedSources.ts`, `repairOfficialProfilePublicationPointers.ts`, `configService.ts`, `backfillProfileBiosFromOfficialUrls.ts`, `departmentLeadRepairPlanCore.ts`, `cli.ts`, `ScraperContext`, `studentVisibilityRepairTargets.ts`, `opportunityDetailService.ts`, `programController.ts`, `centersInstitutesScraper.ts`, `studentDecisionLLMExtractor.ts`, `field`, `researchEntityCoverageAudit.ts`, `analytics.ts`, `openAlexPaperScraper.ts`, `postedOpportunityService.ts`, `assertPublicHttpUrl`, `arxivPreprintScraper.ts`, `launchTrustContractService.ts`, `pathwayQualityAudit.ts`, `promoteAcceptedBetaCopy.ts`, `profileController.ts`, `logSanitizer.ts`, `migrateResearchEntityCollections.ts`, `migrateResearchEntities.ts`, `disambiguateSurnameLabNames.ts`, `repairDuplicateAccessSignals.ts`, `fellowshipController.ts`, `repairArchivedEntityArtifacts.ts`, `repairMismatchedPersonEmailsCore.ts`, `errorHandler.ts`, `cronRunner.ts`, `entityMaterializer.test.ts`, `userEmailHygiene.ts`, `paperQualityService.ts`, `profileBioCoverageAudit.ts`, `initializeConnections`, `staleObservationConflictReview.ts`, `researchGroupController.ts`, `cleanupLegacyMongoCollections.ts`, `launchReviewExceptions.ts`, `ResearchGroupMember`, `materializePaperObservationsFromRun`, `migrateMongoNaming.ts`, `repairProfileDescriptionBackfillConflicts.ts`, `redactDirectContactInfo`, `betaSeedEnvironment.ts`, `betaReadinessGate.ts`, `auditResearchEntityRename.ts`, `backfillPostedOpportunitiesFromListings.ts`, `acceptedInputs.ts`, `claimGate.ts`, `scraperIntegrityDuplicateReview.ts`, `clearBetaStudentAnalytics.ts`, `assertScriptApplyAllowed`, `materializeEntity`, `backfillResearchDescriptions.ts`, `backfillResearchHomeOfficialUrls.ts`, `backfillCenterDirectors.ts`, `betaRepairQueue.ts`, `pathwayRelevanceReview.ts`, `users.ts`, `dedupeExploratoryContactPathways.ts`, `repairListingResearchEntityProfiles.ts`, `scraperIntegrityGate.ts`, `programs.ts`, `backfillProgramClassifications.ts`, `listings.ts`, `refreshGateScorecards.ts`, `fellowships.ts`, `importFaculty.ts`, `launchAcquisitionReport.ts`, `researchAreas.ts`?**
+  _High betweenness centrality (0.129) - this node is a cross-community bridge._
+- **Why does `field()` connect `field` to `types.ts`, `buildStaleObservationConflictSummary`, `labMicrositeUndergradLLMExtractor.ts`, `safeHttpUrl`, `initializeConnections`, `betaDataQuality.ts`, `acceptedInputsCore.ts`, `labMicrositeDescriptionLLMExtractor.ts`, `cleanPublicHttpUrl`, `sourceHealth.ts`, `integrityGate.ts`, `analyticsService.ts`, `runReport.ts`, `User`, `scraperIntegrityDuplicateReview.ts`, `ImportRootDataFiles.ts`, `visibilityRepairQueueService.ts`, `adminListingsTableReducer.ts`, `index.ts`, `officialProfilePiBackfillScraper.ts`, `entryPathwayService.ts`, `AdminFacultyProfilesTable.tsx`, `materializeEntity`, `crossSourceObservationConflictReview.ts`, `fellowshipService.ts`, `AdminFellowshipsTable.tsx`, `openAlexPaperScraper.ts`, `confidenceResolver.ts`, `arxivPreprintScraper.ts`, `promoteAcceptedBetaCopy.ts`, `listingClaimRequestService.ts`, `betaDataQualityCore.test.ts`?**
+  _High betweenness centrality (0.081) - this node is a cross-community bridge._
+- **Why does `member()` connect `textValue` to `research-detail-professor-audit.mjs`, `departmentRosterScraper.ts`, `labDetail.ts`, `profileBioCoverageAudit.ts`, `labDetail.tsx`, `Observation`, `studentVisibilityTier.ts`, `ResearchGroupMember`, `researchEntitySearchIndexService.ts`, `researchGroupService.ts`, `researchQualitySearchReview.ts`, `centersInstitutesScraper.ts`, `disambiguateSurnameLabNames.ts`?**
+  _High betweenness centrality (0.075) - this node is a cross-community bridge._
 - **What connects `name`, `version`, `private` to the rest of the system?**
   _2207 weakly-connected nodes found - possible documentation gaps or missing edges._
-- **Should `Decisions` be split into smaller, more focused modules?**
-  _Cohesion score 0.03947583947583948 - nodes in this community are weakly interconnected._
-- **Should `labDetail.tsx` be split into smaller, more focused modules?**
-  _Cohesion score 0.04728317659352142 - nodes in this community are weakly interconnected._
-- **Should `browsable.ts` be split into smaller, more focused modules?**
-  _Cohesion score 0.03753501400560224 - nodes in this community are weakly interconnected._
+- **Should `types.tsx` be split into smaller, more focused modules?**
+  _Cohesion score 0.04647160068846816 - nodes in this community are weakly interconnected._
+- **Should `types.ts` be split into smaller, more focused modules?**
+  _Cohesion score 0.05092592592592592 - nodes in this community are weakly interconnected._
+- **Should `UserContext.ts` be split into smaller, more focused modules?**
+  _Cohesion score 0.04245614035087719 - nodes in this community are weakly interconnected._

--- a/server/src/services/__tests__/researchGroupService.test.ts
+++ b/server/src/services/__tests__/researchGroupService.test.ts
@@ -276,17 +276,26 @@ describe('searchResearchGroupsViaMeili', () => {
     mocks.search.mockResolvedValueOnce({
       hits: [],
       estimatedTotalHits: 0,
+      facetDistribution: {
+        school: { 'Yale College': 3 },
+        departments: { 'Computer Science': 2 },
+      },
     });
 
-    await searchResearchGroupsViaMeili('AI', {}, 1, 24);
+    const result = await searchResearchGroupsViaMeili('AI', {}, 1, 24);
 
     expect(mocks.search).toHaveBeenCalledWith(
       'artificial intelligence machine learning deep learning ai',
       expect.objectContaining({
         attributesToSearchOn: ['studentSearchTerms', 'researchAreas', 'keywords', 'departments'],
+        facets: ['school', 'departments'],
       }),
     );
     expect(mocks.search.mock.calls[0][1]).not.toHaveProperty('hybrid');
+    expect(result.facetDistribution).toEqual({
+      school: { 'Yale College': 3 },
+      departments: { 'Computer Science': 2 },
+    });
   });
 
   it('strips professor noise while preserving faculty surname searches', async () => {

--- a/server/src/services/researchGroupService.ts
+++ b/server/src/services/researchGroupService.ts
@@ -247,6 +247,7 @@ export interface ResearchGroupSearchResult {
   estimatedTotalHits: number;
   page: number;
   pageSize: number;
+  facetDistribution?: Record<string, Record<string, number>>;
   degraded?: boolean;
 }
 
@@ -602,6 +603,7 @@ export async function searchResearchGroupsViaMeili(
     filter: filterString,
     limit: safePageSize,
     offset,
+    facets: ['school', 'departments'],
   };
   if (sortConfig.length > 0) {
     searchParams.sort = sortConfig;
@@ -625,6 +627,7 @@ export async function searchResearchGroupsViaMeili(
   const searchWithFallbacks = async (): Promise<{
     hits?: any[];
     estimatedTotalHits?: number;
+    facetDistribution?: Record<string, Record<string, number>>;
   }> => {
     // Each attempt uses an immutable params object; degrading clones rather than
     // mutating, so already-issued calls keep the params they were sent.
@@ -656,6 +659,7 @@ export async function searchResearchGroupsViaMeili(
   let searchResult: {
     hits?: any[];
     estimatedTotalHits?: number;
+    facetDistribution?: Record<string, Record<string, number>>;
   };
   try {
     searchResult = await searchWithFallbacks();
@@ -670,7 +674,7 @@ export async function searchResearchGroupsViaMeili(
       safeOptions,
     );
   }
-  const { hits, estimatedTotalHits } = searchResult;
+  const { hits, estimatedTotalHits, facetDistribution } = searchResult;
 
   const hitIds = (hits || [])
     .map((hit: any) => hit.id || hit._id)
@@ -723,6 +727,7 @@ export async function searchResearchGroupsViaMeili(
       estimatedTotalHits: estimatedTotalHits ?? normalizedHits.length,
       page: safePage,
       pageSize: safePageSize,
+      facetDistribution,
     },
     { includeOperatorFields: safeOptions.includeNonPublic },
   );
@@ -772,6 +777,18 @@ const researchEntityMatchesQuery = (entity: any, query: string): boolean => {
     if (aliases) return aliases.some((alias) => haystackHasTerm(haystack, alias));
     return haystackHasTerm(haystack, token);
   });
+};
+
+const facetCounts = (entities: any[], field: string): Record<string, number> => {
+  const counts: Record<string, number> = {};
+  for (const entity of entities) {
+    const values = Array.isArray(entity?.[field]) ? entity[field] : [entity?.[field]];
+    for (const value of new Set(values)) {
+      if (typeof value !== 'string' || !value.trim()) continue;
+      counts[value] = (counts[value] || 0) + 1;
+    }
+  }
+  return counts;
 };
 
 const sortResearchEntitiesForMongoFallback = (
@@ -831,6 +848,10 @@ const searchResearchGroupsViaMongoFallback = async (
   const visibleCandidates = (candidates as any[]).filter((entity) =>
     researchEntityMatchesQuery(entity, trimmedQuery),
   );
+  const facetDistribution = {
+    school: facetCounts(visibleCandidates, 'school'),
+    departments: facetCounts(visibleCandidates, 'departments'),
+  };
   const sortedCandidates = sortResearchEntitiesForMongoFallback(
     visibleCandidates,
     trimmedQuery,
@@ -861,6 +882,7 @@ const searchResearchGroupsViaMongoFallback = async (
       estimatedTotalHits: sortedCandidates.length,
       page: safePage,
       pageSize: safePageSize,
+      facetDistribution,
       degraded: true,
     },
     { includeOperatorFields: options.includeNonPublic },


### PR DESCRIPTION
## Summary

- Add accessible school, department, and undergraduate-evidence filters to research search results.
- Persist facet selections in shareable URLs and restore them with search state.
- Return school and department facet distributions from Meilisearch and Mongo fallback while preserving totals and pagination.
- Keep readiness, quality, and visibility controls admin-only.

## Evidence model

The undergraduate-evidence filter reuses the existing conservative verified-or-likely predicate: explicit undergraduate acceptance, independent-study availability, or a positive current-undergraduate count. It does not invent an unpopulated field.

## Validation

- Client: 94 files, 762 tests passed
- Server: 218 files, 2526 tests passed
- Server TypeScript check passed
- Server and client production builds passed
- Graphify refreshed

Repo-wide lint remains baseline-red with 24 pre-existing errors outside this change; changed files introduce no lint errors.