### PR TITLE
Activate verified ways in and reachable outreach

### DIFF
--- a/client/src/components/labs/LabInquireModal.tsx
+++ b/client/src/components/labs/LabInquireModal.tsx
@@ -8,7 +8,7 @@ import { ResearchGroup } from '../../types/researchGroup';
 import { LabContactRoute, LabMember } from '../../types/labDetail';
 import { isFacultyResearchEntity } from '../../utils/researchEntityCopy';
 import { resolveLabOutreachContact } from '../../utils/labOutreachContact';
-import { safeMailtoHref } from '../../utils/url';
+import { safeHttpUrl, safeMailtoHref } from '../../utils/url';
 
 interface LabInquireModalProps {
   isOpen: boolean;
@@ -16,6 +16,7 @@ interface LabInquireModalProps {
   group: ResearchGroup;
   members: LabMember[];
   contactRoutes?: LabContactRoute[];
+  onOfficialRouteOpen?: () => void;
 }
 
 const LabInquireModal = ({
@@ -24,6 +25,7 @@ const LabInquireModal = ({
   group,
   members,
   contactRoutes = [],
+  onOfficialRouteOpen,
 }: LabInquireModalProps) => {
   if (!isOpen) return null;
 
@@ -38,6 +40,10 @@ const LabInquireModal = ({
       }.\n\nA bit about me:\n  - Year & major:\n  - Relevant coursework:\n  - Why this research home:\n\nWould you have time to chat in the next couple of weeks?\n\nThank you,\n`
     : '';
   const mailto = contact ? safeMailtoHref(contact.email, { subject, body }) : '';
+  const officialRoute = contactRoutes.find(
+    (route) => route.reviewStatus === 'approved' && safeHttpUrl(route.url),
+  );
+  const officialRouteUrl = safeHttpUrl(officialRoute?.url);
 
   const handleBackdropClick = (e: React.MouseEvent) => {
     if (e.target === e.currentTarget) onClose();
@@ -79,10 +85,27 @@ const LabInquireModal = ({
         </div>
 
         <div className="px-6 py-5 space-y-4">
-          {!contact ? (
+          {!contact ? officialRouteUrl ? (
+            <div className="space-y-3 text-sm text-gray-700">
+              <p>
+                Yale Research does not release a direct email for this profile. Use the approved
+                official route after reviewing its current instructions.
+              </p>
+              <div className="rounded-md border border-[var(--yr-line)] bg-[var(--yr-panel-muted)] p-3">
+                <p className="font-semibold text-gray-900">
+                  {officialRoute?.label || 'Official contact route'}
+                </p>
+                {officialRoute?.rationale && <p className="mt-1">{officialRoute.rationale}</p>}
+                <p className="mt-2 text-xs text-gray-600">
+                  Personalize your note with your year, relevant coursework, and a specific
+                  connection to this research before submitting it.
+                </p>
+              </div>
+            </div>
+          ) : (
             <p className="text-sm text-gray-700">
-              We don't have a public contact email for this research home yet. Try the website
-              or check back later.
+              No verified contact route is available yet. Administrators review official sources
+              before a route appears here.
             </p>
           ) : (
             <>
@@ -124,6 +147,20 @@ const LabInquireModal = ({
               className="px-4 py-2 bg-blue-600 text-white text-sm font-semibold rounded-lg hover:bg-blue-700 transition-colors"
             >
               Open in email
+            </a>
+          )}
+          {!mailto && officialRouteUrl && (
+            <a
+              href={officialRouteUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => {
+                onOfficialRouteOpen?.();
+                onClose();
+              }}
+              className="px-4 py-2 bg-blue-600 text-white text-sm font-semibold rounded-lg hover:bg-blue-700 transition-colors"
+            >
+              Open approved route
             </a>
           )}
         </div>

--- a/client/src/components/labs/__tests__/LabInquireModal.test.tsx
+++ b/client/src/components/labs/__tests__/LabInquireModal.test.tsx
@@ -46,4 +46,32 @@ describe('LabInquireModal', () => {
     expect(screen.queryByText('lab-contact@example.edu?bcc=attacker@example.test')).toBeNull();
     expect(container.querySelector('a[href^="mailto:"]')).toBeNull();
   });
+
+  it('offers an approved official route without rendering an email', () => {
+    const onOfficialRouteOpen = vi.fn();
+    render(
+      <LabInquireModal
+        isOpen
+        onClose={vi.fn()}
+        group={baseGroup}
+        members={[]}
+        contactRoutes={[{
+          routeType: 'PROGRAM_MANAGER',
+          label: 'Undergraduate research contact form',
+          url: 'https://research.yale.edu/contact',
+          sourceUrl: 'https://research.yale.edu/about',
+          reviewStatus: 'approved',
+          visibility: 'PUBLIC',
+          contactPolicy: 'OFFICIAL_ROUTE_PREFERRED',
+        }]}
+        onOfficialRouteOpen={onOfficialRouteOpen}
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: 'Open approved route' });
+    expect(link.getAttribute('href')).toBe('https://research.yale.edu/contact');
+    link.click();
+    expect(onOfficialRouteOpen).toHaveBeenCalledOnce();
+    expect(document.querySelector('a[href^="mailto:"]')).toBeNull();
+  });
 });

--- a/client/src/pages/__tests__/research.test.tsx
+++ b/client/src/pages/__tests__/research.test.tsx
@@ -1138,9 +1138,11 @@ describe('Research page', () => {
   it('reveals one research-home result stream with inline ways-in context after a search', async () => {
     mockSearchResponses((url, body) => {
       if (body.q === 'protein folding') {
-        return url === '/research/search'
-          ? researchSearchResponse([{ ...researchEntity, waysIn: [pathwayHit] }])
-          : unexpectedSearchEndpoint(url);
+        if (url === '/research/search') return researchSearchResponse([researchEntity]);
+        if (url === '/pathways/search') {
+          return { data: { hits: [pathwayHit], estimatedTotalHits: 1, page: 1, pageSize: 12 } };
+        }
+        return unexpectedSearchEndpoint(url);
       }
 
       return url === '/research/search' ? researchSearchResponse() : unexpectedSearchEndpoint(url);
@@ -1160,7 +1162,7 @@ describe('Research page', () => {
         '1 research home, 1 contact',
       );
     });
-    expect(screen.getByRole('status').textContent).not.toContain('way in');
+    expect(screen.getAllByRole('status')[0].textContent).toContain('1 verified way in');
     expect(screen.queryByRole('link', { name: /Compare .*pathway/i })).toBeNull();
     expect(container.textContent).toContain('Research homes');
     expect(container.textContent).not.toContain('How to use this');
@@ -1179,8 +1181,10 @@ describe('Research page', () => {
     expect(container.textContent).toContain('Computer Science · Yale College');
     expect(container.textContent).not.toContain('Why it might fit');
     expect(container.textContent).not.toContain('Official Yale source found');
-    const searchSection = screen.getByLabelText('Search results');
-    const searchGrid = searchSection.querySelector('.grid.gap-3');
+    const researchHomesSection = screen
+      .getByRole('heading', { name: 'Research homes' })
+      .closest('section');
+    const searchGrid = researchHomesSection?.querySelector('.grid.gap-3');
     expect(searchGrid?.className).toContain('lg:grid-cols-2');
     expect(searchGrid?.className).toContain('2xl:grid-cols-[repeat(3,minmax(0,1fr))]');
     expect(searchGrid?.className).not.toContain('items-start');
@@ -1190,8 +1194,8 @@ describe('Research page', () => {
         .getAllByRole('link', { name: 'AI Safety Lab' })
       .some((link) => link.getAttribute('href') === '/research/ai-safety-lab'),
     ).toBe(true);
-    expect(container.textContent).toContain('Review source context');
-    expect(container.textContent).toContain('Source route');
+    expect(container.textContent).toContain('Verified ways in');
+    expect(screen.getByRole('link', { name: 'Review evidence' })).toBeTruthy();
     expect(container.textContent).not.toContain('Contact the program manager.');
 
     await waitFor(() => {
@@ -1255,12 +1259,13 @@ describe('Research page', () => {
 
     mockSearchResponses((url, body) => {
       if (body.q === 'machine learning') {
-        return url === '/research/search'
-          ? researchSearchResponse([
-              { ...researchEntity, waysIn: [postedPathway] },
-              nonMatchingEntity,
-            ])
-          : unexpectedSearchEndpoint(url);
+        if (url === '/research/search') {
+          return researchSearchResponse([researchEntity, nonMatchingEntity]);
+        }
+        if (url === '/pathways/search') {
+          return { data: { hits: [postedPathway], estimatedTotalHits: 1, page: 1, pageSize: 12 } };
+        }
+        return unexpectedSearchEndpoint(url);
       }
 
       return url === '/research/search' ? researchSearchResponse() : unexpectedSearchEndpoint(url);
@@ -1280,13 +1285,11 @@ describe('Research page', () => {
     expect(screen.queryByRole('button', { name: 'Thesis possible' })).toBeNull();
     expect(container.textContent).toContain('AI Safety Lab');
     expect(container.textContent).toContain('Archives Lab');
-    expect(container.textContent).toContain('Posted route');
+    expect(container.textContent).toContain('Verified ways in');
     expect(container.textContent).not.toContain('Open role');
     expect(container.textContent).not.toContain('Paid/funded');
     expect(container.textContent).not.toContain('Thesis fit');
-    expect(screen.getByRole('link', { name: 'View posted opportunity' }).getAttribute('href')).toBe(
-      '/opportunities/opportunity-1',
-    );
+    expect(screen.getByRole('link', { name: 'Review evidence' })).toBeTruthy();
     expect(container.textContent).not.toContain('Pathway Preview');
     expect(container.textContent).not.toContain('Compare pathways');
   });

--- a/client/src/pages/labDetail.tsx
+++ b/client/src/pages/labDetail.tsx
@@ -22,6 +22,7 @@ import {
 import LabHeader from '../components/labs/LabHeader';
 import LabMembersList from '../components/labs/LabMembersList';
 import LabPapersList from '../components/labs/LabPapersList';
+import LabInquireModal from '../components/labs/LabInquireModal';
 import LongText from '../components/shared/LongText';
 import FirstSaveCallout from '../components/shared/FirstSaveCallout';
 import FavoriteButton from '../components/shared/FavoriteButton';
@@ -979,10 +980,11 @@ const LabDetail = () => {
     undefined,
     () => createInitialLabDetailState(),
   );
-  const { payload, loading, error } = state;
+  const { payload, loading, error, isInquireModalOpen } = state;
   const requestIdRef = useRef(0);
   const fetchAbortRef = useRef<AbortController | null>(null);
   const [showResearchPlanSavedCallout, setShowResearchPlanSavedCallout] = useState(false);
+  const [outreachRecordError, setOutreachRecordError] = useState('');
   const {
     favIds: savedResearchPlanIds,
     setFavorite: setSavedResearchPlanFavorite,
@@ -1113,6 +1115,9 @@ const LabDetail = () => {
     contactRoutes,
     group,
   );
+  const approvedOutreachRoute = contactRoutes.find(
+    (route) => route.reviewStatus === 'approved' && Boolean(safeHttpUrl(route.url)),
+  );
   const principalInvestigators = dedupeLeadMembers(members);
   const membersById = new Map(members.map((member) => [memberId(member), member]));
   const primaryRecentWorkMember =
@@ -1172,6 +1177,36 @@ const LabDetail = () => {
             hasActivePostedOpportunity={hasActivePostedOpportunity}
             leadProfessor={principalInvestigators[0]}
           />
+
+          <section className="rounded-md border border-[var(--yr-line)] bg-[var(--yr-panel)] p-4">
+            <SectionHeading>Contact options</SectionHeading>
+            {approvedOutreachRoute ? (
+              <>
+                <p className="text-sm leading-relaxed text-gray-700">
+                  An administrator reviewed this official route and its source. Direct email is
+                  withheld; review the current instructions before contacting the research home.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setOutreachRecordError('');
+                    dispatch({ type: 'OPEN_INQUIRE_MODAL' });
+                  }}
+                  className="mt-3 inline-flex min-h-11 items-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+                >
+                  Prepare inquiry
+                </button>
+              </>
+            ) : (
+              <p className="text-sm leading-relaxed text-gray-700">
+                No verified contact route is available yet. Administrators must approve an
+                official source before outreach is enabled.
+              </p>
+            )}
+            {outreachRecordError && (
+              <p role="alert" className="mt-2 text-sm text-amber-800">{outreachRecordError}</p>
+            )}
+          </section>
 
           <section>
             <SectionHeading>Principal Investigator</SectionHeading>
@@ -1241,6 +1276,23 @@ const LabDetail = () => {
           )}
         </div>
       </div>
+
+      <LabInquireModal
+        isOpen={isInquireModalOpen}
+        onClose={() => dispatch({ type: 'CLOSE_INQUIRE_MODAL' })}
+        group={group}
+        members={members}
+        contactRoutes={contactRoutes}
+        onOfficialRouteOpen={() => {
+          axios.post(`/research/${safeRouteSegment(slug || '')}/outreach`, {}).catch((err) => {
+            setOutreachRecordError(
+              err?.response?.status === 401 || err?.response?.status === 403
+                ? 'Sign in with a student profile to record this outreach attempt.'
+                : 'The official route opened, but this outreach attempt was not recorded.',
+            );
+          });
+        }}
+      />
 
     </div>
   );

--- a/client/src/pages/research.tsx
+++ b/client/src/pages/research.tsx
@@ -1,6 +1,6 @@
 import { FormEvent, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { isCancel } from 'axios';
-import { useSearchParams } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 
 import ResearchHomeCard from '../components/research/ResearchHomeCard';
 import InfiniteScrollLoadingDots from '../components/shared/InfiniteScrollLoadingDots';
@@ -24,7 +24,9 @@ import useDocumentTitle from '../hooks/useDocumentTitle';
 import type {
   PathwaySearchFilters,
   PathwaySearchHit,
+  PathwaySearchResponse,
 } from '../types/pathway';
+import { safeHttpUrl, safeRouteSegment } from '../utils/url';
 
 interface DepartmentResearchHomeConfig {
   abbreviation?: string;
@@ -174,6 +176,19 @@ const searchResearchEntities = async (
   };
 };
 
+const searchStudentPathways = async (
+  q: string,
+  signal?: AbortSignal,
+  filters: ResearchSearchFilters = {},
+): Promise<PathwaySearchResponse> => {
+  const response = await axios.post<PathwaySearchResponse>(
+    '/pathways/search',
+    { q, page: 1, pageSize: 12, filters },
+    { signal },
+  );
+  return response.data;
+};
+
 const waysInFromResearchEntities = (researchEntities: ResearchEntity[]): PathwaySearchHit[] =>
   researchEntities.flatMap((entity) => (Array.isArray(entity.waysIn) ? entity.waysIn : []));
 
@@ -225,6 +240,9 @@ const resultSummary = (
   }
   if (results.papers.length > 0) {
     parts.push(`${pluralize(results.papers.length, 'paper')} via profiles`);
+  }
+  if (results.pathways.length > 0) {
+    parts.push(pluralize(results.pathways.length, 'verified way in', 'verified ways in'));
   }
   return parts.join(', ');
 };
@@ -546,24 +564,36 @@ const Research = () => {
     }
 
     try {
-      const researchEntitiesPage = await searchResearchEntities(
-        searchQuery.trim(),
-        24,
-        controller.signal,
-        filters,
-        1,
-        {
-          trustTierFilters: isAdmin ? trustTierFilters : [],
-          includeSuppressed: isAdmin && trustTierFilters.includes('suppressed'),
-        },
-      );
+      const [pathwayResult, researchEntitiesPage] = await Promise.all([
+        searchStudentPathways(searchQuery.trim(), controller.signal, filters)
+          .then((result) => ({ result, unavailable: false }))
+          .catch(() => ({
+            result: { hits: [], estimatedTotalHits: 0, page: 1, pageSize: 12 },
+            unavailable: true,
+          })),
+        searchResearchEntities(
+          searchQuery.trim(),
+          24,
+          controller.signal,
+          filters,
+          1,
+          {
+            trustTierFilters: isAdmin ? trustTierFilters : [],
+            includeSuppressed: isAdmin && trustTierFilters.includes('suppressed'),
+          },
+        ),
+      ]);
 
       if (requestId !== searchRequestIdRef.current || controller.signal.aborted) return;
 
       const researchEntities = researchEntitiesPage.researchEntities;
-      const pathways = waysInFromResearchEntities(researchEntities);
+      const pathways = pathwayResult.result.hits;
 
-      setSearchError('');
+      setSearchError(
+        pathwayResult.unavailable
+          ? 'Verified ways in are temporarily unavailable. Research profile results are still current.'
+          : '',
+      );
       setSearchResultResearchEntities(researchEntities);
       setSearchTotal(researchEntitiesPage.estimatedTotalHits);
       setSearchExhausted(isResearchEntitySearchExhausted(researchEntitiesPage));
@@ -619,11 +649,11 @@ const Research = () => {
 
       setSearchResultResearchEntities((current) => {
         const nextResearchEntities = [...current, ...visibleResearchEntities];
-        setGroupedResults(
+        setGroupedResults((currentResults) =>
           buildGroupedSearchResults({
             query: submittedQuery,
             researchEntities: nextResearchEntities,
-            pathways: waysInFromResearchEntities(nextResearchEntities),
+            pathways: currentResults.pathways,
             papers: [],
           }),
         );
@@ -941,7 +971,7 @@ const Research = () => {
             className="mt-2 max-w-2xl text-sm leading-relaxed text-slate-600 sm:mt-3 sm:text-base"
           >
             Search by interest, professor, course topic, method, or question. We&apos;ll help you
-            find relevant research profiles and possible next steps.
+            find relevant research profiles and verified ways in when the source evidence is strong enough.
           </p>
 
           <form onSubmit={onSubmit} className="mt-4 sm:mt-7">
@@ -1143,12 +1173,74 @@ const Research = () => {
 
             {searchError && (
               <div
-                role="alert"
+                role={searchError.startsWith('Verified ways in') ? 'status' : 'alert'}
                 className="mt-4 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900"
               >
                 {searchError}
               </div>
             )}
+
+            <section className="mt-5" aria-label="Verified ways in">
+              <SectionHeading>Verified ways in</SectionHeading>
+              {searchLoading && activeResults.pathways.length === 0 ? (
+                <ClusterLoadingCard />
+              ) : activeResults.pathways.length > 0 ? (
+                <div className="grid gap-3 lg:grid-cols-2">
+                  {activeResults.pathways.map((pathway) => {
+                    const sourceUrl = safeHttpUrl(
+                      pathway.evidence?.[0]?.sourceUrl || pathway.sourceUrls?.[0],
+                    );
+                    const entityName =
+                      pathway.researchEntity.displayName || pathway.researchEntity.name;
+                    return (
+                      <article
+                        key={pathway._id}
+                        className="yr-card rounded-md p-4"
+                      >
+                        <div className="flex flex-wrap items-center gap-2 text-xs font-semibold text-slate-600">
+                          <span>{pathway.evidenceStrength.toLowerCase()} evidence</span>
+                          {typeof pathway.confidence === 'number' && (
+                            <span>{Math.round(pathway.confidence * 100)}% confidence</span>
+                          )}
+                        </div>
+                        <h3 className="mt-2 text-base font-semibold text-slate-950">
+                          {pathway.studentFacingLabel}
+                        </h3>
+                        <p className="mt-1 text-sm text-slate-700">{entityName}</p>
+                        {pathway.explanation && (
+                          <p className="mt-2 text-sm leading-relaxed text-slate-600">
+                            {pathway.explanation}
+                          </p>
+                        )}
+                        <div className="mt-3 flex flex-wrap gap-2">
+                          <Link
+                            to={`/research/${safeRouteSegment(pathway.researchEntity.slug)}`}
+                            className="inline-flex min-h-11 items-center rounded-md bg-[var(--yr-blue)] px-3 py-2 text-sm font-semibold text-white"
+                          >
+                            Open research profile
+                          </Link>
+                          {sourceUrl && (
+                            <a
+                              href={sourceUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="inline-flex min-h-11 items-center rounded-md border border-[var(--yr-line-strong)] px-3 py-2 text-sm font-semibold text-slate-800"
+                            >
+                              Review evidence
+                            </a>
+                          )}
+                        </div>
+                      </article>
+                    );
+                  })}
+                </div>
+              ) : (
+                <EmptyGroup>
+                  No pathways meet the current evidence and confidence standard for this search.
+                  Research profiles may still provide useful planning context.
+                </EmptyGroup>
+              )}
+            </section>
 
             <section className="mt-5">
               <SectionHeading>Research homes</SectionHeading>

--- a/client/src/types/labDetail.ts
+++ b/client/src/types/labDetail.ts
@@ -145,6 +145,7 @@ export interface LabContactRoute {
   contactPolicy?: string;
   rationale?: string;
   sourceUrl?: string;
+  reviewStatus?: string;
 }
 
 export interface LabPostedOpportunity {

--- a/docs/research-model.md
+++ b/docs/research-model.md
@@ -430,6 +430,20 @@ Admins need a way to inspect derived access records before deeper editorial work
 
 Implementation note: `GET /api/admin/access-review` returns research entities with counts of related `EntryPathway`, `AccessSignal`, `ContactRoute`, and `PostedOpportunity` rows. `GET /api/admin/access-review/:id` returns the full derived access bundle for one entity. `PUT /api/admin/access-review/:id/manual-locks` updates manually locked entity fields, and record-level review endpoints update per-record status/notes/locks. The admin UI can inspect source evidence, update review state, manage locks, and filter records by review/evidence/contact/archive gaps before Beta.
 
+### Student publication readiness
+
+The existing admin role owns publication review for contact routes through the access-review surface.
+No additional privileged role is required.
+Student outreach is enabled only when a `ContactRoute` is `PUBLIC`, has an admin review status of `approved`, uses a policy other than `UNKNOWN` or `NO_DIRECT_CONTACT`, and has both a safe public destination URL and a safe public source URL.
+The public detail payload continues to omit route email fields, and the outreach endpoint repeats the policy check before recording an attempt.
+
+Student pathway search uses a deterministic minimum quality bar.
+A pathway must be `ACTIVE` or `RECURRING`, have `DIRECT`, `STRONG`, or `MODERATE` evidence, have confidence of at least `0.70`, and cite at least one safe public HTTP source.
+This threshold excludes the large 0.50-confidence exploratory-contact population while retaining stronger volunteer, recurring, and source-backed pathways for review in search.
+
+Before enabling or promoting the differentiator in an environment, administrators should work the contact-route queue in `/admin/access-review`, confirm that qualifying pathway counts are nonzero, rebuild the pathway index with `yarn --cwd server meili:rebuild-pathways`, and smoke-test `/research` plus one approved profile route.
+An empty result is a valid fail-closed state and should not be interpreted as proof that no undergraduate route exists.
+
 ## Product Vocabulary
 
 Use precise internal names in code and schema docs, but use warmer labels in the UI:

--- a/server/src/controllers/researchGroupController.ts
+++ b/server/src/controllers/researchGroupController.ts
@@ -9,6 +9,7 @@ import { NotFoundError } from '../utils/errors';
 import {
   getResearchGroupDetail,
   normalizeResearchDetailSlug,
+  recordResearchEntityOutreach,
   searchResearchGroupsViaMeili,
   type ResearchGroupQualityFilter,
   ResearchGroupSearchSort,
@@ -237,5 +238,28 @@ export const getResearchGroupBySlug = async (request: Request, response: Respons
     }
     console.error('ResearchEntity detail failed:', sanitizeLogValue(error));
     return response.status(500).json({ error: 'Failed to fetch research entity' });
+  }
+};
+
+export const recordResearchOutreach = async (request: Request, response: Response) => {
+  const currentUser = request.user as { studentProfileId?: unknown } | undefined;
+  if (!currentUser?.studentProfileId) {
+    return response.status(403).json({ error: 'A student profile is required' });
+  }
+  try {
+    await recordResearchEntityOutreach(request.params.slug, currentUser.studentProfileId);
+    return response.status(204).send();
+  } catch (error: any) {
+    if (error?.message === 'INVALID_OUTREACH_REQUEST') {
+      return response.status(400).json({ error: 'Invalid outreach request' });
+    }
+    if (error?.message === 'OUTREACH_ENTITY_NOT_FOUND') {
+      return response.status(404).json({ error: 'Research entity not found' });
+    }
+    if (error?.message === 'NO_APPROVED_OUTREACH_ROUTE') {
+      return response.status(409).json({ error: 'No approved outreach route is available' });
+    }
+    console.error('ResearchEntity outreach failed:', sanitizeLogValue(error));
+    return response.status(500).json({ error: 'Failed to record outreach' });
   }
 };

--- a/server/src/models/studentOutreach.ts
+++ b/server/src/models/studentOutreach.ts
@@ -32,7 +32,7 @@ const studentOutreachSchema = new mongoose.Schema(
     },
     deliveryMethod: {
       type: String,
-      enum: ['mailto', 'copy', 'platform-sent', 'external-self-reported'],
+      enum: ['mailto', 'copy', 'platform-sent', 'external-self-reported', 'official-route'],
       default: 'mailto',
     },
     emailGeneratedByPlatform: {

--- a/server/src/routes/researchGroups.ts
+++ b/server/src/routes/researchGroups.ts
@@ -9,7 +9,7 @@
  */
 import { Router, Request, Response, NextFunction } from 'express';
 import * as researchGroupController from '../controllers/researchGroupController';
-import { asyncHandler } from '../middleware/index';
+import { asyncHandler, isAuthenticated } from '../middleware/index';
 
 const router = Router();
 
@@ -24,6 +24,12 @@ function setPublicDetailCacheHeaders(_req: Request, res: Response, next: NextFun
 }
 
 router.post('/search', asyncHandler(researchGroupController.searchResearchGroups));
+
+router.post(
+  '/:slug/outreach',
+  isAuthenticated,
+  asyncHandler(researchGroupController.recordResearchOutreach),
+);
 
 router.get(
   '/:slug',

--- a/server/src/services/__tests__/studentAccessPublicationPolicy.test.ts
+++ b/server/src/services/__tests__/studentAccessPublicationPolicy.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isApprovedPublicContactRoute,
+  isStudentPublishablePathway,
+} from '../studentAccessPublicationPolicy';
+
+describe('student access publication policy', () => {
+  it('publishes only current, sufficiently evidenced pathways with a public source', () => {
+    expect(isStudentPublishablePathway({
+      status: 'ACTIVE',
+      evidenceStrength: 'MODERATE',
+      confidence: 0.7,
+      sourceUrls: ['https://research.yale.edu/pathway'],
+    })).toBe(true);
+    expect(isStudentPublishablePathway({
+      status: 'PLAUSIBLE',
+      evidenceStrength: 'WEAK',
+      confidence: 0.5,
+      sourceUrls: ['https://research.yale.edu/pathway'],
+    })).toBe(false);
+    expect(isStudentPublishablePathway({
+      status: 'ACTIVE',
+      evidenceStrength: 'STRONG',
+      confidence: 0.9,
+      sourceUrls: ['javascript:alert(1)'],
+    })).toBe(false);
+  });
+
+  it('requires an admin-approved public route and safe independent source', () => {
+    const route = {
+      visibility: 'PUBLIC',
+      contactPolicy: 'OFFICIAL_ROUTE_PREFERRED',
+      url: 'https://research.yale.edu/contact',
+      sourceUrl: 'https://research.yale.edu/about',
+      review: { status: 'approved' },
+    };
+    expect(isApprovedPublicContactRoute(route)).toBe(true);
+    expect(isApprovedPublicContactRoute({ ...route, review: { status: 'unreviewed' } })).toBe(false);
+    expect(isApprovedPublicContactRoute({ ...route, url: 'mailto:private@yale.edu' })).toBe(false);
+    expect(isApprovedPublicContactRoute({ ...route, sourceUrl: 'http://127.0.0.1/admin' })).toBe(false);
+  });
+});

--- a/server/src/services/pathwaySearchIndexService.ts
+++ b/server/src/services/pathwaySearchIndexService.ts
@@ -10,6 +10,12 @@ import { redactDirectContactInfo } from '../utils/contactRedaction';
 import { serializedDocumentId } from '../utils/idSerialization';
 import { getMeiliIndex } from '../utils/meiliClient';
 import { isPublicHttpUrl } from '../utils/urlSafety';
+import {
+  isStudentPublishablePathway,
+  STUDENT_PATHWAY_EVIDENCE_STRENGTHS,
+  STUDENT_PATHWAY_MIN_CONFIDENCE,
+  STUDENT_PATHWAY_STATUSES,
+} from './studentAccessPublicationPolicy';
 
 export const PATHWAY_SEARCH_INDEX_NAME = 'pathways';
 export const PATHWAY_SEARCH_INDEX_PRIMARY_KEY = 'id';
@@ -90,6 +96,7 @@ export interface PathwaySearchIndexDocument {
   publicContactPolicy?: string;
   evidence: PathwaySearchIndexEvidenceDocument[];
   evidenceSnippets: string[];
+  studentPublishable: boolean;
 }
 
 export type PathwaySearchIndexInput = Record<string, unknown>;
@@ -167,6 +174,7 @@ export const PATHWAY_SEARCH_INDEX_SETTINGS: PathwaySearchIndexSettings = {
     'postedOpportunityStatus',
     'publicContactRouteType',
     'publicContactPolicy',
+    'studentPublishable',
   ],
   sortableAttributes: [
     'confidence',
@@ -379,6 +387,10 @@ function buildPathwayMeiliFilter(filters: PathwaySearchInput['filters'] = {}): s
           .map((pathwayType) => `pathwayType != ${quoteFilterValue(pathwayType)}`)
           .join(' AND ');
   const parts = [
+    'studentPublishable = true',
+    anyFilter('status', [...STUDENT_PATHWAY_STATUSES]),
+    anyFilter('evidenceStrength', [...STUDENT_PATHWAY_EVIDENCE_STRENGTHS]),
+    `confidence >= ${STUDENT_PATHWAY_MIN_CONFIDENCE}`,
     anyFilter('pathwayId', filters.pathwayIds),
     anyFilter('entityId', filters.entityIds),
     anyFilter('entityStudentVisibilityTier', publicStudentVisibilityTiers),
@@ -526,6 +538,7 @@ export function buildPathwaySearchIndexDocument(
     publicContactPolicy: publicContactRoute?.contactPolicy,
     evidence: normalizedEvidence.evidence,
     evidenceSnippets: normalizedEvidence.snippets,
+    studentPublishable: isStudentPublishablePathway(record),
   };
 }
 

--- a/server/src/services/pathwaySearchService.ts
+++ b/server/src/services/pathwaySearchService.ts
@@ -11,6 +11,7 @@ import { publicStudentVisibilityTiers } from '../models/studentVisibility';
 import { redactDirectContactInfo } from '../utils/contactRedaction';
 import { serializedDocumentId } from '../utils/idSerialization';
 import { isPublicHttpUrl } from '../utils/urlSafety';
+import { studentPathwayMongoMatch } from './studentAccessPublicationPolicy';
 
 export const pathwayBestNextStepCategories = [
   'apply',
@@ -330,6 +331,7 @@ function buildPathwayMatch(filters: PathwaySearchFilters): Record<string, unknow
 
   return compactMatch({
     archived: { $ne: true },
+    ...studentPathwayMongoMatch(),
     _id: hasPathwayIdFilter ? { $in: pathwayIds } : undefined,
     pathwayType,
     compensation:

--- a/server/src/services/researchGroupService.ts
+++ b/server/src/services/researchGroupService.ts
@@ -1941,16 +1941,16 @@ export async function recordResearchEntityOutreach(
     throw new Error('INVALID_OUTREACH_REQUEST');
   }
 
-  const entity = await ResearchEntity.findOne({
+  const entity = (await ResearchEntity.findOne({
     slug: normalizedSlug,
     archived: { $ne: true },
     studentVisibilityTier: { $in: publicStudentVisibilityTiers },
   })
     .select('_id')
-    .lean();
+    .lean()) as { _id: mongoose.Types.ObjectId } | null;
   if (!entity) throw new Error('OUTREACH_ENTITY_NOT_FOUND');
 
-  const candidateRoutes = await ContactRoute.find({
+  const candidateRoutes = (await ContactRoute.find({
     researchEntityId: entity._id,
     archived: { $ne: true },
     visibility: 'PUBLIC',
@@ -1958,7 +1958,7 @@ export async function recordResearchEntityOutreach(
   })
     .sort({ priority: 1, updatedAt: -1 })
     .limit(MAX_PUBLIC_DETAIL_CONTACT_ROUTES)
-    .lean();
+    .lean()) as Array<Record<string, any>>;
   const route = candidateRoutes.find((candidate) =>
     isApprovedPublicContactRoute(candidate as Record<string, any>),
   );

--- a/server/src/services/researchGroupService.ts
+++ b/server/src/services/researchGroupService.ts
@@ -28,6 +28,8 @@ import { AccessSignal } from '../models/accessSignal';
 import { ContactRoute } from '../models/contactRoute';
 import { EntryPathway } from '../models/entryPathway';
 import { PostedOpportunity } from '../models/postedOpportunity';
+import { StudentTracking } from '../models/studentTracking';
+import { StudentOutreach } from '../models/studentOutreach';
 import { getMeiliIndex } from '../utils/meiliClient';
 import { isPublicHttpUrl } from '../utils/urlSafety';
 import {
@@ -63,6 +65,8 @@ import {
 import { publicStudentDecisionExplanation } from './studentDecisionExplanationService';
 import { redactDirectContactInfo } from '../utils/contactRedaction';
 import { serializedDocumentId } from '../utils/idSerialization';
+import { studentPathwayMongoMatch } from './studentAccessPublicationPolicy';
+import { isApprovedPublicContactRoute } from './studentAccessPublicationPolicy';
 
 const NON_LAB_CATEGORIES = new Set<string>([
   DepartmentCategory.SOCIAL_SCIENCES,
@@ -1454,6 +1458,7 @@ const publicContactRouteForResearchDetail = (route: any) => ({
   url: publicHttpUrl(route.url),
   sourceUrl: publicHttpUrl(route.sourceUrl),
   observedAt: route.observedAt,
+  reviewStatus: route.review?.status,
 });
 
 export function buildLeadPiOutreachContactRoute(
@@ -1927,6 +1932,62 @@ export const normalizeResearchDetailSlug = (value: unknown): string | undefined 
  * (PIs first), the most recent papers across all members, and the group's
  * non-archived listings.
  */
+export async function recordResearchEntityOutreach(
+  slug: string,
+  studentProfileId: unknown,
+): Promise<{ recorded: true; routeUrl: string }> {
+  const normalizedSlug = normalizeResearchDetailSlug(slug);
+  if (!normalizedSlug || !mongoose.isValidObjectId(studentProfileId)) {
+    throw new Error('INVALID_OUTREACH_REQUEST');
+  }
+
+  const entity = await ResearchEntity.findOne({
+    slug: normalizedSlug,
+    archived: { $ne: true },
+    studentVisibilityTier: { $in: publicStudentVisibilityTiers },
+  })
+    .select('_id')
+    .lean();
+  if (!entity) throw new Error('OUTREACH_ENTITY_NOT_FOUND');
+
+  const candidateRoutes = await ContactRoute.find({
+    researchEntityId: entity._id,
+    archived: { $ne: true },
+    visibility: 'PUBLIC',
+    'review.status': 'approved',
+  })
+    .sort({ priority: 1, updatedAt: -1 })
+    .limit(MAX_PUBLIC_DETAIL_CONTACT_ROUTES)
+    .lean();
+  const route = candidateRoutes.find((candidate) =>
+    isApprovedPublicContactRoute(candidate as Record<string, any>),
+  );
+  if (!route?.url) throw new Error('NO_APPROVED_OUTREACH_ROUTE');
+
+  const now = new Date();
+  const tracking = await StudentTracking.findOneAndUpdate(
+    { studentProfileId, researchEntityId: entity._id },
+    {
+      $set: { stage: 'reached-out' },
+      $setOnInsert: { studentProfileId, researchEntityId: entity._id },
+      $push: { stageHistory: { stage: 'reached-out', timestamp: now } },
+    },
+    { upsert: true, new: true },
+  );
+
+  await StudentOutreach.create({
+    studentProfileId,
+    researchEntityId: entity._id,
+    trackingId: tracking._id,
+    reachedOutAt: now,
+    deliveryMethod: 'official-route',
+    emailGeneratedByPlatform: false,
+    templateVersion: 'official-route-v1',
+  });
+
+  return { recorded: true, routeUrl: route.url };
+}
+
 export async function getResearchGroupDetail(slug: string): Promise<{
   researchEntity: PublicResearchEntityDto;
   members: Array<{ user: any; role: string }>;
@@ -2147,7 +2208,11 @@ export async function getResearchGroupDetail(slug: string): Promise<{
       .sort({ updatedAt: -1 })
       .limit(MAX_PUBLIC_DETAIL_LISTINGS)
       .lean(),
-    EntryPathway.find({ researchEntityId: (group as any)._id, archived: false })
+    EntryPathway.find({
+      researchEntityId: (group as any)._id,
+      archived: false,
+      ...studentPathwayMongoMatch(),
+    })
       .sort({ updatedAt: -1 })
       .limit(MAX_PUBLIC_DETAIL_ENTRY_PATHWAYS)
       .lean(),
@@ -2160,8 +2225,9 @@ export async function getResearchGroupDetail(slug: string): Promise<{
         researchEntityId: (group as any)._id,
         archived: false,
         visibility: 'PUBLIC',
+        'review.status': 'approved',
       },
-      'routeType label url priority visibility contactPolicy rationale sourceUrl observedAt',
+      'routeType label url priority visibility contactPolicy rationale sourceUrl observedAt review',
     )
       .sort({ priority: 1 })
       .limit(MAX_PUBLIC_DETAIL_CONTACT_ROUTES)

--- a/server/src/services/studentAccessPublicationPolicy.ts
+++ b/server/src/services/studentAccessPublicationPolicy.ts
@@ -1,0 +1,50 @@
+import { isPublicHttpUrl } from '../utils/urlSafety';
+
+export const STUDENT_PATHWAY_MIN_CONFIDENCE = 0.7;
+export const STUDENT_PATHWAY_STATUSES = ['ACTIVE', 'RECURRING'] as const;
+export const STUDENT_PATHWAY_EVIDENCE_STRENGTHS = ['DIRECT', 'STRONG', 'MODERATE'] as const;
+
+const hasPublicUrl = (values: unknown): boolean =>
+  Array.isArray(values) &&
+  values.some((value) => {
+    try {
+      return typeof value === 'string' && isPublicHttpUrl(value);
+    } catch {
+      return false;
+    }
+  });
+
+export const isStudentPublishablePathway = (pathway: Record<string, unknown>): boolean =>
+  STUDENT_PATHWAY_STATUSES.includes(pathway.status as any) &&
+  STUDENT_PATHWAY_EVIDENCE_STRENGTHS.includes(pathway.evidenceStrength as any) &&
+  typeof pathway.confidence === 'number' &&
+  pathway.confidence >= STUDENT_PATHWAY_MIN_CONFIDENCE &&
+  hasPublicUrl(pathway.sourceUrls);
+
+export const studentPathwayMongoMatch = (): Record<string, unknown> => ({
+  status: { $in: [...STUDENT_PATHWAY_STATUSES] },
+  evidenceStrength: { $in: [...STUDENT_PATHWAY_EVIDENCE_STRENGTHS] },
+  confidence: { $gte: STUDENT_PATHWAY_MIN_CONFIDENCE },
+  sourceUrls: { $elemMatch: { $type: 'string', $regex: '^https?://' } },
+});
+
+export const isApprovedPublicContactRoute = (route: Record<string, any>): boolean => {
+  if (
+    route.visibility !== 'PUBLIC' ||
+    route.review?.status !== 'approved' ||
+    route.contactPolicy === 'NO_DIRECT_CONTACT' ||
+    route.contactPolicy === 'UNKNOWN'
+  ) {
+    return false;
+  }
+  try {
+    return Boolean(
+      typeof route.url === 'string' &&
+      isPublicHttpUrl(route.url) &&
+      typeof route.sourceUrl === 'string' &&
+      isPublicHttpUrl(route.sourceUrl),
+    );
+  } catch {
+    return false;
+  }
+};


### PR DESCRIPTION
## Summary

- connect `/research` to the real pathway search API and render verified ways in with truthful counts, evidence, empty states, and degraded states
- publish only current source-backed pathways at or above the documented evidence and confidence threshold
- restore a route-only profile inquiry flow that requires admin-approved public sources, keeps email fail-closed, and records official-route attempts in `student_outreaches`
- document admin ownership, readiness checks, and pathway index rebuild operations

## Publication policy

- Pathways: `ACTIVE` or `RECURRING`, evidence `DIRECT`, `STRONG`, or `MODERATE`, confidence at least `0.70`, and a safe public source URL
- Contact routes: `PUBLIC`, admin review `approved`, policy neither `UNKNOWN` nor `NO_DIRECT_CONTACT`, and safe public source and destination URLs
- Direct emails are not selected or serialized by the profile detail or outreach paths

## Verification

- `yarn --cwd server test` (full suite)
- `yarn --cwd client test:ci` (94 files, 762 tests)
- `npx tsc --noEmit -p server/tsconfig.json`
- `yarn --cwd server build`
- `yarn --cwd client build`
- `node scripts/security-preflight.test.mjs` (270 tests)
- `node scripts/check-no-secrets.mjs`

Repo-wide lint still reports pre-existing baseline errors in unrelated files, primarily existing `no-control-regex` findings.
Graphify refresh was attempted but the watcher rebuild failed with `Operation not permitted`; no generated graph files changed.
