### PR TITLE
feat: add topic-aware planning analytics

### DIFF
--- a/client/src/contexts/FellowshipSearchContext.ts
+++ b/client/src/contexts/FellowshipSearchContext.ts
@@ -23,6 +23,8 @@ export interface FellowshipSearchContextType {
   setSelectedTermOfAward: React.Dispatch<React.SetStateAction<string[]>>;
   selectedPurpose: string[];
   setSelectedPurpose: React.Dispatch<React.SetStateAction<string[]>>;
+  selectedSubjects: string[];
+  setSelectedSubjects: React.Dispatch<React.SetStateAction<string[]>>;
   selectedRegions: string[];
   setSelectedRegions: React.Dispatch<React.SetStateAction<string[]>>;
   selectedCitizenship: string[];
@@ -76,6 +78,8 @@ export const defaultFellowshipSearchContext: FellowshipSearchContextType = {
   setSelectedTermOfAward: () => {},
   selectedPurpose: [],
   setSelectedPurpose: () => {},
+  selectedSubjects: [],
+  setSelectedSubjects: () => {},
   selectedRegions: [],
   setSelectedRegions: () => {},
   selectedCitizenship: [],
@@ -105,6 +109,7 @@ export const defaultFellowshipSearchContext: FellowshipSearchContextType = {
     purpose: [],
     globalRegions: [],
     citizenshipStatus: [],
+    subjects: [],
   },
   sortableKeys: [],
   refreshFellowships: () => {},

--- a/client/src/pages/__tests__/analytics.test.tsx
+++ b/client/src/pages/__tests__/analytics.test.tsx
@@ -237,6 +237,10 @@ describe('Analytics page', () => {
             searchesWithResults: 16,
             zeroResultSearches: 4,
             zeroResultRate: 0.2,
+            engagedSearches: 6,
+            returnedButIgnoredSearches: 10,
+            engagementRate: 0.3,
+            attributionWindowMinutes: 30,
             avgResults: 7.5,
             lowResultQueries: [{ query: 'quantum materials', count: 2 }],
           },
@@ -308,6 +312,12 @@ describe('Analytics page', () => {
     await waitFor(() => {
       expect(screen.getAllByText('Review zero-result searches').length).toBeGreaterThan(0);
       expect(screen.getAllByText('quantum materials').length).toBeGreaterThan(0);
+      expect(
+        screen.getByText(/6 of 20 searches led to a view or save within 30 minutes/),
+      ).toBeTruthy();
+      expect(
+        screen.getByText(/10 searches returned results but led to no view or save/),
+      ).toBeTruthy();
     });
   });
 
@@ -383,7 +393,7 @@ describe('Analytics page', () => {
     expect(screen.getByText('Fixture Admin')).toBeTruthy();
     expect(screen.getByText('manual')).toBeTruthy();
     expect(
-      screen.getByText(/legacy admin profile row without active grants: fixture-legacy-admin/i)
+      screen.getByText(/legacy admin profile row without active grants: fixture-legacy-admin/i),
     ).toBeTruthy();
   });
 

--- a/client/src/pages/analytics.tsx
+++ b/client/src/pages/analytics.tsx
@@ -226,7 +226,7 @@ const Analytics = () => {
     try {
       const response = await axios.get<AnalyticsUserDrilldownResponse>(
         `/analytics/users/${encodeURIComponent(netid)}`,
-        { withCredentials: true }
+        { withCredentials: true },
       );
       setSelectedUser({
         ...response.data,
@@ -246,24 +246,25 @@ const Analytics = () => {
     setImpactError(null);
 
     try {
-      const [searchQualityResponse, searchQueriesResponse, funnelResponse, actionsResponse] = await Promise.all([
-        axios.get<AnalyticsSearchQualityResponse>('/analytics/search-quality', {
-          withCredentials: true,
-          params: { range: analyticsRange },
-        }),
-        axios.get<AnalyticsSearchQueryResponse>('/analytics/search-queries', {
-          withCredentials: true,
-          params: { range: analyticsRange, limit: 25 },
-        }),
-        axios.get<AnalyticsFunnelResponse>('/analytics/funnel', {
-          withCredentials: true,
-          params: { range: analyticsRange },
-        }),
-        axios.get<AnalyticsActionNeededResponse>('/analytics/actions', {
-          withCredentials: true,
-          params: { range: analyticsRange },
-        }),
-      ]);
+      const [searchQualityResponse, searchQueriesResponse, funnelResponse, actionsResponse] =
+        await Promise.all([
+          axios.get<AnalyticsSearchQualityResponse>('/analytics/search-quality', {
+            withCredentials: true,
+            params: { range: analyticsRange },
+          }),
+          axios.get<AnalyticsSearchQueryResponse>('/analytics/search-queries', {
+            withCredentials: true,
+            params: { range: analyticsRange, limit: 25 },
+          }),
+          axios.get<AnalyticsFunnelResponse>('/analytics/funnel', {
+            withCredentials: true,
+            params: { range: analyticsRange },
+          }),
+          axios.get<AnalyticsActionNeededResponse>('/analytics/actions', {
+            withCredentials: true,
+            params: { range: analyticsRange },
+          }),
+        ]);
 
       setSearchQuality(searchQualityResponse.data);
       setSearchQueries(searchQueriesResponse.data);
@@ -316,9 +317,7 @@ const Analytics = () => {
       <div className="flex min-h-screen items-center justify-center px-4">
         <div className="max-w-md rounded-lg border border-red-200 bg-[var(--yr-panel)] p-6 text-center shadow-sm">
           <h1 className="mb-3 text-2xl font-bold text-gray-900">Analytics unavailable</h1>
-          <p className="mb-5 text-sm text-gray-600">
-            {error || 'Failed to load analytics data'}
-          </p>
+          <p className="mb-5 text-sm text-gray-600">{error || 'Failed to load analytics data'}</p>
           <button
             type="button"
             onClick={fetchAnalytics}
@@ -376,13 +375,7 @@ const Analytics = () => {
     );
   };
 
-  const DetailSectionHeader = ({
-    title,
-    description,
-  }: {
-    title: string;
-    description?: string;
-  }) => (
+  const DetailSectionHeader = ({ title, description }: { title: string; description?: string }) => (
     <div className="mb-4 flex flex-col gap-1 border-b border-[var(--yr-line)] pb-3">
       <h2 className="text-xl font-semibold text-gray-900">{title}</h2>
       {description && <p className="text-sm text-gray-500">{description}</p>}
@@ -547,9 +540,8 @@ const Analytics = () => {
   };
 
   const searchTotal = searchQuality?.totalSearches || 0;
-  const searchZeroResults = searchQuality?.zeroResultSearches || 0;
-  const searchesWithResults =
-    searchQuality?.searchesWithResults ?? Math.max(searchTotal - searchZeroResults, 0);
+  const engagedSearches = searchQuality?.engagedSearches || 0;
+  const returnedButIgnoredSearches = searchQuality?.returnedButIgnoredSearches || 0;
   const avgResults = searchQuality?.avgResults ?? searchQuality?.avgResultsPerSearch;
   const zeroResultQueries = searchQuality?.zeroResultQueries || [];
   const lowResultQueries = searchQuality?.lowResultQueries || [];
@@ -563,12 +555,10 @@ const Analytics = () => {
     { key: 'favorites', label: 'Saved', count: funnel?.favoriteCount || 0 },
     { key: 'applications', label: 'Outreach Clicked', count: funnel?.applicantCount || 0 },
   ].filter((stage) => stage.count > 0);
-  const funnelStages: AnalyticsFunnelStage[] =
-    funnel?.stages ||
-    fallbackFunnelStages;
+  const funnelStages: AnalyticsFunnelStage[] = funnel?.stages || fallbackFunnelStages;
   const selectedRangeLabel =
     analyticsRanges.find((range) => range.value === analyticsRange)?.label || 'Selected range';
-  const searchSuccessRate = searchTotal > 0 ? searchesWithResults / searchTotal : null;
+  const searchSuccessRate = searchTotal > 0 ? engagedSearches / searchTotal : null;
   const researchCoverage = data.researchEntities;
   const activeEntities = researchCoverage.overview.active;
   const studentReadyEntities =
@@ -578,8 +568,7 @@ const Analytics = () => {
   const freshShare = activeEntities > 0 ? freshEntities / activeEntities : null;
   const staleEntities =
     researchCoverage.freshness.staleOver90Days + researchCoverage.freshness.neverObserved;
-  const attentionCount =
-    actionCards.length + zeroResultQueries.length + lowResultQueries.length;
+  const attentionCount = actionCards.length + zeroResultQueries.length + lowResultQueries.length;
   const healthTone =
     attentionCount > 4 || (searchSuccessRate !== null && searchSuccessRate < 0.75)
       ? 'red'
@@ -591,1218 +580,438 @@ const Analytics = () => {
 
   return (
     <div className="yr-page min-h-[calc(100vh-8rem)]">
-    <div className="mx-auto max-w-7xl px-4 py-8">
-      <section className="yr-panel mb-8 rounded-md">
-        <div className="border-b border-[var(--yr-line)] p-5 lg:flex lg:items-start lg:justify-between lg:gap-8">
-          <div className="max-w-3xl">
-            <p className="yr-kicker">Primary dashboard question</p>
-            <h1 className="mt-2 text-3xl font-semibold text-slate-950">Research Discovery Health</h1>
-            <p className="mt-3 text-base leading-7 text-slate-600">
-              Are students finding credible research next steps, and where should admins intervene?
-            </p>
-          </div>
-          <div className="mt-5 flex flex-col gap-3 sm:flex-row sm:items-end lg:mt-0">
-            <label className="block sm:w-56">
-              <span className="mb-1 block text-xs font-semibold uppercase text-gray-500">
-                Range
-              </span>
-              <select
-                value={analyticsRange}
-                onChange={(event) => setAnalyticsRange(event.target.value as AnalyticsRange)}
-                className="min-h-[44px] w-full rounded-md border border-[var(--yr-line-strong)] bg-[var(--yr-panel)] px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
-              >
-                {analyticsRanges.map((range) => (
-                  <option key={range.value} value={range.value}>
-                    {range.label}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <button
-              onClick={() => {
-                fetchAnalytics();
-                fetchImpactAnalytics();
-                fetchAdminAccess();
-              }}
-              className="inline-flex min-h-[44px] items-center justify-center rounded-md bg-[var(--yr-blue)] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
-            >
-              Refresh Data
-            </button>
-          </div>
-        </div>
-
-        <div className="grid grid-cols-1 gap-4 p-5 lg:grid-cols-4">
-          <DashboardMetric
-            title="Search success"
-            value={searchSuccessRate === null ? '-' : formatPercent(searchSuccessRate)}
-            context={`${formatNumber(searchesWithResults)} of ${formatNumber(searchTotal)} searches returned results in ${selectedRangeLabel}.`}
-            tone={searchSuccessRate !== null && searchSuccessRate < 0.75 ? 'amber' : 'green'}
-          />
-          <DashboardMetric
-            title="Student action funnel"
-            value={formatPercent(funnel?.overallConversionRate)}
-            context="Share of visitors reaching a concrete save or outreach-style action."
-            tone="blue"
-          />
-          <DashboardMetric
-            title="Student-ready research"
-            value={studentReadyShare === null ? '-' : formatPercent(studentReadyShare)}
-            context={`${formatNumber(studentReadyEntities)} of ${formatNumber(activeEntities)} active research entities are student-ready.`}
-            tone="blue"
-          />
-          <DashboardMetric
-            title="Needs attention"
-            value={formatNumber(attentionCount)}
-            context={topAction}
-            tone={healthTone}
-          />
-        </div>
-
-        <div className="grid grid-cols-1 gap-5 border-t border-[var(--yr-line)] p-5 xl:grid-cols-[1fr_1.2fr]">
-          <div>
-            <h2 className="text-lg font-semibold text-gray-900">Decision Readout</h2>
-            <div className="mt-3 space-y-3 text-sm leading-6 text-gray-600">
-              <p>
-                Start with search success and funnel movement: they show whether discovery intent
-                becomes visible next-step behavior.
+      <div className="mx-auto max-w-7xl px-4 py-8">
+        <section className="yr-panel mb-8 rounded-md">
+          <div className="border-b border-[var(--yr-line)] p-5 lg:flex lg:items-start lg:justify-between lg:gap-8">
+            <div className="max-w-3xl">
+              <p className="yr-kicker">Primary dashboard question</p>
+              <h1 className="mt-2 text-3xl font-semibold text-slate-950">
+                Research Discovery Health
+              </h1>
+              <p className="mt-3 text-base leading-7 text-slate-600">
+                Are students finding credible research next steps, and where should admins
+                intervene?
               </p>
-              <p>
-                Treat low-result queries and action cards as the work queue, not just warnings.
-              </p>
-              <p className="text-gray-500">Last updated: {lastUpdated || 'Not refreshed yet'}</p>
             </div>
-          </div>
-
-          <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
-            <div>
-              <h3 className="text-sm font-semibold text-gray-900">Funnel Snapshot</h3>
-              <div className="mt-3 space-y-3">
-                {funnelStages.length > 0 ? (
-                  funnelStages.map((stage) => (
-                    <div key={stage.key || stage.stage || stage.label}>
-                      <div className="mb-1 flex items-center justify-between gap-3 text-sm">
-                        <span className="font-medium text-gray-700">{stage.label}</span>
-                        <span className="text-gray-500">{formatNumber(stage.count)}</span>
-                      </div>
-                      <div className="h-2 rounded-full bg-[var(--yr-panel-muted)]">
-                        <div
-                          className="h-2 rounded-full bg-blue-600"
-                          style={{
-                            width: `${Math.min((stage.count / largestFunnelStageCount) * 100, 100)}%`,
-                          }}
-                        />
-                      </div>
-                    </div>
-                  ))
-                ) : (
-                  <p className="text-sm text-gray-500">No funnel stages returned.</p>
-                )}
-              </div>
-            </div>
-
-            <div>
-              <h3 className="text-sm font-semibold text-gray-900">Search Gaps</h3>
-              <div className="mt-3 space-y-2">
-                {[...zeroResultQueries, ...lowResultQueries].slice(0, 5).map((query, index) => (
-                  <div
-                    key={`${query.query}-${index}`}
-                    className="flex items-center justify-between gap-3 rounded-md border border-[var(--yr-line)] px-3 py-2 text-sm"
-                  >
-                    <span className="min-w-0 truncate text-gray-700">
-                      {query.query || '(empty search)'}
-                    </span>
-                    <span className="shrink-0 font-medium text-gray-900">
-                      {formatCompactMetric(query.zeroResults ?? query.count)}
-                    </span>
-                  </div>
-                ))}
-                {zeroResultQueries.length === 0 && lowResultQueries.length === 0 && (
-                  <p className="text-sm text-gray-500">No search quality flags returned.</p>
-                )}
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section className="mb-10">
-        <div className="mb-4 flex flex-col gap-2 border-b border-slate-200 pb-2 md:flex-row md:items-end md:justify-between">
-          <div>
-            <h2 className="text-2xl font-bold text-gray-800">Admin Access</h2>
-            <p className="text-sm text-gray-500">
-              Current admin authority comes from active admin grants, not profile user type.
-            </p>
-          </div>
-          <span className="rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-800">
-            {formatNumber(adminAccess.activeCount)} active admin
-            {adminAccess.activeCount === 1 ? '' : 's'}
-          </span>
-        </div>
-
-        {adminAccessError && (
-          <div className="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-            {adminAccessError}
-          </div>
-        )}
-
-        <form
-          className="mb-4 grid gap-3 rounded-lg border border-[var(--yr-line)] bg-[var(--yr-panel)] p-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1.5fr)_auto]"
-          onSubmit={(event) => {
-            void handleGrantAdminAccess(event);
-          }}
-        >
-          <label className="block">
-            <span className="mb-1 block text-xs font-semibold uppercase text-gray-500">
-              Grant admin NetID
-            </span>
-            <input
-              className="min-h-[44px] w-full rounded-md border border-[var(--yr-line-strong)] px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
-              value={adminGrantNetid}
-              onChange={(event) => setAdminGrantNetid(event.target.value)}
-              placeholder="fixture-admin"
-            />
-          </label>
-          <label className="block">
-            <span className="mb-1 block text-xs font-semibold uppercase text-gray-500">
-              Admin grant note
-            </span>
-            <input
-              className="min-h-[44px] w-full rounded-md border border-[var(--yr-line-strong)] px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
-              value={adminGrantNote}
-              onChange={(event) => setAdminGrantNote(event.target.value)}
-              placeholder="Optional"
-            />
-          </label>
-          <button
-            className="inline-flex min-h-[44px] items-center justify-center self-end rounded-md bg-[var(--yr-blue)] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-900 disabled:cursor-not-allowed disabled:bg-blue-300"
-            type="submit"
-            disabled={adminAccessActionNetid !== null}
-          >
-            Grant Admin
-          </button>
-        </form>
-
-        {adminAccessActionError && (
-          <div className="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-            {adminAccessActionError}
-          </div>
-        )}
-
-        {adminAccessActionMessage && (
-          <div className="mb-4 rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
-            {adminAccessActionMessage}
-          </div>
-        )}
-
-        {adminAccess.legacyAdminsWithoutGrant.length > 0 && (
-          <div className="mb-4 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
-            {adminAccess.legacyAdminsWithoutGrant.length} legacy admin profile row
-            {adminAccess.legacyAdminsWithoutGrant.length === 1 ? '' : 's'} without active grants:{' '}
-            {adminAccess.legacyAdminsWithoutGrant.map((user) => user.netid).join(', ')}
-            <div className="mt-3 flex flex-wrap gap-2">
-              {adminAccess.legacyAdminsWithoutGrant.map((user) => (
-                <button
-                  key={user.netid}
-                  type="button"
-                  className="rounded-md border border-amber-300 bg-white px-3 py-1 text-xs font-semibold text-amber-900 hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-60"
-                  disabled={adminAccessActionNetid !== null}
-                  onClick={() => {
-                    void handleGrantAdminAccess(undefined, user.netid);
-                  }}
+            <div className="mt-5 flex flex-col gap-3 sm:flex-row sm:items-end lg:mt-0">
+              <label className="block sm:w-56">
+                <span className="mb-1 block text-xs font-semibold uppercase text-gray-500">
+                  Range
+                </span>
+                <select
+                  value={analyticsRange}
+                  onChange={(event) => setAnalyticsRange(event.target.value as AnalyticsRange)}
+                  className="min-h-[44px] w-full rounded-md border border-[var(--yr-line-strong)] bg-[var(--yr-panel)] px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
                 >
-                  Grant {user.netid}
-                </button>
-              ))}
-            </div>
-          </div>
-        )}
-
-        <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-md">
-          <div className="overflow-x-auto">
-            <table className="min-w-full">
-              <thead>
-                <tr className="border-b bg-gray-50">
-                  <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
-                    NetID
-                  </th>
-                  <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
-                    Person
-                  </th>
-                  <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
-                    Source
-                  </th>
-                  <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
-                    Granted
-                  </th>
-                  <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
-                    Granted By
-                  </th>
-                  <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
-                    Status
-                  </th>
-                  <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
-                    Actions
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {adminAccess.grants.length > 0 ? (
-                  adminAccess.grants.map((grant) => {
-                    const name = [grant.user?.fname, grant.user?.lname].filter(Boolean).join(' ');
-                    const isCurrentAdmin = grant.netid === adminActorNetid;
-                    return (
-                      <tr key={`${grant.netid}-${grant.status}`} className="border-b hover:bg-gray-50">
-                        <td className="px-4 py-3 font-medium text-gray-900">{grant.netid}</td>
-                        <td className="px-4 py-3 text-gray-700">
-                          {name || grant.user?.email || '-'}
-                        </td>
-                        <td className="px-4 py-3 text-gray-700">{grant.source}</td>
-                        <td className="px-4 py-3 text-sm text-gray-600">
-                          {formatDateTime(grant.grantedAt)}
-                        </td>
-                        <td className="px-4 py-3 text-gray-700">{grant.grantedBy || '-'}</td>
-                        <td className="px-4 py-3">
-                          <span
-                            className={`rounded-md px-2 py-1 text-xs font-semibold ${
-                              grant.status === 'active'
-                                ? 'bg-emerald-50 text-emerald-700'
-                                : 'bg-gray-100 text-gray-600'
-                            }`}
-                          >
-                            {grant.status}
-                          </span>
-                        </td>
-                        <td className="px-4 py-3">
-                          {grant.status !== 'active' ? (
-                            <span className="text-sm text-gray-500">-</span>
-                          ) : isCurrentAdmin ? (
-                            <button
-                              type="button"
-                              disabled
-                              className="rounded-md border border-gray-200 px-3 py-1 text-xs font-semibold text-gray-500"
-                            >
-                              Current session
-                            </button>
-                          ) : (
-                            <button
-                              type="button"
-                              aria-label={`Revoke ${grant.netid}`}
-                              className="rounded-md border border-red-200 bg-red-50 px-3 py-1 text-xs font-semibold text-red-700 hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-60"
-                              disabled={adminAccessActionNetid !== null}
-                              onClick={() => {
-                                void handleRevokeAdminAccess(grant.netid);
-                              }}
-                            >
-                              Revoke
-                            </button>
-                          )}
-                        </td>
-                      </tr>
-                    );
-                  })
-                ) : (
-                  <tr>
-                    <td className="px-4 py-6 text-center text-gray-500" colSpan={7}>
-                      No admin grants returned.
-                    </td>
-                  </tr>
-                )}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </section>
-
-      <DetailSectionHeader
-        title="Supporting Detail"
-        description="Operational tables and lower-priority counts remain below the readout for drilldown."
-      />
-
-      <nav
-        aria-label="Analytics detail sections"
-        className="mb-6 flex flex-wrap gap-2 text-sm font-semibold"
-      >
-        <a className="rounded-md border border-[var(--yr-line)] px-3 py-2 text-blue-700" href="#visitor-statistics">
-          Visitors
-        </a>
-        <a className="rounded-md border border-[var(--yr-line)] px-3 py-2 text-blue-700" href="#diagnostics">
-          Diagnostics
-        </a>
-        <a
-          className="rounded-md border border-[var(--yr-line)] px-3 py-2 text-blue-700"
-          href="#research-coverage"
-        >
-          Research Coverage
-        </a>
-      </nav>
-
-      <section id="research-coverage" className="mb-10">
-        <div className="mb-4 flex flex-col gap-2 border-b border-[var(--yr-line)] pb-2 md:flex-row md:items-end md:justify-between">
-          <div>
-            <h2 className="text-2xl font-bold text-gray-800">Research Data Coverage</h2>
-            <p className="text-sm text-gray-500">
-              Scraped ResearchEntity corpus — the primary catalog students browse. Counts cover
-              active (non-archived) entities.
-            </p>
-          </div>
-        </div>
-
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
-          <StatCard
-            title="Active Research Entities"
-            value={researchCoverage.overview.active}
-            subtitle={`${formatNumber(researchCoverage.overview.archived)} archived`}
-          />
-          <StatCard
-            title="Student-Ready"
-            value={studentReadyEntities}
-            subtitle={studentReadyShare === null ? undefined : `${formatPercent(studentReadyShare)} of active`}
-          />
-          <StatCard
-            title="Refreshed (30 Days)"
-            value={freshEntities}
-            subtitle={freshShare === null ? undefined : `${formatPercent(freshShare)} of active`}
-          />
-          <StatCard
-            title="Stale or Never Observed"
-            value={staleEntities}
-            subtitle={`${formatNumber(researchCoverage.freshness.neverObserved)} never observed`}
-          />
-        </div>
-
-        <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-          <div className="bg-[var(--yr-panel)] rounded-lg shadow-md border border-[var(--yr-line)] overflow-hidden">
-            <div className="border-b border-[var(--yr-line)] p-4">
-              <h3 className="text-lg font-semibold text-gray-800">By Entity Type</h3>
-              <p className="text-sm text-gray-500">What kinds of research homes exist</p>
-            </div>
-            <div className="overflow-x-auto">
-              <table className="min-w-full text-sm">
-                <thead>
-                  <tr className="border-b bg-[var(--yr-panel-muted)]">
-                    <th className="px-4 py-2 text-left font-semibold text-gray-700">Type</th>
-                    <th className="px-4 py-2 text-right font-semibold text-gray-700">Entities</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {researchCoverage.byType.length > 0 ? (
-                    researchCoverage.byType.map((row) => (
-                      <tr
-                        key={row.entityType || 'unknown'}
-                        className="border-b last:border-0 hover:bg-[var(--yr-panel-muted)]"
-                      >
-                        <td className="px-4 py-2 text-gray-800">
-                          {formatEntityType(row.entityType)}
-                        </td>
-                        <td className="px-4 py-2 text-right font-medium">
-                          {formatNumber(row.count)}
-                        </td>
-                      </tr>
-                    ))
-                  ) : (
-                    <tr>
-                      <td className="px-4 py-4 text-center text-gray-500" colSpan={2}>
-                        No research entities returned.
-                      </td>
-                    </tr>
-                  )}
-                </tbody>
-              </table>
-            </div>
-          </div>
-
-          <div className="bg-[var(--yr-panel)] rounded-lg shadow-md border border-[var(--yr-line)] overflow-hidden">
-            <div className="border-b border-[var(--yr-line)] p-4">
-              <h3 className="text-lg font-semibold text-gray-800">By Visibility Tier</h3>
-              <p className="text-sm text-gray-500">Student-facing exposure gating</p>
-            </div>
-            <div className="space-y-2 p-4 text-sm">
-              {researchCoverage.byVisibilityTier.length > 0 ? (
-                researchCoverage.byVisibilityTier.map((row) => (
-                  <div key={row.tier || 'unknown'} className="flex items-center justify-between">
-                    <span className="text-gray-600">{formatVisibilityTier(row.tier)}</span>
-                    <span className="font-medium text-gray-900">{formatNumber(row.count)}</span>
-                  </div>
-                ))
-              ) : (
-                <p className="text-gray-500">No tier data returned.</p>
-              )}
-            </div>
-          </div>
-
-          <div className="bg-[var(--yr-panel)] rounded-lg shadow-md border border-[var(--yr-line)] overflow-hidden">
-            <div className="border-b border-[var(--yr-line)] p-4">
-              <h3 className="text-lg font-semibold text-gray-800">Openness & Scholarly Signal</h3>
-              <p className="text-sm text-gray-500">Access posture and recent activity</p>
-            </div>
-            <div className="space-y-2 p-4 text-sm">
-              {researchCoverage.byOpenness.map((row) => (
-                <div key={row.status || 'unknown'} className="flex items-center justify-between">
-                  <span className="text-gray-600">{formatOpenness(row.status)}</span>
-                  <span className="font-medium text-gray-900">{formatNumber(row.count)}</span>
-                </div>
-              ))}
-              <div className="mt-3 flex items-center justify-between border-t border-[var(--yr-line)] pt-3">
-                <span className="text-gray-600">With recent papers</span>
-                <span className="font-medium text-gray-900">
-                  {formatNumber(researchCoverage.scholarly.withRecentPapers)}
-                </span>
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="text-gray-600">With recent grants</span>
-                <span className="font-medium text-gray-900">
-                  {formatNumber(researchCoverage.scholarly.withRecentGrants)}
-                </span>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section id="visitor-statistics" className="mb-10">
-        <h2 className="text-2xl font-semibold mb-4 text-slate-950 border-b border-[var(--yr-line)] pb-2">
-          Visitor Statistics
-        </h2>
-
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
-          <StatCard
-            title="Total Visitors (Lifetime)"
-            value={data.visitors.lifetime.total}
-            subtitle="Unique users who've logged in"
-          />
-          <StatCard
-            title="Visitors (Last 7 Days)"
-            value={data.visitors.last7Days.total}
-            subtitle="Active in past week"
-          />
-          <StatCard
-            title="Visitors Today"
-            value={data.visitors.today.total}
-            subtitle="Logged in today"
-          />
-        </div>
-
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
-          <StatCard
-            title="Total Login Events"
-            value={data.visitors.loginFrequency.totalLogins}
-            subtitle="All-time login count"
-          />
-          <StatCard
-            title="Logins (Last 7 Days)"
-            value={data.visitors.loginFrequency.loginsLast7Days}
-            subtitle="Total logins this week"
-          />
-          <StatCard
-            title="Logins Today"
-            value={data.visitors.loginFrequency.loginsToday}
-            subtitle="Login events today"
-          />
-        </div>
-
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          <div className="bg-[var(--yr-panel)] rounded-lg shadow-md p-6 border border-[var(--yr-line)]">
-            <h3 className="text-sm font-semibold text-gray-700 mb-3">Lifetime Visitors by Type</h3>
-            <div className="space-y-2">
-              {data.visitors.lifetime.byType.map((item) => (
-                <div key={item.userType} className="flex justify-between text-sm">
-                  <span className="text-gray-600">{formatUserType(item.userType)}:</span>
-                  <span className="font-medium">{item.count}</span>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          <div className="bg-[var(--yr-panel)] rounded-lg shadow-md p-6 border border-[var(--yr-line)]">
-            <h3 className="text-sm font-semibold text-gray-700 mb-3">Last 7 Days by Type</h3>
-            <div className="space-y-2">
-              {data.visitors.last7Days.byType.map((item) => (
-                <div key={item.userType} className="flex justify-between text-sm">
-                  <span className="text-gray-600">{formatUserType(item.userType)}:</span>
-                  <span className="font-medium">{item.count}</span>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          <div className="bg-[var(--yr-panel)] rounded-lg shadow-md p-6 border border-[var(--yr-line)]">
-            <h3 className="text-sm font-semibold text-gray-700 mb-3">Today by Type</h3>
-            <div className="space-y-2">
-              {data.visitors.today.byType.length > 0 ? (
-                data.visitors.today.byType.map((item) => (
-                  <div key={item.userType} className="flex justify-between text-sm">
-                    <span className="text-gray-600">{formatUserType(item.userType)}:</span>
-                    <span className="font-medium">{item.count}</span>
-                  </div>
-                ))
-              ) : (
-                <p className="text-sm text-gray-500">No visitors yet today</p>
-              )}
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section id="diagnostics" className="mb-10">
-        <h2 className="text-2xl font-semibold mb-4 text-slate-950 border-b border-[var(--yr-line)] pb-2">
-          User Engagement
-        </h2>
-
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
-          <StatCard
-            title="Total Searches"
-            value={data.engagement.search.totalSearches}
-            subtitle="All-time search queries"
-          />
-          <StatCard
-            title="Searches (Last 7 Days)"
-            value={data.engagement.search.searchesLast7Days}
-            subtitle="Recent searches"
-          />
-          <StatCard
-            title="Searches Today"
-            value={data.engagement.search.searchesToday}
-            subtitle="Searches today"
-          />
-        </div>
-
-        {data.engagement.topSearchQueries.length > 0 && (
-          <div className="bg-[var(--yr-panel)] rounded-lg shadow-md p-6 border border-[var(--yr-line)] mb-6">
-            <h3 className="text-lg font-semibold text-gray-700 mb-4">
-              Top Search Queries (Last 30 Days)
-            </h3>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              {data.engagement.topSearchQueries.map((item, index) => (
-                <div key={index} className="flex justify-between border-b pb-2">
-                  <span className="text-gray-700">{item.query || '(empty search)'}</span>
-                  <span className="font-medium text-blue-600">{item.count} searches</span>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
-
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <StatCard
-            title="Active Users (Last 7 Days)"
-            value={data.engagement.userActivity.activeUsers}
-            subtitle="Users with activity"
-          />
-          <StatCard
-            title="Avg Events Per User"
-            value={data.engagement.userActivity.avgEventsPerUser.toFixed(1)}
-            subtitle="Last 7 days"
-          />
-        </div>
-      </section>
-
-      <section className="mb-10">
-        <h2 className="text-2xl font-semibold mb-4 text-slate-950 border-b border-[var(--yr-line)] pb-2">
-          Outreach Loop
-        </h2>
-
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
-          <StatCard
-            title="Email Contact Clicks"
-            value={outreach.summary.totalAttempts}
-            subtitle={`${outreach.summary.attemptsLast7Days} in last 7 days`}
-          />
-          <StatCard
-            title="Reported Outcomes"
-            value={outreach.summary.totalOutcomes}
-            subtitle={`${outreach.summary.outcomesLast7Days} in last 7 days`}
-          />
-          <StatCard
-            title="Contact Details Revealed"
-            value={outreach.summary.totalReveals}
-            subtitle={`${outreach.summary.revealsLast7Days} in last 7 days`}
-          />
-        </div>
-
-        <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-          <div className="bg-[var(--yr-panel)] rounded-lg shadow-md p-6 border border-[var(--yr-line)]">
-            <h3 className="text-lg font-semibold text-gray-700 mb-4">Outcomes</h3>
-            <div className="space-y-3">
-              {outreach.byOutcome.length > 0 ? (
-                outreach.byOutcome.map((item) => (
-                  <div key={item.outcome} className="flex justify-between">
-                    <span className="text-gray-600">{formatOutcome(item.outcome)}</span>
-                    <span className="font-bold text-lg">{item.count}</span>
-                  </div>
-                ))
-              ) : (
-                <p className="text-sm text-gray-500">No reported outcomes yet.</p>
-              )}
-            </div>
-          </div>
-
-          <div className="bg-[var(--yr-panel)] rounded-lg shadow-md p-6 border border-[var(--yr-line)] lg:col-span-2">
-            <h3 className="text-lg font-semibold text-gray-700 mb-4">Top Outreach Contacts</h3>
-            <div className="overflow-x-auto">
-              <table className="min-w-full">
-                <thead>
-                  <tr className="border-b bg-[var(--yr-panel-muted)]">
-                    <th className="px-4 py-2 text-left font-semibold text-gray-700">Contact</th>
-                    <th className="px-4 py-2 text-right font-semibold text-gray-700">Attempts</th>
-                    <th className="px-4 py-2 text-right font-semibold text-gray-700">Outcomes</th>
-                    <th className="px-4 py-2 text-right font-semibold text-gray-700">Users</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {outreach.topListings.length > 0 ? (
-                    outreach.topListings.map((listing) => (
-                      <tr key={listing.listingId} className="border-b hover:bg-[var(--yr-panel-muted)]">
-                        <td className="py-3 px-4 text-gray-800">
-                          <div className="font-medium">{listing.title || 'Unknown listing'}</div>
-                          <div className="text-xs text-gray-500">
-                            {[listing.ownerFirstName, listing.ownerLastName].filter(Boolean).join(' ') ||
-                              listing.listingId}
-                          </div>
-                        </td>
-                        <td className="py-3 px-4 text-right font-medium">{listing.attempts}</td>
-                        <td className="py-3 px-4 text-right font-medium">{listing.outcomes}</td>
-                        <td className="py-3 px-4 text-right font-medium">{listing.uniqueUsers}</td>
-                      </tr>
-                    ))
-                  ) : (
-                    <tr>
-                      <td className="py-4 px-4 text-sm text-gray-500" colSpan={4}>
-                        No outreach activity yet.
-                      </td>
-                    </tr>
-                  )}
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-
-        {outreach.recentEvents.length > 0 && (
-          <div className="mt-6 bg-[var(--yr-panel)] rounded-lg shadow-md p-6 border border-[var(--yr-line)]">
-            <h3 className="text-lg font-semibold text-gray-700 mb-4">Recent Outreach Events</h3>
-            <div className="overflow-x-auto">
-              <table className="min-w-full">
-                <thead>
-                  <tr className="border-b bg-[var(--yr-panel-muted)]">
-                    <th className="px-4 py-2 text-left font-semibold text-gray-700">When</th>
-                    <th className="px-4 py-2 text-left font-semibold text-gray-700">Listing</th>
-                    <th className="px-4 py-2 text-left font-semibold text-gray-700">Action</th>
-                    <th className="px-4 py-2 text-left font-semibold text-gray-700">User Type</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {outreach.recentEvents.map((event, index) => (
-                    <tr
-                      key={`${event.listingId}-${event.timestamp}-${index}`}
-                      className="border-b hover:bg-[var(--yr-panel-muted)]"
-                    >
-                      <td className="py-3 px-4 text-gray-600">{formatDateTime(event.timestamp)}</td>
-                      <td className="py-3 px-4 text-gray-800">{event.title || event.listingId}</td>
-                      <td className="py-3 px-4 text-gray-600">{formatOutcome(event.outcome)}</td>
-                      <td className="py-3 px-4 text-gray-600">{formatUserType(event.userType)}</td>
-                    </tr>
+                  {analyticsRanges.map((range) => (
+                    <option key={range.value} value={range.value}>
+                      {range.label}
+                    </option>
                   ))}
-                </tbody>
-              </table>
+                </select>
+              </label>
+              <button
+                onClick={() => {
+                  fetchAnalytics();
+                  fetchImpactAnalytics();
+                  fetchAdminAccess();
+                }}
+                className="inline-flex min-h-[44px] items-center justify-center rounded-md bg-[var(--yr-blue)] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+              >
+                Refresh Data
+              </button>
             </div>
           </div>
-        )}
-      </section>
 
-      <section id="high-impact-diagnostics" className="mb-10">
-        <div className="mb-4 flex flex-col gap-2 border-b border-[var(--yr-line)] pb-2 md:flex-row md:items-end md:justify-between">
-          <div>
-            <h2 className="text-2xl font-bold text-gray-800">High-Impact Diagnostics</h2>
-            <p className="text-sm text-gray-500">
-              {analyticsRanges.find((range) => range.value === analyticsRange)?.label} snapshot
-            </p>
+          <div className="grid grid-cols-1 gap-4 p-5 lg:grid-cols-4">
+            <DashboardMetric
+              title="Search success"
+              value={searchSuccessRate === null ? '-' : formatPercent(searchSuccessRate)}
+              context={`${formatNumber(engagedSearches)} of ${formatNumber(searchTotal)} searches led to a view or save within ${formatNumber(searchQuality?.attributionWindowMinutes || 30)} minutes in ${selectedRangeLabel}.`}
+              tone={searchSuccessRate !== null && searchSuccessRate < 0.75 ? 'amber' : 'green'}
+            />
+            <DashboardMetric
+              title="Student action funnel"
+              value={formatPercent(funnel?.overallConversionRate)}
+              context="Share of visitors reaching a concrete save or outreach-style action."
+              tone="blue"
+            />
+            <DashboardMetric
+              title="Student-ready research"
+              value={studentReadyShare === null ? '-' : formatPercent(studentReadyShare)}
+              context={`${formatNumber(studentReadyEntities)} of ${formatNumber(activeEntities)} active research entities are student-ready.`}
+              tone="blue"
+            />
+            <DashboardMetric
+              title="Needs attention"
+              value={formatNumber(attentionCount)}
+              context={topAction}
+              tone={healthTone}
+            />
           </div>
-          {isImpactLoading && <span className="text-sm text-gray-500">Loading diagnostics...</span>}
-        </div>
 
-        {impactError && (
-          <div className="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-            {impactError}
-          </div>
-        )}
-
-        <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
-          <div className="bg-[var(--yr-panel)] rounded-lg shadow-md border border-[var(--yr-line)] overflow-hidden">
-            <div className="border-b border-[var(--yr-line)] p-4">
-              <h3 className="text-lg font-semibold text-gray-800">Search Quality</h3>
-              <p className="text-sm text-gray-500">Results coverage and failed intent signals</p>
-            </div>
-            <div className="grid grid-cols-3 gap-3 p-4 text-sm">
-              <div>
-                <p className="text-gray-500">Searches</p>
-                <p className="text-xl font-semibold text-gray-900">{formatNumber(searchTotal)}</p>
-              </div>
-              <div>
-                <p className="text-gray-500">With Results</p>
-                <p className="text-xl font-semibold text-gray-900">
-                  {formatNumber(searchesWithResults)}
+          <div className="grid grid-cols-1 gap-5 border-t border-[var(--yr-line)] p-5 xl:grid-cols-[1fr_1.2fr]">
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900">Decision Readout</h2>
+              <div className="mt-3 space-y-3 text-sm leading-6 text-gray-600">
+                <p>
+                  Start with search success and funnel movement: they show whether discovery intent
+                  becomes visible next-step behavior.
                 </p>
+                <p>
+                  Treat low-result queries and action cards as the work queue, not just warnings.
+                </p>
+                <p className="text-gray-500">Last updated: {lastUpdated || 'Not refreshed yet'}</p>
               </div>
+            </div>
+
+            <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
               <div>
-                <p className="text-gray-500">Zero-Result</p>
-                <p className="text-xl font-semibold text-gray-900">
-                  {formatPercent(searchQuality?.zeroResultRate)}
-                </p>
-              </div>
-            </div>
-            <div className="border-t border-[var(--yr-line)] px-4 py-3 text-sm">
-              <div className="mb-2 flex justify-between text-gray-600">
-                <span>Avg results/search</span>
-                <span className="font-medium text-gray-900">{formatNumber(avgResults, 1)}</span>
-              </div>
-              <div className="mb-3 flex justify-between text-gray-600">
-                <span>Avg latency</span>
-                <span className="font-medium text-gray-900">
-                  {searchQuality?.avgLatencyMs ? `${formatNumber(searchQuality.avgLatencyMs)} ms` : '-'}
-                </span>
-              </div>
-              <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
-                Zero or Low Result Queries
-              </h4>
-              <div className="space-y-2">
-                {[...zeroResultQueries, ...lowResultQueries].slice(0, 5).map((query, index) => (
-                  <div
-                    key={`${query.query}-${index}`}
-                    className="flex items-center justify-between gap-3 border-b border-[var(--yr-line)] pb-2 last:border-0 last:pb-0"
-                  >
-                    <span className="min-w-0 truncate text-gray-700">
-                      {query.query || '(empty search)'}
-                    </span>
-                    <span className="shrink-0 text-xs font-medium text-blue-600">
-                      {query.zeroResults ?? query.count} hits
-                    </span>
-                  </div>
-                ))}
-                {zeroResultQueries.length === 0 && lowResultQueries.length === 0 && (
-                  <p className="text-gray-500">No search quality flags returned.</p>
-                )}
-              </div>
-            </div>
-          </div>
-
-          <div className="bg-[var(--yr-panel)] rounded-lg shadow-md border border-[var(--yr-line)] overflow-hidden">
-            <div className="border-b border-[var(--yr-line)] p-4">
-              <h3 className="text-lg font-semibold text-gray-800">Student Funnel</h3>
-              <p className="text-sm text-gray-500">Visitor progression through key actions</p>
-            </div>
-            <div className="p-4">
-              <div className="mb-4 rounded-md bg-[var(--yr-blue-soft)] p-3">
-                <p className="text-sm text-blue-700">Overall conversion</p>
-                <p className="text-2xl font-semibold text-blue-900">
-                  {formatPercent(funnel?.overallConversionRate)}
-                </p>
-              </div>
-              <div className="space-y-3">
-                {funnelStages.length > 0 ? (
-                  funnelStages.map((stage, index) => {
-                    const previousCount = index > 0 ? funnelStages[index - 1].count : stage.count;
-                    const derivedRate =
-                      stage.conversionRate ??
-                      (previousCount > 0 ? stage.count / previousCount : undefined);
-
-                    return (
+                <h3 className="text-sm font-semibold text-gray-900">Funnel Snapshot</h3>
+                <div className="mt-3 space-y-3">
+                  {funnelStages.length > 0 ? (
+                    funnelStages.map((stage) => (
                       <div key={stage.key || stage.stage || stage.label}>
-                        <div className="mb-1 flex items-center justify-between text-sm">
+                        <div className="mb-1 flex items-center justify-between gap-3 text-sm">
                           <span className="font-medium text-gray-700">{stage.label}</span>
-                          <span className="text-gray-500">
-                            {formatNumber(stage.count)} ({formatPercent(derivedRate)})
-                          </span>
+                          <span className="text-gray-500">{formatNumber(stage.count)}</span>
                         </div>
-                        <div className="h-2 overflow-hidden rounded-full bg-[var(--yr-panel-muted)]">
+                        <div className="h-2 rounded-full bg-[var(--yr-panel-muted)]">
                           <div
-                            className="h-full rounded-full bg-blue-600"
-                            style={{ width: `${Math.min(Math.max((derivedRate || 0) * 100, 0), 100)}%` }}
+                            className="h-2 rounded-full bg-blue-600"
+                            style={{
+                              width: `${Math.min((stage.count / largestFunnelStageCount) * 100, 100)}%`,
+                            }}
                           />
                         </div>
                       </div>
-                    );
-                  })
-                ) : (
-                  <p className="text-sm text-gray-500">No funnel stages returned.</p>
-                )}
-              </div>
-            </div>
-          </div>
-
-          <div className="bg-[var(--yr-panel)] rounded-lg shadow-md border border-[var(--yr-line)] overflow-hidden">
-            <div className="border-b border-[var(--yr-line)] p-4">
-              <h3 className="text-lg font-semibold text-gray-800">Action Needed</h3>
-              <p className="text-sm text-gray-500">Highest-priority admin follow-ups</p>
-            </div>
-            <div className="grid grid-cols-1 gap-3 p-4 sm:grid-cols-2 xl:grid-cols-1">
-              {actionCards.length > 0 ? (
-                actionCards.slice(0, 4).map((card, index) => (
-                  <div
-                    key={card.id || card._id || `${card.title}-${index}`}
-                    className={`rounded-md border px-3 py-2 ${actionPriorityClass(card.priority)}`}
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <p className="font-medium">{card.title}</p>
-                      <span className="shrink-0 text-sm font-semibold">
-                        {formatCompactMetric(card.metric ?? card.count)}
-                      </span>
-                    </div>
-                    {(card.owner || card.department || card.type) && (
-                      <p className="mt-1 text-xs opacity-80">
-                        {[card.owner, card.department, card.type].filter(Boolean).join(' - ')}
-                      </p>
-                    )}
-                  </div>
-                ))
-              ) : (
-                <p className="text-sm text-gray-500">No action cards returned.</p>
-              )}
-            </div>
-            {actionItems.length > 0 && (
-              <div className="border-t border-[var(--yr-line)] p-4">
-                <div className="overflow-x-auto">
-                  <table className="min-w-full text-sm">
-                    <thead>
-                      <tr className="border-b text-gray-600">
-                        <th className="py-2 pr-3 text-left font-semibold">Item</th>
-                        <th className="py-2 px-3 text-left font-semibold">Owner</th>
-                        <th className="py-2 pl-3 text-right font-semibold">Metric</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {actionItems.slice(0, 5).map((item, index) => (
-                        <tr
-                          key={item.id || item._id || `${item.title}-${index}`}
-                          className="border-b last:border-0"
-                        >
-                          <td className="py-2 pr-3 text-gray-800">{item.title}</td>
-                          <td className="py-2 px-3 text-gray-600">{item.owner || '-'}</td>
-                          <td className="py-2 pl-3 text-right font-medium text-gray-900">
-                            {formatCompactMetric(item.metric ?? item.count)}
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
+                    ))
+                  ) : (
+                    <p className="text-sm text-gray-500">No funnel stages returned.</p>
+                  )}
                 </div>
               </div>
-            )}
-          </div>
-        </div>
-      </section>
 
-      <section className="mb-10">
-        <div className="mb-4 flex flex-col gap-2 border-b border-[var(--yr-line)] pb-2 md:flex-row md:items-end md:justify-between">
-          <div>
-            <h2 className="text-2xl font-bold text-gray-800">Search Query Analytics</h2>
-            <p className="text-sm text-gray-500">
-              Most popular search queries and the NetIDs behind them for the selected range.
-            </p>
-          </div>
-        </div>
-
-        <div className="overflow-hidden rounded-lg border border-[var(--yr-line)] bg-[var(--yr-panel)] shadow-md">
-          <div className="overflow-x-auto">
-            <table className="min-w-full">
-              <thead>
-                <tr className="border-b bg-[var(--yr-panel-muted)]">
-                  <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
-                    Query
-                  </th>
-                  <th className="px-4 py-3 text-right text-sm font-semibold text-gray-700">
-                    Searches
-                  </th>
-                  <th className="px-4 py-3 text-right text-sm font-semibold text-gray-700">
-                    Searchers
-                  </th>
-                  <th className="px-4 py-3 text-right text-sm font-semibold text-gray-700">
-                    Zero Results
-                  </th>
-                  <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
-                    Who Searched
-                  </th>
-                  <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
-                    Last Search
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {searchQueryRows.length > 0 ? (
-                  searchQueryRows.map((query) => (
-                    <tr key={query.query} className="border-b align-top hover:bg-[var(--yr-panel-muted)]">
-                      <td className="max-w-xs px-4 py-3 font-medium text-gray-900">
+              <div>
+                <h3 className="text-sm font-semibold text-gray-900">Search Gaps</h3>
+                <p className="mt-1 text-xs text-gray-500">
+                  {formatNumber(returnedButIgnoredSearches)} searches returned results but led to no
+                  view or save.
+                </p>
+                <div className="mt-3 space-y-2">
+                  {[...zeroResultQueries, ...lowResultQueries].slice(0, 5).map((query, index) => (
+                    <div
+                      key={`${query.query}-${index}`}
+                      className="flex items-center justify-between gap-3 rounded-md border border-[var(--yr-line)] px-3 py-2 text-sm"
+                    >
+                      <span className="min-w-0 truncate text-gray-700">
                         {query.query || '(empty search)'}
-                      </td>
-                      <td className="px-4 py-3 text-right font-medium text-blue-600">
-                        {formatNumber(query.totalSearches)}
-                      </td>
-                      <td className="px-4 py-3 text-right">{formatNumber(query.uniqueSearchers)}</td>
-                      <td className="px-4 py-3 text-right">
-                        {formatNumber(query.zeroResultSearches || 0)}
-                      </td>
-                      <td className="px-4 py-3">
-                        <div className="flex max-w-xl flex-wrap gap-2">
-                          {query.searchers.slice(0, 8).map((searcher) => (
-                            <span
-                              key={`${query.query}-${searcher.netid}`}
-                              className="rounded-md border border-[var(--yr-line)] bg-[var(--yr-panel-muted)] px-2 py-1 text-xs text-gray-700"
-                            >
-                              {formatSearcherName(searcher)} - {searcher.searchCount}
-                            </span>
-                          ))}
-                          {query.searchers.length > 8 && (
-                            <span className="px-1 py-1 text-xs text-gray-500">
-                              +{query.searchers.length - 8} more
-                            </span>
-                          )}
-                        </div>
-                      </td>
-                      <td className="px-4 py-3 text-sm text-gray-600">
-                        {formatDateTime(query.lastSearchedAt)}
-                      </td>
-                    </tr>
-                  ))
-                ) : (
-                  <tr>
-                    <td className="px-4 py-6 text-center text-gray-500" colSpan={6}>
-                      No tracked search queries for this range.
-                    </td>
-                  </tr>
-                )}
-              </tbody>
-            </table>
+                      </span>
+                      <span className="shrink-0 font-medium text-gray-900">
+                        {formatCompactMetric(query.zeroResults ?? query.count)}
+                      </span>
+                    </div>
+                  ))}
+                  {zeroResultQueries.length === 0 && lowResultQueries.length === 0 && (
+                    <p className="text-sm text-gray-500">No search quality flags returned.</p>
+                  )}
+                </div>
+              </div>
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
 
-      {data.engagement.mostActiveUsers.length > 0 && (
         <section className="mb-10">
-          <h2 className="text-2xl font-semibold mb-4 text-slate-950 border-b border-[var(--yr-line)] pb-2">
-            Most Active Users (Last 30 Days)
-          </h2>
-          <div className="bg-[var(--yr-panel)] rounded-lg shadow-md p-6 border border-[var(--yr-line)]">
+          <div className="mb-4 flex flex-col gap-2 border-b border-slate-200 pb-2 md:flex-row md:items-end md:justify-between">
+            <div>
+              <h2 className="text-2xl font-bold text-gray-800">Admin Access</h2>
+              <p className="text-sm text-gray-500">
+                Current admin authority comes from active admin grants, not profile user type.
+              </p>
+            </div>
+            <span className="rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-800">
+              {formatNumber(adminAccess.activeCount)} active admin
+              {adminAccess.activeCount === 1 ? '' : 's'}
+            </span>
+          </div>
+
+          {adminAccessError && (
+            <div className="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+              {adminAccessError}
+            </div>
+          )}
+
+          <form
+            className="mb-4 grid gap-3 rounded-lg border border-[var(--yr-line)] bg-[var(--yr-panel)] p-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1.5fr)_auto]"
+            onSubmit={(event) => {
+              void handleGrantAdminAccess(event);
+            }}
+          >
+            <label className="block">
+              <span className="mb-1 block text-xs font-semibold uppercase text-gray-500">
+                Grant admin NetID
+              </span>
+              <input
+                className="min-h-[44px] w-full rounded-md border border-[var(--yr-line-strong)] px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+                value={adminGrantNetid}
+                onChange={(event) => setAdminGrantNetid(event.target.value)}
+                placeholder="fixture-admin"
+              />
+            </label>
+            <label className="block">
+              <span className="mb-1 block text-xs font-semibold uppercase text-gray-500">
+                Admin grant note
+              </span>
+              <input
+                className="min-h-[44px] w-full rounded-md border border-[var(--yr-line-strong)] px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+                value={adminGrantNote}
+                onChange={(event) => setAdminGrantNote(event.target.value)}
+                placeholder="Optional"
+              />
+            </label>
+            <button
+              className="inline-flex min-h-[44px] items-center justify-center self-end rounded-md bg-[var(--yr-blue)] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-900 disabled:cursor-not-allowed disabled:bg-blue-300"
+              type="submit"
+              disabled={adminAccessActionNetid !== null}
+            >
+              Grant Admin
+            </button>
+          </form>
+
+          {adminAccessActionError && (
+            <div className="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+              {adminAccessActionError}
+            </div>
+          )}
+
+          {adminAccessActionMessage && (
+            <div className="mb-4 rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+              {adminAccessActionMessage}
+            </div>
+          )}
+
+          {adminAccess.legacyAdminsWithoutGrant.length > 0 && (
+            <div className="mb-4 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+              {adminAccess.legacyAdminsWithoutGrant.length} legacy admin profile row
+              {adminAccess.legacyAdminsWithoutGrant.length === 1 ? '' : 's'} without active grants:{' '}
+              {adminAccess.legacyAdminsWithoutGrant.map((user) => user.netid).join(', ')}
+              <div className="mt-3 flex flex-wrap gap-2">
+                {adminAccess.legacyAdminsWithoutGrant.map((user) => (
+                  <button
+                    key={user.netid}
+                    type="button"
+                    className="rounded-md border border-amber-300 bg-white px-3 py-1 text-xs font-semibold text-amber-900 hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-60"
+                    disabled={adminAccessActionNetid !== null}
+                    onClick={() => {
+                      void handleGrantAdminAccess(undefined, user.netid);
+                    }}
+                  >
+                    Grant {user.netid}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-md">
             <div className="overflow-x-auto">
               <table className="min-w-full">
                 <thead>
-                  <tr className="border-b">
-                    <th className="text-left py-3 px-4 font-semibold text-gray-700">User ID</th>
-                    <th className="text-left py-3 px-4 font-semibold text-gray-700">Type</th>
-                    <th className="text-right py-3 px-4 font-semibold text-gray-700">Events</th>
+                  <tr className="border-b bg-gray-50">
+                    <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
+                      NetID
+                    </th>
+                    <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
+                      Person
+                    </th>
+                    <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
+                      Source
+                    </th>
+                    <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
+                      Granted
+                    </th>
+                    <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
+                      Granted By
+                    </th>
+                    <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
+                      Status
+                    </th>
+                    <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
+                      Actions
+                    </th>
                   </tr>
                 </thead>
                 <tbody>
-                  {data.engagement.mostActiveUsers.map((user, index) => (
-                    <tr key={`${user.userId}-${index}`} className="border-b hover:bg-[var(--yr-panel-muted)]">
-                      <td className="py-3 px-4 text-gray-800">{user.userId}</td>
-                      <td className="py-3 px-4 text-gray-600">{formatUserType(user.userType)}</td>
-                      <td className="py-3 px-4 text-right font-medium">{user.eventCount}</td>
+                  {adminAccess.grants.length > 0 ? (
+                    adminAccess.grants.map((grant) => {
+                      const name = [grant.user?.fname, grant.user?.lname].filter(Boolean).join(' ');
+                      const isCurrentAdmin = grant.netid === adminActorNetid;
+                      return (
+                        <tr
+                          key={`${grant.netid}-${grant.status}`}
+                          className="border-b hover:bg-gray-50"
+                        >
+                          <td className="px-4 py-3 font-medium text-gray-900">{grant.netid}</td>
+                          <td className="px-4 py-3 text-gray-700">
+                            {name || grant.user?.email || '-'}
+                          </td>
+                          <td className="px-4 py-3 text-gray-700">{grant.source}</td>
+                          <td className="px-4 py-3 text-sm text-gray-600">
+                            {formatDateTime(grant.grantedAt)}
+                          </td>
+                          <td className="px-4 py-3 text-gray-700">{grant.grantedBy || '-'}</td>
+                          <td className="px-4 py-3">
+                            <span
+                              className={`rounded-md px-2 py-1 text-xs font-semibold ${
+                                grant.status === 'active'
+                                  ? 'bg-emerald-50 text-emerald-700'
+                                  : 'bg-gray-100 text-gray-600'
+                              }`}
+                            >
+                              {grant.status}
+                            </span>
+                          </td>
+                          <td className="px-4 py-3">
+                            {grant.status !== 'active' ? (
+                              <span className="text-sm text-gray-500">-</span>
+                            ) : isCurrentAdmin ? (
+                              <button
+                                type="button"
+                                disabled
+                                className="rounded-md border border-gray-200 px-3 py-1 text-xs font-semibold text-gray-500"
+                              >
+                                Current session
+                              </button>
+                            ) : (
+                              <button
+                                type="button"
+                                aria-label={`Revoke ${grant.netid}`}
+                                className="rounded-md border border-red-200 bg-red-50 px-3 py-1 text-xs font-semibold text-red-700 hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-60"
+                                disabled={adminAccessActionNetid !== null}
+                                onClick={() => {
+                                  void handleRevokeAdminAccess(grant.netid);
+                                }}
+                              >
+                                Revoke
+                              </button>
+                            )}
+                          </td>
+                        </tr>
+                      );
+                    })
+                  ) : (
+                    <tr>
+                      <td className="px-4 py-6 text-center text-gray-500" colSpan={7}>
+                        No admin grants returned.
+                      </td>
                     </tr>
-                  ))}
+                  )}
                 </tbody>
               </table>
             </div>
           </div>
         </section>
-      )}
 
-      <section className="mb-10">
-        <div className="flex flex-col gap-3 mb-4 border-b border-[var(--yr-line)] pb-2 md:flex-row md:items-end md:justify-between">
-          <div>
-            <h2 className="text-2xl font-bold text-gray-800">NetID User Activity</h2>
-            <p className="text-sm text-gray-500">
-              Admin-only activity lookup from tracked analytics events
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={fetchUserActivity}
-            className="inline-flex min-h-[44px] items-center justify-center self-start rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300 md:self-auto"
-            disabled={isUserActivityLoading}
+        <DetailSectionHeader
+          title="Supporting Detail"
+          description="Operational tables and lower-priority counts remain below the readout for drilldown."
+        />
+
+        <nav
+          aria-label="Analytics detail sections"
+          className="mb-6 flex flex-wrap gap-2 text-sm font-semibold"
+        >
+          <a
+            className="rounded-md border border-[var(--yr-line)] px-3 py-2 text-blue-700"
+            href="#visitor-statistics"
           >
-            {isUserActivityLoading ? 'Refreshing...' : 'Refresh Users'}
-          </button>
-        </div>
+            Visitors
+          </a>
+          <a
+            className="rounded-md border border-[var(--yr-line)] px-3 py-2 text-blue-700"
+            href="#diagnostics"
+          >
+            Diagnostics
+          </a>
+          <a
+            className="rounded-md border border-[var(--yr-line)] px-3 py-2 text-blue-700"
+            href="#research-coverage"
+          >
+            Research Coverage
+          </a>
+        </nav>
 
-        <div className="bg-[var(--yr-panel)] rounded-lg shadow-md border border-[var(--yr-line)] overflow-hidden">
-          <div className="grid grid-cols-1 gap-4 border-b border-[var(--yr-line)] p-4 lg:grid-cols-5">
-            <label className="block lg:col-span-2">
-              <span className="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">
-                Search NetID
-              </span>
-              <input
-                type="search"
-                value={userSearch}
-                onChange={(event) => setUserSearch(event.target.value)}
-                placeholder="e.g. abc123"
-                className="min-h-[44px] w-full rounded-md border border-[var(--yr-line-strong)] px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
-              />
-            </label>
-
-            <label className="block">
-              <span className="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">
-                User Type
-              </span>
-              <select
-                value={userTypeFilter}
-                onChange={(event) => setUserTypeFilter(event.target.value)}
-                className="min-h-[44px] w-full rounded-md border border-[var(--yr-line-strong)] px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
-              >
-                <option value="all">All Types</option>
-                <option value="undergraduate">Undergrads</option>
-                <option value="graduate">Graduates</option>
-                <option value="professor">Faculty & Professors</option>
-                <option value="admin">Admins</option>
-                <option value="unknown">Unknown</option>
-              </select>
-            </label>
-
-            <label className="block">
-              <span className="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">
-                Sort
-              </span>
-              <select
-                value={userActivitySort}
-                onChange={(event) => setUserActivitySort(event.target.value as UserActivitySort)}
-                className="min-h-[44px] w-full rounded-md border border-[var(--yr-line-strong)] px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
-              >
-                <option value="lastActive">Last Active</option>
-                <option value="totalEvents">Total Events</option>
-                <option value="logins">Logins</option>
-                <option value="searches">Searches</option>
-                <option value="views">Views</option>
-              </select>
-            </label>
-
-            <label className="block">
-              <span className="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">
-                Limit
-              </span>
-              <select
-                value={userActivityLimit}
-                onChange={(event) => setUserActivityLimit(Number(event.target.value))}
-                className="min-h-[44px] w-full rounded-md border border-[var(--yr-line-strong)] px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
-              >
-                <option value={10}>10 users</option>
-                <option value={25}>25 users</option>
-                <option value={50}>50 users</option>
-                <option value={100}>100 users</option>
-              </select>
-            </label>
+        <section id="research-coverage" className="mb-10">
+          <div className="mb-4 flex flex-col gap-2 border-b border-[var(--yr-line)] pb-2 md:flex-row md:items-end md:justify-between">
+            <div>
+              <h2 className="text-2xl font-bold text-gray-800">Research Data Coverage</h2>
+              <p className="text-sm text-gray-500">
+                Scraped ResearchEntity corpus — the primary catalog students browse. Counts cover
+                active (non-archived) entities.
+              </p>
+            </div>
           </div>
 
-          <div className="flex flex-col gap-6 p-4 xl:flex-row">
-            <div className="min-w-0 flex-1">
-              <div className="mb-3 flex flex-col gap-2 text-sm text-gray-500 sm:flex-row sm:items-center sm:justify-between">
-                <span>
-                  Showing {userActivity.users.length} of {userActivity.total} matching users
-                </span>
-                <button
-                  type="button"
-                  onClick={() =>
-                    setUserActivityOrder(userActivityOrder === 'asc' ? 'desc' : 'asc')
-                  }
-                  className="inline-flex min-h-[44px] items-center self-start rounded-md border border-[var(--yr-line-strong)] px-3 py-2 text-gray-700 transition-colors hover:bg-[var(--yr-panel-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200 sm:self-auto"
-                >
-                  Order: {userActivityOrder === 'asc' ? 'Ascending' : 'Descending'}
-                </button>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
+            <StatCard
+              title="Active Research Entities"
+              value={researchCoverage.overview.active}
+              subtitle={`${formatNumber(researchCoverage.overview.archived)} archived`}
+            />
+            <StatCard
+              title="Student-Ready"
+              value={studentReadyEntities}
+              subtitle={
+                studentReadyShare === null
+                  ? undefined
+                  : `${formatPercent(studentReadyShare)} of active`
+              }
+            />
+            <StatCard
+              title="Refreshed (30 Days)"
+              value={freshEntities}
+              subtitle={freshShare === null ? undefined : `${formatPercent(freshShare)} of active`}
+            />
+            <StatCard
+              title="Stale or Never Observed"
+              value={staleEntities}
+              subtitle={`${formatNumber(researchCoverage.freshness.neverObserved)} never observed`}
+            />
+          </div>
+
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+            <div className="bg-[var(--yr-panel)] rounded-lg shadow-md border border-[var(--yr-line)] overflow-hidden">
+              <div className="border-b border-[var(--yr-line)] p-4">
+                <h3 className="text-lg font-semibold text-gray-800">By Entity Type</h3>
+                <p className="text-sm text-gray-500">What kinds of research homes exist</p>
               </div>
-
-              {userActivityError && (
-                <div className="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-                  {userActivityError}
-                </div>
-              )}
-
               <div className="overflow-x-auto">
-                <table className="min-w-full">
+                <table className="min-w-full text-sm">
                   <thead>
                     <tr className="border-b bg-[var(--yr-panel-muted)]">
-                      <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
-                        NetID
-                      </th>
-                      <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
-                        Type
-                      </th>
-                      <th className="px-4 py-3 text-right text-sm font-semibold text-gray-700">
-                        <button
-                          type="button"
-                          onClick={() => updateUserActivitySort('totalEvents')}
-                          className="inline-flex min-h-[44px] items-center rounded-md px-2 hover:bg-[var(--yr-panel-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
-                        >
-                          Events{sortLabel('totalEvents')}
-                        </button>
-                      </th>
-                      <th className="px-4 py-3 text-right text-sm font-semibold text-gray-700">
-                        <button
-                          type="button"
-                          onClick={() => updateUserActivitySort('logins')}
-                          className="inline-flex min-h-[44px] items-center rounded-md px-2 hover:bg-[var(--yr-panel-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
-                        >
-                          Logins{sortLabel('logins')}
-                        </button>
-                      </th>
-                      <th className="px-4 py-3 text-right text-sm font-semibold text-gray-700">
-                        <button
-                          type="button"
-                          onClick={() => updateUserActivitySort('searches')}
-                          className="inline-flex min-h-[44px] items-center rounded-md px-2 hover:bg-[var(--yr-panel-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
-                        >
-                          Searches{sortLabel('searches')}
-                        </button>
-                      </th>
-                      <th className="px-4 py-3 text-right text-sm font-semibold text-gray-700">
-                        <button
-                          type="button"
-                          onClick={() => updateUserActivitySort('views')}
-                          className="inline-flex min-h-[44px] items-center rounded-md px-2 hover:bg-[var(--yr-panel-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
-                        >
-                          Views{sortLabel('views')}
-                        </button>
-                      </th>
-                      <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
-                        <button
-                          type="button"
-                          onClick={() => updateUserActivitySort('lastActive')}
-                          className="inline-flex min-h-[44px] items-center rounded-md px-2 hover:bg-[var(--yr-panel-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
-                        >
-                          Last Active{sortLabel('lastActive')}
-                        </button>
-                      </th>
+                      <th className="px-4 py-2 text-left font-semibold text-gray-700">Type</th>
+                      <th className="px-4 py-2 text-right font-semibold text-gray-700">Entities</th>
                     </tr>
                   </thead>
                   <tbody>
-                    {isUserActivityLoading && userActivity.users.length === 0 ? (
-                      <tr>
-                        <td className="px-4 py-6 text-center text-gray-500" colSpan={7}>
-                          Loading user activity...
-                        </td>
-                      </tr>
-                    ) : userActivity.users.length > 0 ? (
-                      userActivity.users.map((user, index) => (
+                    {researchCoverage.byType.length > 0 ? (
+                      researchCoverage.byType.map((row) => (
                         <tr
-                          key={`${user.netid}-${index}`}
-                          className={`cursor-pointer border-b transition-colors hover:bg-[var(--yr-blue-soft)] ${
-                            selectedNetid === user.netid ? 'bg-[var(--yr-blue-soft)]' : ''
-                          }`}
-                          onClick={() => setSelectedNetid(user.netid)}
+                          key={row.entityType || 'unknown'}
+                          className="border-b last:border-0 hover:bg-[var(--yr-panel-muted)]"
                         >
-                          <td className="px-4 py-3 font-medium text-gray-900">{user.netid}</td>
-                          <td className="px-4 py-3 text-gray-600">
-                            {formatUserType(user.userType)}
+                          <td className="px-4 py-2 text-gray-800">
+                            {formatEntityType(row.entityType)}
                           </td>
-                          <td className="px-4 py-3 text-right font-medium">{user.totalEvents}</td>
-                          <td className="px-4 py-3 text-right">{user.logins}</td>
-                          <td className="px-4 py-3 text-right">{user.searches}</td>
-                          <td className="px-4 py-3 text-right">{user.views}</td>
-                          <td className="px-4 py-3 text-sm text-gray-600">
-                            {formatDateTime(user.lastActive)}
+                          <td className="px-4 py-2 text-right font-medium">
+                            {formatNumber(row.count)}
                           </td>
                         </tr>
                       ))
                     ) : (
                       <tr>
-                        <td className="px-4 py-6 text-center text-gray-500" colSpan={7}>
-                          No users match the current filters.
+                        <td className="px-4 py-4 text-center text-gray-500" colSpan={2}>
+                          No research entities returned.
                         </td>
                       </tr>
                     )}
@@ -1811,245 +1020,1079 @@ const Analytics = () => {
               </div>
             </div>
 
-            <aside className="w-full rounded-lg border border-[var(--yr-line)] bg-[var(--yr-panel-muted)] p-4 xl:w-96">
-              <div className="mb-4 flex items-start justify-between gap-3">
-                <div>
-                  <h3 className="text-lg font-semibold text-gray-800">
-                    {selectedNetid ? selectedNetid : 'Select a NetID'}
-                  </h3>
-                  {selectedUserSummary && (
-                    <p className="text-sm text-gray-500">
-                      {formatUserType(selectedUserSummary.userType)} -{' '}
-                      {selectedUserSummary.totalEvents} events
-                    </p>
-                  )}
-                </div>
-                {selectedNetid && (
-                  <button
-                    type="button"
-                    onClick={() => setSelectedNetid(null)}
-                    className="inline-flex min-h-[44px] items-center rounded-md border border-[var(--yr-line-strong)] px-3 py-2 text-xs text-gray-600 hover:bg-[var(--yr-panel)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
-                  >
-                    Clear
-                  </button>
+            <div className="bg-[var(--yr-panel)] rounded-lg shadow-md border border-[var(--yr-line)] overflow-hidden">
+              <div className="border-b border-[var(--yr-line)] p-4">
+                <h3 className="text-lg font-semibold text-gray-800">By Visibility Tier</h3>
+                <p className="text-sm text-gray-500">Student-facing exposure gating</p>
+              </div>
+              <div className="space-y-2 p-4 text-sm">
+                {researchCoverage.byVisibilityTier.length > 0 ? (
+                  researchCoverage.byVisibilityTier.map((row) => (
+                    <div key={row.tier || 'unknown'} className="flex items-center justify-between">
+                      <span className="text-gray-600">{formatVisibilityTier(row.tier)}</span>
+                      <span className="font-medium text-gray-900">{formatNumber(row.count)}</span>
+                    </div>
+                  ))
+                ) : (
+                  <p className="text-gray-500">No tier data returned.</p>
                 )}
               </div>
+            </div>
 
-              {!selectedNetid && (
-                <p className="text-sm text-gray-500">
-                  Pick a row to inspect the latest events for that NetID.
-                </p>
-              )}
-
-              {selectedNetid && isSelectedUserLoading && (
-                <p className="text-sm text-gray-500">Loading recent events...</p>
-              )}
-
-              {selectedNetid && selectedUserError && (
-                <div className="rounded-md border border-red-200 bg-[var(--yr-panel)] px-3 py-2 text-sm text-red-700">
-                  {selectedUserError}
-                </div>
-              )}
-
-              {selectedUser && !isSelectedUserLoading && (
-                <div>
-                  <div className="mb-4 grid grid-cols-2 gap-3 text-sm">
-                    <div className="rounded-md bg-[var(--yr-panel)] p-3">
-                      <p className="text-gray-500">Logins</p>
-                      <p className="text-lg font-semibold text-gray-900">
-                        {selectedUser.user.logins}
-                      </p>
-                    </div>
-                    <div className="rounded-md bg-[var(--yr-panel)] p-3">
-                      <p className="text-gray-500">Searches</p>
-                      <p className="text-lg font-semibold text-gray-900">
-                        {selectedUser.user.searches}
-                      </p>
-                    </div>
-                    <div className="rounded-md bg-[var(--yr-panel)] p-3">
-                      <p className="text-gray-500">Views</p>
-                      <p className="text-lg font-semibold text-gray-900">
-                        {selectedUser.user.views}
-                      </p>
-                    </div>
-                    <div className="rounded-md bg-[var(--yr-panel)] p-3">
-                      <p className="text-gray-500">Saves</p>
-                      <p className="text-lg font-semibold text-gray-900">
-                        {selectedUser.user.listingFavorites}
-                      </p>
-                    </div>
+            <div className="bg-[var(--yr-panel)] rounded-lg shadow-md border border-[var(--yr-line)] overflow-hidden">
+              <div className="border-b border-[var(--yr-line)] p-4">
+                <h3 className="text-lg font-semibold text-gray-800">Openness & Scholarly Signal</h3>
+                <p className="text-sm text-gray-500">Access posture and recent activity</p>
+              </div>
+              <div className="space-y-2 p-4 text-sm">
+                {researchCoverage.byOpenness.map((row) => (
+                  <div key={row.status || 'unknown'} className="flex items-center justify-between">
+                    <span className="text-gray-600">{formatOpenness(row.status)}</span>
+                    <span className="font-medium text-gray-900">{formatNumber(row.count)}</span>
                   </div>
-
-                  <h4 className="mb-2 text-sm font-semibold uppercase tracking-wide text-gray-500">
-                    Recent Events
-                  </h4>
-                  <div className="max-h-96 space-y-3 overflow-y-auto pr-1">
-                    {selectedUser.events.length > 0 ? (
-                      selectedUser.events.map((event, index) => (
-                        <div
-                          key={event.id || event._id || `${event.eventType}-${event.timestamp}-${index}`}
-                          className="rounded-md border border-[var(--yr-line)] bg-[var(--yr-panel)] p-3"
-                        >
-                          <div className="flex items-start justify-between gap-3">
-                            <p className="font-medium text-gray-800">
-                              {formatEventType(event.eventType)}
-                            </p>
-                            <p className="shrink-0 text-right text-xs text-gray-500">
-                              {formatDateTime(event.timestamp)}
-                            </p>
-                          </div>
-                          {event.searchQuery && (
-                            <p className="mt-1 text-sm text-gray-600">Query: {event.searchQuery}</p>
-                          )}
-                          {event.listingId && (
-                            <p className="mt-1 text-sm text-gray-600">
-                              Opportunity: {event.listingId}
-                            </p>
-                          )}
-                        </div>
-                      ))
-                    ) : (
-                      <p className="text-sm text-gray-500">No recent events returned.</p>
-                    )}
-                  </div>
+                ))}
+                <div className="mt-3 flex items-center justify-between border-t border-[var(--yr-line)] pt-3">
+                  <span className="text-gray-600">With recent papers</span>
+                  <span className="font-medium text-gray-900">
+                    {formatNumber(researchCoverage.scholarly.withRecentPapers)}
+                  </span>
                 </div>
-              )}
-            </aside>
+                <div className="flex items-center justify-between">
+                  <span className="text-gray-600">With recent grants</span>
+                  <span className="font-medium text-gray-900">
+                    {formatNumber(researchCoverage.scholarly.withRecentGrants)}
+                  </span>
+                </div>
+              </div>
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
 
-      <section className="mb-10">
-        <DetailSectionHeader
-          title="Research Engagement"
-          description="Student-facing research surface events across profiles, opportunities, and programs."
-        />
+        <section id="visitor-statistics" className="mb-10">
+          <h2 className="text-2xl font-semibold mb-4 text-slate-950 border-b border-[var(--yr-line)] pb-2">
+            Visitor Statistics
+          </h2>
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
-          {data.research.byEventType.slice(0, 3).map((item) => (
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
             <StatCard
-              key={item.eventType}
-              title={formatEventType(item.eventType)}
-              value={item.total}
-              subtitle={`${item.last7Days} last 7 days, ${item.today} today`}
+              title="Total Visitors (Lifetime)"
+              value={data.visitors.lifetime.total}
+              subtitle="Unique users who've logged in"
             />
-          ))}
-          {data.research.byEventType.length === 0 && (
-            <div className="rounded-md border border-[var(--yr-line)] bg-[var(--yr-panel)] p-6 text-sm text-gray-500 md:col-span-3">
-              No research engagement events yet.
+            <StatCard
+              title="Visitors (Last 7 Days)"
+              value={data.visitors.last7Days.total}
+              subtitle="Active in past week"
+            />
+            <StatCard
+              title="Visitors Today"
+              value={data.visitors.today.total}
+              subtitle="Logged in today"
+            />
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
+            <StatCard
+              title="Total Login Events"
+              value={data.visitors.loginFrequency.totalLogins}
+              subtitle="All-time login count"
+            />
+            <StatCard
+              title="Logins (Last 7 Days)"
+              value={data.visitors.loginFrequency.loginsLast7Days}
+              subtitle="Total logins this week"
+            />
+            <StatCard
+              title="Logins Today"
+              value={data.visitors.loginFrequency.loginsToday}
+              subtitle="Login events today"
+            />
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <div className="bg-[var(--yr-panel)] rounded-lg shadow-md p-6 border border-[var(--yr-line)]">
+              <h3 className="text-sm font-semibold text-gray-700 mb-3">
+                Lifetime Visitors by Type
+              </h3>
+              <div className="space-y-2">
+                {data.visitors.lifetime.byType.map((item) => (
+                  <div key={item.userType} className="flex justify-between text-sm">
+                    <span className="text-gray-600">{formatUserType(item.userType)}:</span>
+                    <span className="font-medium">{item.count}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="bg-[var(--yr-panel)] rounded-lg shadow-md p-6 border border-[var(--yr-line)]">
+              <h3 className="text-sm font-semibold text-gray-700 mb-3">Last 7 Days by Type</h3>
+              <div className="space-y-2">
+                {data.visitors.last7Days.byType.map((item) => (
+                  <div key={item.userType} className="flex justify-between text-sm">
+                    <span className="text-gray-600">{formatUserType(item.userType)}:</span>
+                    <span className="font-medium">{item.count}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="bg-[var(--yr-panel)] rounded-lg shadow-md p-6 border border-[var(--yr-line)]">
+              <h3 className="text-sm font-semibold text-gray-700 mb-3">Today by Type</h3>
+              <div className="space-y-2">
+                {data.visitors.today.byType.length > 0 ? (
+                  data.visitors.today.byType.map((item) => (
+                    <div key={item.userType} className="flex justify-between text-sm">
+                      <span className="text-gray-600">{formatUserType(item.userType)}:</span>
+                      <span className="font-medium">{item.count}</span>
+                    </div>
+                  ))
+                ) : (
+                  <p className="text-sm text-gray-500">No visitors yet today</p>
+                )}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section id="diagnostics" className="mb-10">
+          <h2 className="text-2xl font-semibold mb-4 text-slate-950 border-b border-[var(--yr-line)] pb-2">
+            User Engagement
+          </h2>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
+            <StatCard
+              title="Total Searches"
+              value={data.engagement.search.totalSearches}
+              subtitle="All-time search queries"
+            />
+            <StatCard
+              title="Searches (Last 7 Days)"
+              value={data.engagement.search.searchesLast7Days}
+              subtitle="Recent searches"
+            />
+            <StatCard
+              title="Searches Today"
+              value={data.engagement.search.searchesToday}
+              subtitle="Searches today"
+            />
+          </div>
+
+          {data.engagement.topSearchQueries.length > 0 && (
+            <div className="bg-[var(--yr-panel)] rounded-lg shadow-md p-6 border border-[var(--yr-line)] mb-6">
+              <h3 className="text-lg font-semibold text-gray-700 mb-4">
+                Top Search Queries (Last 30 Days)
+              </h3>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {data.engagement.topSearchQueries.map((item, index) => (
+                  <div key={index} className="flex justify-between border-b pb-2">
+                    <span className="text-gray-700">{item.query || '(empty search)'}</span>
+                    <span className="font-medium text-blue-600">{item.count} searches</span>
+                  </div>
+                ))}
+              </div>
             </div>
           )}
-        </div>
 
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          <div className="bg-[var(--yr-panel)] rounded-lg shadow-md p-6 border border-[var(--yr-line)]">
-            <h3 className="text-lg font-semibold text-gray-700 mb-4">Events by Entity</h3>
-            <div className="space-y-2">
-              {data.research.byEntityType.length > 0 ? (
-                data.research.byEntityType.slice(0, 8).map((item) => (
-                  <div
-                    key={`${item.entityType}-${item.eventType}`}
-                    className="flex justify-between gap-3 text-sm"
-                  >
-                    <span className="text-gray-600 capitalize">
-                      {item.entityType} / {formatEventType(item.eventType)}
-                    </span>
-                    <span className="font-medium">{item.count}</span>
-                  </div>
-                ))
-              ) : (
-                <p className="text-sm text-gray-500">No entity events yet.</p>
-              )}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <StatCard
+              title="Active Users (Last 7 Days)"
+              value={data.engagement.userActivity.activeUsers}
+              subtitle="Users with activity"
+            />
+            <StatCard
+              title="Avg Events Per User"
+              value={data.engagement.userActivity.avgEventsPerUser.toFixed(1)}
+              subtitle="Last 7 days"
+            />
+          </div>
+        </section>
+
+        <section className="mb-10">
+          <h2 className="text-2xl font-semibold mb-4 text-slate-950 border-b border-[var(--yr-line)] pb-2">
+            Outreach Loop
+          </h2>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
+            <StatCard
+              title="Email Contact Clicks"
+              value={outreach.summary.totalAttempts}
+              subtitle={`${outreach.summary.attemptsLast7Days} in last 7 days`}
+            />
+            <StatCard
+              title="Reported Outcomes"
+              value={outreach.summary.totalOutcomes}
+              subtitle={`${outreach.summary.outcomesLast7Days} in last 7 days`}
+            />
+            <StatCard
+              title="Contact Details Revealed"
+              value={outreach.summary.totalReveals}
+              subtitle={`${outreach.summary.revealsLast7Days} in last 7 days`}
+            />
+          </div>
+
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+            <div className="bg-[var(--yr-panel)] rounded-lg shadow-md p-6 border border-[var(--yr-line)]">
+              <h3 className="text-lg font-semibold text-gray-700 mb-4">Outcomes</h3>
+              <div className="space-y-3">
+                {outreach.byOutcome.length > 0 ? (
+                  outreach.byOutcome.map((item) => (
+                    <div key={item.outcome} className="flex justify-between">
+                      <span className="text-gray-600">{formatOutcome(item.outcome)}</span>
+                      <span className="font-bold text-lg">{item.count}</span>
+                    </div>
+                  ))
+                ) : (
+                  <p className="text-sm text-gray-500">No reported outcomes yet.</p>
+                )}
+              </div>
+            </div>
+
+            <div className="bg-[var(--yr-panel)] rounded-lg shadow-md p-6 border border-[var(--yr-line)] lg:col-span-2">
+              <h3 className="text-lg font-semibold text-gray-700 mb-4">Top Outreach Contacts</h3>
+              <div className="overflow-x-auto">
+                <table className="min-w-full">
+                  <thead>
+                    <tr className="border-b bg-[var(--yr-panel-muted)]">
+                      <th className="px-4 py-2 text-left font-semibold text-gray-700">Contact</th>
+                      <th className="px-4 py-2 text-right font-semibold text-gray-700">Attempts</th>
+                      <th className="px-4 py-2 text-right font-semibold text-gray-700">Outcomes</th>
+                      <th className="px-4 py-2 text-right font-semibold text-gray-700">Users</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {outreach.topListings.length > 0 ? (
+                      outreach.topListings.map((listing) => (
+                        <tr
+                          key={listing.listingId}
+                          className="border-b hover:bg-[var(--yr-panel-muted)]"
+                        >
+                          <td className="py-3 px-4 text-gray-800">
+                            <div className="font-medium">{listing.title || 'Unknown listing'}</div>
+                            <div className="text-xs text-gray-500">
+                              {[listing.ownerFirstName, listing.ownerLastName]
+                                .filter(Boolean)
+                                .join(' ') || listing.listingId}
+                            </div>
+                          </td>
+                          <td className="py-3 px-4 text-right font-medium">{listing.attempts}</td>
+                          <td className="py-3 px-4 text-right font-medium">{listing.outcomes}</td>
+                          <td className="py-3 px-4 text-right font-medium">
+                            {listing.uniqueUsers}
+                          </td>
+                        </tr>
+                      ))
+                    ) : (
+                      <tr>
+                        <td className="py-4 px-4 text-sm text-gray-500" colSpan={4}>
+                          No outreach activity yet.
+                        </td>
+                      </tr>
+                    )}
+                  </tbody>
+                </table>
+              </div>
             </div>
           </div>
 
-          <div className="bg-[var(--yr-panel)] rounded-lg shadow-md p-6 border border-[var(--yr-line)]">
-            <h3 className="text-lg font-semibold text-gray-700 mb-4">Research Users</h3>
-            <div className="space-y-2">
-              {data.research.byUserType.length > 0 ? (
-                data.research.byUserType.map((item) => (
-                  <div key={item.userType} className="flex justify-between text-sm">
-                    <span className="text-gray-600">{formatUserType(item.userType)}</span>
-                    <span className="font-medium">{item.count}</span>
-                  </div>
-                ))
-              ) : (
-                <p className="text-sm text-gray-500">No research users yet.</p>
-              )}
+          {outreach.recentEvents.length > 0 && (
+            <div className="mt-6 bg-[var(--yr-panel)] rounded-lg shadow-md p-6 border border-[var(--yr-line)]">
+              <h3 className="text-lg font-semibold text-gray-700 mb-4">Recent Outreach Events</h3>
+              <div className="overflow-x-auto">
+                <table className="min-w-full">
+                  <thead>
+                    <tr className="border-b bg-[var(--yr-panel-muted)]">
+                      <th className="px-4 py-2 text-left font-semibold text-gray-700">When</th>
+                      <th className="px-4 py-2 text-left font-semibold text-gray-700">Listing</th>
+                      <th className="px-4 py-2 text-left font-semibold text-gray-700">Action</th>
+                      <th className="px-4 py-2 text-left font-semibold text-gray-700">User Type</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {outreach.recentEvents.map((event, index) => (
+                      <tr
+                        key={`${event.listingId}-${event.timestamp}-${index}`}
+                        className="border-b hover:bg-[var(--yr-panel-muted)]"
+                      >
+                        <td className="py-3 px-4 text-gray-600">
+                          {formatDateTime(event.timestamp)}
+                        </td>
+                        <td className="py-3 px-4 text-gray-800">
+                          {event.title || event.listingId}
+                        </td>
+                        <td className="py-3 px-4 text-gray-600">{formatOutcome(event.outcome)}</td>
+                        <td className="py-3 px-4 text-gray-600">
+                          {formatUserType(event.userType)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
             </div>
+          )}
+        </section>
+
+        <section id="high-impact-diagnostics" className="mb-10">
+          <div className="mb-4 flex flex-col gap-2 border-b border-[var(--yr-line)] pb-2 md:flex-row md:items-end md:justify-between">
+            <div>
+              <h2 className="text-2xl font-bold text-gray-800">High-Impact Diagnostics</h2>
+              <p className="text-sm text-gray-500">
+                {analyticsRanges.find((range) => range.value === analyticsRange)?.label} snapshot
+              </p>
+            </div>
+            {isImpactLoading && (
+              <span className="text-sm text-gray-500">Loading diagnostics...</span>
+            )}
           </div>
 
-          <div className="bg-[var(--yr-panel)] rounded-lg shadow-md p-6 border border-[var(--yr-line)]">
-            <h3 className="text-lg font-semibold text-gray-700 mb-4">
-              Top Research Entities (30 Days)
-            </h3>
-            <div className="space-y-2">
-              {data.research.topEntities.length > 0 ? (
-                data.research.topEntities.slice(0, 8).map((item) => (
-                  <div
-                    key={`${item.entityType}-${item.entityId}`}
-                    className="flex justify-between gap-3 text-sm"
-                  >
-                    <span className="truncate text-gray-600">
-                      <span className="capitalize">{item.entityType}</span> {item.entityId}
-                    </span>
-                    <span className="whitespace-nowrap font-medium">
-                      {item.views} views / {item.uniqueViewers} users
-                    </span>
-                  </div>
-                ))
-              ) : (
-                <p className="text-sm text-gray-500">No viewed entities yet.</p>
-              )}
+          {impactError && (
+            <div className="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+              {impactError}
             </div>
-          </div>
-        </div>
-      </section>
+          )}
 
-      <section className="mb-10">
-        <h2 className="text-2xl font-semibold mb-4 text-slate-950 border-b border-[var(--yr-line)] pb-2">
-          User Statistics
-        </h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
-          <StatCard title="Total Users" value={data.users.overview.total} />
-          <StatCard title="Confirmed Users" value={data.users.overview.confirmed} />
-          <StatCard title="New Users (7 Days)" value={data.users.newUsersLast7Days} />
-          <StatCard title="New Users Today" value={data.users.newUsersToday} />
-        </div>
-
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div className="bg-[var(--yr-panel)] rounded-lg shadow-md p-6 border border-[var(--yr-line)]">
-            <h3 className="text-lg font-semibold text-gray-700 mb-4">Users by Type</h3>
-            <div className="space-y-3">
-              {data.users.byType.map((item) => (
-                <div key={item.userType} className="flex justify-between">
-                  <span className="text-gray-600">{formatUserType(item.userType)}:</span>
-                  <span className="font-bold text-lg">{item.count}</span>
+          <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+            <div className="bg-[var(--yr-panel)] rounded-lg shadow-md border border-[var(--yr-line)] overflow-hidden">
+              <div className="border-b border-[var(--yr-line)] p-4">
+                <h3 className="text-lg font-semibold text-gray-800">Search Quality</h3>
+                <p className="text-sm text-gray-500">Results coverage and failed intent signals</p>
+              </div>
+              <div className="grid grid-cols-3 gap-3 p-4 text-sm">
+                <div>
+                  <p className="text-gray-500">Searches</p>
+                  <p className="text-xl font-semibold text-gray-900">{formatNumber(searchTotal)}</p>
                 </div>
-              ))}
+                <div>
+                  <p className="text-gray-500">Led to Action</p>
+                  <p className="text-xl font-semibold text-gray-900">
+                    {formatNumber(engagedSearches)}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-gray-500">Zero-Result</p>
+                  <p className="text-xl font-semibold text-gray-900">
+                    {formatPercent(searchQuality?.zeroResultRate)}
+                  </p>
+                </div>
+              </div>
+              <div className="border-t border-[var(--yr-line)] px-4 py-3 text-sm">
+                <div className="mb-2 flex justify-between text-gray-600">
+                  <span>Avg results/search</span>
+                  <span className="font-medium text-gray-900">{formatNumber(avgResults, 1)}</span>
+                </div>
+                <div className="mb-3 flex justify-between text-gray-600">
+                  <span>Avg latency</span>
+                  <span className="font-medium text-gray-900">
+                    {searchQuality?.avgLatencyMs
+                      ? `${formatNumber(searchQuality.avgLatencyMs)} ms`
+                      : '-'}
+                  </span>
+                </div>
+                <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  Zero or Low Result Queries
+                </h4>
+                <div className="space-y-2">
+                  {[...zeroResultQueries, ...lowResultQueries].slice(0, 5).map((query, index) => (
+                    <div
+                      key={`${query.query}-${index}`}
+                      className="flex items-center justify-between gap-3 border-b border-[var(--yr-line)] pb-2 last:border-0 last:pb-0"
+                    >
+                      <span className="min-w-0 truncate text-gray-700">
+                        {query.query || '(empty search)'}
+                      </span>
+                      <span className="shrink-0 text-xs font-medium text-blue-600">
+                        {query.zeroResults ?? query.count} hits
+                      </span>
+                    </div>
+                  ))}
+                  {zeroResultQueries.length === 0 && lowResultQueries.length === 0 && (
+                    <p className="text-gray-500">No search quality flags returned.</p>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            <div className="bg-[var(--yr-panel)] rounded-lg shadow-md border border-[var(--yr-line)] overflow-hidden">
+              <div className="border-b border-[var(--yr-line)] p-4">
+                <h3 className="text-lg font-semibold text-gray-800">Student Funnel</h3>
+                <p className="text-sm text-gray-500">Visitor progression through key actions</p>
+              </div>
+              <div className="p-4">
+                <div className="mb-4 rounded-md bg-[var(--yr-blue-soft)] p-3">
+                  <p className="text-sm text-blue-700">Overall conversion</p>
+                  <p className="text-2xl font-semibold text-blue-900">
+                    {formatPercent(funnel?.overallConversionRate)}
+                  </p>
+                </div>
+                <div className="space-y-3">
+                  {funnelStages.length > 0 ? (
+                    funnelStages.map((stage, index) => {
+                      const previousCount = index > 0 ? funnelStages[index - 1].count : stage.count;
+                      const derivedRate =
+                        stage.conversionRate ??
+                        (previousCount > 0 ? stage.count / previousCount : undefined);
+
+                      return (
+                        <div key={stage.key || stage.stage || stage.label}>
+                          <div className="mb-1 flex items-center justify-between text-sm">
+                            <span className="font-medium text-gray-700">{stage.label}</span>
+                            <span className="text-gray-500">
+                              {formatNumber(stage.count)} ({formatPercent(derivedRate)})
+                            </span>
+                          </div>
+                          <div className="h-2 overflow-hidden rounded-full bg-[var(--yr-panel-muted)]">
+                            <div
+                              className="h-full rounded-full bg-blue-600"
+                              style={{
+                                width: `${Math.min(Math.max((derivedRate || 0) * 100, 0), 100)}%`,
+                              }}
+                            />
+                          </div>
+                        </div>
+                      );
+                    })
+                  ) : (
+                    <p className="text-sm text-gray-500">No funnel stages returned.</p>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            <div className="bg-[var(--yr-panel)] rounded-lg shadow-md border border-[var(--yr-line)] overflow-hidden">
+              <div className="border-b border-[var(--yr-line)] p-4">
+                <h3 className="text-lg font-semibold text-gray-800">Action Needed</h3>
+                <p className="text-sm text-gray-500">Highest-priority admin follow-ups</p>
+              </div>
+              <div className="grid grid-cols-1 gap-3 p-4 sm:grid-cols-2 xl:grid-cols-1">
+                {actionCards.length > 0 ? (
+                  actionCards.slice(0, 4).map((card, index) => (
+                    <div
+                      key={card.id || card._id || `${card.title}-${index}`}
+                      className={`rounded-md border px-3 py-2 ${actionPriorityClass(card.priority)}`}
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <p className="font-medium">{card.title}</p>
+                        <span className="shrink-0 text-sm font-semibold">
+                          {formatCompactMetric(card.metric ?? card.count)}
+                        </span>
+                      </div>
+                      {(card.owner || card.department || card.type) && (
+                        <p className="mt-1 text-xs opacity-80">
+                          {[card.owner, card.department, card.type].filter(Boolean).join(' - ')}
+                        </p>
+                      )}
+                    </div>
+                  ))
+                ) : (
+                  <p className="text-sm text-gray-500">No action cards returned.</p>
+                )}
+              </div>
+              {actionItems.length > 0 && (
+                <div className="border-t border-[var(--yr-line)] p-4">
+                  <div className="overflow-x-auto">
+                    <table className="min-w-full text-sm">
+                      <thead>
+                        <tr className="border-b text-gray-600">
+                          <th className="py-2 pr-3 text-left font-semibold">Item</th>
+                          <th className="py-2 px-3 text-left font-semibold">Owner</th>
+                          <th className="py-2 pl-3 text-right font-semibold">Metric</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {actionItems.slice(0, 5).map((item, index) => (
+                          <tr
+                            key={item.id || item._id || `${item.title}-${index}`}
+                            className="border-b last:border-0"
+                          >
+                            <td className="py-2 pr-3 text-gray-800">{item.title}</td>
+                            <td className="py-2 px-3 text-gray-600">{item.owner || '-'}</td>
+                            <td className="py-2 pl-3 text-right font-medium text-gray-900">
+                              {formatCompactMetric(item.metric ?? item.count)}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </section>
+
+        <section className="mb-10">
+          <div className="mb-4 flex flex-col gap-2 border-b border-[var(--yr-line)] pb-2 md:flex-row md:items-end md:justify-between">
+            <div>
+              <h2 className="text-2xl font-bold text-gray-800">Search Query Analytics</h2>
+              <p className="text-sm text-gray-500">
+                Most popular search queries and the NetIDs behind them for the selected range.
+              </p>
             </div>
           </div>
 
-          <div className="bg-[var(--yr-panel)] rounded-lg shadow-md p-6 border border-[var(--yr-line)]">
-            <h3 className="text-lg font-semibold text-gray-700 mb-4">New Users Today by Type</h3>
-            <div className="space-y-3">
-              {data.users.newUsersTodayByType.length > 0 ? (
-                data.users.newUsersTodayByType.map((item) => (
+          <div className="overflow-hidden rounded-lg border border-[var(--yr-line)] bg-[var(--yr-panel)] shadow-md">
+            <div className="overflow-x-auto">
+              <table className="min-w-full">
+                <thead>
+                  <tr className="border-b bg-[var(--yr-panel-muted)]">
+                    <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
+                      Query
+                    </th>
+                    <th className="px-4 py-3 text-right text-sm font-semibold text-gray-700">
+                      Searches
+                    </th>
+                    <th className="px-4 py-3 text-right text-sm font-semibold text-gray-700">
+                      Searchers
+                    </th>
+                    <th className="px-4 py-3 text-right text-sm font-semibold text-gray-700">
+                      Zero Results
+                    </th>
+                    <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
+                      Who Searched
+                    </th>
+                    <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
+                      Last Search
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {searchQueryRows.length > 0 ? (
+                    searchQueryRows.map((query) => (
+                      <tr
+                        key={query.query}
+                        className="border-b align-top hover:bg-[var(--yr-panel-muted)]"
+                      >
+                        <td className="max-w-xs px-4 py-3 font-medium text-gray-900">
+                          {query.query || '(empty search)'}
+                        </td>
+                        <td className="px-4 py-3 text-right font-medium text-blue-600">
+                          {formatNumber(query.totalSearches)}
+                        </td>
+                        <td className="px-4 py-3 text-right">
+                          {formatNumber(query.uniqueSearchers)}
+                        </td>
+                        <td className="px-4 py-3 text-right">
+                          {formatNumber(query.zeroResultSearches || 0)}
+                        </td>
+                        <td className="px-4 py-3">
+                          <div className="flex max-w-xl flex-wrap gap-2">
+                            {query.searchers.slice(0, 8).map((searcher) => (
+                              <span
+                                key={`${query.query}-${searcher.netid}`}
+                                className="rounded-md border border-[var(--yr-line)] bg-[var(--yr-panel-muted)] px-2 py-1 text-xs text-gray-700"
+                              >
+                                {formatSearcherName(searcher)} - {searcher.searchCount}
+                              </span>
+                            ))}
+                            {query.searchers.length > 8 && (
+                              <span className="px-1 py-1 text-xs text-gray-500">
+                                +{query.searchers.length - 8} more
+                              </span>
+                            )}
+                          </div>
+                        </td>
+                        <td className="px-4 py-3 text-sm text-gray-600">
+                          {formatDateTime(query.lastSearchedAt)}
+                        </td>
+                      </tr>
+                    ))
+                  ) : (
+                    <tr>
+                      <td className="px-4 py-6 text-center text-gray-500" colSpan={6}>
+                        No tracked search queries for this range.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+
+        {data.engagement.mostActiveUsers.length > 0 && (
+          <section className="mb-10">
+            <h2 className="text-2xl font-semibold mb-4 text-slate-950 border-b border-[var(--yr-line)] pb-2">
+              Most Active Users (Last 30 Days)
+            </h2>
+            <div className="bg-[var(--yr-panel)] rounded-lg shadow-md p-6 border border-[var(--yr-line)]">
+              <div className="overflow-x-auto">
+                <table className="min-w-full">
+                  <thead>
+                    <tr className="border-b">
+                      <th className="text-left py-3 px-4 font-semibold text-gray-700">User ID</th>
+                      <th className="text-left py-3 px-4 font-semibold text-gray-700">Type</th>
+                      <th className="text-right py-3 px-4 font-semibold text-gray-700">Events</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.engagement.mostActiveUsers.map((user, index) => (
+                      <tr
+                        key={`${user.userId}-${index}`}
+                        className="border-b hover:bg-[var(--yr-panel-muted)]"
+                      >
+                        <td className="py-3 px-4 text-gray-800">{user.userId}</td>
+                        <td className="py-3 px-4 text-gray-600">{formatUserType(user.userType)}</td>
+                        <td className="py-3 px-4 text-right font-medium">{user.eventCount}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </section>
+        )}
+
+        <section className="mb-10">
+          <div className="flex flex-col gap-3 mb-4 border-b border-[var(--yr-line)] pb-2 md:flex-row md:items-end md:justify-between">
+            <div>
+              <h2 className="text-2xl font-bold text-gray-800">NetID User Activity</h2>
+              <p className="text-sm text-gray-500">
+                Admin-only activity lookup from tracked analytics events
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={fetchUserActivity}
+              className="inline-flex min-h-[44px] items-center justify-center self-start rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300 md:self-auto"
+              disabled={isUserActivityLoading}
+            >
+              {isUserActivityLoading ? 'Refreshing...' : 'Refresh Users'}
+            </button>
+          </div>
+
+          <div className="bg-[var(--yr-panel)] rounded-lg shadow-md border border-[var(--yr-line)] overflow-hidden">
+            <div className="grid grid-cols-1 gap-4 border-b border-[var(--yr-line)] p-4 lg:grid-cols-5">
+              <label className="block lg:col-span-2">
+                <span className="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  Search NetID
+                </span>
+                <input
+                  type="search"
+                  value={userSearch}
+                  onChange={(event) => setUserSearch(event.target.value)}
+                  placeholder="e.g. abc123"
+                  className="min-h-[44px] w-full rounded-md border border-[var(--yr-line-strong)] px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+                />
+              </label>
+
+              <label className="block">
+                <span className="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  User Type
+                </span>
+                <select
+                  value={userTypeFilter}
+                  onChange={(event) => setUserTypeFilter(event.target.value)}
+                  className="min-h-[44px] w-full rounded-md border border-[var(--yr-line-strong)] px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+                >
+                  <option value="all">All Types</option>
+                  <option value="undergraduate">Undergrads</option>
+                  <option value="graduate">Graduates</option>
+                  <option value="professor">Faculty & Professors</option>
+                  <option value="admin">Admins</option>
+                  <option value="unknown">Unknown</option>
+                </select>
+              </label>
+
+              <label className="block">
+                <span className="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  Sort
+                </span>
+                <select
+                  value={userActivitySort}
+                  onChange={(event) => setUserActivitySort(event.target.value as UserActivitySort)}
+                  className="min-h-[44px] w-full rounded-md border border-[var(--yr-line-strong)] px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+                >
+                  <option value="lastActive">Last Active</option>
+                  <option value="totalEvents">Total Events</option>
+                  <option value="logins">Logins</option>
+                  <option value="searches">Searches</option>
+                  <option value="views">Views</option>
+                </select>
+              </label>
+
+              <label className="block">
+                <span className="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  Limit
+                </span>
+                <select
+                  value={userActivityLimit}
+                  onChange={(event) => setUserActivityLimit(Number(event.target.value))}
+                  className="min-h-[44px] w-full rounded-md border border-[var(--yr-line-strong)] px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+                >
+                  <option value={10}>10 users</option>
+                  <option value={25}>25 users</option>
+                  <option value={50}>50 users</option>
+                  <option value={100}>100 users</option>
+                </select>
+              </label>
+            </div>
+
+            <div className="flex flex-col gap-6 p-4 xl:flex-row">
+              <div className="min-w-0 flex-1">
+                <div className="mb-3 flex flex-col gap-2 text-sm text-gray-500 sm:flex-row sm:items-center sm:justify-between">
+                  <span>
+                    Showing {userActivity.users.length} of {userActivity.total} matching users
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setUserActivityOrder(userActivityOrder === 'asc' ? 'desc' : 'asc')
+                    }
+                    className="inline-flex min-h-[44px] items-center self-start rounded-md border border-[var(--yr-line-strong)] px-3 py-2 text-gray-700 transition-colors hover:bg-[var(--yr-panel-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200 sm:self-auto"
+                  >
+                    Order: {userActivityOrder === 'asc' ? 'Ascending' : 'Descending'}
+                  </button>
+                </div>
+
+                {userActivityError && (
+                  <div className="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+                    {userActivityError}
+                  </div>
+                )}
+
+                <div className="overflow-x-auto">
+                  <table className="min-w-full">
+                    <thead>
+                      <tr className="border-b bg-[var(--yr-panel-muted)]">
+                        <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
+                          NetID
+                        </th>
+                        <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
+                          Type
+                        </th>
+                        <th className="px-4 py-3 text-right text-sm font-semibold text-gray-700">
+                          <button
+                            type="button"
+                            onClick={() => updateUserActivitySort('totalEvents')}
+                            className="inline-flex min-h-[44px] items-center rounded-md px-2 hover:bg-[var(--yr-panel-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+                          >
+                            Events{sortLabel('totalEvents')}
+                          </button>
+                        </th>
+                        <th className="px-4 py-3 text-right text-sm font-semibold text-gray-700">
+                          <button
+                            type="button"
+                            onClick={() => updateUserActivitySort('logins')}
+                            className="inline-flex min-h-[44px] items-center rounded-md px-2 hover:bg-[var(--yr-panel-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+                          >
+                            Logins{sortLabel('logins')}
+                          </button>
+                        </th>
+                        <th className="px-4 py-3 text-right text-sm font-semibold text-gray-700">
+                          <button
+                            type="button"
+                            onClick={() => updateUserActivitySort('searches')}
+                            className="inline-flex min-h-[44px] items-center rounded-md px-2 hover:bg-[var(--yr-panel-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+                          >
+                            Searches{sortLabel('searches')}
+                          </button>
+                        </th>
+                        <th className="px-4 py-3 text-right text-sm font-semibold text-gray-700">
+                          <button
+                            type="button"
+                            onClick={() => updateUserActivitySort('views')}
+                            className="inline-flex min-h-[44px] items-center rounded-md px-2 hover:bg-[var(--yr-panel-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+                          >
+                            Views{sortLabel('views')}
+                          </button>
+                        </th>
+                        <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">
+                          <button
+                            type="button"
+                            onClick={() => updateUserActivitySort('lastActive')}
+                            className="inline-flex min-h-[44px] items-center rounded-md px-2 hover:bg-[var(--yr-panel-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+                          >
+                            Last Active{sortLabel('lastActive')}
+                          </button>
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {isUserActivityLoading && userActivity.users.length === 0 ? (
+                        <tr>
+                          <td className="px-4 py-6 text-center text-gray-500" colSpan={7}>
+                            Loading user activity...
+                          </td>
+                        </tr>
+                      ) : userActivity.users.length > 0 ? (
+                        userActivity.users.map((user, index) => (
+                          <tr
+                            key={`${user.netid}-${index}`}
+                            className={`cursor-pointer border-b transition-colors hover:bg-[var(--yr-blue-soft)] ${
+                              selectedNetid === user.netid ? 'bg-[var(--yr-blue-soft)]' : ''
+                            }`}
+                            onClick={() => setSelectedNetid(user.netid)}
+                          >
+                            <td className="px-4 py-3 font-medium text-gray-900">{user.netid}</td>
+                            <td className="px-4 py-3 text-gray-600">
+                              {formatUserType(user.userType)}
+                            </td>
+                            <td className="px-4 py-3 text-right font-medium">{user.totalEvents}</td>
+                            <td className="px-4 py-3 text-right">{user.logins}</td>
+                            <td className="px-4 py-3 text-right">{user.searches}</td>
+                            <td className="px-4 py-3 text-right">{user.views}</td>
+                            <td className="px-4 py-3 text-sm text-gray-600">
+                              {formatDateTime(user.lastActive)}
+                            </td>
+                          </tr>
+                        ))
+                      ) : (
+                        <tr>
+                          <td className="px-4 py-6 text-center text-gray-500" colSpan={7}>
+                            No users match the current filters.
+                          </td>
+                        </tr>
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+
+              <aside className="w-full rounded-lg border border-[var(--yr-line)] bg-[var(--yr-panel-muted)] p-4 xl:w-96">
+                <div className="mb-4 flex items-start justify-between gap-3">
+                  <div>
+                    <h3 className="text-lg font-semibold text-gray-800">
+                      {selectedNetid ? selectedNetid : 'Select a NetID'}
+                    </h3>
+                    {selectedUserSummary && (
+                      <p className="text-sm text-gray-500">
+                        {formatUserType(selectedUserSummary.userType)} -{' '}
+                        {selectedUserSummary.totalEvents} events
+                      </p>
+                    )}
+                  </div>
+                  {selectedNetid && (
+                    <button
+                      type="button"
+                      onClick={() => setSelectedNetid(null)}
+                      className="inline-flex min-h-[44px] items-center rounded-md border border-[var(--yr-line-strong)] px-3 py-2 text-xs text-gray-600 hover:bg-[var(--yr-panel)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+                    >
+                      Clear
+                    </button>
+                  )}
+                </div>
+
+                {!selectedNetid && (
+                  <p className="text-sm text-gray-500">
+                    Pick a row to inspect the latest events for that NetID.
+                  </p>
+                )}
+
+                {selectedNetid && isSelectedUserLoading && (
+                  <p className="text-sm text-gray-500">Loading recent events...</p>
+                )}
+
+                {selectedNetid && selectedUserError && (
+                  <div className="rounded-md border border-red-200 bg-[var(--yr-panel)] px-3 py-2 text-sm text-red-700">
+                    {selectedUserError}
+                  </div>
+                )}
+
+                {selectedUser && !isSelectedUserLoading && (
+                  <div>
+                    <div className="mb-4 grid grid-cols-2 gap-3 text-sm">
+                      <div className="rounded-md bg-[var(--yr-panel)] p-3">
+                        <p className="text-gray-500">Logins</p>
+                        <p className="text-lg font-semibold text-gray-900">
+                          {selectedUser.user.logins}
+                        </p>
+                      </div>
+                      <div className="rounded-md bg-[var(--yr-panel)] p-3">
+                        <p className="text-gray-500">Searches</p>
+                        <p className="text-lg font-semibold text-gray-900">
+                          {selectedUser.user.searches}
+                        </p>
+                      </div>
+                      <div className="rounded-md bg-[var(--yr-panel)] p-3">
+                        <p className="text-gray-500">Views</p>
+                        <p className="text-lg font-semibold text-gray-900">
+                          {selectedUser.user.views}
+                        </p>
+                      </div>
+                      <div className="rounded-md bg-[var(--yr-panel)] p-3">
+                        <p className="text-gray-500">Saves</p>
+                        <p className="text-lg font-semibold text-gray-900">
+                          {selectedUser.user.listingFavorites}
+                        </p>
+                      </div>
+                    </div>
+
+                    <h4 className="mb-2 text-sm font-semibold uppercase tracking-wide text-gray-500">
+                      Recent Events
+                    </h4>
+                    <div className="max-h-96 space-y-3 overflow-y-auto pr-1">
+                      {selectedUser.events.length > 0 ? (
+                        selectedUser.events.map((event, index) => (
+                          <div
+                            key={
+                              event.id ||
+                              event._id ||
+                              `${event.eventType}-${event.timestamp}-${index}`
+                            }
+                            className="rounded-md border border-[var(--yr-line)] bg-[var(--yr-panel)] p-3"
+                          >
+                            <div className="flex items-start justify-between gap-3">
+                              <p className="font-medium text-gray-800">
+                                {formatEventType(event.eventType)}
+                              </p>
+                              <p className="shrink-0 text-right text-xs text-gray-500">
+                                {formatDateTime(event.timestamp)}
+                              </p>
+                            </div>
+                            {event.searchQuery && (
+                              <p className="mt-1 text-sm text-gray-600">
+                                Query: {event.searchQuery}
+                              </p>
+                            )}
+                            {event.listingId && (
+                              <p className="mt-1 text-sm text-gray-600">
+                                Opportunity: {event.listingId}
+                              </p>
+                            )}
+                          </div>
+                        ))
+                      ) : (
+                        <p className="text-sm text-gray-500">No recent events returned.</p>
+                      )}
+                    </div>
+                  </div>
+                )}
+              </aside>
+            </div>
+          </div>
+        </section>
+
+        <section className="mb-10">
+          <DetailSectionHeader
+            title="Research Engagement"
+            description="Student-facing research surface events across profiles, opportunities, and programs."
+          />
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
+            {data.research.byEventType.slice(0, 3).map((item) => (
+              <StatCard
+                key={item.eventType}
+                title={formatEventType(item.eventType)}
+                value={item.total}
+                subtitle={`${item.last7Days} last 7 days, ${item.today} today`}
+              />
+            ))}
+            {data.research.byEventType.length === 0 && (
+              <div className="rounded-md border border-[var(--yr-line)] bg-[var(--yr-panel)] p-6 text-sm text-gray-500 md:col-span-3">
+                No research engagement events yet.
+              </div>
+            )}
+          </div>
+
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            <div className="bg-[var(--yr-panel)] rounded-lg shadow-md p-6 border border-[var(--yr-line)]">
+              <h3 className="text-lg font-semibold text-gray-700 mb-4">Events by Entity</h3>
+              <div className="space-y-2">
+                {data.research.byEntityType.length > 0 ? (
+                  data.research.byEntityType.slice(0, 8).map((item) => (
+                    <div
+                      key={`${item.entityType}-${item.eventType}`}
+                      className="flex justify-between gap-3 text-sm"
+                    >
+                      <span className="text-gray-600 capitalize">
+                        {item.entityType} / {formatEventType(item.eventType)}
+                      </span>
+                      <span className="font-medium">{item.count}</span>
+                    </div>
+                  ))
+                ) : (
+                  <p className="text-sm text-gray-500">No entity events yet.</p>
+                )}
+              </div>
+            </div>
+
+            <div className="bg-[var(--yr-panel)] rounded-lg shadow-md p-6 border border-[var(--yr-line)]">
+              <h3 className="text-lg font-semibold text-gray-700 mb-4">Research Users</h3>
+              <div className="space-y-2">
+                {data.research.byUserType.length > 0 ? (
+                  data.research.byUserType.map((item) => (
+                    <div key={item.userType} className="flex justify-between text-sm">
+                      <span className="text-gray-600">{formatUserType(item.userType)}</span>
+                      <span className="font-medium">{item.count}</span>
+                    </div>
+                  ))
+                ) : (
+                  <p className="text-sm text-gray-500">No research users yet.</p>
+                )}
+              </div>
+            </div>
+
+            <div className="bg-[var(--yr-panel)] rounded-lg shadow-md p-6 border border-[var(--yr-line)]">
+              <h3 className="text-lg font-semibold text-gray-700 mb-4">
+                Top Research Entities (30 Days)
+              </h3>
+              <div className="space-y-2">
+                {data.research.topEntities.length > 0 ? (
+                  data.research.topEntities.slice(0, 8).map((item) => (
+                    <div
+                      key={`${item.entityType}-${item.entityId}`}
+                      className="flex justify-between gap-3 text-sm"
+                    >
+                      <span className="truncate text-gray-600">
+                        <span className="capitalize">{item.entityType}</span> {item.entityId}
+                      </span>
+                      <span className="whitespace-nowrap font-medium">
+                        {item.views} views / {item.uniqueViewers} users
+                      </span>
+                    </div>
+                  ))
+                ) : (
+                  <p className="text-sm text-gray-500">No viewed entities yet.</p>
+                )}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="mb-10">
+          <h2 className="text-2xl font-semibold mb-4 text-slate-950 border-b border-[var(--yr-line)] pb-2">
+            User Statistics
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
+            <StatCard title="Total Users" value={data.users.overview.total} />
+            <StatCard title="Confirmed Users" value={data.users.overview.confirmed} />
+            <StatCard title="New Users (7 Days)" value={data.users.newUsersLast7Days} />
+            <StatCard title="New Users Today" value={data.users.newUsersToday} />
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div className="bg-[var(--yr-panel)] rounded-lg shadow-md p-6 border border-[var(--yr-line)]">
+              <h3 className="text-lg font-semibold text-gray-700 mb-4">Users by Type</h3>
+              <div className="space-y-3">
+                {data.users.byType.map((item) => (
                   <div key={item.userType} className="flex justify-between">
                     <span className="text-gray-600">{formatUserType(item.userType)}:</span>
                     <span className="font-bold text-lg">{item.count}</span>
                   </div>
-                ))
-              ) : (
-                <p className="text-gray-500">No new users today</p>
-              )}
+                ))}
+              </div>
+            </div>
+
+            <div className="bg-[var(--yr-panel)] rounded-lg shadow-md p-6 border border-[var(--yr-line)]">
+              <h3 className="text-lg font-semibold text-gray-700 mb-4">New Users Today by Type</h3>
+              <div className="space-y-3">
+                {data.users.newUsersTodayByType.length > 0 ? (
+                  data.users.newUsersTodayByType.map((item) => (
+                    <div key={item.userType} className="flex justify-between">
+                      <span className="text-gray-600">{formatUserType(item.userType)}:</span>
+                      <span className="font-bold text-lg">{item.count}</span>
+                    </div>
+                  ))
+                ) : (
+                  <p className="text-gray-500">No new users today</p>
+                )}
+              </div>
             </div>
           </div>
-        </div>
-      </section>
+        </section>
 
-      <AdminPanel />
-    </div>
+        <AdminPanel />
+      </div>
     </div>
   );
 };

--- a/client/src/pages/fellowships.tsx
+++ b/client/src/pages/fellowships.tsx
@@ -268,6 +268,8 @@ const Fellowships = () => {
     setSelectedTermOfAward,
     selectedPurpose,
     setSelectedPurpose,
+    selectedSubjects = [],
+    setSelectedSubjects = () => {},
     selectedRegions,
     setSelectedRegions,
     selectedCitizenship,
@@ -387,6 +389,13 @@ const Fellowships = () => {
       setSelected: setSelectedTermOfAward,
     },
     {
+      key: 'subjects',
+      label: 'Subject',
+      options: filterOptions.subjects || [],
+      selected: selectedSubjects,
+      setSelected: setSelectedSubjects,
+    },
+    {
       key: 'purpose',
       label: 'Purpose',
       options: filterOptions.purpose,
@@ -425,6 +434,7 @@ const Fellowships = () => {
     { label: 'Year', values: selectedYearOfStudy, clear: () => setSelectedYearOfStudy([]) },
     { label: 'Term', values: selectedTermOfAward, clear: () => setSelectedTermOfAward([]) },
     { label: 'Purpose', values: selectedPurpose, clear: () => setSelectedPurpose([]) },
+    { label: 'Subject', values: selectedSubjects, clear: () => setSelectedSubjects([]) },
     { label: 'Region', values: selectedRegions, clear: () => setSelectedRegions([]) },
     { label: 'Citizenship', values: selectedCitizenship, clear: () => setSelectedCitizenship([]) },
   ].filter((g) => g.values.length > 0);

--- a/client/src/pages/research.tsx
+++ b/client/src/pages/research.tsx
@@ -1144,67 +1144,24 @@ const Research = () => {
               className="mt-4 flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center"
               aria-label="Suggested research searches"
             >
-              Search by interest, professor, course topic, method, or question. We&apos;ll help you
-              find relevant research profiles and possible next steps.
-            </p>
-
-            <form onSubmit={onSubmit} className="mt-4 sm:mt-7">
-              <label
-                htmlFor="research-search"
-                className="mb-2 block text-sm font-semibold text-slate-950"
-              >
-                Search Yale research
-              </label>
-              <div className="flex flex-col gap-2 sm:flex-row 2xl:flex-col">
-                <input
-                  id="research-search"
-                  ref={searchInputRef}
-                  type="search"
-                  value={query}
-                  onChange={(event) => {
-                    const nextQuery = event.target.value;
-                    setQuery(nextQuery);
-                    if (!nextQuery.trim() && hasSubmittedSearch) {
-                      resetSearch();
-                    }
-                  }}
-                  aria-describedby="research-search-context research-search-help"
-                  placeholder="Type a topic, professor, lab, method, or research question"
-                  className="min-h-12 min-w-0 flex-1 rounded-md border border-[var(--yr-line-strong)] bg-[var(--yr-panel)] px-4 text-base text-slate-950 placeholder:text-slate-400 focus:border-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200 sm:min-h-14"
-                />
-                <button
-                  type="submit"
-                  className="min-h-12 rounded-md bg-[var(--yr-blue)] px-6 text-sm font-semibold text-white hover:bg-blue-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200 disabled:bg-slate-200 disabled:text-slate-700 sm:min-h-14"
-                  disabled={searchDisabled}
-                >
-                  {searchLoading ? 'Searching...' : 'Search'}
-                </button>
+              <span className="yr-kicker text-[0.7rem]">Try a starting point</span>
+              <div className="flex flex-wrap gap-2">
+                {QUICK_START_PROMPTS.map((prompt) => (
+                  <button
+                    key={prompt.query}
+                    type="button"
+                    onClick={() => {
+                      setQuery(prompt.query);
+                      runSearch(prompt.query);
+                    }}
+                    className="yr-pill yr-pill-blue min-h-[44px] rounded-md px-3 py-2 transition-colors hover:border-blue-300 hover:bg-[var(--yr-panel)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+                  >
+                    {prompt.label}
+                  </button>
+                ))}
               </div>
-              <p id="research-search-help" className="mt-2 text-sm text-slate-600">
-                {searchHelpText}
-              </p>
-              <div
-                className="mt-4 flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center"
-                aria-label="Suggested research searches"
-              >
-                <span className="yr-kicker text-[0.7rem]">Try a starting point</span>
-                <div className="flex flex-wrap gap-2">
-                  {QUICK_START_PROMPTS.map((prompt) => (
-                    <button
-                      key={prompt.query}
-                      type="button"
-                      onClick={() => {
-                        setQuery(prompt.query);
-                        runSearch(prompt.query);
-                      }}
-                      className="yr-pill yr-pill-blue min-h-[44px] rounded-md px-3 py-2 transition-colors hover:border-blue-300 hover:bg-[var(--yr-panel)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
-                    >
-                      {prompt.label}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            </form>
+            </div>
+          </form>
           </header>
 
           <div className="min-w-0">
@@ -1229,15 +1186,100 @@ const Research = () => {
                     </label>
                   )}
                 </div>
-              </div>
-            ) : (
-              <EmptyGroup>
-                No research homes match these filters. Try a broader topic, professor name, lab,
-                method, or research question.
-              </EmptyGroup>
+                {defaultSearchError && (
+                  <div
+                    role="alert"
+                    className="mb-4 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900"
+                  >
+                    {defaultSearchError}
+                  </div>
+                )}
+                {isAdmin && showWeakestProfilesFirst && (
+                  <div
+                    className="yr-muted-surface mb-4 flex flex-wrap gap-2 rounded-md p-2"
+                    aria-label="Quality filters"
+                  >
+                    {QUALITY_FILTER_OPTIONS.map((option) => {
+                      const isActive = qualityFilters.includes(option.value);
+                      return (
+                        <button
+                          key={option.value}
+                          type="button"
+                          aria-pressed={isActive}
+                          onClick={() => toggleQualityFilter(option.value)}
+                          className={`min-h-10 rounded-md border px-3 py-1.5 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200 ${
+                            isActive
+                              ? 'border-blue-700 bg-[var(--yr-panel)] text-blue-900'
+                              : 'border-[var(--yr-border-warm)] bg-transparent text-slate-700 hover:bg-[var(--yr-panel)]'
+                          }`}
+                        >
+                          {option.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+                {isAdmin && (
+                  <div
+                    className="mb-4 flex flex-wrap gap-2 rounded-md border border-[var(--yr-line)] bg-[var(--yr-panel)] p-2"
+                    aria-label="Trust tier filters"
+                  >
+                    {TRUST_TIER_FILTER_OPTIONS.map((option) => {
+                      const isActive = trustTierFilters.includes(option.value);
+                      return (
+                        <button
+                          key={option.value}
+                          type="button"
+                          aria-pressed={isActive}
+                          onClick={() => toggleTrustTierFilter(option.value)}
+                          className={`min-h-10 rounded-md border px-3 py-1.5 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200 ${
+                            isActive
+                              ? 'border-slate-900 bg-slate-900 text-white'
+                              : 'border-[var(--yr-line)] bg-[var(--yr-panel)] text-slate-700 hover:bg-[var(--yr-panel-muted)]'
+                          }`}
+                        >
+                          {option.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+                {defaultSearchLoading && defaultGroupedResults.clusters.length === 0 ? (
+                  <div className="grid gap-3">
+                    {Array.from({ length: 3 }).map((_, index) => (
+                      <ClusterLoadingCard key={index} />
+                    ))}
+                  </div>
+                ) : defaultGroupedResults.clusters.length > 0 ? (
+                  <div className="grid gap-5">
+                    <div>
+                      <div className="grid gap-3 lg:grid-cols-2 2xl:grid-cols-[repeat(3,minmax(0,1fr))]">
+                        {defaultGroupedResults.clusters.map((cluster) => (
+                          <ResearchHomeCard
+                            key={cluster.id}
+                            home={cluster}
+                            onSelect={exploreHome}
+                            variant="compact"
+                            showAdminQuality={isAdmin && showWeakestProfilesFirst}
+                          />
+                        ))}
+                      </div>
+                      {defaultSearchLoading && defaultGroupedResults.clusters.length > 0 && (
+                        <InfiniteScrollLoadingDots label="Loading more research homes" />
+                      )}
+                      {!defaultSearchExhausted && (
+                        <div ref={defaultSentinelRef} className="h-10 w-full" />
+                      )}
+                    </div>
+                  </div>
+                ) : (
+                  <EmptyGroup>
+                    No research homes match these filters. Try a broader topic, professor name, lab,
+                    method, or research question.
+                  </EmptyGroup>
+                )}
+              </section>
             )}
-          </section>
-        )}
 
         {hasSubmittedSearch && (
           <section aria-busy={searchLoading} aria-label="Search results">
@@ -1333,18 +1375,9 @@ const Research = () => {
               )}
             </section>
 
-            <section className="mt-5">
-              <SectionHeading>Research homes</SectionHeading>
-              {searchLoading && activeResults.clusters.length === 0 ? (
-                <div className="grid gap-3">
-                  {Array.from({ length: 3 }).map((_, index) => (
-                    <ClusterLoadingCard key={index} />
-                  ))}
-                </div>
-
-                <fieldset className="mt-3 border-0 p-0">
-                  <legend className="sr-only">Narrow research results</legend>
-                  <div className="grid gap-4 rounded-md border border-[var(--yr-line)] bg-[var(--yr-panel)] p-3 sm:grid-cols-2 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto_auto] xl:items-end">
+            <fieldset className="mt-3 border-0 p-0">
+              <legend className="sr-only">Narrow research results</legend>
+              <div className="grid gap-4 rounded-md border border-[var(--yr-line)] bg-[var(--yr-panel)] p-3 sm:grid-cols-2 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto_auto] xl:items-end">
                     <label className="block text-sm font-medium text-slate-800">
                       School
                       <select
@@ -1414,65 +1447,56 @@ const Research = () => {
                         Clear filters
                       </button>
                     )}
-                  </div>
-                </fieldset>
+              </div>
+            </fieldset>
 
-                {searchError && (
-                  <div
-                    role="alert"
-                    className="mt-4 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900"
-                  >
-                    {searchError}
-                  </div>
-                )}
-
-                <section className="mt-5">
-                  <SectionHeading>Research homes</SectionHeading>
-                  {searchLoading && activeResults.clusters.length === 0 ? (
-                    <div className="grid gap-3">
-                      {Array.from({ length: 3 }).map((_, index) => (
-                        <ClusterLoadingCard key={index} />
+            <section className="mt-5">
+              <SectionHeading>Research homes</SectionHeading>
+              {searchLoading && activeResults.clusters.length === 0 ? (
+                <div className="grid gap-3">
+                  {Array.from({ length: 3 }).map((_, index) => (
+                    <ClusterLoadingCard key={index} />
+                  ))}
+                </div>
+              ) : activeResults.clusters.length > 0 ? (
+                <>
+                  <div className="grid gap-5">
+                    <div className="grid gap-3 lg:grid-cols-2 2xl:grid-cols-[repeat(3,minmax(0,1fr))]">
+                      {activeResults.clusters.map((cluster) => (
+                        <ResearchHomeCard
+                          key={cluster.id}
+                          home={cluster}
+                          onSelect={exploreHome}
+                          variant="compact"
+                        />
                       ))}
                     </div>
-                  ) : activeResults.clusters.length > 0 ? (
-                    <>
-                      <div className="grid gap-5">
-                        <div className="grid gap-3 lg:grid-cols-2 2xl:grid-cols-[repeat(3,minmax(0,1fr))]">
-                          {activeResults.clusters.map((cluster) => (
-                            <ResearchHomeCard
-                              key={cluster.id}
-                              home={cluster}
-                              onSelect={exploreHome}
-                              variant="compact"
-                            />
-                          ))}
-                        </div>
-                      </div>
-                      {searchLoading && activeResults.clusters.length > 0 && (
-                        <InfiniteScrollLoadingDots label="Loading more research homes" />
-                      )}
-                      {!searchExhausted && <div ref={searchSentinelRef} className="h-10 w-full" />}
-                    </>
-                  ) : (
-                    <EmptyGroup>
-                      {departmentSearch
-                        ? 'This is a data coverage gap, not proof that the department has no undergraduate research. Try a topic, method, professor, or adjacent department while this department is being seeded.'
-                        : 'No indexed research homes matched this search yet. Try a broader topic, related method, professor, or adjacent department while coverage improves.'}
-                    </EmptyGroup>
+                  </div>
+                  {searchLoading && activeResults.clusters.length > 0 && (
+                    <InfiniteScrollLoadingDots label="Loading more research homes" />
                   )}
-                </section>
+                  {!searchExhausted && <div ref={searchSentinelRef} className="h-10 w-full" />}
+                </>
+              ) : (
+                <EmptyGroup>
+                  {departmentSearch
+                    ? 'This is a data coverage gap, not proof that the department has no undergraduate research. Try a topic, method, professor, or adjacent department while this department is being seeded.'
+                    : 'No indexed research homes matched this search yet. Try a broader topic, related method, professor, or adjacent department while coverage improves.'}
+                </EmptyGroup>
+              )}
+            </section>
 
-                {activeResults.papers.length > 0 && (
-                  <section className="mt-5">
-                    <SectionHeading>Papers via profiles</SectionHeading>
-                    <LabPapersList
-                      papers={activeResults.papers}
-                      emptyText="No related profile papers matched this search yet."
-                    />
-                  </section>
-                )}
+            {activeResults.papers.length > 0 && (
+              <section className="mt-5">
+                <SectionHeading>Papers via profiles</SectionHeading>
+                <LabPapersList
+                  papers={activeResults.papers}
+                  emptyText="No related profile papers matched this search yet."
+                />
               </section>
             )}
+          </section>
+        )}
           </div>
         </div>
       </div>

--- a/client/src/providers/FellowshipSearchContextProvider.tsx
+++ b/client/src/providers/FellowshipSearchContextProvider.tsx
@@ -52,6 +52,7 @@ const FellowshipSearchContextProvider: FC<FellowshipSearchContextProviderProps> 
     selectedYearOfStudy,
     selectedTermOfAward,
     selectedPurpose,
+    selectedSubjects,
     selectedRegions,
     selectedCitizenship,
     selectedStudentVisibilityTier,
@@ -102,6 +103,10 @@ const FellowshipSearchContextProvider: FC<FellowshipSearchContextProviderProps> 
 
   const setSelectedPurpose = useCallback((value: React.SetStateAction<string[]>) => {
     dispatch({ type: 'SET_SELECTED_PURPOSE', payload: value });
+  }, []) as React.Dispatch<React.SetStateAction<string[]>>;
+
+  const setSelectedSubjects = useCallback((value: React.SetStateAction<string[]>) => {
+    dispatch({ type: 'SET_SELECTED_SUBJECTS', payload: value });
   }, []) as React.Dispatch<React.SetStateAction<string[]>>;
 
   const setSelectedRegions = useCallback((value: React.SetStateAction<string[]>) => {
@@ -155,6 +160,7 @@ const FellowshipSearchContextProvider: FC<FellowshipSearchContextProviderProps> 
     selectedYearOfStudy,
     selectedTermOfAward,
     selectedPurpose,
+    selectedSubjects,
     selectedRegions,
     selectedCitizenship,
     selectedStudentVisibilityTier,
@@ -170,6 +176,7 @@ const FellowshipSearchContextProvider: FC<FellowshipSearchContextProviderProps> 
     selectedYearOfStudy,
     selectedTermOfAward,
     selectedPurpose,
+    selectedSubjects,
     selectedRegions,
     selectedCitizenship,
     selectedStudentVisibilityTier,
@@ -202,6 +209,7 @@ const FellowshipSearchContextProvider: FC<FellowshipSearchContextProviderProps> 
             purpose: response.data.purpose || [],
             globalRegions: response.data.globalRegions || [],
             citizenshipStatus: response.data.citizenshipStatus || [],
+            subjects: response.data.subjects || [],
           },
         });
         dispatch({ type: 'MARK_FILTER_OPTIONS_LOADED' });
@@ -243,6 +251,9 @@ const FellowshipSearchContextProvider: FC<FellowshipSearchContextProviderProps> 
       }
       if (f.selectedPurpose.length > 0) {
         url += `&purpose=${encodeURIComponent(f.selectedPurpose.join(','))}`;
+      }
+      if (f.selectedSubjects.length > 0) {
+        url += `&subjects=${encodeURIComponent(f.selectedSubjects.join(','))}`;
       }
       if (f.selectedRegions.length > 0) {
         url += `&globalRegions=${encodeURIComponent(f.selectedRegions.join(','))}`;
@@ -342,6 +353,7 @@ const FellowshipSearchContextProvider: FC<FellowshipSearchContextProviderProps> 
     selectedStudentFacingCategory,
     selectedTermOfAward,
     selectedPurpose,
+    selectedSubjects,
     selectedRegions,
     selectedCitizenship,
     selectedStudentVisibilityTier,
@@ -377,6 +389,8 @@ const FellowshipSearchContextProvider: FC<FellowshipSearchContextProviderProps> 
         setSelectedTermOfAward,
         selectedPurpose,
         setSelectedPurpose,
+        selectedSubjects,
+        setSelectedSubjects,
         selectedRegions,
         setSelectedRegions,
         selectedCitizenship,

--- a/client/src/reducers/analyticsReducer.ts
+++ b/client/src/reducers/analyticsReducer.ts
@@ -255,6 +255,10 @@ export interface AnalyticsSearchQualityResponse {
   avgResults?: number;
   avgResultsPerSearch?: number;
   avgLatencyMs?: number;
+  engagedSearches?: number;
+  returnedButIgnoredSearches?: number;
+  engagementRate?: number;
+  attributionWindowMinutes?: number;
   topQueries?: AnalyticsSearchQualityQuery[];
   zeroResultQueries?: AnalyticsSearchQualityQuery[];
   topZeroResultQueries?: AnalyticsSearchQualityQuery[];

--- a/client/src/reducers/fellowshipSearchReducer.ts
+++ b/client/src/reducers/fellowshipSearchReducer.ts
@@ -23,6 +23,7 @@ export interface FellowshipSearchState {
   selectedStudentFacingCategory: string[];
   selectedTermOfAward: string[];
   selectedPurpose: string[];
+  selectedSubjects: string[];
   selectedRegions: string[];
   selectedCitizenship: string[];
   selectedStudentVisibilityTier: StudentVisibilityTier[];
@@ -55,11 +56,14 @@ export type FellowshipSearchAction =
   | { type: 'SET_SELECTED_YEAR_OF_STUDY'; payload: string[] | ((prev: string[]) => string[]) }
   | { type: 'SET_SELECTED_TERM_OF_AWARD'; payload: string[] | ((prev: string[]) => string[]) }
   | { type: 'SET_SELECTED_PURPOSE'; payload: string[] | ((prev: string[]) => string[]) }
+  | { type: 'SET_SELECTED_SUBJECTS'; payload: string[] | ((prev: string[]) => string[]) }
   | { type: 'SET_SELECTED_REGIONS'; payload: string[] | ((prev: string[]) => string[]) }
   | { type: 'SET_SELECTED_CITIZENSHIP'; payload: string[] | ((prev: string[]) => string[]) }
   | {
       type: 'SET_SELECTED_STUDENT_VISIBILITY_TIER';
-      payload: StudentVisibilityTier[] | ((prev: StudentVisibilityTier[]) => StudentVisibilityTier[]);
+      payload:
+        | StudentVisibilityTier[]
+        | ((prev: StudentVisibilityTier[]) => StudentVisibilityTier[]);
     }
   | { type: 'SET_SORT_BY'; payload: string }
   | { type: 'SET_SORT_ORDER'; payload: number }
@@ -96,6 +100,7 @@ export const createInitialFellowshipSearchState = (
   selectedYearOfStudy: [],
   selectedTermOfAward: [],
   selectedPurpose: [],
+  selectedSubjects: [],
   selectedRegions: [],
   selectedCitizenship: [],
   selectedStudentVisibilityTier: [],
@@ -117,6 +122,7 @@ export const createInitialFellowshipSearchState = (
     purpose: [],
     globalRegions: [],
     citizenshipStatus: [],
+    subjects: [],
   },
   quickFilter: null,
   filterBarHeight: 0,
@@ -159,10 +165,7 @@ export function fellowshipSearchReducer(
     case 'SET_SELECTED_STUDENT_FACING_CATEGORY':
       return {
         ...state,
-        selectedStudentFacingCategory: resolve(
-          action.payload,
-          state.selectedStudentFacingCategory,
-        ),
+        selectedStudentFacingCategory: resolve(action.payload, state.selectedStudentFacingCategory),
       };
 
     case 'SET_SELECTED_YEAR_OF_STUDY':
@@ -174,6 +177,9 @@ export function fellowshipSearchReducer(
     case 'SET_SELECTED_PURPOSE':
       return { ...state, selectedPurpose: resolve(action.payload, state.selectedPurpose) };
 
+    case 'SET_SELECTED_SUBJECTS':
+      return { ...state, selectedSubjects: resolve(action.payload, state.selectedSubjects) };
+
     case 'SET_SELECTED_REGIONS':
       return { ...state, selectedRegions: resolve(action.payload, state.selectedRegions) };
 
@@ -183,10 +189,7 @@ export function fellowshipSearchReducer(
     case 'SET_SELECTED_STUDENT_VISIBILITY_TIER':
       return {
         ...state,
-        selectedStudentVisibilityTier: resolve(
-          action.payload,
-          state.selectedStudentVisibilityTier,
-        ),
+        selectedStudentVisibilityTier: resolve(action.payload, state.selectedStudentVisibilityTier),
       };
 
     case 'SET_SORT_BY':

--- a/client/src/types/types.tsx
+++ b/client/src/types/types.tsx
@@ -132,6 +132,7 @@ export type FellowshipFilterOptions = {
   purpose: string[];
   globalRegions: string[];
   citizenshipStatus: string[];
+  subjects?: string[];
 };
 
 export type User = {

--- a/docs/topic-matching-and-search-engagement.md
+++ b/docs/topic-matching-and-search-engagement.md
@@ -1,0 +1,25 @@
+# Topic matching and search engagement
+
+## Program topics
+
+Program discovery uses a deliberately small canonical subject taxonomy in `programTopicService.ts`.
+Each subject has explicit aliases, including common student language such as `AI`, `ML`, `NLP`, and `computer vision`.
+Normalization lowercases text, removes punctuation, and matches whole normalized phrases.
+
+Subjects are inferred at read time only from existing source-backed program fields such as title, summary, description, eligibility, application information, purpose, and student-facing category.
+An inferred subject is a discovery aid, not a claim that an operator curated the program.
+Programs with no supported topic evidence receive no inferred subjects.
+
+The same taxonomy normalizes saved-plan research areas and research-home names for fellowship matching.
+Topic overlap contributes to the match score alongside compensation, fellowship-compatible evidence, department overlap, application-route evidence, and cycle status.
+It does not bypass existing deadline demotion, minimum-score, source, or eligibility caveats.
+
+## Search engagement
+
+The admin search-success metric is action-aware.
+A search is engaged when the same signed-in user views a research home, listing, or program, or saves a pathway, listing, or program, within 30 minutes and before that user's next search.
+The next-search boundary avoids attributing an action to multiple earlier queries in the same browsing session.
+
+The dashboard reports engaged searches separately from searches that returned results but received no attributed view or save.
+Zero-result rate remains available as a coverage diagnostic.
+Attribution is computed from existing bounded analytics events and does not copy query text or direct contact information onto action events.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,348 +1,340 @@
-# Graph Report - ylabs  (2026-07-10)
+# Graph Report - ylabs-fr8-fr11  (2026-07-10)
 
 ## Corpus Check
-- 846 files · ~1,319,391 words
+- 849 files · ~1,320,846 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8498 nodes · 21686 edges · 338 communities (300 shown, 38 thin omitted)
-- Extraction: 98% EXTRACTED · 2% INFERRED · 0% AMBIGUOUS · INFERRED: 479 edges (avg confidence: 0.63)
+- 8513 nodes · 21722 edges · 330 communities (292 shown, 38 thin omitted)
+- Extraction: 98% EXTRACTED · 2% INFERRED · 0% AMBIGUOUS · INFERRED: 480 edges (avg confidence: 0.63)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `0cb191c2`
+- Built from commit: `606a5151`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
 ## Community Hubs (Navigation)
-- [[_COMMUNITY_Decisions|Decisions]]
-- [[_COMMUNITY_labDetail.tsx|labDetail.tsx]]
-- [[_COMMUNITY_browsable.ts|browsable.ts]]
-- [[_COMMUNITY_security-preflight.test.mjs|security-preflight.test.mjs]]
-- [[_COMMUNITY_departmentRosterScraper.ts|departmentRosterScraper.ts]]
-- [[_COMMUNITY_labDetail.ts|labDetail.ts]]
-- [[_COMMUNITY_App.tsx|App.tsx]]
-- [[_COMMUNITY_logSanitizer.ts|logSanitizer.ts]]
-- [[_COMMUNITY_adminListingsTableReducer.ts|adminListingsTableReducer.ts]]
-- [[_COMMUNITY_profileService.ts|profileService.ts]]
-- [[_COMMUNITY_labMicrositeDescriptionLLMExtractor.ts|labMicrositeDescriptionLLMExtractor.ts]]
-- [[_COMMUNITY_AdminAccessReview.tsx|AdminAccessReview.tsx]]
-- [[_COMMUNITY_materializeEntity|materializeEntity]]
-- [[_COMMUNITY_researchGroupService.ts|researchGroupService.ts]]
-- [[_COMMUNITY_researchEntitySearchIndexService.ts|researchEntitySearchIndexService.ts]]
-- [[_COMMUNITY_accessMaterializer.ts|accessMaterializer.ts]]
-- [[_COMMUNITY_UserContext.ts|UserContext.ts]]
-- [[_COMMUNITY_index.ts|index.ts]]
-- [[_COMMUNITY_sanitizeLogValue|sanitizeLogValue]]
-- [[_COMMUNITY_integrityGate.ts|integrityGate.ts]]
-- [[_COMMUNITY_passport.ts|passport.ts]]
-- [[_COMMUNITY_Navbar.tsx|Navbar.tsx]]
-- [[_COMMUNITY_undergradFellowshipRecipientScraper.ts|undergradFellowshipRecipientScraper.ts]]
-- [[_COMMUNITY_duplicateEntityNameReview.ts|duplicateEntityNameReview.ts]]
-- [[_COMMUNITY_app.ts|app.ts]]
-- [[_COMMUNITY_dedupeResearchEntitiesByPi.ts|dedupeResearchEntitiesByPi.ts]]
-- [[_COMMUNITY_admin.ts|admin.ts]]
-- [[_COMMUNITY_safeHttpUrl|safeHttpUrl]]
-- [[_COMMUNITY_researchDiscoveryAdapters.ts|researchDiscoveryAdapters.ts]]
-- [[_COMMUNITY_ysmAtoZScraper.ts|ysmAtoZScraper.ts]]
-- [[_COMMUNITY_advisees|advisees]]
-- [[_COMMUNITY_launchAcquisitionReportService.ts|launchAcquisitionReportService.ts]]
-- [[_COMMUNITY_profileDataQualityAudit.ts|profileDataQualityAudit.ts]]
-- [[_COMMUNITY_centersInstitutesScraper.ts|centersInstitutesScraper.ts]]
 - [[_COMMUNITY_types.tsx|types.tsx]]
 - [[_COMMUNITY_ScraperContext|ScraperContext]]
-- [[_COMMUNITY_studentVisibilityGateService.ts|studentVisibilityGateService.ts]]
-- [[_COMMUNITY_buildUserBioObservationScore|buildUserBioObservationScore]]
-- [[_COMMUNITY_User|User]]
-- [[_COMMUNITY_userService.ts|userService.ts]]
-- [[_COMMUNITY_backfillStudentVisibilityTiers.ts|backfillStudentVisibilityTiers.ts]]
-- [[_COMMUNITY_AdminDepartments.tsx|AdminDepartments.tsx]]
-- [[_COMMUNITY_getUniqueDepartmentLabels|getUniqueDepartmentLabels]]
-- [[_COMMUNITY_researchEntityCoverageAudit.ts|researchEntityCoverageAudit.ts]]
-- [[_COMMUNITY_researchAnalytics.ts|researchAnalytics.ts]]
-- [[_COMMUNITY_sourceHealth.ts|sourceHealth.ts]]
-- [[_COMMUNITY_researchEntity.ts|researchEntity.ts]]
-- [[_COMMUNITY_textValue|textValue]]
-- [[_COMMUNITY_ResearchGroupMember|ResearchGroupMember]]
-- [[_COMMUNITY_listingService.ts|listingService.ts]]
-- [[_COMMUNITY_redactDirectContactInfo|redactDirectContactInfo]]
-- [[_COMMUNITY_betaDataQualityCore.ts|betaDataQualityCore.ts]]
-- [[_COMMUNITY_scripts|scripts]]
-- [[_COMMUNITY_productionPromotionSmoke.mjs|productionPromotionSmoke.mjs]]
-- [[_COMMUNITY_research.tsx|research.tsx]]
-- [[_COMMUNITY_runReport.ts|runReport.ts]]
-- [[_COMMUNITY_opportunityDetailService.ts|opportunityDetailService.ts]]
-- [[_COMMUNITY_staleObservationConflictReview.ts|staleObservationConflictReview.ts]]
-- [[_COMMUNITY_researchEntityDescriptionQuality.ts|researchEntityDescriptionQuality.ts]]
-- [[_COMMUNITY_betaDataQuality.ts|betaDataQuality.ts]]
-- [[_COMMUNITY_studentVisibilityTier.ts|studentVisibilityTier.ts]]
-- [[_COMMUNITY_listingController.ts|listingController.ts]]
-- [[_COMMUNITY_researchGroup.ts|researchGroup.ts]]
-- [[_COMMUNITY_analyticsService.ts|analyticsService.ts]]
-- [[_COMMUNITY_BOOLEAN_FLAGS|BOOLEAN_FLAGS]]
-- [[_COMMUNITY_acceptedInputsCore.ts|acceptedInputsCore.ts]]
-- [[_COMMUNITY_serializedDocumentId|serializedDocumentId]]
-- [[_COMMUNITY_researchEntityEvidenceCoverage.ts|researchEntityEvidenceCoverage.ts]]
-- [[_COMMUNITY_fellowshipMatchingService.ts|fellowshipMatchingService.ts]]
-- [[_COMMUNITY_AdminOperatorBoard.tsx|AdminOperatorBoard.tsx]]
-- [[_COMMUNITY_nsfAwardScraper.ts|nsfAwardScraper.ts]]
-- [[_COMMUNITY_fellowshipInputs.ts|fellowshipInputs.ts]]
-- [[_COMMUNITY_repairOfficialProfilePublicationPointers.ts|repairOfficialProfilePublicationPointers.ts]]
-- [[_COMMUNITY_postedOpportunityService.ts|postedOpportunityService.ts]]
-- [[_COMMUNITY_profileController.ts|profileController.ts]]
-- [[_COMMUNITY_analytics.ts|analytics.ts]]
-- [[_COMMUNITY_openAlexPaperScraper.ts|openAlexPaperScraper.ts]]
+- [[_COMMUNITY_UserContext.ts|UserContext.ts]]
+- [[_COMMUNITY_sanitizeLogValue|sanitizeLogValue]]
+- [[_COMMUNITY_departmentRosterScraper.ts|departmentRosterScraper.ts]]
 - [[_COMMUNITY_labMicrositeUndergradLLMExtractor.ts|labMicrositeUndergradLLMExtractor.ts]]
-- [[_COMMUNITY_researchEntityMemberReferenceAudit.ts|researchEntityMemberReferenceAudit.ts]]
+- [[_COMMUNITY_scripts|scripts]]
+- [[_COMMUNITY_researchEntityDescriptionQuality.ts|researchEntityDescriptionQuality.ts]]
+- [[_COMMUNITY_App.tsx|App.tsx]]
+- [[_COMMUNITY_safeHttpUrl|safeHttpUrl]]
+- [[_COMMUNITY_researchDiscoveryAdapters.ts|researchDiscoveryAdapters.ts]]
+- [[_COMMUNITY_index.ts|index.ts]]
+- [[_COMMUNITY_client|client]]
+- [[_COMMUNITY_duplicateEntityNameReview.ts|duplicateEntityNameReview.ts]]
+- [[_COMMUNITY_labDetail.tsx|labDetail.tsx]]
+- [[_COMMUNITY_v4MigrationUtils.ts|v4MigrationUtils.ts]]
+- [[_COMMUNITY_listingController.ts|listingController.ts]]
+- [[_COMMUNITY_betaDataQuality.ts|betaDataQuality.ts]]
+- [[_COMMUNITY_auditProgramResearchRelevance.ts|auditProgramResearchRelevance.ts]]
+- [[_COMMUNITY_acceptedInputsCore.ts|acceptedInputsCore.ts]]
+- [[_COMMUNITY_dedupeResearchEntitiesByPi.ts|dedupeResearchEntitiesByPi.ts]]
+- [[_COMMUNITY_listingService.ts|listingService.ts]]
+- [[_COMMUNITY_profileDataQualityAudit.ts|profileDataQualityAudit.ts]]
+- [[_COMMUNITY_researchGroupService.ts|researchGroupService.ts]]
+- [[_COMMUNITY_researchQualitySearchReview.ts|researchQualitySearchReview.ts]]
+- [[_COMMUNITY_browsable.ts|browsable.ts]]
+- [[_COMMUNITY_passport.ts|passport.ts]]
+- [[_COMMUNITY_launchAcquisitionReportService.ts|launchAcquisitionReportService.ts]]
+- [[_COMMUNITY_labMicrositeDescriptionLLMExtractor.ts|labMicrositeDescriptionLLMExtractor.ts]]
+- [[_COMMUNITY_betaDataQualityCore.ts|betaDataQualityCore.ts]]
+- [[_COMMUNITY_sourceHealth.ts|sourceHealth.ts]]
+- [[_COMMUNITY_ysmAtoZScraper.ts|ysmAtoZScraper.ts]]
+- [[_COMMUNITY_integrityGate.ts|integrityGate.ts]]
+- [[_COMMUNITY_analyticsService.ts|analyticsService.ts]]
+- [[_COMMUNITY_userService.ts|userService.ts]]
+- [[_COMMUNITY_studentVisibilityGateService.ts|studentVisibilityGateService.ts]]
+- [[_COMMUNITY_AdminDepartments.tsx|AdminDepartments.tsx]]
+- [[_COMMUNITY_runReport.ts|runReport.ts]]
+- [[_COMMUNITY_accessMaterializer.ts|accessMaterializer.ts]]
+- [[_COMMUNITY_User|User]]
+- [[_COMMUNITY_profileService.ts|profileService.ts]]
+- [[_COMMUNITY_labDetail.ts|labDetail.ts]]
 - [[_COMMUNITY_SavedPathwaysSection.tsx|SavedPathwaysSection.tsx]]
-- [[_COMMUNITY_departmentUndergradResearchScraper.ts|departmentUndergradResearchScraper.ts]]
+- [[_COMMUNITY_ImportRootDataFiles.ts|ImportRootDataFiles.ts]]
+- [[_COMMUNITY_scholarlyLinkSuppressionAudit.ts|scholarlyLinkSuppressionAudit.ts]]
 - [[_COMMUNITY_pathwaySearchIndexService.ts|pathwaySearchIndexService.ts]]
-- [[_COMMUNITY_researchEntity.ts|researchEntity.ts]]
+- [[_COMMUNITY_studentVisibilityTier.ts|studentVisibilityTier.ts]]
+- [[_COMMUNITY_dataOps.ts|dataOps.ts]]
+- [[_COMMUNITY_fellowshipInputs.ts|fellowshipInputs.ts]]
 - [[_COMMUNITY_adminOperatorBoardService.ts|adminOperatorBoardService.ts]]
 - [[_COMMUNITY_Listing|Listing]]
-- [[_COMMUNITY_promoteAcceptedBetaCopy.ts|promoteAcceptedBetaCopy.ts]]
-- [[_COMMUNITY_Yale Research - Developer Guide|Yale Research - Developer Guide]]
-- [[_COMMUNITY_paperAuthorshipAudit.ts|paperAuthorshipAudit.ts]]
-- [[_COMMUNITY_Observation|Observation]]
-- [[_COMMUNITY_Environment Progression|Environment Progression]]
-- [[_COMMUNITY_devDependencies|devDependencies]]
-- [[_COMMUNITY_Per-Source Audit Playbooks|Per-Source Audit Playbooks]]
-- [[_COMMUNITY_assertPublicHttpUrl|assertPublicHttpUrl]]
-- [[_COMMUNITY_studentDecisionLLMExtractor.ts|studentDecisionLLMExtractor.ts]]
-- [[_COMMUNITY_adminFellowshipFormReducer.ts|adminFellowshipFormReducer.ts]]
-- [[_COMMUNITY_ResearchHomeCard.tsx|ResearchHomeCard.tsx]]
-- [[_COMMUNITY_applyProfileResearchAreaFallback|applyProfileResearchAreaFallback]]
-- [[_COMMUNITY_backfillProfileBiosFromOfficialUrls.ts|backfillProfileBiosFromOfficialUrls.ts]]
-- [[_COMMUNITY_rebuildPathwaySearchIndex.ts|rebuildPathwaySearchIndex.ts]]
-- [[_COMMUNITY_claimGate.ts|claimGate.ts]]
-- [[_COMMUNITY_dedupeUsersByIdentityCore.ts|dedupeUsersByIdentityCore.ts]]
-- [[_COMMUNITY_longText.ts|longText.ts]]
-- [[_COMMUNITY_attempt|attempt]]
-- [[_COMMUNITY_launchTrustContractService.ts|launchTrustContractService.ts]]
-- [[_COMMUNITY_buildAdminOperatorBoard|buildAdminOperatorBoard]]
-- [[_COMMUNITY_analytics.tsx|analytics.tsx]]
+- [[_COMMUNITY_admin.ts|admin.ts]]
 - [[_COMMUNITY_officialProfilePiBackfillScraper.ts|officialProfilePiBackfillScraper.ts]]
-- [[_COMMUNITY_pathwaySearchService.ts|pathwaySearchService.ts]]
-- [[_COMMUNITY_renderedFetch.ts|renderedFetch.ts]]
-- [[_COMMUNITY_BackfillV4FacultyMembers.ts|BackfillV4FacultyMembers.ts]]
-- [[_COMMUNITY_repairArchivedEntityArtifacts.ts|repairArchivedEntityArtifacts.ts]]
-- [[_COMMUNITY_listingClaimRequestService.ts|listingClaimRequestService.ts]]
-- [[_COMMUNITY_brianFeed|brianFeed]]
-- [[_COMMUNITY_betaRepairQueue.ts|betaRepairQueue.ts]]
-- [[_COMMUNITY_assessment|assessment]]
 - [[_COMMUNITY_yaleCollegeFellowshipsOfficeScraper.ts|yaleCollegeFellowshipsOfficeScraper.ts]]
-- [[_COMMUNITY_scripts|scripts]]
-- [[_COMMUNITY_pathwayQualityAudit.ts|pathwayQualityAudit.ts]]
-- [[_COMMUNITY_base|base]]
-- [[_COMMUNITY_isNonBiographicalPublicBio|isNonBiographicalPublicBio]]
-- [[_COMMUNITY_cronRunner.ts|cronRunner.ts]]
-- [[_COMMUNITY_normalizeProfileUpdateForStorage|normalizeProfileUpdateForStorage]]
-- [[_COMMUNITY_yaleResearchOfficialScraper.ts|yaleResearchOfficialScraper.ts]]
-- [[_COMMUNITY_Adding a New Endpoint|Adding a New Endpoint]]
-- [[_COMMUNITY_yaleDirectoryScraper.ts|yaleDirectoryScraper.ts]]
-- [[_COMMUNITY_fellowshipController.ts|fellowshipController.ts]]
-- [[_COMMUNITY_ListingDetailModal.tsx|ListingDetailModal.tsx]]
-- [[_COMMUNITY_scholarlyLinkSuppressionAudit.ts|scholarlyLinkSuppressionAudit.ts]]
-- [[_COMMUNITY_pathwayController.ts|pathwayController.ts]]
-- [[_COMMUNITY_researchEntityDescriptionText.ts|researchEntityDescriptionText.ts]]
-- [[_COMMUNITY_dir|dir]]
-- [[_COMMUNITY_launchReviewExceptions.ts|launchReviewExceptions.ts]]
-- [[_COMMUNITY_adminRender|adminRender]]
-- [[_COMMUNITY_Session Notes|Session Notes]]
-- [[_COMMUNITY_acceptedInputs.ts|acceptedInputs.ts]]
-- [[_COMMUNITY_scraperIntegrityGate.ts|scraperIntegrityGate.ts]]
-- [[_COMMUNITY_research-detail-professor-audit.mjs|research-detail-professor-audit.mjs]]
-- [[_COMMUNITY_dedupeUsersByIdentity.ts|dedupeUsersByIdentity.ts]]
-- [[_COMMUNITY_ImportRootDataFiles.ts|ImportRootDataFiles.ts]]
-- [[_COMMUNITY_candidateDescriptionCrawlUrls|candidateDescriptionCrawlUrls]]
-- [[_COMMUNITY_getResearchGroupDetail|getResearchGroupDetail]]
+- [[_COMMUNITY_fellowships.tsx|fellowships.tsx]]
+- [[_COMMUNITY_pathwaySearchService.ts|pathwaySearchService.ts]]
+- [[_COMMUNITY_paperAuthorshipAudit.ts|paperAuthorshipAudit.ts]]
+- [[_COMMUNITY_entryPathwayService.ts|entryPathwayService.ts]]
+- [[_COMMUNITY_package.json|package.json]]
 - [[_COMMUNITY_applicationRoutePathwayBackfillCore.ts|applicationRoutePathwayBackfillCore.ts]]
-- [[_COMMUNITY_generateKeywords.ts|generateKeywords.ts]]
-- [[_COMMUNITY_scriptWriteGuards.ts|scriptWriteGuards.ts]]
-- [[_COMMUNITY_types.ts|types.ts]]
-- [[_COMMUNITY_client|client]]
-- [[_COMMUNITY_departmentGroundTruth.ts|departmentGroundTruth.ts]]
-- [[_COMMUNITY_profileBioCoverageAudit.ts|profileBioCoverageAudit.ts]]
-- [[_COMMUNITY_Research Model|Research Model]]
-- [[_COMMUNITY_cli.ts|cli.ts]]
-- [[_COMMUNITY_AdminFellowshipsTable.tsx|AdminFellowshipsTable.tsx]]
-- [[_COMMUNITY_smartTitle.ts|smartTitle.ts]]
-- [[_COMMUNITY_crossSourceObservationConflictReview.ts|crossSourceObservationConflictReview.ts]]
-- [[_COMMUNITY_migrateResearchEntities.ts|migrateResearchEntities.ts]]
-- [[_COMMUNITY_visibilityRepairQueueService.ts|visibilityRepairQueueService.ts]]
-- [[_COMMUNITY_abstractBios|abstractBios]]
+- [[_COMMUNITY_backfillStudentVisibilityTiers.ts|backfillStudentVisibilityTiers.ts]]
+- [[_COMMUNITY_entityMaterializer.ts|entityMaterializer.ts]]
+- [[_COMMUNITY_AdminOperatorBoard.tsx|AdminOperatorBoard.tsx]]
 - [[_COMMUNITY_researchEntity.ts|researchEntity.ts]]
-- [[_COMMUNITY_researchQualitySearchReview.ts|researchQualitySearchReview.ts]]
-- [[_COMMUNITY_{ container }|{ container }]]
+- [[_COMMUNITY_scripts|scripts]]
+- [[_COMMUNITY_officialProfilePiBackfillScraper.test.ts|officialProfilePiBackfillScraper.test.ts]]
+- [[_COMMUNITY_undergradFellowshipRecipientScraper.ts|undergradFellowshipRecipientScraper.ts]]
+- [[_COMMUNITY_crossSourceObservationConflictReview.ts|crossSourceObservationConflictReview.ts]]
+- [[_COMMUNITY_researchEntityMemberReferenceAudit.ts|researchEntityMemberReferenceAudit.ts]]
+- [[_COMMUNITY_productionPromotionSmoke.mjs|productionPromotionSmoke.mjs]]
+- [[_COMMUNITY_ListingDetailModal.tsx|ListingDetailModal.tsx]]
+- [[_COMMUNITY_seedSources.ts|seedSources.ts]]
+- [[_COMMUNITY_repairOfficialProfilePublicationPointers.ts|repairOfficialProfilePublicationPointers.ts]]
+- [[_COMMUNITY_fellowshipService.ts|fellowshipService.ts]]
+- [[_COMMUNITY_researchGroup.ts|researchGroup.ts]]
+- [[_COMMUNITY_index.ts|index.ts]]
+- [[_COMMUNITY_researchAnalytics.ts|researchAnalytics.ts]]
+- [[_COMMUNITY_analytics.tsx|analytics.tsx]]
+- [[_COMMUNITY_scripts|scripts]]
+- [[_COMMUNITY_configService.ts|configService.ts]]
+- [[_COMMUNITY_backfillProfileBiosFromOfficialUrls.ts|backfillProfileBiosFromOfficialUrls.ts]]
+- [[_COMMUNITY_departmentLeadRepairPlanCore.ts|departmentLeadRepairPlanCore.ts]]
+- [[_COMMUNITY_researchEntityEvidenceCoverage.ts|researchEntityEvidenceCoverage.ts]]
+- [[_COMMUNITY_scriptWriteGuards.ts|scriptWriteGuards.ts]]
+- [[_COMMUNITY_nihReporterScraper.ts|nihReporterScraper.ts]]
+- [[_COMMUNITY_studentVisibilityRepairTargets.ts|studentVisibilityRepairTargets.ts]]
+- [[_COMMUNITY_researchEntitySearchIndexService.ts|researchEntitySearchIndexService.ts]]
+- [[_COMMUNITY_redactDirectContactInfo|redactDirectContactInfo]]
+- [[_COMMUNITY_programController.ts|programController.ts]]
+- [[_COMMUNITY_departmentUndergradResearchScraper.ts|departmentUndergradResearchScraper.ts]]
+- [[_COMMUNITY_centersInstitutesScraper.ts|centersInstitutesScraper.ts]]
+- [[_COMMUNITY_studentDecisionLLMExtractor.ts|studentDecisionLLMExtractor.ts]]
+- [[_COMMUNITY_dedupeUsersByIdentity.ts|dedupeUsersByIdentity.ts]]
+- [[_COMMUNITY_researchEntityCoverageAudit.ts|researchEntityCoverageAudit.ts]]
+- [[_COMMUNITY_research.tsx|research.tsx]]
+- [[_COMMUNITY_isLikelyPersonUrl|isLikelyPersonUrl]]
+- [[_COMMUNITY_research-detail-professor-audit.mjs|research-detail-professor-audit.mjs]]
+- [[_COMMUNITY_renderedFetch.ts|renderedFetch.ts]]
+- [[_COMMUNITY_analytics.ts|analytics.ts]]
+- [[_COMMUNITY_dedupeUsersByIdentityCore.ts|dedupeUsersByIdentityCore.ts]]
+- [[_COMMUNITY_openAlexPaperScraper.ts|openAlexPaperScraper.ts]]
+- [[_COMMUNITY_dependencies|dependencies]]
+- [[_COMMUNITY_getUniqueDepartmentLabels|getUniqueDepartmentLabels]]
+- [[_COMMUNITY_apiBaseUrl.ts|apiBaseUrl.ts]]
+- [[_COMMUNITY_postedOpportunityService.ts|postedOpportunityService.ts]]
+- [[_COMMUNITY_ObservationInput|ObservationInput]]
+- [[_COMMUNITY_centerDirectorLLMExtractor.ts|centerDirectorLLMExtractor.ts]]
+- [[_COMMUNITY_launchTrustContractService.ts|launchTrustContractService.ts]]
+- [[_COMMUNITY_pathwayQualityAudit.ts|pathwayQualityAudit.ts]]
+- [[_COMMUNITY_promoteAcceptedBetaCopy.ts|promoteAcceptedBetaCopy.ts]]
+- [[_COMMUNITY_visibilityRepairQueueService.ts|visibilityRepairQueueService.ts]]
+- [[_COMMUNITY_departmentGroundTruth.ts|departmentGroundTruth.ts]]
+- [[_COMMUNITY_app.ts|app.ts]]
+- [[_COMMUNITY_listingClaimRequestService.ts|listingClaimRequestService.ts]]
+- [[_COMMUNITY_profileController.ts|profileController.ts]]
+- [[_COMMUNITY_backfillCenterDirectors.ts|backfillCenterDirectors.ts]]
+- [[_COMMUNITY_adminAccessReviewService.ts|adminAccessReviewService.ts]]
 - [[_COMMUNITY_migrateResearchEntityCollections.ts|migrateResearchEntityCollections.ts]]
-- [[_COMMUNITY_researchGroupController.ts|researchGroupController.ts]]
-- [[_COMMUNITY_migrateSmartTitles.ts|migrateSmartTitles.ts]]
-- [[_COMMUNITY_externalIdsSchema|externalIdsSchema]]
-- [[_COMMUNITY_studentDecisionExplanationService.ts|studentDecisionExplanationService.ts]]
+- [[_COMMUNITY_scholarlyLinkToPublicLink|scholarlyLinkToPublicLink]]
+- [[_COMMUNITY_UserContextProvider.tsx|UserContextProvider.tsx]]
+- [[_COMMUNITY_profile.tsx|profile.tsx]]
+- [[_COMMUNITY_nsfAwardScraper.ts|nsfAwardScraper.ts]]
+- [[_COMMUNITY_migrateResearchEntities.ts|migrateResearchEntities.ts]]
+- [[_COMMUNITY_buildAdminOperatorBoard|buildAdminOperatorBoard]]
+- [[_COMMUNITY_axios.ts|axios.ts]]
 - [[_COMMUNITY_disambiguateSurnameLabNames.ts|disambiguateSurnameLabNames.ts]]
 - [[_COMMUNITY_repairDuplicateAccessSignals.ts|repairDuplicateAccessSignals.ts]]
-- [[_COMMUNITY_arxivPreprintScraper.ts|arxivPreprintScraper.ts]]
-- [[_COMMUNITY_EvidenceQualitySection|EvidenceQualitySection]]
-- [[_COMMUNITY_LIVE|LIVE]]
-- [[_COMMUNITY_dependencies|dependencies]]
-- [[_COMMUNITY_normalizeOfficialProfileUrl|normalizeOfficialProfileUrl]]
-- [[_COMMUNITY_axios.ts|axios.ts]]
-- [[_COMMUNITY_programController.ts|programController.ts]]
-- [[_COMMUNITY_seedDepartments.ts|seedDepartments.ts]]
-- [[_COMMUNITY_Active Detail Docs|Active Detail Docs]]
+- [[_COMMUNITY_fellowshipMatchingService.ts|fellowshipMatchingService.ts]]
+- [[_COMMUNITY_fellowshipController.ts|fellowshipController.ts]]
+- [[_COMMUNITY_environment.ts|environment.ts]]
+- [[_COMMUNITY_repairArchivedEntityArtifacts.ts|repairArchivedEntityArtifacts.ts]]
 - [[_COMMUNITY_repairMismatchedPersonEmailsCore.ts|repairMismatchedPersonEmailsCore.ts]]
-- [[_COMMUNITY_betaReadinessGate.ts|betaReadinessGate.ts]]
-- [[_COMMUNITY_buildDescriptionLLMPrompt|buildDescriptionLLMPrompt]]
-- [[_COMMUNITY_index.tsx|index.tsx]]
-- [[_COMMUNITY_callLLM|callLLM]]
-- [[_COMMUNITY_adminAccessReviewService.ts|adminAccessReviewService.ts]]
-- [[_COMMUNITY_studentVisibilityRepairTargets.ts|studentVisibilityRepairTargets.ts]]
-- [[_COMMUNITY_scripts|scripts]]
-- [[_COMMUNITY_v4MigrationUtils.ts|v4MigrationUtils.ts]]
-- [[_COMMUNITY_source.ts|source.ts]]
-- [[_COMMUNITY_cleanupLegacyMongoCollections.ts|cleanupLegacyMongoCollections.ts]]
-- [[_COMMUNITY_seedSources.ts|seedSources.ts]]
-- [[_COMMUNITY_AdminProfileEditModal.tsx|AdminProfileEditModal.tsx]]
-- [[_COMMUNITY_configService.ts|configService.ts]]
-- [[_COMMUNITY_publicResearchSeo.ts|publicResearchSeo.ts]]
-- [[_COMMUNITY_migrateMongoNaming.ts|migrateMongoNaming.ts]]
+- [[_COMMUNITY_errorHandler.ts|errorHandler.ts]]
 - [[_COMMUNITY_researchEntityPiDedupeCore.ts|researchEntityPiDedupeCore.ts]]
-- [[_COMMUNITY_staleObservationConflictReview.test.ts|staleObservationConflictReview.test.ts]]
-- [[_COMMUNITY_launchTrustContract.ts|launchTrustContract.ts]]
-- [[_COMMUNITY_EvidenceSourceRow.tsx|EvidenceSourceRow.tsx]]
-- [[_COMMUNITY_adminGrantService.ts|adminGrantService.ts]]
-- [[_COMMUNITY_resolveSafeJsonReportOutputPath|resolveSafeJsonReportOutputPath]]
-- [[_COMMUNITY_dependencies|dependencies]]
-- [[_COMMUNITY_users.ts|users.ts]]
-- [[_COMMUNITY_unified-research-search-audit.mjs|unified-research-search-audit.mjs]]
-- [[_COMMUNITY_index.ts|index.ts]]
-- [[_COMMUNITY_userEmailHygiene.ts|userEmailHygiene.ts]]
-- [[_COMMUNITY_orcidWorksScraper.ts|orcidWorksScraper.ts]]
-- [[_COMMUNITY_backfillResearchHomeOfficialUrls.ts|backfillResearchHomeOfficialUrls.ts]]
-- [[_COMMUNITY_backfillFacultyWaysIn.ts|backfillFacultyWaysIn.ts]]
-- [[_COMMUNITY_publicationsTableReducer.ts|publicationsTableReducer.ts]]
-- [[_COMMUNITY_AdminFacultyProfilesTable.tsx|AdminFacultyProfilesTable.tsx]]
-- [[_COMMUNITY_meiliSyncService.ts|meiliSyncService.ts]]
-- [[_COMMUNITY_AdminOperatorBoard|AdminOperatorBoard]]
-- [[_COMMUNITY_departmentResolver.ts|departmentResolver.ts]]
 - [[_COMMUNITY_isPublicHttpUrl|isPublicHttpUrl]]
-- [[_COMMUNITY_repairProfileDescriptionBackfillConflicts.ts|repairProfileDescriptionBackfillConflicts.ts]]
-- [[_COMMUNITY_clearBetaStudentAnalytics.ts|clearBetaStudentAnalytics.ts]]
-- [[_COMMUNITY_scraperIntegrityDuplicateReview.ts|scraperIntegrityDuplicateReview.ts]]
-- [[_COMMUNITY_normalizePublicProfile|normalizePublicProfile]]
-- [[_COMMUNITY_departmentLeadRepairPlanCore.ts|departmentLeadRepairPlanCore.ts]]
-- [[_COMMUNITY_auditResearchEntityRename.ts|auditResearchEntityRename.ts]]
-- [[_COMMUNITY_normalizeName|normalizeName]]
-- [[_COMMUNITY_authorshipEvidence|authorshipEvidence]]
-- [[_COMMUNITY_actor|actor]]
-- [[_COMMUNITY_compilerOptions|compilerOptions]]
-- [[_COMMUNITY_backfillPostedOpportunitiesFromListings.ts|backfillPostedOpportunitiesFromListings.ts]]
-- [[_COMMUNITY_acronymExpansion|acronymExpansion]]
+- [[_COMMUNITY_researchEntityQuality.ts|researchEntityQuality.ts]]
+- [[_COMMUNITY_cronRunner.ts|cronRunner.ts]]
+- [[_COMMUNITY_assertPublicHttpUrl|assertPublicHttpUrl]]
+- [[_COMMUNITY_userEmailHygiene.ts|userEmailHygiene.ts]]
 - [[_COMMUNITY_paperQualityService.ts|paperQualityService.ts]]
-- [[_COMMUNITY_dataOps.ts|dataOps.ts]]
-- [[_COMMUNITY_actionabilityMatch|actionabilityMatch]]
-- [[_COMMUNITY_pathwayRelevanceReview.ts|pathwayRelevanceReview.ts]]
-- [[_COMMUNITY_profileImageQualityAudit.ts|profileImageQualityAudit.ts]]
-- [[_COMMUNITY_researchGroupService.test.ts|researchGroupService.test.ts]]
-- [[_COMMUNITY_programs.ts|programs.ts]]
-- [[_COMMUNITY_bare|bare]]
-- [[_COMMUNITY_crossrefFreeFullText|crossrefFreeFullText]]
+- [[_COMMUNITY_profileBioCoverageAudit.ts|profileBioCoverageAudit.ts]]
+- [[_COMMUNITY_logSanitizer.ts|logSanitizer.ts]]
+- [[_COMMUNITY_staleObservationConflictReview.ts|staleObservationConflictReview.ts]]
+- [[_COMMUNITY_betaDataQualityCore.test.ts|betaDataQualityCore.test.ts]]
+- [[_COMMUNITY_AdminProfileEditModal.tsx|AdminProfileEditModal.tsx]]
+- [[_COMMUNITY_seedDepartments.ts|seedDepartments.ts]]
+- [[_COMMUNITY_unified-research-search-audit.mjs|unified-research-search-audit.mjs]]
+- [[_COMMUNITY_researchGroupController.ts|researchGroupController.ts]]
+- [[_COMMUNITY_yaleResearchOfficialScraper.ts|yaleResearchOfficialScraper.ts]]
+- [[_COMMUNITY_cleanupLegacyMongoCollections.ts|cleanupLegacyMongoCollections.ts]]
+- [[_COMMUNITY_launchReviewExceptions.ts|launchReviewExceptions.ts]]
+- [[_COMMUNITY_Observation|Observation]]
+- [[_COMMUNITY_idSerialization.ts|idSerialization.ts]]
+- [[_COMMUNITY_isNonBiographicalPublicBio|isNonBiographicalPublicBio]]
+- [[_COMMUNITY_Yale Research - Developer Guide|Yale Research - Developer Guide]]
+- [[_COMMUNITY_migrateMongoNaming.ts|migrateMongoNaming.ts]]
+- [[_COMMUNITY_repairProfileDescriptionBackfillConflicts.ts|repairProfileDescriptionBackfillConflicts.ts]]
+- [[_COMMUNITY_normalizePublicProfile|normalizePublicProfile]]
+- [[_COMMUNITY_migrateSmartTitles.ts|migrateSmartTitles.ts]]
+- [[_COMMUNITY_courseTableService.ts|courseTableService.ts]]
+- [[_COMMUNITY_betaSeedEnvironment.ts|betaSeedEnvironment.ts]]
+- [[_COMMUNITY_agent-workflow|agent-workflow.md]]
+- [[_COMMUNITY_betaReadinessGate.ts|betaReadinessGate.ts]]
+- [[_COMMUNITY_source.ts|source.ts]]
+- [[_COMMUNITY_auditResearchEntityRename.ts|auditResearchEntityRename.ts]]
+- [[_COMMUNITY_resolveSafeJsonReportOutputPath|resolveSafeJsonReportOutputPath]]
+- [[_COMMUNITY_Session Notes|Session Notes]]
+- [[_COMMUNITY_devDependencies|devDependencies]]
+- [[_COMMUNITY_acceptedInputs.ts|acceptedInputs.ts]]
+- [[_COMMUNITY_accessClaims.ts|accessClaims.ts]]
+- [[_COMMUNITY_scraperIntegrityDuplicateReview.ts|scraperIntegrityDuplicateReview.ts]]
+- [[_COMMUNITY_clearBetaStudentAnalytics.ts|clearBetaStudentAnalytics.ts]]
+- [[_COMMUNITY_ResearchAreaInput.tsx|ResearchAreaInput.tsx]]
+- [[_COMMUNITY_Yale Research|Yale Research]]
+- [[_COMMUNITY_adminListingsTableReducer.ts|adminListingsTableReducer.ts]]
 - [[_COMMUNITY_compilerOptions|compilerOptions]]
-- [[_COMMUNITY_seo.ts|seo.ts]]
-- [[_COMMUNITY_MigratePublicationsToPapers.ts|MigratePublicationsToPapers.ts]]
+- [[_COMMUNITY_seedResearchAreas.ts|seedResearchAreas.ts]]
+- [[_COMMUNITY_Decisions|Decisions]]
+- [[_COMMUNITY_Research Data Pipeline|Research Data Pipeline]]
+- [[_COMMUNITY_Research Model|Research Model]]
+- [[_COMMUNITY_auth.ts|auth.ts]]
+- [[_COMMUNITY_adminGrantService.ts|adminGrantService.ts]]
+- [[_COMMUNITY_profileImageQualityAudit.ts|profileImageQualityAudit.ts]]
+- [[_COMMUNITY_rebuildPathwaySearchIndex.ts|rebuildPathwaySearchIndex.ts]]
+- [[_COMMUNITY_researchDetailSources.ts|researchDetailSources.ts]]
+- [[_COMMUNITY_AdminListingEditModal.tsx|AdminListingEditModal.tsx]]
+- [[_COMMUNITY_compilerOptions|compilerOptions]]
+- [[_COMMUNITY_AdminFacultyProfilesTable.tsx|AdminFacultyProfilesTable.tsx]]
+- [[_COMMUNITY_generateKeywords.ts|generateKeywords.ts]]
+- [[_COMMUNITY_Per-Source Audit Playbooks|Per-Source Audit Playbooks]]
+- [[_COMMUNITY_PublicationsTable.tsx|PublicationsTable.tsx]]
+- [[_COMMUNITY_seed.ts|seed.ts]]
+- [[_COMMUNITY_backfillResearchDescriptions.ts|backfillResearchDescriptions.ts]]
+- [[_COMMUNITY_backfillResearchHomeOfficialUrls.ts|backfillResearchHomeOfficialUrls.ts]]
+- [[_COMMUNITY_scraperIntegrityGate.ts|scraperIntegrityGate.ts]]
+- [[_COMMUNITY_researchEntityDto.ts|researchEntityDto.ts]]
+- [[_COMMUNITY_serializedDocumentId|serializedDocumentId]]
+- [[_COMMUNITY_normalizeName|normalizeName]]
+- [[_COMMUNITY_betaRepairQueue.ts|betaRepairQueue.ts]]
+- [[_COMMUNITY_researchAccessTypes.ts|researchAccessTypes.ts]]
+- [[_COMMUNITY_pathwayRelevanceReview.ts|pathwayRelevanceReview.ts]]
+- [[_COMMUNITY_accessSummaryService.ts|accessSummaryService.ts]]
 - [[_COMMUNITY_sourceHealthService.ts|sourceHealthService.ts]]
+- [[_COMMUNITY_adminFacultyProfilesTableReducer.ts|adminFacultyProfilesTableReducer.ts]]
+- [[_COMMUNITY_resolutions|resolutions]]
+- [[_COMMUNITY_publicResearchSeo.ts|publicResearchSeo.ts]]
+- [[_COMMUNITY_devDependencies|devDependencies]]
+- [[_COMMUNITY_visibilityReleaseQueueItem.ts|visibilityReleaseQueueItem.ts]]
+- [[_COMMUNITY_users.ts|users.ts]]
+- [[_COMMUNITY_fellowshipApplicationCycleEvidenceService.ts|fellowshipApplicationCycleEvidenceService.ts]]
+- [[_COMMUNITY_dependencies|dependencies]]
+- [[_COMMUNITY_dedupeExploratoryContactPathways.ts|dedupeExploratoryContactPathways.ts]]
+- [[_COMMUNITY_repairListingResearchEntityProfiles.ts|repairListingResearchEntityProfiles.ts]]
+- [[_COMMUNITY_resolutions|resolutions]]
+- [[_COMMUNITY_longText.ts|longText.ts]]
+- [[_COMMUNITY_csrfOriginGuard.ts|csrfOriginGuard.ts]]
+- [[_COMMUNITY_compilerOptions|compilerOptions]]
+- [[_COMMUNITY_Environment Progression|Environment Progression]]
+- [[_COMMUNITY_ScrapeRun|ScrapeRun]]
+- [[_COMMUNITY_programs.ts|programs.ts]]
+- [[_COMMUNITY_backfillProgramClassifications.ts|backfillProgramClassifications.ts]]
+- [[_COMMUNITY_package.json|package.json]]
+- [[_COMMUNITY_classifyDuplicateEntityCluster|classifyDuplicateEntityCluster]]
+- [[_COMMUNITY_seo.ts|seo.ts]]
+- [[_COMMUNITY_BackfillV4StudentProfiles.ts|BackfillV4StudentProfiles.ts]]
+- [[_COMMUNITY_assertScriptApplyAllowed|assertScriptApplyAllowed]]
+- [[_COMMUNITY_Graphify repo memory|Graphify repo memory]]
+- [[_COMMUNITY_securityHeaders.ts|securityHeaders.ts]]
+- [[_COMMUNITY_ssrfGuard.ts|ssrfGuard.ts]]
 - [[_COMMUNITY_listings.ts|listings.ts]]
 - [[_COMMUNITY_confidenceResolver.ts|confidenceResolver.ts]]
-- [[_COMMUNITY_facultyResearch|facultyResearch]]
-- [[_COMMUNITY_filterDuplicateRunObservations|filterDuplicateRunObservations]]
-- [[_COMMUNITY_authenticatedRouteDoc|authenticatedRouteDoc]]
-- [[_COMMUNITY_normalizeAcceptedDecisionValidation|normalizeAcceptedDecisionValidation]]
-- [[_COMMUNITY_isLocalHostValue|isLocalHostValue]]
-- [[_COMMUNITY_UIUX Direction|UI/UX Direction]]
-- [[_COMMUNITY_LEGACY_EXPLORATORY_CONTACT_PATHWAY_DERIVATION_KEYS|LEGACY_EXPLORATORY_CONTACT_PATHWAY_DERIVATION_KEYS]]
-- [[_COMMUNITY_firstSentence|firstSentence]]
-- [[_COMMUNITY_loadCandidateCollisions|loadCandidateCollisions]]
-- [[_COMMUNITY_entityMaterializer.test.ts|entityMaterializer.test.ts]]
-- [[_COMMUNITY_backfillCenterDirectors.ts|backfillCenterDirectors.ts]]
-- [[_COMMUNITY_programClassifier.ts|programClassifier.ts]]
-- [[_COMMUNITY_seed.ts|seed.ts]]
-- [[_COMMUNITY_index.ts|index.ts]]
-- [[_COMMUNITY_seedResearchAreas.ts|seedResearchAreas.ts]]
-- [[_COMMUNITY_fellowships.tsx|fellowships.tsx]]
-- [[_COMMUNITY_securityHeaders.ts|securityHeaders.ts]]
-- [[_COMMUNITY_dir|dir]]
-- [[_COMMUNITY_leadMemberDisplayName|leadMemberDisplayName]]
-- [[_COMMUNITY_environment.ts|environment.ts]]
-- [[_COMMUNITY_sourceReviewDecisionHandoffs|sourceReviewDecisionHandoffs]]
-- [[_COMMUNITY_dependencies|dependencies]]
-- [[_COMMUNITY_sourceReviewDecisionValidationProbeCommands|sourceReviewDecisionValidationProbeCommands]]
-- [[_COMMUNITY_departmentGroundTruth.test.ts|departmentGroundTruth.test.ts]]
-- [[_COMMUNITY_applyProfileResearchAreasForIndexDocument|applyProfileResearchAreasForIndexDocument]]
-- [[_COMMUNITY_csv|csv]]
-- [[_COMMUNITY_entryToMemberObservations|entryToMemberObservations]]
-- [[_COMMUNITY_dir|dir]]
-- [[_COMMUNITY_repairListingResearchEntityProfiles.ts|repairListingResearchEntityProfiles.ts]]
-- [[_COMMUNITY_CanonicalDepartmentListResult|CanonicalDepartmentListResult]]
-- [[_COMMUNITY_ArtifactFreshnessStrip|ArtifactFreshnessStrip]]
-- [[_COMMUNITY_MockBroadcastChannel|MockBroadcastChannel]]
-- [[_COMMUNITY_Product Context|Product Context]]
-- [[_COMMUNITY_1. Admin And Search Gates|1. Admin And Search Gates]]
-- [[_COMMUNITY_apiBaseUrl.ts|apiBaseUrl.ts]]
-- [[_COMMUNITY_resolutions|resolutions]]
-- [[_COMMUNITY_sourceReviewDecisionValidationLines|sourceReviewDecisionValidationLines]]
-- [[_COMMUNITY_spreadsheetSafety.ts|spreadsheetSafety.ts]]
-- [[_COMMUNITY_summary|summary]]
-- [[_COMMUNITY_trustedLeadResearchHomeBioFallback|trustedLeadResearchHomeBioFallback]]
-- [[_COMMUNITY_README|README.md]]
-- [[_COMMUNITY_paragraphs|paragraphs]]
-- [[_COMMUNITY_opportunity.ts|opportunity.ts]]
-- [[_COMMUNITY_README|README.md]]
-- [[_COMMUNITY_BackfillV4Grants.ts|BackfillV4Grants.ts]]
-- [[_COMMUNITY_isLikelyPersonUrl|isLikelyPersonUrl]]
-- [[_COMMUNITY_sanitizeMongo.ts|sanitizeMongo.ts]]
-- [[_COMMUNITY_index.ts|index.ts]]
-- [[_COMMUNITY_OfficialProfilePublicationValue|OfficialProfilePublicationValue]]
-- [[_COMMUNITY_.run|.run]]
-- [[_COMMUNITY_researchEntityRelationship.ts|researchEntityRelationship.ts]]
-- [[_COMMUNITY_corsOrigin.ts|corsOrigin.ts]]
-- [[_COMMUNITY_Codex Guide|Codex Guide]]
-- [[_COMMUNITY_dataMigrationV4GrantBackfill.test.ts|dataMigrationV4GrantBackfill.test.ts]]
 - [[_COMMUNITY_refreshGateScorecards.ts|refreshGateScorecards.ts]]
-- [[_COMMUNITY_createInitialAdminTableState|createInitialAdminTableState]]
-- [[_COMMUNITY_dedupeExploratoryContactPathways.ts|dedupeExploratoryContactPathways.ts]]
-- [[_COMMUNITY_args|args]]
-- [[_COMMUNITY_compilerOptions|compilerOptions]]
-- [[_COMMUNITY_devDependencies|devDependencies]]
-- [[_COMMUNITY_CliOptions|CliOptions]]
-- [[_COMMUNITY_testFixturePrivacy.test.ts|testFixturePrivacy.test.ts]]
-- [[_COMMUNITY_{ ctx }|{ ctx }]]
-- [[_COMMUNITY_itemOperations.ts|itemOperations.ts]]
+- [[_COMMUNITY_AdminOperatorBoard|AdminOperatorBoard]]
+- [[_COMMUNITY_scripts|scripts]]
+- [[_COMMUNITY_BackfillV4FacultyMembers.ts|BackfillV4FacultyMembers.ts]]
 - [[_COMMUNITY_useFavorites.ts|useFavorites.ts]]
+- [[_COMMUNITY_fellowships.ts|fellowships.ts]]
+- [[_COMMUNITY_Auth and Security|Auth and Security]]
+- [[_COMMUNITY_Yale Research Product Context|Yale Research Product Context]]
+- [[_COMMUNITY_AdminFellowshipsTable.tsx|AdminFellowshipsTable.tsx]]
+- [[_COMMUNITY_ScraperMetrics|ScraperMetrics]]
+- [[_COMMUNITY_Local Development Setup|Local Development Setup]]
+- [[_COMMUNITY_Product Context|Product Context]]
+- [[_COMMUNITY_UIUX Direction|UI/UX Direction]]
+- [[_COMMUNITY_ensure-server-build-fresh.mjs|ensure-server-build-fresh.mjs]]
+- [[_COMMUNITY_corsOrigin.ts|corsOrigin.ts]]
+- [[_COMMUNITY_sanitizeMongo.ts|sanitizeMongo.ts]]
+- [[_COMMUNITY_staleObservationConflictReview.test.ts|staleObservationConflictReview.test.ts]]
+- [[_COMMUNITY_Architecture|Architecture]]
+- [[_COMMUNITY_listingFormReducer.ts|listingFormReducer.ts]]
+- [[_COMMUNITY_Scraper Deployment Runbook|Scraper Deployment Runbook]]
+- [[_COMMUNITY_devDependencies|devDependencies]]
+- [[_COMMUNITY_resolutions|resolutions]]
+- [[_COMMUNITY_orcidWorksScraper.ts|orcidWorksScraper.ts]]
+- [[_COMMUNITY_importFaculty.ts|importFaculty.ts]]
+- [[_COMMUNITY_launchAcquisitionReport.ts|launchAcquisitionReport.ts]]
+- [[_COMMUNITY_Topic matching and search engagement|Topic matching and search engagement]]
+- [[_COMMUNITY_researchAreaResolver.ts|researchAreaResolver.ts]]
+- [[_COMMUNITY_EvidenceSourceRow.tsx|EvidenceSourceRow.tsx]]
+- [[_COMMUNITY_buildCandidateSample|buildCandidateSample]]
+- [[_COMMUNITY_buildStaleObservationConflictSummary|buildStaleObservationConflictSummary]]
+- [[_COMMUNITY_testFixturePrivacy.test.ts|testFixturePrivacy.test.ts]]
+- [[_COMMUNITY_manifest.json|manifest.json]]
+- [[_COMMUNITY_Available Scripts|Available Scripts]]
+- [[_COMMUNITY_departmentGroundTruth.test.ts|departmentGroundTruth.test.ts]]
+- [[_COMMUNITY_package.json|package.json]]
+- [[_COMMUNITY_buildCandidateSample|buildCandidateSample]]
+- [[_COMMUNITY_itemOperations.ts|itemOperations.ts]]
+- [[_COMMUNITY_check-no-secrets-core.mjs|check-no-secrets-core.mjs]]
+- [[_COMMUNITY_security-preflight.test.mjs|security-preflight.test.mjs]]
+- [[_COMMUNITY_runStaleObservationConflictReview|runStaleObservationConflictReview]]
+- [[_COMMUNITY_MockBroadcastChannel|MockBroadcastChannel]]
+- [[_COMMUNITY_parseStaleObservationConflictReviewArgs|parseStaleObservationConflictReviewArgs]]
+- [[_COMMUNITY_normalizeAcceptedDecisionValidation|normalizeAcceptedDecisionValidation]]
+- [[_COMMUNITY_researchAreas.ts|researchAreas.ts]]
+- [[_COMMUNITY_Contributing endpoints, pages, schema|Contributing: endpoints, pages, schema]]
+- [[_COMMUNITY_Scrapers|Scrapers]]
+- [[_COMMUNITY_Search and Data|Search and Data]]
+- [[_COMMUNITY_checker.py|checker.py]]
+- [[_COMMUNITY_dependencies|dependencies]]
+- [[_COMMUNITY_normalizeStaleObservationReviewDecision|normalizeStaleObservationReviewDecision]]
+- [[_COMMUNITY_with-playwright-libs.sh|with-playwright-libs.sh]]
+- [[_COMMUNITY_validateStaleObservationReviewDecisions|validateStaleObservationReviewDecisions]]
+- [[_COMMUNITY_dataMigrationPackageScripts.test.ts|dataMigrationPackageScripts.test.ts]]
+- [[_COMMUNITY_dataMigrationV4GrantBackfill.test.ts|dataMigrationV4GrantBackfill.test.ts]]
+- [[_COMMUNITY_departmentMigrationCliSafety.test.ts|departmentMigrationCliSafety.test.ts]]
+- [[_COMMUNITY_publicationMigrationCliSafety.test.ts|publicationMigrationCliSafety.test.ts]]
+- [[_COMMUNITY_rootDataImportCliSafety.test.ts|rootDataImportCliSafety.test.ts]]
+- [[_COMMUNITY_userMigrationCliSafety.test.ts|userMigrationCliSafety.test.ts]]
+- [[_COMMUNITY_useDebouncedLocalStorage.test.tsx|useDebouncedLocalStorage.test.tsx]]
+- [[_COMMUNITY_vite-env.d.ts|vite-env.d.ts]]
+- [[_COMMUNITY_README|README.md]]
+- [[_COMMUNITY_dataMigrationV4DeprecatedBackfills.test.ts|dataMigrationV4DeprecatedBackfills.test.ts]]
+- [[_COMMUNITY_dataMigrationV4IdentityBackfills.test.ts|dataMigrationV4IdentityBackfills.test.ts]]
+- [[_COMMUNITY_yaliesService.test.ts|yaliesService.test.ts]]
 - [[_COMMUNITY_appSecurityRuntime.test.ts|appSecurityRuntime.test.ts]]
-- [[_COMMUNITY_entityMaterializer.ts|entityMaterializer.ts]]
+- [[_COMMUNITY_postcss.config.js|postcss.config.js]]
 - [[_COMMUNITY_ArtifactFreshnessStrip|ArtifactFreshnessStrip]]
 - [[_COMMUNITY_sourceReviewDecisionHandoffs|sourceReviewDecisionHandoffs]]
-- [[_COMMUNITY_astronomyConfig|astronomyConfig]]
-- [[_COMMUNITY_runStaleObservationConflictReview|runStaleObservationConflictReview]]
+- [[_COMMUNITY_sourceReviewDecisionValidationLines|sourceReviewDecisionValidationLines]]
+- [[_COMMUNITY_sourceReviewDecisionValidationProbeCommands|sourceReviewDecisionValidationProbeCommands]]
 - [[_COMMUNITY_diffDepartmentRows|diffDepartmentRows]]
 - [[_COMMUNITY_README|README.md]]
-- [[_COMMUNITY_safeSpreadsheetCell|safeSpreadsheetCell]]
-- [[_COMMUNITY_10. P2 Fellowship, Course, And Contact Materialization|10. P2 Fellowship, Course, And Contact Materialization]]
-- [[_COMMUNITY_Research Data Pipeline|Research Data Pipeline]]
+- [[_COMMUNITY_update_rdb.py|update_rdb.py]]
+- [[_COMMUNITY_getSavedResearchPlanFundingMatches|getSavedResearchPlanFundingMatches]]
+- [[_COMMUNITY_buildFetchMetric|buildFetchMetric]]
 - [[_COMMUNITY_BETA_REPAIR_QUEUE_REPORT_MAX_AGE_HOURS|BETA_REPAIR_QUEUE_REPORT_MAX_AGE_HOURS]]
 - [[_COMMUNITY_DATA_QUALITY_SCORECARD_MAX_AGE_HOURS|DATA_QUALITY_SCORECARD_MAX_AGE_HOURS]]
 - [[_COMMUNITY_LAUNCH_ACQUISITION_REPORT_MAX_AGE_HOURS|LAUNCH_ACQUISITION_REPORT_MAX_AGE_HOURS]]
 - [[_COMMUNITY_LAUNCH_REVIEW_EXCEPTIONS_REPORT_MAX_AGE_HOURS|LAUNCH_REVIEW_EXCEPTIONS_REPORT_MAX_AGE_HOURS]]
 - [[_COMMUNITY_LAUNCH_TRUST_SCORECARD_MAX_AGE_HOURS|LAUNCH_TRUST_SCORECARD_MAX_AGE_HOURS]]
-- [[_COMMUNITY_courseTableService.ts|courseTableService.ts]]
-- [[_COMMUNITY_importFaculty.ts|importFaculty.ts]]
-- [[_COMMUNITY_1. M1.2 Client API-Boundary Vocabulary|1. M1.2 Client API-Boundary Vocabulary]]
+- [[_COMMUNITY_PROMOTION_COPY_DRY_RUN_REPORT_MAX_AGE_HOURS|PROMOTION_COPY_DRY_RUN_REPORT_MAX_AGE_HOURS]]
+- [[_COMMUNITY_SCRAPER_INTEGRITY_SCORECARD_MAX_AGE_HOURS|SCRAPER_INTEGRITY_SCORECARD_MAX_AGE_HOURS]]
+- [[_COMMUNITY_archiveProgram|archiveProgram]]
 - [[_COMMUNITY_bulkCreatePrograms|bulkCreatePrograms]]
-- [[_COMMUNITY_AdminListingsTable.tsx|AdminListingsTable.tsx]]
+- [[_COMMUNITY_createProgram|createProgram]]
 - [[_COMMUNITY_deleteProgram|deleteProgram]]
-- [[_COMMUNITY_devDependencies|devDependencies]]
-- [[_COMMUNITY_errorHandler.ts|errorHandler.ts]]
-- [[_COMMUNITY_next|next]]
+- [[_COMMUNITY_readAllPrograms|readAllPrograms]]
+- [[_COMMUNITY_unarchiveProgram|unarchiveProgram]]
+- [[_COMMUNITY_updateProgram|updateProgram]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `sanitizeLogValue()` - 251 edges
@@ -371,977 +363,977 @@
 ## Import Cycles
 - None detected.
 
-## Communities (338 total, 38 thin omitted)
+## Communities (330 total, 38 thin omitted)
 
-### Community 0 - "Decisions"
-Cohesion: 0.04
-Nodes (73): AdminFellowshipEditModal(), Props, FellowshipModal(), FellowshipModalProps, trackFellowshipApplyClick(), fellowship, renderModal(), sortOptions (+65 more)
+### Community 0 - "types.tsx"
+Cohesion: 0.07
+Nodes (36): AdminFellowshipEditModal(), Props, fellowship, renderModal(), COLUMNS, FellowshipKanbanBoardProps, defaultFellowshipSearchContext, FellowshipSearchContextType (+28 more)
 
-### Community 1 - "labDetail.tsx"
-Cohesion: 0.05
-Nodes (57): ScraperOrchestrator, CallCenterDirectorLLMFn, CandidateCenter, CenterDirector, CenterDirectorExtraction, CenterDirectorLLMExtractor, CenterDirectorLLMExtractorDeps, CenterFinderFn (+49 more)
-
-### Community 2 - "browsable.ts"
-Cohesion: 0.04
-Nodes (56): baseProfile, renderProfileHeader(), fellowship, item, renderAdmin(), listing, renderModal(), listing (+48 more)
-
-### Community 3 - "security-preflight.test.mjs"
+### Community 1 - "ScraperContext"
 Cohesion: 0.08
-Nodes (77): mocks, privateProgram, addFavFellowships(), addFavListings(), addFavPathways(), addSavedPrograms(), addSavedResearchPlans(), ALLOWED_SELF_USER_TYPES (+69 more)
+Nodes (28): ScraperOrchestrator, CrossrefFetcher, CrossrefMessage, crossrefMessageToObservations(), CrossrefPaperScraper, CrossrefPaperScraperOptions, dateFromParts(), normalizeDoi() (+20 more)
+
+### Community 2 - "UserContext.ts"
+Cohesion: 0.04
+Nodes (55): baseProfile, renderProfileHeader(), fellowship, item, renderAdmin(), listing, renderModal(), listing (+47 more)
+
+### Community 3 - "sanitizeLogValue"
+Cohesion: 0.11
+Nodes (52): mocks, privateProgram, addFavFellowships(), addFavListings(), addFavPathways(), addSavedPrograms(), addSavedResearchPlans(), ALLOWED_SELF_USER_TYPES (+44 more)
 
 ### Community 4 - "departmentRosterScraper.ts"
-Cohesion: 0.07
-Nodes (72): memberObservationsForEntityKey(), absolutize(), canonicalProfileUrlFromHtml(), cleanProfileSectionText(), cleanText(), csFacultyDataExtractor(), csJsRenderedStub(), csRenderedExtractor() (+64 more)
+Cohesion: 0.09
+Nodes (59): summarizeFetchMetrics, absolutize(), canonicalProfileUrlFromHtml(), cleanProfileSectionText(), cleanText(), csFacultyDataExtractor(), csJsRenderedStub(), csRenderedExtractor() (+51 more)
 
-### Community 5 - "labDetail.ts"
-Cohesion: 0.05
-Nodes (66): average(), boundedRenderedFetchTimeout(), buildFetchAttemptMetrics(), createScraplingRenderedFetcher(), currentMemoryBytes(), DEFAULT_BRIDGE_PATH, defaultRenderedSeedRedirectCheck(), execFileAsync (+58 more)
+### Community 5 - "labMicrositeUndergradLLMExtractor.ts"
+Cohesion: 0.09
+Nodes (38): RenderedFetcher, buildLLMPrompt(), CallLLMFn, candidateCrawlUrls(), CandidateLab, candidateLabFromResearchEntityDoc(), candidateSubPageUrls(), cleanResearchSummary() (+30 more)
 
-### Community 6 - "App.tsx"
+### Community 6 - "scripts"
 Cohesion: 0.03
 Nodes (75): scripts, accepted-inputs, access-signals:repair-duplicates, application-routes:backfill-pathways, beta:clear-student-analytics, beta:data-quality, beta:readiness, beta:repair-queue (+67 more)
 
-### Community 7 - "logSanitizer.ts"
-Cohesion: 0.08
-Nodes (71): activeAreasOfResearchSummary(), assessResearchEntityDescriptionQuality(), deriveShortDescriptionFromFullDescription(), DescriptionQualityFlag, FieldQuality, fullDescriptionQuality(), hasBrokenTemplate(), hasDuplicatedLongFragment() (+63 more)
+### Community 7 - "researchEntityDescriptionQuality.ts"
+Cohesion: 0.06
+Nodes (89): actionSet, cleanHttpUrl(), cleanText(), containsDirectEmail(), hasActivePostedOpportunity(), hasPublicOfficialApplicationRoute(), hasPublicRoute(), hasUndergraduateAccessEvidence() (+81 more)
 
-### Community 8 - "adminListingsTableReducer.ts"
-Cohesion: 0.04
-Nodes (38): PlanningOverview(), PlanningOverviewProps, pluralize(), HttpStatusNotifier(), scrollPositions, ScrollToTop(), normalizeReturnPath(), SignInButton() (+30 more)
-
-### Community 9 - "profileService.ts"
+### Community 8 - "App.tsx"
 Cohesion: 0.05
-Nodes (62): AccessReviewCounts, AccessReviewDetail, AccessReviewEntitySummary, AccessSignal, AdminAccessReview(), ContactRoute, EntryPathway, evidenceIds() (+54 more)
+Nodes (37): PlanningOverview(), PlanningOverviewProps, pluralize(), scrollPositions, ScrollToTop(), normalizeReturnPath(), SignInButton(), SignInButtonProps (+29 more)
 
-### Community 10 - "labMicrositeDescriptionLLMExtractor.ts"
-Cohesion: 0.05
-Nodes (67): directoryFirstNextStep(), directoryFirstPathwayLabel(), formatDate(), PathwayActionCard(), PathwayActionCardProps, LabPaper, PathwayActionability, PathwayBestNextStepCategory (+59 more)
-
-### Community 11 - "AdminAccessReview.tsx"
-Cohesion: 0.06
-Nodes (50): AccessSignal, accessSignalSchema, ContactRoute, contactRouteSchema, categoryColorKeys, Department, DepartmentCodeSystem, departmentSchema (+42 more)
-
-### Community 12 - "materializeEntity"
-Cohesion: 0.06
-Nodes (58): csvCell(), dateFormatter, deadlineEndOfUtcDay(), FavoritesManager(), FavoritesManagerProps, fellowshipToBrowsable(), savedProgramDeadlineSummary(), validDeadlineDate() (+50 more)
-
-### Community 13 - "researchGroupService.ts"
-Cohesion: 0.06
-Nodes (67): DuplicateEntityReviewCategory, DuplicateEntityReviewEntity, DuplicateEntityReviewSummary, applyResearchEntityDedupeGroupsSequentially, ResearchEntityDedupeMergeGroup, ACTIVE_FILTER, assertDuplicateEntityNameReviewApplyAllowed(), asString() (+59 more)
-
-### Community 14 - "researchEntitySearchIndexService.ts"
-Cohesion: 0.06
-Nodes (57): copy, FirstSaveCallout(), FirstSaveCalloutProps, mockedAxios, mockedSwal, Endpoints, FavoritesKind, useFavorites() (+49 more)
-
-### Community 15 - "accessMaterializer.ts"
+### Community 9 - "safeHttpUrl"
 Cohesion: 0.07
-Nodes (53): backfillV4Grants(), buildV4GrantBackfillOutput(), __dirname, __filename, normalizeAgency(), V4GrantBackfillResult, writeV4GrantBackfillOutput(), backfillV4PaperGraph() (+45 more)
+Nodes (47): AccessReviewCounts, AccessReviewDetail, AccessReviewEntitySummary, AccessSignal, AdminAccessReview(), ContactRoute, EntryPathway, evidenceIds() (+39 more)
 
-### Community 16 - "UserContext.ts"
+### Community 10 - "researchDiscoveryAdapters.ts"
+Cohesion: 0.06
+Nodes (65): directoryFirstNextStep(), directoryFirstPathwayLabel(), formatDate(), PathwayActionCard(), PathwayActionCardProps, emptyGroupedResults(), PathwayActionability, PathwayBestNextStepCategory (+57 more)
+
+### Community 11 - "index.ts"
 Cohesion: 0.07
-Nodes (58): addViewToListing(), archiveListingForCurrentUser(), boundedListingSearchQuery(), buildListingOutreachEvent(), buildMongoFilterMatch(), buildRobustFilterMatch(), createListingForCurrentUser(), deleteListingForCurrentUser() (+50 more)
+Nodes (35): FacultyMember, facultyMemberSchema, Grant, grantSchema, fieldProvenanceSchema, opennessSignalSchema, Paper, paperSchema (+27 more)
 
-### Community 17 - "index.ts"
-Cohesion: 0.08
-Nodes (61): ACTIVE_FILTER, asString(), asStringArray(), buildBetaDataQualityScorecard(), buildCollectionCounts(), buildDescriptionQuality(), buildDuplicateEntityNames(), buildLiveLinkCheck() (+53 more)
+### Community 12 - "client"
+Cohesion: 0.06
+Nodes (56): csvCell(), dateFormatter, deadlineEndOfUtcDay(), FavoritesManager(), FavoritesManagerProps, fellowshipToBrowsable(), savedProgramDeadlineSummary(), validDeadlineDate() (+48 more)
 
-### Community 18 - "sanitizeLogValue"
-Cohesion: 0.08
-Nodes (49): initializeConnections(), CliOptions, FILTER, main(), parseArgs(), CliOptions, main(), parseArgs() (+41 more)
+### Community 13 - "duplicateEntityNameReview.ts"
+Cohesion: 0.06
+Nodes (66): DuplicateEntityReviewCategory, DuplicateEntityReviewEntity, DuplicateEntityReviewSummary, applyResearchEntityDedupeGroupsSequentially, ACTIVE_FILTER, assertDuplicateEntityNameReviewApplyAllowed(), asString(), asStringArray() (+58 more)
 
-### Community 19 - "integrityGate.ts"
+### Community 14 - "labDetail.tsx"
+Cohesion: 0.06
+Nodes (63): copy, FirstSaveCallout(), FirstSaveCalloutProps, adminQualityNotes(), AffiliatedResearchEntitiesSection(), compactDepartmentLabels(), decisionNextStep(), DecisionSummary() (+55 more)
+
+### Community 15 - "v4MigrationUtils.ts"
+Cohesion: 0.12
+Nodes (31): backfillV4Grants(), buildV4GrantBackfillOutput(), __dirname, __filename, normalizeAgency(), V4GrantBackfillResult, writeV4GrantBackfillOutput(), backfillV4PaperGraph() (+23 more)
+
+### Community 16 - "listingController.ts"
 Cohesion: 0.07
-Nodes (58): AcceptedInputIssue, AcceptedInputUser, applyOrcidCrosswalkCsv(), ArxivResolvedTarget, ArxivValidationResult, buildAcceptedInputsStatus(), buildArxivCandidateRows(), buildScholarCandidateRows() (+50 more)
+Nodes (56): addViewToListing(), archiveListingForCurrentUser(), boundedListingSearchQuery(), buildListingOutreachEvent(), buildMongoFilterMatch(), buildRobustFilterMatch(), createListingForCurrentUser(), deleteListingForCurrentUser() (+48 more)
 
-### Community 20 - "passport.ts"
+### Community 17 - "betaDataQuality.ts"
+Cohesion: 0.10
+Nodes (44): ACTIVE_FILTER, asString(), asStringArray(), buildBetaDataQualityScorecard(), buildCollectionCounts(), buildDescriptionQuality(), buildDuplicateEntityNames(), buildLiveLinkCheck() (+36 more)
+
+### Community 18 - "auditProgramResearchRelevance.ts"
+Cohesion: 0.15
+Nodes (22): CliOptions, main(), parseArgs(), assertStudentVisibilityGateApplyConfirmed(), buildStudentVisibilityGateOutput(), main(), parsePositiveInteger(), parseStudentVisibilityGateArgs() (+14 more)
+
+### Community 19 - "acceptedInputsCore.ts"
 Cohesion: 0.07
-Nodes (60): applyDeleteModeArtifactPlan(), applyResearchEntityDedupeMergeGroup(), applyResearchEntityPiDedupeGroupsSequentially(), archiveOrDeleteDuplicateDocument(), ARRAY_REFERENCE_SPECS, ARTIFACT_SPECS, assertResearchEntityPiDedupeApplyAllowed(), assertResearchEntityPiDedupeApplyBounded() (+52 more)
+Nodes (63): AcceptedInputIssue, AcceptedInputUser, applyOrcidCrosswalkCsv(), ArxivResolvedTarget, ArxivValidationResult, asString(), asStringArray(), buildAcceptedInputsStatus() (+55 more)
 
-### Community 21 - "Navbar.tsx"
-Cohesion: 0.08
-Nodes (55): getListingModel(), addFavorite(), archiveListing(), boundedListingDate(), boundedListingNetid(), boundedListingNetidArray(), boundedListingNumber(), boundedListingString() (+47 more)
+### Community 20 - "dedupeResearchEntitiesByPi.ts"
+Cohesion: 0.07
+Nodes (58): applyDeleteModeArtifactPlan(), applyResearchEntityDedupeMergeGroup(), applyResearchEntityPiDedupeGroupsSequentially(), archiveOrDeleteDuplicateDocument(), ARRAY_REFERENCE_SPECS, ARTIFACT_SPECS, assertResearchEntityPiDedupeApplyAllowed(), assertResearchEntityPiDedupeApplyBounded() (+50 more)
 
-### Community 22 - "undergradFellowshipRecipientScraper.ts"
+### Community 21 - "listingService.ts"
+Cohesion: 0.11
+Nodes (45): getListingModel(), addFavorite(), addView(), archiveListing(), boundedListingDate(), boundedListingNetid(), boundedListingNetidArray(), boundedListingNumber() (+37 more)
+
+### Community 22 - "profileDataQualityAudit.ts"
 Cohesion: 0.10
 Nodes (58): auditProfileRecord(), candidateOfficialProfileUrls(), candidateProfileFactsMatchUser(), classifyStoredBioIssue(), classifyStoredTitleIssue(), collectObjects(), compareOfficialProfileFacts(), corpusForProfile() (+50 more)
 
-### Community 23 - "duplicateEntityNameReview.ts"
-Cohesion: 0.07
-Nodes (58): mapResearchGroupKindToEntityType(), PublicResearchEntityDto, addPublicMemberField(), addPublicMemberInternalProfilePath(), addPublicMemberProfileUrls(), boundedResearchFilterValues(), boundedResearchSearchQuery(), escapedRegExp() (+50 more)
+### Community 23 - "researchGroupService.ts"
+Cohesion: 0.04
+Nodes (109): defaultOwnerToGroupSlug(), addPublicMemberField(), addPublicMemberInternalProfilePath(), addPublicMemberProfileUrls(), addPublicPaperField(), boundedResearchFilterValues(), boundedResearchSearchQuery(), buildLeadPiOutreachContactRoute() (+101 more)
 
-### Community 24 - "app.ts"
+### Community 24 - "researchQualitySearchReview.ts"
 Cohesion: 0.07
 Nodes (54): addMapSet(), aggregateCountAndTypes(), aggregateCountMap(), buildLexicalReasons(), buildResearchQualitySearchReviewOutput(), buildReview(), collectSearchCandidates(), countMap() (+46 more)
 
-### Community 25 - "dedupeResearchEntitiesByPi.ts"
-Cohesion: 0.07
-Nodes (39): ArchivedBadge(), BrowseCard, BrowseCardProps, BrowseGrid(), BrowseGridProps, BrowseListItem, BrowseListItemProps, FavoriteButton (+31 more)
+### Community 25 - "browsable.ts"
+Cohesion: 0.05
+Nodes (65): FellowshipModal(), FellowshipModalProps, trackFellowshipApplyClick(), ArchivedBadge(), BrowseCard, BrowseCardProps, BrowseGrid(), BrowseGridProps (+57 more)
 
-### Community 26 - "admin.ts"
+### Community 26 - "passport.ts"
 Cohesion: 0.07
-Nodes (49): authConfig, authDebug(), AuthenticatedSessionUser, buildDirectoryUpdate(), casLogin(), DEV_LOGIN_PROFILES, ensureDevLoginUser(), findOrCreateUser() (+41 more)
+Nodes (48): authConfig, authDebug(), AuthenticatedSessionUser, buildDirectoryUpdate(), casLogin(), DEV_LOGIN_PROFILES, ensureDevLoginUser(), findOrCreateUser() (+40 more)
 
-### Community 27 - "safeHttpUrl"
+### Community 27 - "launchAcquisitionReportService.ts"
 Cohesion: 0.09
-Nodes (54): AccessRecordCounts, ActionEvidenceGroups, addGroup(), buildActionGroups(), buildActionManifestRow(), buildLaunchAcquisitionReport(), buildManifestRow(), buildPiGroups() (+46 more)
+Nodes (53): AccessRecordCounts, ActionEvidenceGroups, addGroup(), buildActionGroups(), buildActionManifestRow(), buildLaunchAcquisitionReport(), buildManifestRow(), buildPiGroups() (+45 more)
 
-### Community 28 - "researchDiscoveryAdapters.ts"
+### Community 28 - "labMicrositeDescriptionLLMExtractor.ts"
 Cohesion: 0.08
-Nodes (51): ObservedEntityType, CallDescriptionLLMFn, CandidateDescriptionLab, CandidateDescriptionLabDoc, candidateDescriptionLabsFromDocs(), candidateKeyMatches(), candidateUrlsForDoc(), defaultCallLLM() (+43 more)
+Nodes (52): ObservedEntityType, CallDescriptionLLMFn, CandidateDescriptionLab, CandidateDescriptionLabDoc, candidateDescriptionLabsFromDocs(), candidateKeyMatches(), candidateUrlsForDoc(), defaultCallLLM() (+44 more)
 
-### Community 29 - "ysmAtoZScraper.ts"
+### Community 29 - "betaDataQualityCore.ts"
+Cohesion: 0.07
+Nodes (43): BETA_CHECK_OPERATOR_METADATA, betaCommand(), BetaDataQualityCheck, BetaDataQualityDiagnostics, BetaDataQualityProgressEvent, BetaDataQualitySeverity, BetaDataQualitySummary, BetaDataQualitySummaryInput (+35 more)
+
+### Community 30 - "sourceHealth.ts"
 Cohesion: 0.06
-Nodes (56): DuplicateEntityCluster, BETA_CHECK_OPERATOR_METADATA, betaCommand(), BetaDataQualityCheck, BetaDataQualityDiagnostics, BetaDataQualityProgressEvent, BetaDataQualitySeverity, BetaDataQualitySummary (+48 more)
+Nodes (57): buildSourceHealthSummary(), classifySourceWarning(), AcceptedDecisionValidationCommandInput, attachAcceptedDecisionValidationSummary(), attachReviewArtifactSummary(), buildCrossSourceObservationReviewCommand(), buildReviewArtifactRollups(), buildReviewArtifactStatus() (+49 more)
 
-### Community 30 - "advisees"
+### Community 31 - "ysmAtoZScraper.ts"
+Cohesion: 0.11
+Nodes (32): absoluteUrl(), cleanDescription(), cleanProfileTitle(), clippedDescription(), decodeHtmlEntities(), escapeRegex(), extractLabHomepageDescription(), extractProfileContactWidgetProfile() (+24 more)
+
+### Community 32 - "integrityGate.ts"
+Cohesion: 0.09
+Nodes (36): ActiveArtifactOnArchivedEntity, buildDuplicateResearchPaperGroupsFromRows(), BuildPostMaterializationIntegrityInput, buildPostMaterializationIntegritySummary(), buildSamePiNameDuplicateGroupsFromDedupeRows(), CurrentMemberOnArchivedEntity, DuplicateCurrentMemberGroup, DuplicateExploratoryContactPathwayGroup (+28 more)
+
+### Community 33 - "analyticsService.ts"
 Cohesion: 0.07
-Nodes (55): AcceptedDecisionValidationCommandInput, attachAcceptedDecisionValidationSummary(), attachReviewArtifactSummary(), buildCrossSourceObservationReviewCommand(), buildReviewArtifactRollups(), buildReviewArtifactStatus(), buildReviewDecisionValidationStatus(), buildReviewQueues() (+47 more)
+Nodes (62): AnalyticsEvent, ActionNeededAnalytics, ANALYTICS_EVENT_TYPES, ANALYTICS_NON_USER_NETIDS, ANALYTICS_RESEARCH_ENTITY_TYPES, AnalyticsUserDrilldownQuery, AnalyticsUserDrilldownResult, AnalyticsUsersQuery (+54 more)
 
-### Community 31 - "launchAcquisitionReportService.ts"
+### Community 34 - "userService.ts"
+Cohesion: 0.07
+Nodes (75): getFavPathwayFundingMatches(), getFavPathwayIds(), getFavPathways(), getSavedResearchPlanIds(), getSavedResearchPlans(), normalizeStoredPathwayIdsForAccountRead(), confirmListing(), readListing() (+67 more)
+
+### Community 35 - "studentVisibilityGateService.ts"
 Cohesion: 0.08
-Nodes (47): defaultFetchUrl(), defaultFetchPage(), fetchHtml(), defaultFetchHtml(), defaultFetchPage(), defaultFetchPage(), fetchHtml(), defaultFetcher() (+39 more)
+Nodes (46): actionRepairReasons, buildNameOnlyVisibilityDedupeRows(), buildSamePiVisibilityDedupeRows(), countByEntityId(), defaultGateDeps, entityDuplicateUrls(), evidenceReasons, exactDuplicateCanonicalScore() (+38 more)
 
-### Community 32 - "profileDataQualityAudit.ts"
+### Community 36 - "AdminDepartments.tsx"
+Cohesion: 0.09
+Nodes (30): AdminDepartments(), CATEGORY_COLORS, DEPARTMENT_CATEGORIES, DepartmentAction, DepartmentDoc, DepartmentState, EditDraft, INITIAL_NEW_DRAFT (+22 more)
+
+### Community 37 - "runReport.ts"
 Cohesion: 0.07
-Nodes (50): ActiveArtifactOnArchivedEntity, buildDuplicateAccessSignalGroupsFromRows(), buildDuplicateResearchPaperGroupsFromRows(), BuildPostMaterializationIntegrityInput, buildPostMaterializationIntegritySummary(), buildSamePiNameDuplicateGroupsFromDedupeRows(), CurrentMemberOnArchivedEntity, DuplicateCurrentMemberGroup (+42 more)
+Nodes (46): ACCESS_ARTIFACT_TYPES, ACCESS_EVIDENCE_CONFLICT_FIELDS, ADDITIVE_METADATA_CONFLICT_FIELDS, buildCoverageFetchSummary(), buildCoverageSourceSummary(), buildMaterializationConflictEntityClauses(), buildMaterializationConflictReview(), buildPostMaterializationSummary() (+38 more)
 
-### Community 33 - "centersInstitutesScraper.ts"
-Cohesion: 0.07
-Nodes (53): ActionNeededAnalytics, ANALYTICS_EVENT_TYPES, ANALYTICS_NON_USER_NETIDS, ANALYTICS_RESEARCH_ENTITY_TYPES, AnalyticsUserDrilldownQuery, AnalyticsUserDrilldownResult, AnalyticsUsersQuery, AnalyticsUsersResult (+45 more)
+### Community 38 - "accessMaterializer.ts"
+Cohesion: 0.09
+Nodes (50): ContactPolicy, ContactRouteVisibility, accessArtifactCandidatesFromDerived(), AccessMaterializationResult, AccessObservation, bestObservation(), confidenceLabel(), contactSignalExcerpt() (+42 more)
 
-### Community 34 - "types.tsx"
-Cohesion: 0.08
-Nodes (50): confirmListing(), readListing(), unconfirmListing(), addDepartments(), assertSafeUserUpdateDocument(), badRequestError(), buildCaseInsensitiveNetidFilter(), buildSavedPathwayPlansExport() (+42 more)
-
-### Community 35 - "ScraperContext"
-Cohesion: 0.07
-Nodes (50): actionRepairReasons, buildNameOnlyVisibilityDedupeRows(), buildSamePiVisibilityDedupeRows(), countByEntityId(), defaultGateDeps, entityDuplicateUrls(), evidenceReasons, exactDuplicateCanonicalScore() (+42 more)
-
-### Community 36 - "studentVisibilityGateService.ts"
+### Community 39 - "User"
 Cohesion: 0.06
-Nodes (42): AdminDepartments(), CATEGORY_COLORS, DEPARTMENT_CATEGORIES, DepartmentAction, DepartmentDoc, DepartmentState, EditDraft, INITIAL_NEW_DRAFT (+34 more)
+Nodes (42): normalizeUserType(), publicationSchema, User, userSchema, ProfileBackedFacultyResearchAreaMemberDeps, arxivEntryToObservations(), ArxivFetcher, ArxivPreprintScraper (+34 more)
 
-### Community 37 - "buildUserBioObservationScore"
+### Community 40 - "profileService.ts"
+Cohesion: 0.06
+Nodes (67): ADMIN_PROFILE_USER_TYPES, ADMIN_UPDATE_FIELDS, adminUpdateProfile(), ALLOWED_SELF_UPDATE_FIELDS, boundedAdminProfileEmail(), boundedAdminProfileNumber(), boundedAdminProfileText(), boundedProfileString() (+59 more)
+
+### Community 41 - "labDetail.ts"
 Cohesion: 0.07
-Nodes (51): ACCESS_ARTIFACT_TYPES, ACCESS_EVIDENCE_CONFLICT_FIELDS, ADDITIVE_METADATA_CONFLICT_FIELDS, buildCoverageFetchSummary(), buildCoverageSourceSummary(), buildMaterializationConflictEntityClauses(), buildMaterializationConflictReview(), buildPostMaterializationSummary() (+43 more)
+Nodes (45): LabInquireModalProps, LabMembersList(), LabMembersListProps, ROLE_LABELS, ROLE_ORDER, ROLE_PILL_CLASSES, decodeHtmlEntities(), decodeNumericEntity() (+37 more)
 
-### Community 38 - "User"
-Cohesion: 0.09
-Nodes (50): AccessSignalConfidence, ContactPolicy, ContactRouteVisibility, accessArtifactCandidatesFromDerived(), AccessMaterializationResult, AccessObservation, bestObservation(), confidenceLabel() (+42 more)
-
-### Community 39 - "userService.ts"
-Cohesion: 0.07
-Nodes (36): publicationSchema, User, userSchema, summarizeFetchMetrics, arxivEntryToObservations(), ArxivFetcher, ArxivPreprintScraper, ArxivPreprintScraperOptions (+28 more)
-
-### Community 40 - "backfillStudentVisibilityTiers.ts"
-Cohesion: 0.09
-Nodes (51): ADMIN_UPDATE_FIELDS, ALLOWED_SELF_UPDATE_FIELDS, appointmentTitleCount(), capitalizeSentenceStart(), cleanPublicProfileBio(), cleanResearchHomeSummaryForBio(), clipPublicProfileBio(), dedupeProfileResearchEntities() (+43 more)
-
-### Community 41 - "AdminDepartments.tsx"
-Cohesion: 0.07
-Nodes (42): LabInquireModalProps, LabMembersList(), LabMembersListProps, ROLE_LABELS, ROLE_ORDER, ROLE_PILL_CLASSES, baseGroup, baseGroup (+34 more)
-
-### Community 42 - "getUniqueDepartmentLabels"
+### Community 42 - "SavedPathwaysSection.tsx"
 Cohesion: 0.09
 Nodes (44): CHECKLIST_TEMPLATES, daysUntil(), DeadlineReminder, deadlineReminderForPathway(), defaultIntentForPathway(), FellowshipFundingMatch, filterStoredPlansForSavedPathways(), formatDeadline() (+36 more)
 
-### Community 43 - "researchEntityCoverageAudit.ts"
+### Community 43 - "ImportRootDataFiles.ts"
 Cohesion: 0.09
-Nodes (47): asPlainObject(), assertRootDataImportApplyAllowed(), buildDepartmentMap(), buildRootDataImportOutput(), cleanText(), confidenceFor(), countCsvRows(), DEFAULT_OPTIONS (+39 more)
+Nodes (48): LabHeaderProps, ResearchGroup, asPlainObject(), assertRootDataImportApplyAllowed(), buildDepartmentMap(), buildRootDataImportOutput(), cleanText(), confidenceFor() (+40 more)
 
-### Community 44 - "researchAnalytics.ts"
-Cohesion: 0.08
-Nodes (40): researchScholarlyAttributionSchema, researchScholarlyLinkSchema, assertScholarlyLinkProvenanceAuditApplyAllowed(), buildScholarlyLinkProvenanceAuditOutput(), __filename, main(), nullTargetAttributionFilter, orphanAttributionIds() (+32 more)
+### Community 44 - "scholarlyLinkSuppressionAudit.ts"
+Cohesion: 0.09
+Nodes (38): assertScholarlyLinkProvenanceAuditApplyAllowed(), buildScholarlyLinkProvenanceAuditOutput(), __filename, main(), nullTargetAttributionFilter, orphanAttributionIds(), ownerlessLinkFilter, parseNonNegativeInteger() (+30 more)
 
-### Community 45 - "sourceHealth.ts"
+### Community 45 - "pathwaySearchIndexService.ts"
 Cohesion: 0.10
-Nodes (45): anyFilter(), boundedFilterValues(), boundedSearchQuery(), buildPathwayMeiliFilter(), buildPathwayMeiliSort(), buildPathwaySearchIndexDocument(), buildPathwaySearchIndexDocuments(), configurePathwaySearchIndex() (+37 more)
+Nodes (43): anyFilter(), boundedFilterValues(), boundedSearchQuery(), buildPathwayMeiliFilter(), buildPathwayMeiliSort(), buildPathwaySearchIndexDocument(), buildPathwaySearchIndexDocuments(), configurePathwaySearchIndex() (+35 more)
 
-### Community 46 - "researchEntity.ts"
-Cohesion: 0.09
-Nodes (41): classifyProgramResearchRelevance(), ProgramResearchRelevanceInput, ProgramResearchRelevanceResult, RESEARCH_PROGRAM_KINDS, RESEARCH_PURPOSES, text(), computeProgramStudentVisibility(), computeResearchEntityStudentVisibility() (+33 more)
+### Community 46 - "studentVisibilityTier.ts"
+Cohesion: 0.11
+Nodes (35): computeProgramStudentVisibility(), computeResearchEntityStudentVisibility(), entityUrls(), ENTRY_PROGRAM_KINDS, ENTRY_PROGRAM_MODES, FORMALIZATION_PROGRAM_KINDS, genericDirectoryUrlPathPatterns, hasAnyHttpUrl() (+27 more)
 
-### Community 47 - "textValue"
+### Community 47 - "dataOps.ts"
 Cohesion: 0.11
 Nodes (41): assertDestinationMatchesTarget(), assertExplicitCsvForExecute(), assertMeilisearchTargetMatches(), assertMongoTargetMatches(), assertSafeWrite(), DataOpsDestinations, DataOpsOptions, DataOpsTarget (+33 more)
 
-### Community 48 - "ResearchGroupMember"
-Cohesion: 0.09
-Nodes (41): ACCEPTED_INPUT_FILE_EXTENSIONS, acceptedPath(), AdvisorResolution, AdvisorResolver, assertAcceptedInputPathRoot(), assertSafeAcceptedInputPathText(), candidateRowsFromText(), coerceReviewRow() (+33 more)
+### Community 48 - "fellowshipInputs.ts"
+Cohesion: 0.10
+Nodes (36): acceptedPath(), AdvisorResolution, AdvisorResolver, candidateRowsFromText(), coerceReviewRow(), escapeCsvCell(), escapeRegex(), exportAcceptedFellowshipRows() (+28 more)
 
-### Community 49 - "listingService.ts"
+### Community 49 - "adminOperatorBoardService.ts"
 Cohesion: 0.06
 Nodes (44): BetaRepairQueueGateArtifact, buildQueueSummaries(), buildReleaseQueueSummary(), buildRepairQueueSummary(), buildSourceFreshness(), classifyOperatorQueueReason(), compactProgramSample(), compactResearchSample() (+36 more)
 
-### Community 50 - "redactDirectContactInfo"
-Cohesion: 0.09
-Nodes (29): ListingEditor(), DepartmentInput(), DepartmentInputProps, VennDiagramToggle(), VennDiagramToggleProps, CombinedFilterDropdown(), CombinedFilterDropdownProps, FilterTabConfig (+21 more)
-
-### Community 51 - "betaDataQualityCore.ts"
-Cohesion: 0.08
-Nodes (38): ACCESS_REVIEW_RECORD_TYPES, ADMIN_FELLOWSHIP_SORT_FIELDS, ADMIN_LISTING_SORT_FIELDS, ADMIN_PROFILE_SORT_FIELDS, ADMIN_SEARCH_ERROR_MESSAGES, adminAccessReviewLockedFields(), adminAccessReviewRecordUpdateDto(), adminActorNetid() (+30 more)
-
-### Community 52 - "scripts"
-Cohesion: 0.08
-Nodes (43): absolutize(), canonicalLegacyResearchHomeUrl(), canonicalUrlFromHtml(), cleanInterestForBio(), derivedBioFromOfficialProfile(), derivedBioFromOfficialProfileInterests(), entityExpectedPeople(), entityLeadDirectWebsiteToObservations() (+35 more)
-
-### Community 53 - "productionPromotionSmoke.mjs"
+### Community 50 - "Listing"
 Cohesion: 0.11
-Nodes (41): absoluteUrl(), bestDeadlineText(), candidateFromDetailPage(), candidateFromLink(), candidateToObservations(), compactTitleIdentity(), DEFAULT_PAGE_URLS, existingKeyForCandidate() (+33 more)
+Nodes (23): ListingEditor(), VennDiagramToggle(), VennDiagramToggleProps, CombinedFilterDropdown(), CombinedFilterDropdownProps, FilterTabConfig, COLUMNS, KanbanBoardProps (+15 more)
 
-### Community 54 - "research.tsx"
+### Community 51 - "admin.ts"
+Cohesion: 0.07
+Nodes (44): ACCESS_REVIEW_RECORD_TYPES, ADMIN_FELLOWSHIP_SORT_FIELDS, ADMIN_LISTING_SORT_FIELDS, ADMIN_PROFILE_SORT_FIELDS, ADMIN_SEARCH_ERROR_MESSAGES, ADMIN_URL_CHECK_ALLOWED_PORTS, adminAccessReviewLockedFields(), adminAccessReviewRecordUpdateDto() (+36 more)
+
+### Community 52 - "officialProfilePiBackfillScraper.ts"
 Cohesion: 0.06
-Nodes (22): AboutButton(), AnalyticsButton(), FeedbackButton(), getAcademicDisciplineColor(), getResearchAreaChipColor(), listingQuickFilters, Navbar(), NavbarSearchBar() (+14 more)
+Nodes (81): absolutize(), affiliationValuesFromProfiles(), canonicalLegacyResearchHomeUrl(), canonicalResearchHomeName(), canonicalUrlFromHtml(), classifyResearchHome(), cleanInterestForBio(), cleanOfficialProfileDisplayName() (+73 more)
 
-### Community 55 - "runReport.ts"
-Cohesion: 0.08
-Nodes (40): EntryPathwayStatus, EntryPathwayType, EvidenceStrength, DerivedEntryPathway, RouteClassification, UpsertEntryPathwayInput, BestNextStepSnapshot, boundedFilterValues() (+32 more)
-
-### Community 56 - "opportunityDetailService.ts"
-Cohesion: 0.11
-Nodes (41): Paper, PaperAuthor, CrossrefPaperScraperOptions, applyCleanup(), applyIntegrityCleanup(), assertPaperAuthorshipAuditApplyAllowed(), AUTHORSHIP_METHODS, AUTHORSHIP_SOURCES (+33 more)
-
-### Community 57 - "staleObservationConflictReview.ts"
-Cohesion: 0.11
-Nodes (32): AccessSignalServiceDeps, AccessSignalUpsertResult, compactObject(), getAccessSignalModel(), toStoredId(), toStoredObjectId(), upsertAccessSignal(), compactObject() (+24 more)
-
-### Community 58 - "researchEntityDescriptionQuality.ts"
-Cohesion: 0.05
-Nodes (41): browserslist, development, production, devDependencies, agentation, autoprefixer, jsdom, postcss (+33 more)
-
-### Community 59 - "betaDataQuality.ts"
-Cohesion: 0.11
-Nodes (39): ContactRouteType, materializeAccessForResearchGroup(), pathwayDerivationKeyForRoute(), pathwayDerivationKeyForSignal(), applicationRouteBackfillDerivationKey(), ApplicationRoutePathwayBackfillDeps, ApplicationRoutePathwayBackfillEntity, ApplicationRoutePathwayBackfillOptions (+31 more)
-
-### Community 60 - "studentVisibilityTier.ts"
-Cohesion: 0.10
-Nodes (38): publicSafeStudentVisibilityTiers, publicStudentVisibilityTiers, StudentVisibilityTier, studentVisibilityTiers, applyProgramUpdates(), applyResearchUpdates(), assertStudentVisibilityBackfillApplyAllowed(), buildNameOnlyVisibilityDedupeRows() (+30 more)
-
-### Community 61 - "listingController.ts"
+### Community 53 - "yaleCollegeFellowshipsOfficeScraper.ts"
 Cohesion: 0.09
-Nodes (41): normalizeUserType(), ResolvedField, buildOfficialProfileScholarlyLinkUpserts(), cleanScholarlyHttpUrl(), cleanScholarlyText(), compactPersonName(), comparableObservationValue(), deptUserNameFilters() (+33 more)
+Nodes (51): ProgramCategory, ProgramEntryMode, ProgramKind, absoluteUrl(), bestDeadlineText(), candidateFromDetailPage(), candidateFromLink(), candidateToObservations() (+43 more)
 
-### Community 62 - "researchGroup.ts"
+### Community 54 - "fellowships.tsx"
+Cohesion: 0.05
+Nodes (29): AboutButton(), AnalyticsButton(), FeedbackButton(), getAcademicDisciplineColor(), getResearchAreaChipColor(), listingQuickFilters, Navbar(), NavbarSearchBar() (+21 more)
+
+### Community 55 - "pathwaySearchService.ts"
+Cohesion: 0.10
+Nodes (33): BestNextStepSnapshot, boundedFilterValues(), boundedSearchQuery(), buildBestNextStepCategoryExpression(), buildEntityMatch(), buildPathwayMatch(), buildSort(), buildTextMatch() (+25 more)
+
+### Community 56 - "paperAuthorshipAudit.ts"
+Cohesion: 0.11
+Nodes (39): PaperAuthor, applyCleanup(), applyIntegrityCleanup(), assertPaperAuthorshipAuditApplyAllowed(), AUTHORSHIP_METHODS, AUTHORSHIP_SOURCES, backfillOpenAlexPaperAuthors(), buildPaperAuthorshipAudit() (+31 more)
+
+### Community 57 - "entryPathwayService.ts"
+Cohesion: 0.11
+Nodes (34): AccessSignalServiceDeps, AccessSignalUpsertResult, compactObject(), getAccessSignalModel(), toStoredId(), toStoredObjectId(), upsertAccessSignal(), compactObject() (+26 more)
+
+### Community 58 - "package.json"
+Cohesion: 0.17
+Nodes (11): browserslist, development, production, engines, node, eslintConfig, extends, name (+3 more)
+
+### Community 59 - "applicationRoutePathwayBackfillCore.ts"
+Cohesion: 0.12
+Nodes (37): ContactRouteType, applicationRouteBackfillDerivationKey(), ApplicationRoutePathwayBackfillDeps, ApplicationRoutePathwayBackfillEntity, ApplicationRoutePathwayBackfillOptions, ApplicationRoutePathwayBackfillResult, ApplicationRoutePathwayBackfillRoute, backfillApplicationRoutePathways() (+29 more)
+
+### Community 60 - "backfillStudentVisibilityTiers.ts"
+Cohesion: 0.13
+Nodes (30): applyProgramUpdates(), applyResearchUpdates(), assertStudentVisibilityBackfillApplyAllowed(), buildNameOnlyVisibilityDedupeRows(), buildSamePiVisibilityDedupeRows(), buildStudentVisibilityBackfillOutput(), countByEntityId(), FORMALIZATION_ONLY_ENTRY_PATHWAY_TYPES (+22 more)
+
+### Community 61 - "entityMaterializer.ts"
+Cohesion: 0.05
+Nodes (118): resolveAllFields(), ResolvedField, addPostMaterializationMetrics(), addUniqueValuesToSet(), authorshipEvidenceFromPaperObservations(), buildInferredPiMemberUpsert(), buildOfficialProfileScholarlyLinkUpserts(), buildPaperUpdateFromObservations() (+110 more)
+
+### Community 62 - "AdminOperatorBoard.tsx"
 Cohesion: 0.05
 Nodes (33): DataQualityDuplicateNamePreflight, DataQualitySamePiDedupeReview, DataQualitySuspiciousUserEmailCopy, decisionLaneCopy, evidenceReasons, GATE_LABELS, GateArtifactFreshness, LaunchReviewExceptionDecisionValidation (+25 more)
 
-### Community 63 - "analyticsService.ts"
-Cohesion: 0.09
-Nodes (36): LabDetailAction, LabDetailState, otherPayload, sampleGroup, sampleListing, samplePayload, MaybeResearchEntityDetailPayload, NormalizedResearchEntitySearchResponse (+28 more)
+### Community 63 - "researchEntity.ts"
+Cohesion: 0.13
+Nodes (29): MaybeResearchEntityDetailPayload, NormalizedResearchEntitySearchResponse, normalizeResearchEntity(), normalizeSearchMatch(), normalizeStudentDecisionExplanation(), ResearchEntityDescriptionState, ResearchEntityLeadState, ResearchEntityQualitySummary (+21 more)
 
-### Community 64 - "BOOLEAN_FLAGS"
+### Community 64 - "scripts"
 Cohesion: 0.05
 Nodes (40): dependencies, csv-parse, dotenv, meilisearch, mongoose, openai, description, devDependencies (+32 more)
 
-### Community 65 - "acceptedInputsCore.ts"
-Cohesion: 0.12
-Nodes (38): annotateEntitiesWithLeadUsers(), annotateEntitiesWithSourceObservationUrls(), annotateProfileDescriptionPreferredSourceEvidence(), entityResearchHomeToObservations(), firstNonDuplicateLeadDirectWebsiteUrl(), generatedOfficialProfileUrlCandidatesForPerson(), identityToResearchEntityDescriptionObservations(), identityToResearchEntityPiKeyObservations() (+30 more)
+### Community 65 - "officialProfilePiBackfillScraper.test.ts"
+Cohesion: 0.14
+Nodes (35): annotateEntitiesWithLeadUsers(), annotateEntitiesWithSourceObservationUrls(), annotateProfileDescriptionPreferredSourceEvidence(), entityLeadDirectWebsiteToObservations(), entityResearchHomeToObservations(), firstNonDuplicateLeadDirectWebsiteUrl(), identityToResearchEntityDescriptionObservations(), identityToResearchEntityPiKeyObservations() (+27 more)
 
-### Community 66 - "serializedDocumentId"
-Cohesion: 0.10
-Nodes (34): AdvisorAggregateRow, buildObservationsForAdvisor(), DEFAULT_ACCEPTED_FELLOWSHIP_RECIPIENT_PDF_DIR, DEFAULT_PROGRAM_CONFIGS, defaultOwnerToGroupSlug(), drupalRecipientRowExtractor(), escapeRegex(), ExtractorCtx (+26 more)
+### Community 66 - "undergradFellowshipRecipientScraper.ts"
+Cohesion: 0.11
+Nodes (32): AdvisorAggregateRow, buildObservationsForAdvisor(), DEFAULT_ACCEPTED_FELLOWSHIP_RECIPIENT_PDF_DIR, DEFAULT_PROGRAM_CONFIGS, drupalRecipientRowExtractor(), escapeRegex(), ExtractorCtx, FellowshipRecipient (+24 more)
 
-### Community 67 - "researchEntityEvidenceCoverage.ts"
-Cohesion: 0.07
-Nodes (40): ACCESS_EVIDENCE_CONFLICT_FIELDS, ADDITIVE_METADATA_CONFLICT_FIELDS, AggregatedCrossSourceObservationConflictGroup, buildCategoryCounts(), buildConflictPlan(), buildCrossSourceObservationConflictSummary(), buildFieldCounts(), buildPolicyBucketCounts() (+32 more)
+### Community 67 - "crossSourceObservationConflictReview.ts"
+Cohesion: 0.06
+Nodes (58): ACCESS_EVIDENCE_CONFLICT_FIELDS, ADDITIVE_METADATA_CONFLICT_FIELDS, AggregatedCrossSourceObservationConflictGroup, asString(), asStringArray(), buildCategoryCounts(), buildConflictPlan(), buildCrossSourceObservationConflictReviewOutput() (+50 more)
 
-### Community 68 - "fellowshipMatchingService.ts"
-Cohesion: 0.12
-Nodes (38): applyMemberReferenceRepairs(), buildCurrentMemberOnArchivedEntityPipeline(), buildExistingMemberMatchQuery(), buildOrphanMemberUserReferencePipeline(), CURRENT_MEMBER_ON_ARCHIVED_ENTITY_STAGES, escapeRegExp(), exactCaseInsensitive(), loadCandidateUsers() (+30 more)
+### Community 68 - "researchEntityMemberReferenceAudit.ts"
+Cohesion: 0.14
+Nodes (33): applyMemberReferenceRepairs(), buildExistingMemberMatchQuery(), buildOrphanMemberUserReferencePipeline(), CURRENT_MEMBER_ON_ARCHIVED_ENTITY_STAGES, escapeRegExp(), exactCaseInsensitive(), main(), normalizeMemberReferenceObjectId() (+25 more)
 
-### Community 69 - "AdminOperatorBoard.tsx"
+### Community 69 - "productionPromotionSmoke.mjs"
 Cohesion: 0.13
 Nodes (37): addCheck(), checkOpportunityDetail(), checkProgramApis(), config, discoverResearch(), failOnInternalLabels(), installRoutes(), main() (+29 more)
 
-### Community 70 - "nsfAwardScraper.ts"
+### Community 70 - "ListingDetailModal.tsx"
 Cohesion: 0.09
 Nodes (30): EvidenceRail(), formatEvidenceDate(), getEvidenceHost(), getSafeEvidenceUrl(), ListingDetailModal(), ListingDetailModalProps, MockIntersectionObserver, TestScroller() (+22 more)
 
-### Community 71 - "fellowshipInputs.ts"
-Cohesion: 0.08
-Nodes (31): sourceSchema, SourceCoverageArtifactType, sourceCoverageArtifactTypes, sourceCoverageEvidenceCategories, SourceCoverageEvidenceCategory, SourceCoverageMetadata, SourceCoverageTier, sourceCoverageTiers (+23 more)
+### Community 71 - "seedSources.ts"
+Cohesion: 0.13
+Nodes (19): assertSeedSourcesWriteAllowed(), buildSeedSourcesOutput(), __dirname, __filename, main(), parseRequiredOutputPath(), parseSeedSourcesArgs(), RETIRED_SOURCE_NAMES (+11 more)
 
 ### Community 72 - "repairOfficialProfilePublicationPointers.ts"
 Cohesion: 0.15
 Nodes (37): absolutize(), archivePointerRow(), assertOfficialProfilePublicationPointerRepairApplyAllowed(), candidateRepairUrls(), cleanText(), crawlFeaturedPublications(), createRepairPageReader(), ExtractedFeaturedPublication (+29 more)
 
-### Community 73 - "postedOpportunityService.ts"
-Cohesion: 0.10
-Nodes (36): adminFellowshipDate(), adminFellowshipLinks(), adminFellowshipNumber(), adminFellowshipStringArray(), adminFellowshipText(), archiveFellowship(), boundedPublicText(), boundedSearchFilterValues() (+28 more)
+### Community 73 - "fellowshipService.ts"
+Cohesion: 0.07
+Nodes (53): Fellowship, fellowshipSchema, programCategories, programEntryModes, programKinds, publicSafeStudentVisibilityTiers, publicStudentVisibilityTiers, studentVisibilityFields (+45 more)
 
-### Community 74 - "profileController.ts"
+### Community 74 - "researchGroup.ts"
+Cohesion: 0.09
+Nodes (28): LabHeader(), normalizeActionUrl(), baseGroup, AccessSummary, IndependentStudyCourse, PastUndergradAdvisee, RecentGrant, ResearchEntityType (+20 more)
+
+### Community 75 - "index.ts"
 Cohesion: 0.11
-Nodes (32): LabHeader(), LabHeaderProps, normalizeActionUrl(), WaysToApproachSection(), approachHeadingLabel(), decisionHeadingLabel(), entityKindLabel(), facultyResearchLabelBase() (+24 more)
+Nodes (14): asyncHandler(), compactPositiveInteger(), requireBody(), requireFields(), validateNetid(), validateObjectId(), validatePagination(), validateQuery() (+6 more)
 
-### Community 75 - "analytics.ts"
-Cohesion: 0.09
-Nodes (17): asyncHandler(), compactPositiveInteger(), requireBody(), requireFields(), validateNetid(), validateObjectId(), validatePagination(), validateQuery() (+9 more)
+### Community 76 - "researchAnalytics.ts"
+Cohesion: 0.10
+Nodes (32): analyticsEventSchema, AnalyticsEventType, RESEARCH_ENTITY_TYPES, ResearchEntityType, AnalyticsUserEvent, LogEventParams, AnalyticsUser, buildResearchEvent() (+24 more)
 
-### Community 76 - "openAlexPaperScraper.ts"
-Cohesion: 0.09
-Nodes (33): analyticsEventSchema, AnalyticsEventType, RESEARCH_ENTITY_TYPES, ResearchEntityType, AnalyticsUserEvent, LogEventParams, AnalyticsUser, buildResearchEvent() (+25 more)
-
-### Community 77 - "labMicrositeUndergradLLMExtractor.ts"
+### Community 77 - "analytics.tsx"
 Cohesion: 0.09
 Nodes (32): Analytics(), analyticsRanges, defaultAdminAccess, defaultUserActivity, SortOrder, UserActivitySort, analyticsData, mockedAxios (+24 more)
 
-### Community 78 - "researchEntityMemberReferenceAudit.ts"
+### Community 78 - "scripts"
 Cohesion: 0.06
 Nodes (36): scripts, audit:research-detail-professors, audit:unified-research, build, build:client, build:server, clean:all, dev:client (+28 more)
 
-### Community 79 - "SavedPathwaysSection.tsx"
-Cohesion: 0.10
-Nodes (24): DepartmentCategory, fieldColorKeys, ResearchArea, researchAreaSchema, ResearchField, router, invokeRouteHandler(), mocks (+16 more)
+### Community 79 - "configService.ts"
+Cohesion: 0.06
+Nodes (40): categoryColorKeys, Department, DepartmentCategory, DepartmentCodeSystem, departmentSchema, sourceRecordSchema, buildDeploymentFingerprint(), ConfigData (+32 more)
 
-### Community 80 - "departmentUndergradResearchScraper.ts"
-Cohesion: 0.13
-Nodes (34): articleForFacultyTitle(), BioBackfillCandidate, BioBackfillDecision, buildCandidates(), composeTitleLedBio(), decideBioBackfill(), detectFieldMismatch(), __dirname (+26 more)
+### Community 80 - "backfillProfileBiosFromOfficialUrls.ts"
+Cohesion: 0.12
+Nodes (36): articleForFacultyTitle(), BioBackfillCandidate, BioBackfillDecision, buildCandidates(), composeTitleLedBio(), decideBioBackfill(), defaultFetcher(), defaultRewriter() (+28 more)
 
-### Community 81 - "pathwaySearchIndexService.ts"
+### Community 81 - "departmentLeadRepairPlanCore.ts"
 Cohesion: 0.11
 Nodes (32): escapeRegExp(), main(), normalizeEmail(), parseDepartmentLeadRepairPlanArgs(), valuesForArg(), buildDepartmentLeadRepairApplyOperations(), buildDepartmentLeadRepairPlan(), compareDepartmentLeadRepairPlans() (+24 more)
 
-### Community 82 - "researchEntity.ts"
+### Community 82 - "researchEntityEvidenceCoverage.ts"
 Cohesion: 0.11
-Nodes (32): assessResearchEntityEvidenceCoverage(), buildEvidenceCoverageImpact(), buildEvidenceCoverageImpactReportForObservations(), descriptionObservationSources(), descriptionState(), entityIdentifierKey(), EvidenceClaimState, EvidenceCoverageAssessment (+24 more)
+Nodes (33): observation(), assessResearchEntityEvidenceCoverage(), buildEvidenceCoverageImpact(), buildEvidenceCoverageImpactReportForObservations(), descriptionObservationSources(), descriptionState(), entityIdentifierKey(), EvidenceClaimState (+25 more)
 
-### Community 83 - "adminOperatorBoardService.ts"
-Cohesion: 0.14
-Nodes (28): __dirname, __filename, main(), BOOLEAN_FLAGS, buildCronOutputPayload(), buildMaterializeOutputPayload(), buildScraperCliOutputPayload(), buildScraperCliPreflight() (+20 more)
+### Community 83 - "scriptWriteGuards.ts"
+Cohesion: 0.09
+Nodes (40): assertDepartmentMigrationApplyAllowed(), buildDepartmentMigrationOutput(), ChangeLog, DepartmentDoc, DepartmentMigrationCliOptions, DepartmentMigrationResult, __dirname, __filename (+32 more)
 
-### Community 84 - "Listing"
+### Community 84 - "nihReporterScraper.ts"
 Cohesion: 0.11
-Nodes (30): canonicalPiName(), DEFAULT_FISCAL_YEARS, escapeRegex(), fetchPage(), FetchPageOpts, findUserForPi(), grantToRecord(), groupGrantsByPi() (+22 more)
+Nodes (28): canonicalPiName(), DEFAULT_FISCAL_YEARS, escapeRegex(), FetchPageOpts, findUserForPi(), grantToRecord(), groupGrantsByPi(), NihAgencyAdmin (+20 more)
 
-### Community 85 - "promoteAcceptedBetaCopy.ts"
+### Community 85 - "studentVisibilityRepairTargets.ts"
 Cohesion: 0.12
 Nodes (31): buildBucket(), buildStudentVisibilityRepairTargetReport(), compactSample(), compareByLabel(), compareDepartmentCandidates(), compareLlmCandidates(), DEPARTMENT_REPAIR_REASONS, DEPARTMENT_UNDERGRAD_RESEARCH_DEPARTMENTS (+23 more)
 
-### Community 86 - "Yale Research - Developer Guide"
+### Community 86 - "researchEntitySearchIndexService.ts"
 Cohesion: 0.11
-Nodes (32): addUniqueSearchTerm(), buildResearchEntitySearchIndexDocument(), buildResearchEntitySearchIndexDocuments(), buildResearchEntitySearchIndexDocumentsWithMemberNames(), buildStudentSearchTerms(), cleanPersonName(), emptyMemberNameFields(), facultyDisplayName() (+24 more)
+Nodes (33): addUniqueSearchTerm(), buildResearchEntitySearchIndexDocument(), buildResearchEntitySearchIndexDocuments(), buildResearchEntitySearchIndexDocumentsWithMemberNames(), buildStudentSearchTerms(), cleanPersonName(), emptyMemberNameFields(), facultyDisplayName() (+25 more)
 
-### Community 87 - "paperAuthorshipAudit.ts"
-Cohesion: 0.11
-Nodes (27): getOpportunityById(), normalizeOpportunityIdParam(), mocks, compactStrings(), evidenceExcerpt(), firstEvidenceText(), getOpportunityApplicationLabel(), getOpportunityApplicationState() (+19 more)
+### Community 87 - "redactDirectContactInfo"
+Cohesion: 0.10
+Nodes (30): getOpportunityById(), normalizeOpportunityIdParam(), mocks, compactStrings(), evidenceExcerpt(), firstEvidenceText(), getOpportunityApplicationLabel(), getOpportunityApplicationState() (+22 more)
 
-### Community 88 - "Observation"
-Cohesion: 0.11
-Nodes (27): addFavoriteToProgram(), addViewToProgram(), boundedSearchQuery(), getProgramById(), numericSearchParam(), OPERATOR_PROGRAM_SORT_FIELDS, parseFilter(), parseStudentVisibilityFilter() (+19 more)
+### Community 88 - "programController.ts"
+Cohesion: 0.10
+Nodes (32): getFellowshipById(), addFavoriteToProgram(), addViewToProgram(), boundedSearchQuery(), getProgramById(), numericSearchParam(), OPERATOR_PROGRAM_SORT_FIELDS, parseFilter() (+24 more)
 
-### Community 89 - "Environment Progression"
+### Community 89 - "departmentUndergradResearchScraper.ts"
 Cohesion: 0.14
-Nodes (30): ResearchGroupKind, absoluteUrl(), bestApplicationUrl(), conciseText(), DEFAULT_DEPARTMENT_UNDERGRAD_RESEARCH_PAGES, departmentEntityKey(), departmentGuidanceDescription(), DepartmentUndergradResearchPageConfig (+22 more)
+Nodes (31): ResearchGroupKind, absoluteUrl(), bestApplicationUrl(), conciseText(), DEFAULT_DEPARTMENT_UNDERGRAD_RESEARCH_PAGES, departmentEntityKey(), departmentGuidanceDescription(), DepartmentUndergradResearchPageConfig (+23 more)
 
-### Community 90 - "devDependencies"
-Cohesion: 0.12
-Nodes (30): absolutize(), CenterConfig, CenterExtractor, CenterKind, CenterMember, centerMemberRelationshipObservations(), centerMemberRelationshipObservationsForEntityKey(), CentersInstitutesScraper (+22 more)
+### Community 90 - "centersInstitutesScraper.ts"
+Cohesion: 0.07
+Nodes (45): affiliationExtractionToObservations(), CallCenterAffiliationLLMFn, CandidateCenter, CenterAffiliationExtraction, CenterAffiliationLLMExtractor, CenterAffiliationLLMExtractorDeps, CenterAffiliationPerson, CenterFinderFn (+37 more)
 
-### Community 91 - "Per-Source Audit Playbooks"
-Cohesion: 0.11
-Nodes (30): buildStudentDecisionPrompt(), candidateMatchesOnly(), clean(), compactSourceUrls(), DecisionCandidate, DecisionCandidateLoader, DecisionCandidateSelectionOptions, decisionExtractionToObservation() (+22 more)
+### Community 91 - "studentDecisionLLMExtractor.ts"
+Cohesion: 0.10
+Nodes (34): ScrapeSnapshot, scrapeSnapshotSchema, getCached(), invalidateCache(), buildStudentDecisionPrompt(), candidateMatchesOnly(), clean(), compactSourceUrls() (+26 more)
 
-### Community 92 - "assertPublicHttpUrl"
-Cohesion: 0.12
-Nodes (31): field(), normalizedHeader(), applyUserIdentityDedupeGroups(), archiveDuplicateUniqueUserReferences(), assertDedupeUsersByIdentityApplyAllowed(), buildDedupeUsersByIdentityOutput(), buildUserIdentityCollisionPipeline(), IDENTITY_FIELDS (+23 more)
+### Community 92 - "dedupeUsersByIdentity.ts"
+Cohesion: 0.10
+Nodes (33): applyUserIdentityDedupeGroups(), archiveDuplicateUniqueUserReferences(), assertDedupeUsersByIdentityApplyAllowed(), buildDedupeUsersByIdentityOutput(), buildUserIdentityCollisionPipeline(), IDENTITY_FIELDS, isMissing(), loadCollisions() (+25 more)
 
-### Community 93 - "studentDecisionLLMExtractor.ts"
+### Community 93 - "researchEntityCoverageAudit.ts"
 Cohesion: 0.13
 Nodes (29): aggregateCountMap(), AuditEntityRecord, buildBulkAudit(), buildObservationFlags(), buildResearchEntityCoverageAuditOutput(), buildSlugAudit(), countMap(), __dirname (+21 more)
 
-### Community 94 - "adminFellowshipFormReducer.ts"
+### Community 94 - "research.tsx"
 Cohesion: 0.09
-Nodes (27): ActiveResearchSearchRequest, buildDepartmentSearchTargets(), DepartmentResearchHomeConfig, DepartmentSearchTarget, emptyGroupedResults(), hasStructuredFilters(), isResearchEntitySearchExhausted(), pluralize() (+19 more)
+Nodes (26): ActiveResearchSearchRequest, buildDepartmentSearchTargets(), DepartmentResearchHomeConfig, DepartmentSearchTarget, hasStructuredFilters(), isResearchEntitySearchExhausted(), pluralize(), QUALITY_FILTER_OPTIONS (+18 more)
 
-### Community 95 - "ResearchHomeCard.tsx"
-Cohesion: 0.11
-Nodes (33): initial(), allNameTokens(), allowsLastNameOnlyPersonUrl(), cleanProfileUrlsForPerson(), cleanPublicHttpUrl(), compoundLastNameMatchedTokens(), expandedResearchAreasPublicBio(), formatPublicBioList() (+25 more)
+### Community 95 - "isLikelyPersonUrl"
+Cohesion: 0.24
+Nodes (17): initial(), allNameTokens(), allowsLastNameOnlyPersonUrl(), cleanProfileUrlsForPerson(), compoundLastNameMatchedTokens(), entityNameMatchesUser(), givenNameAliasMatches(), hasPartialCompoundLastNameProfilePath() (+9 more)
 
-### Community 96 - "applyProfileResearchAreaFallback"
+### Community 96 - "research-detail-professor-audit.mjs"
 Cohesion: 0.11
 Nodes (27): absoluteApiUrl(), absoluteClientUrl(), addFinding(), artifacts, auditEntity(), auditProfileLink(), clientBase, collectResearchEntities() (+19 more)
 
-### Community 97 - "backfillProfileBiosFromOfficialUrls.ts"
-Cohesion: 0.11
-Nodes (33): getResearchGroupBySlug(), route(), addPublicPaperField(), buildLeadPiOutreachContactRoute(), buildResearchActivityLinkPayload(), contactRouteDedupeKey(), contactRouteRank(), dedupePublicContactRoutes() (+25 more)
-
-### Community 98 - "rebuildPathwaySearchIndex.ts"
+### Community 97 - "renderedFetch.ts"
 Cohesion: 0.09
-Nodes (21): AnalyticsEvent, ANALYTICS_SORT_DIRECTIONS, ANALYTICS_USER_SORTS, AnalyticsRequestError, parseAnalyticsSortDirection(), parseAnalyticsUserSort(), router, invokeRouteHandler() (+13 more)
+Nodes (29): average(), boundedRenderedFetchTimeout(), buildFetchAttemptMetrics(), createScraplingRenderedFetcher(), currentMemoryBytes(), DEFAULT_BRIDGE_PATH, defaultRenderedSeedRedirectCheck(), execFileAsync (+21 more)
 
-### Community 99 - "claimGate.ts"
+### Community 98 - "analytics.ts"
+Cohesion: 0.09
+Nodes (13): ANALYTICS_SORT_DIRECTIONS, ANALYTICS_USER_SORTS, AnalyticsRequestError, parseAnalyticsSortDirection(), parseAnalyticsUserSort(), router, invokeRouteHandler(), mocks (+5 more)
+
+### Community 99 - "dedupeUsersByIdentityCore.ts"
+Cohesion: 0.15
+Nodes (26): buildUserIdentityDedupePlan(), buildUserIdentityDedupeSummary(), canonicalScore(), chooseCanonicalUser(), clusterUsersByCompatibleName(), comparePlannedGroups(), compareStrings(), compareWarningGroups() (+18 more)
+
+### Community 100 - "openAlexPaperScraper.ts"
 Cohesion: 0.12
-Nodes (31): DuplicatePersonGroup, buildUserIdentityDedupePlan(), buildUserIdentityDedupeSummary(), canonicalScore(), chooseCanonicalUser(), clusterUsersByCompatibleName(), comparePlannedGroups(), compareStrings() (+23 more)
+Nodes (30): arxivIdFromUrl(), buildExternalIds(), buildOpenAlexAuthorshipEvidence(), extractArxivId(), FacultyRecord, fetchPage(), HttpFetcher, isExactNameMatch() (+22 more)
 
-### Community 100 - "dedupeUsersByIdentityCore.ts"
-Cohesion: 0.13
-Nodes (29): arxivIdFromUrl(), buildExternalIds(), buildOpenAlexAuthorshipEvidence(), extractArxivId(), FacultyRecord, fetchPage(), HttpFetcher, isExactNameMatch() (+21 more)
-
-### Community 101 - "longText.ts"
-Cohesion: 0.08
-Nodes (28): dependencies, axios, @emotion/react, @emotion/styled, @mui/material, react, react-dom, react-router-dom (+20 more)
-
-### Community 102 - "attempt"
-Cohesion: 0.13
-Nodes (25): ProfileEditor(), ProfileEditorProps, orcidHref(), ProfileHeader(), ProfileHeaderProps, profileLinkDedupeKey(), profileUrlLinks(), shouldHideBroadSchoolLabel() (+17 more)
-
-### Community 103 - "launchTrustContractService.ts"
+### Community 101 - "dependencies"
 Cohesion: 0.11
-Nodes (23): AdminRoute(), AdminRouteProps, getLocalAdminDevLoginUrl(), getSafeLocalAdminRedirectTarget(), PrivateRoute(), PrivateRouteProps, InfiniteScrollLoadingDots(), InfiniteScrollLoadingDotsProps (+15 more)
+Nodes (18): dependencies, axios, @emotion/react, @emotion/styled, @mui/material, react, react-router-dom, react-spinners (+10 more)
 
-### Community 104 - "buildAdminOperatorBoard"
-Cohesion: 0.13
-Nodes (30): CompensationType, PostedOpportunityStatus, activeListingBackfillFilter(), backfillPostedOpportunitiesFromListings(), BackfillPostedOpportunitiesFromListingsOptions, BackfillPostedOpportunitiesFromListingsResult, compactObject(), firstUrl() (+22 more)
+### Community 102 - "getUniqueDepartmentLabels"
+Cohesion: 0.09
+Nodes (34): DepartmentInput(), DepartmentInputProps, ProfileEditor(), ProfileEditorProps, orcidHref(), ProfileHeader(), ProfileHeaderProps, profileLinkDedupeKey() (+26 more)
 
-### Community 105 - "analytics.tsx"
-Cohesion: 0.13
-Nodes (25): ScrapeSnapshot, scrapeSnapshotSchema, getCached(), invalidateCache(), setCached(), StudentDecisionLLMExtractor, ACCESS_DETAIL_CONFIGS, accessObservationsForEntity() (+17 more)
+### Community 103 - "apiBaseUrl.ts"
+Cohesion: 0.11
+Nodes (22): AdminRoute(), AdminRouteProps, getLocalAdminDevLoginUrl(), getSafeLocalAdminRedirectTarget(), PrivateRoute(), PrivateRouteProps, InfiniteScrollLoadingDots(), InfiniteScrollLoadingDotsProps (+14 more)
 
-### Community 106 - "officialProfilePiBackfillScraper.ts"
-Cohesion: 0.08
-Nodes (28): affiliationExtractionToObservations(), CallCenterAffiliationLLMFn, CandidateCenter, CenterAffiliationExtraction, CenterAffiliationLLMExtractor, CenterAffiliationLLMExtractorDeps, CenterAffiliationPerson, CenterFinderFn (+20 more)
+### Community 104 - "postedOpportunityService.ts"
+Cohesion: 0.14
+Nodes (28): activeListingBackfillFilter(), backfillPostedOpportunitiesFromListings(), BackfillPostedOpportunitiesFromListingsOptions, BackfillPostedOpportunitiesFromListingsResult, compactObject(), firstUrl(), getEntryPathwayModel(), getEntryPathwayStatusForPostedOpportunity() (+20 more)
 
-### Community 107 - "pathwaySearchService.ts"
-Cohesion: 0.12
-Nodes (27): LaunchReviewExceptionCliOptions, buildLaunchTrustContractOutput(), CliOptions, __filename, main(), parseLaunchTrustContractArgs(), parsePositiveInteger(), parseRequiredValue() (+19 more)
+### Community 105 - "ObservationInput"
+Cohesion: 0.22
+Nodes (17): ACCESS_DETAIL_CONFIGS, accessObservationsForEntity(), cleanName(), entityToObservations(), inferKind(), normalizeUrl(), pageText(), parseCenters() (+9 more)
 
-### Community 108 - "renderedFetch.ts"
+### Community 106 - "centerDirectorLLMExtractor.ts"
+Cohesion: 0.15
+Nodes (18): CallCenterDirectorLLMFn, CandidateCenter, CenterDirector, CenterDirectorExtraction, CenterDirectorLLMExtractor, CenterDirectorLLMExtractorDeps, CenterFinderFn, defaultCallLLM() (+10 more)
+
+### Community 107 - "launchTrustContractService.ts"
+Cohesion: 0.10
+Nodes (29): LaunchReviewExceptionCliOptions, buildLaunchTrustContractOutput(), CliOptions, __filename, main(), parseLaunchTrustContractArgs(), parsePositiveInteger(), parseRequiredValue() (+21 more)
+
+### Community 108 - "pathwayQualityAudit.ts"
 Cohesion: 0.13
 Nodes (28): activeListingFilter(), aggregateCountMap(), buildEntityContexts(), buildPathwayQualityAuditOutput(), countMap(), __dirname, __filename, main() (+20 more)
 
-### Community 109 - "BackfillV4FacultyMembers.ts"
+### Community 109 - "promoteAcceptedBetaCopy.ts"
 Cohesion: 0.11
 Nodes (30): applyCopy(), assertPromotionSummaryCanApply(), assertSafeOptions(), buildApplyBlockers(), buildPlan(), buildPromotionSummary(), COLLECTION_CATEGORY_ORDER, CollectionCategorySummary (+22 more)
 
-### Community 110 - "repairArchivedEntityArtifacts.ts"
-Cohesion: 0.19
-Nodes (31): member(), attemptProgramRepair(), buildResearchSourceDescriptionPatch(), cleanResearchInterest(), entityPersonDisplayName(), hasHttpUrl(), isDescriptionEligibleSourceUrl(), isLeadMember() (+23 more)
+### Community 110 - "visibilityRepairQueueService.ts"
+Cohesion: 0.10
+Nodes (68): member(), actionReasons, archivedResearchEntityRepairBlock(), attemptProgramRepair(), attemptResearchActionEvidenceRepair(), attemptResearchRepair(), attemptVisibilityRepair(), buildResearchSourceDescriptionPatch() (+60 more)
 
-### Community 111 - "listingClaimRequestService.ts"
+### Community 111 - "departmentGroundTruth.ts"
 Cohesion: 0.14
 Nodes (29): addSourceRecord(), buildDepartmentGroundTruth(), buildResolverKeys(), buildRowsFromSources(), categoryColorKeys, chooseCodeSystem(), CuratedDepartment, curatedDepartments (+21 more)
 
-### Community 112 - "brianFeed"
+### Community 112 - "app.ts"
 Cohesion: 0.08
-Nodes (21): allowList, apiLimiter, bypassRuntimeSecurity, clientDistPath, clientIndexPath, corsOptions, deployedBrowserOrigins, __dirname (+13 more)
+Nodes (22): allowList, apiLimiter, app, bypassRuntimeSecurity, clientDistPath, clientIndexPath, corsOptions, deployedBrowserOrigins (+14 more)
 
-### Community 113 - "betaRepairQueue.ts"
+### Community 113 - "listingClaimRequestService.ts"
+Cohesion: 0.11
+Nodes (30): getAdminListingClaimRequest(), listAdminListingClaimRequests(), reviewAdminListingClaimRequest(), submitListingClaimRequest(), ListingClaimRequest, listingClaimRequestSchema, ListingClaimRequestStatus, ListingClaimRequestType (+22 more)
+
+### Community 114 - "profileController.ts"
+Cohesion: 0.13
+Nodes (24): addIfDefined(), getProfile(), getProfileCourses(), getProfileListings(), getPublications(), normalizePublicationPagination(), PUBLICATION_SORT_FIELDS, publicationSortValue() (+16 more)
+
+### Community 115 - "backfillCenterDirectors.ts"
+Cohesion: 0.07
+Nodes (36): MaterializerObservationLike, BrowseRankBackfillCliOptions, BrowseRankBackfillResult, __dirname, __filename, main(), parseBrowseRankBackfillArgs(), parsePositiveInt() (+28 more)
+
+### Community 116 - "adminAccessReviewService.ts"
 Cohesion: 0.14
-Nodes (27): getAdminListingClaimRequest(), listAdminListingClaimRequests(), reviewAdminListingClaimRequest(), submitListingClaimRequest(), ListingClaimRequest, listingClaimRequestSchema, ListingClaimRequestStatus, ListingClaimRequestType (+19 more)
+Nodes (27): recordReviewStatuses, AccessReviewCountSummary, accessReviewDocumentId(), AccessReviewEntitySummary, AccessReviewListInput, AccessReviewRecordType, attachEvidenceItems(), buildReviewSummary() (+19 more)
 
-### Community 114 - "assessment"
-Cohesion: 0.13
-Nodes (23): addIfDefined(), getProfile(), getProfileCourses(), getProfileListings(), getPublications(), normalizePublicationPagination(), PUBLICATION_SORT_FIELDS, publicationSortValue() (+15 more)
-
-### Community 115 - "yaleCollegeFellowshipsOfficeScraper.ts"
-Cohesion: 0.09
-Nodes (25): ApiMode, mongoOptions, BrowseRankBackfillCliOptions, BrowseRankBackfillResult, __dirname, __filename, main(), parseBrowseRankBackfillArgs() (+17 more)
-
-### Community 116 - "scripts"
-Cohesion: 0.13
-Nodes (28): recordReviewStatuses, AccessReviewCountSummary, accessReviewDocumentId(), AccessReviewEntitySummary, AccessReviewListInput, AccessReviewRecordType, AccessReviewRequestError, attachEvidenceItems() (+20 more)
-
-### Community 117 - "pathwayQualityAudit.ts"
+### Community 117 - "migrateResearchEntityCollections.ts"
 Cohesion: 0.14
 Nodes (30): assertResearchEntityCollectionMigrationWriteAllowed(), buildCollectionMigrationLiveFilter(), buildCollectionMigrationTargetReferenceFilter(), buildResearchEntityCollectionMigrationOutput(), COLLECTION_MIGRATIONS, collectionExists(), CollectionMigration, collectionMigrationModeWrites() (+22 more)
 
-### Community 118 - "base"
-Cohesion: 0.10
-Nodes (28): buildProfileResearchMembershipFilter(), cleanScholarlyTitle(), cleanUrl(), dateToIso(), hasInspectableOpenAlexDestination(), isDatasetLikeScholarlyLink(), isGeneratedOfficialProfilePublicationAnchor(), isOfficialProfileScholarlyLink() (+20 more)
+### Community 118 - "scholarlyLinkToPublicLink"
+Cohesion: 0.12
+Nodes (25): buildProfileResearchMembershipFilter(), cleanScholarlyTitle(), cleanUrl(), dateToIso(), isDatasetLikeScholarlyLink(), isGeneratedOfficialProfilePublicationAnchor(), isOfficialProfileScholarlyLink(), isOfficialProfileSourcePagePublicationPointer() (+17 more)
 
-### Community 119 - "isNonBiographicalPublicBio"
+### Community 119 - "UserContextProvider.tsx"
 Cohesion: 0.11
 Nodes (16): ListingEditorProps, ErrorBoundary, ErrorBoundaryProps, ErrorBoundaryState, container, root, UserContextProvider(), sampleUser (+8 more)
 
-### Community 120 - "cronRunner.ts"
-Cohesion: 0.12
-Nodes (24): adminQualityLabels(), contextLabelClass(), countLabel(), directoryFirstBadgeLabel(), directoryFirstPathwayLabel(), evidenceStatusClass(), isInteractiveElement(), ResearchHomeCard() (+16 more)
+### Community 120 - "profile.tsx"
+Cohesion: 0.07
+Nodes (41): cleanResearchInterest(), ResearchInterests(), ResearchInterestsProps, SOURCE_CHROME_PATTERNS, splitCleanResearchInterest(), adminQualityLabels(), contextLabelClass(), countLabel() (+33 more)
 
-### Community 121 - "normalizeProfileUpdateForStorage"
+### Community 121 - "nsfAwardScraper.ts"
 Cohesion: 0.13
-Nodes (24): awardToRecord(), buildCoPiObservations(), buildResearchGroupObservations(), defaultDateStart(), fetchPage(), findUserForPi(), groupAwardsByPi(), maxStartDate() (+16 more)
+Nodes (26): awardToRecord(), buildCoPiObservations(), buildPiUserObservations(), buildResearchGroupObservations(), defaultDateStart(), fetchPage(), findUserForPi(), groupAwardsByPi() (+18 more)
 
-### Community 122 - "yaleResearchOfficialScraper.ts"
+### Community 122 - "migrateResearchEntities.ts"
 Cohesion: 0.13
 Nodes (29): assertResearchEntityMigrationWriteAllowed(), BACKFILL_ARRAY_FIELD_PAIRS, BACKFILL_FIELD_PAIRS, backfillReferences(), buildResearchEntityMigrationOutput(), buildResearchEntityMigrationReferenceMatch(), collectionExists(), copyResearchEntities() (+21 more)
 
-### Community 123 - "Adding a New Endpoint"
+### Community 123 - "buildAdminOperatorBoard"
 Cohesion: 0.16
 Nodes (27): betaTargetCommand(), buildAdminOperatorBoard(), buildGateArtifactFreshness(), buildRecommendedNextActions(), deriveDataQualityGate(), deriveLaunchAcquisitionGate(), deriveLaunchTrustGate(), derivePromotionCopyGate() (+19 more)
 
-### Community 124 - "yaleDirectoryScraper.ts"
-Cohesion: 0.08
-Nodes (18): mockedAxios, CourseTableCourse, CourseTableSection(), CourseTableSectionProps, formatSeason(), ProfileListingsProps, SearchResponse, useSearchCore() (+10 more)
+### Community 124 - "axios.ts"
+Cohesion: 0.05
+Nodes (36): mockedAxios, HttpStatusNotifier(), CourseTableCourse, CourseTableSection(), CourseTableSectionProps, formatSeason(), ProfileListingsProps, SearchResponse (+28 more)
 
-### Community 125 - "fellowshipController.ts"
+### Community 125 - "disambiguateSurnameLabNames.ts"
 Cohesion: 0.12
 Nodes (27): ACTIVE_FILTER, applyPlans(), ApplyResult, assertDisambiguateSurnameLabApplyAllowed(), buildSurnameLabDisambiguationPlans(), cleanNamePart(), consumeValue(), __dirname (+19 more)
 
-### Community 126 - "ListingDetailModal.tsx"
-Cohesion: 0.14
-Nodes (27): applyPlans(), assertDuplicateAccessSignalRepairApplyAllowed(), BlockedDuplicateAccessSignalRepairGroup, buildDuplicateAccessSignalRepairPlans(), __dirname, DuplicateAccessSignalPathwayContext, DuplicateAccessSignalRecord, DuplicateAccessSignalRepairPlanResult (+19 more)
+### Community 126 - "repairDuplicateAccessSignals.ts"
+Cohesion: 0.12
+Nodes (30): buildDuplicateAccessSignalGroupsFromRows(), loadDuplicateAccessSignalGroups(), applyPlans(), assertDuplicateAccessSignalRepairApplyAllowed(), BlockedDuplicateAccessSignalRepairGroup, buildDuplicateAccessSignalRepairPlans(), __dirname, DuplicateAccessSignalPathwayContext (+22 more)
 
-### Community 127 - "scholarlyLinkSuppressionAudit.ts"
-Cohesion: 0.14
-Nodes (24): buildFellowshipApplicationCycleEvidence(), cleanHttpUrl(), cleanString(), dateStatus(), FellowshipApplicationCycleEvidence, hasApplicationRoute(), looksRecurring(), publicFellowshipApplicationCycleEvidence (+16 more)
+### Community 127 - "fellowshipMatchingService.ts"
+Cohesion: 0.17
+Nodes (20): publicFellowshipApplicationCycleEvidence, FellowshipMatch, FellowshipMatchingDeps, FellowshipMatchStrength, hasFellowshipCompatibleEvidence(), matchFellowshipsForPathways(), matchStrength(), overlapCount() (+12 more)
 
-### Community 128 - "pathwayController.ts"
-Cohesion: 0.15
-Nodes (24): addFavoriteToFellowship(), addViewToFellowship(), boundedSearchQuery(), getFellowshipById(), getFellowshipFilterOptions(), numericSearchParam(), parseFilter(), PUBLIC_FELLOWSHIP_SORT_FIELDS (+16 more)
+### Community 128 - "fellowshipController.ts"
+Cohesion: 0.17
+Nodes (18): addFavoriteToFellowship(), addViewToFellowship(), boundedSearchQuery(), getFellowshipFilterOptions(), numericSearchParam(), parseFilter(), PUBLIC_FELLOWSHIP_SORT_FIELDS, publicFellowshipPage() (+10 more)
 
-### Community 129 - "researchEntityDescriptionText.ts"
-Cohesion: 0.16
-Nodes (20): csrfOriginGuard(), isTrustedUnsafeRequestOrigin(), originFromUrl(), SAFE_METHODS, allowedOrigins, ORIGINAL_ENV, requireLocalSeedRuntime(), allowsNonProductionSecurityBypass() (+12 more)
+### Community 129 - "environment.ts"
+Cohesion: 0.31
+Nodes (13): allowsNonProductionSecurityBypass(), isCI(), isDevelopment(), isLocalDevelopmentRuntime(), isLocalHostValue(), isProduction(), isTest(), LOCAL_DEV_HOSTS (+5 more)
 
-### Community 130 - "dir"
+### Community 130 - "repairArchivedEntityArtifacts.ts"
 Cohesion: 0.15
 Nodes (24): applyRepairPlan(), archiveArtifact(), ARTIFACT_SPECS, ArtifactSpec, assertArchivedEntityArtifactRepairApplyAllowed(), buildRepairArchivedEntityArtifactsOutput(), collectionExists(), __filename (+16 more)
 
-### Community 131 - "launchReviewExceptions.ts"
+### Community 131 - "repairMismatchedPersonEmailsCore.ts"
 Cohesion: 0.15
 Nodes (25): applyRepairs(), assertRepairMismatchedPersonEmailsApplyAllowed(), loadUsers(), main(), runRepairMismatchedPersonEmails(), writeOutput(), buildMismatchedExternalIdentityRepairs(), buildMismatchedPersonEmailRepairPlan() (+17 more)
 
-### Community 132 - "adminRender"
-Cohesion: 0.14
-Nodes (16): triggerReconnect(), AsyncRequestHandler, clientErrorStatus(), errorHandler(), notFoundHandler(), publicClientErrorMessage(), ORIGINAL_ENV, BadRequestError (+8 more)
+### Community 132 - "errorHandler.ts"
+Cohesion: 0.18
+Nodes (13): triggerReconnect(), AsyncRequestHandler, clientErrorStatus(), errorHandler(), notFoundHandler(), publicClientErrorMessage(), ORIGINAL_ENV, IncorrectPermissionsError (+5 more)
 
-### Community 133 - "Session Notes"
-Cohesion: 0.19
-Nodes (26): buildFundingGroupFromCluster(), buildFundingResearchEntityDedupePlan(), buildGroupFromCluster(), buildOfficialLabUrlResearchEntityDedupePlan(), buildProfileAreaShellDuplicateGroup(), buildResearchEntityPiDedupePlan(), canonicalScore(), cleanMergedResearchAreas() (+18 more)
+### Community 133 - "researchEntityPiDedupeCore.ts"
+Cohesion: 0.17
+Nodes (27): buildFundingGroupFromCluster(), buildFundingResearchEntityDedupePlan(), buildGroupFromCluster(), buildOfficialLabUrlResearchEntityDedupePlan(), buildProfileAreaShellDuplicateGroup(), buildResearchEntityPiDedupePlan(), canonicalScore(), cleanMergedResearchAreas() (+19 more)
 
-### Community 134 - "acceptedInputs.ts"
+### Community 134 - "isPublicHttpUrl"
 Cohesion: 0.16
-Nodes (23): buildListingResearchEntityProfilePatch(), hasText(), isHttpUrl(), ListingResearchEntityProfileInput, looksLikeOwnerTitle(), looksLikePublicationBlurb(), missingArray(), missingText() (+15 more)
+Nodes (22): buildListingResearchEntityProfilePatch(), hasText(), isHttpUrl(), ListingResearchEntityProfileInput, looksLikeOwnerTitle(), looksLikePublicationBlurb(), missingArray(), missingText() (+14 more)
 
-### Community 135 - "scraperIntegrityGate.ts"
+### Community 135 - "researchEntityQuality.ts"
 Cohesion: 0.14
 Nodes (21): ACCESS_SIGNAL_POINTS, accessPoints(), computeResearchEntityBrowseRank(), descriptionPoints(), leadPoints(), ResearchEntityBrowseRankInput, __testing, buildResearchEntityQualitySummary() (+13 more)
 
-### Community 136 - "research-detail-professor-audit.mjs"
+### Community 136 - "cronRunner.ts"
 Cohesion: 0.17
 Nodes (20): ScrapeJobLock, scrapeJobLockSchema, createCronOwnerId(), createCronRunnerDependencies(), CronRunnerDependencies, loadCronSource(), runScraperCron(), RunScraperCronResult (+12 more)
 
-### Community 137 - "dedupeUsersByIdentity.ts"
-Cohesion: 0.14
-Nodes (26): buildResearchGroupMemberUpsert(), centerRelationshipTypeForResolvedTarget(), findExistingResearchEntityByFacultyResearchAreaIdentity(), findUniqueUserForResearchGroupMember(), findUniqueUserIdByPersonName(), idValue(), isFacultyResearchAreaKey(), isInitialOnlyNameValue() (+18 more)
+### Community 137 - "assertPublicHttpUrl"
+Cohesion: 0.22
+Nodes (22): defaultFetchUrl(), setCached(), defaultFetchPage(), defaultFetchPage(), fetchHtml(), fetchDeptData(), fetchHtml(), defaultFetchHtml() (+14 more)
 
-### Community 138 - "ImportRootDataFiles.ts"
+### Community 138 - "userEmailHygiene.ts"
 Cohesion: 0.18
 Nodes (23): buildEmailHygiene(), buildSuspiciousUserEmailScorecardSummary(), isInvalidOptionalEmail(), assertUserEmailHygieneApplyAllowed(), buildSuspiciousUserEmailFilter(), buildUserEmailHygieneOutput(), loadSuspiciousUsers(), main() (+15 more)
 
-### Community 139 - "candidateDescriptionCrawlUrls"
+### Community 139 - "paperQualityService.ts"
 Cohesion: 0.14
 Nodes (22): buildPaperQualityAuditOutput(), __filename, main(), PaperQualityAuditCliOptions, parseNonNegativeInteger(), parsePaperQualityAuditArgs(), writePaperQualityAuditOutput(), activeScholarlyLinkFilter (+14 more)
 
-### Community 140 - "getResearchGroupDetail"
-Cohesion: 0.17
-Nodes (25): buildProfessorBioCoverageAudit(), emptySourceBuckets(), hasUsefulResearchSummary(), homeFallbackBucketForProfile(), isIndividualResearchHome(), isLeadRole(), isOrcidUrl(), isTrustedResearchHomeWebsite() (+17 more)
-
-### Community 141 - "applicationRoutePathwayBackfillCore.ts"
+### Community 140 - "profileBioCoverageAudit.ts"
 Cohesion: 0.10
-Nodes (21): argValue(), Feeder, FeederResult, FEEDERS, __filenameLocal, runFeeder(), runGateRefresh(), SERVER_ROOT (+13 more)
+Nodes (40): buildProfessorBioCoverageAuditOutput(), buildProfessorBioCoverageInputs(), idValue(), main(), parseInteger(), parseProfessorBioCoverageAuditArgs(), parseRequiredOutputPath(), ProfessorBioCoverageAuditCliOptions (+32 more)
 
-### Community 142 - "generateKeywords.ts"
+### Community 141 - "logSanitizer.ts"
+Cohesion: 0.08
+Nodes (27): ApiMode, getApiMode(), initializeConnections(), mongoOptions, startApp(), CliOptions, FILTER, main() (+19 more)
+
+### Community 142 - "staleObservationConflictReview.ts"
 Cohesion: 0.08
 Nodes (25): ACCESS_EVIDENCE_CONFLICT_FIELDS, ADDITIVE_METADATA_CONFLICT_FIELDS, AggregatedObservationConflictGroup, ALL_KNOWN_CONFLICT_FIELDS, CONTENT_CONFLICT_FIELDS, __filename, FUNDING_CONTEXT_CONFLICT_FIELDS, IDENTITY_OR_ROUTING_CONFLICT_FIELDS (+17 more)
 
-### Community 143 - "scriptWriteGuards.ts"
-Cohesion: 0.12
-Nodes (23): actionReasons, attemptVisibilityRepair(), buildVisibilityRepairPiMemberUpsert(), buildVisibilityRepairPlan(), buildVisibilityRepairPlans(), classifyVisibilityRepairStage(), defaultRepairDeps, interestCorroboratedByBio() (+15 more)
+### Community 143 - "betaDataQualityCore.test.ts"
+Cohesion: 0.15
+Nodes (19): buildReferenceAuditSamples(), buildUrlHygiene(), main(), BetaDataQualityScorecard, buildArrayRefOrphanSamplePipeline(), buildBetaDataQualityOutput(), buildBetaDataQualityRecommendedCommands(), buildBetaDataQualityRetentionOptions() (+11 more)
 
-### Community 144 - "types.ts"
-Cohesion: 0.13
-Nodes (19): AdminProfile, AdminProfileEditModal(), AdminProfileEditModalProps, PublicationsTable(), PublicationsTableProps, SortField, AdminProfileEditAction, adminProfileEditReducer() (+11 more)
+### Community 144 - "AdminProfileEditModal.tsx"
+Cohesion: 0.21
+Nodes (14): AdminProfile, AdminProfileEditModal(), AdminProfileEditModalProps, PublicationsTable(), AdminProfileEditAction, adminProfileEditReducer(), AdminProfileEditState, AdminProfileShape (+6 more)
 
-### Community 145 - "client"
+### Community 145 - "seedDepartments.ts"
 Cohesion: 0.12
 Nodes (24): DepartmentSeedRow, applyDepartmentRows(), assertDepartmentSeedApplyAllowed(), auditUnresolvedDepartmentStrings(), buildDepartmentSeedOutput(), classifyUnresolvedDepartmentString(), Department, DepartmentDiffSummary (+16 more)
 
-### Community 146 - "departmentGroundTruth.ts"
+### Community 146 - "unified-research-search-audit.mjs"
 Cohesion: 0.12
 Nodes (22): artifacts, assert(), assertTextExcludes(), assertTextIncludes(), assertTextMatches(), audit(), bodyText(), clientBase (+14 more)
 
-### Community 147 - "profileBioCoverageAudit.ts"
-Cohesion: 0.13
-Nodes (20): hasOversizedStringList(), isOversizedSearchRequest(), OPERATOR_ALLOWED_SORT_FIELDS, parseFilters(), parsePositiveIntegerParam(), parseQualityFilters(), parseStudentVisibilityTiers(), PUBLIC_ALLOWED_SORT_FIELDS (+12 more)
+### Community 147 - "researchGroupController.ts"
+Cohesion: 0.12
+Nodes (23): getResearchGroupBySlug(), hasOversizedStringList(), isOversizedSearchRequest(), OPERATOR_ALLOWED_SORT_FIELDS, parseFilters(), parsePositiveIntegerParam(), parseQualityFilters(), parseStudentVisibilityTiers() (+15 more)
 
-### Community 148 - "Research Model"
-Cohesion: 0.16
-Nodes (21): ResearchEntityType, absoluteUrl(), cleanText(), DEFAULT_YALE_RESEARCH_DIRECTORY_CONFIGS, entityFromRecord(), entityToObservations(), inferResearchYaleKind(), pageUrlForIndex() (+13 more)
+### Community 148 - "yaleResearchOfficialScraper.ts"
+Cohesion: 0.15
+Nodes (22): ResearchEntityType, absoluteUrl(), cleanText(), DEFAULT_YALE_RESEARCH_DIRECTORY_CONFIGS, entityFromRecord(), entityToObservations(), inferResearchYaleKind(), pageUrlForIndex() (+14 more)
 
-### Community 149 - "cli.ts"
+### Community 149 - "cleanupLegacyMongoCollections.ts"
 Cohesion: 0.17
 Nodes (23): assertLegacyCleanupWriteAllowed(), buildLegacyCleanupOutput(), collectionExists(), copyApplications(), countCollection(), countMissingStudentApplications(), createStudentApplicationIndexes(), dropLegacyCollections() (+15 more)
 
-### Community 150 - "AdminFellowshipsTable.tsx"
+### Community 150 - "launchReviewExceptions.ts"
 Cohesion: 0.15
 Nodes (21): buildLaunchReviewExceptionCandidates(), buildLaunchReviewExceptionDecisionTemplate(), buildLaunchReviewExceptionOutput(), buildLaunchReviewExceptionPlan(), buildLaunchReviewExceptionReview(), __filename, isStudentReadyLaunchViolation(), LAUNCH_REVIEW_EXCEPTION_DECISION_VALUES (+13 more)
 
-### Community 151 - "smartTitle.ts"
-Cohesion: 0.14
-Nodes (17): cleanResearchInterest(), ResearchInterests(), ResearchInterestsProps, SOURCE_CHROME_PATTERNS, splitCleanResearchInterest(), formatRoleLabel(), Profile(), ROLE_LABELS (+9 more)
+### Community 151 - "Observation"
+Cohesion: 0.21
+Nodes (15): entityKeyFor(), GroupRow, LATEST_WINS, Result, run(), Observation, observationSchema, ListingPostedOpportunityMetricDeps (+7 more)
 
-### Community 152 - "crossSourceObservationConflictReview.ts"
-Cohesion: 0.14
-Nodes (21): ResearchGroupMember, ProfileBackedFacultyResearchAreaMemberDeps, ResolvedRelationshipMaterializationDeps, deleteFromIndex(), ENTITY_REGISTRY, EntityIndexConfig, getConfig(), isSyncableEntityType() (+13 more)
+### Community 152 - "idSerialization.ts"
+Cohesion: 0.15
+Nodes (17): deleteFromIndex(), ENTITY_REGISTRY, EntityIndexConfig, getConfig(), MaybePromise, stripInternalFields(), SyncableEntityType, syncEntities() (+9 more)
 
-### Community 153 - "migrateResearchEntities.ts"
-Cohesion: 0.18
-Nodes (24): resolveAllFields(), addUniqueValuesToSet(), authorshipEvidenceFromPaperObservations(), buildPaperUpdateFromObservations(), entityModelFor(), findEntityDocByIdentifier(), findPaperForObservationGroup(), isArxivPaperKey() (+16 more)
+### Community 153 - "isNonBiographicalPublicBio"
+Cohesion: 0.15
+Nodes (18): appointmentTitleCount(), degreeTokenCount(), hasPublicProfileEmail(), hasResearchDescriptionVerb(), isAffiliationOnlyResearchSummary(), isAppointmentListOnlyProfileBio(), isAppointmentOnlyProfileBio(), isCitationLikePublicationList() (+10 more)
 
-### Community 154 - "visibilityRepairQueueService.ts"
+### Community 154 - "Yale Research - Developer Guide"
 Cohesion: 0.09
 Nodes (23): Adding Things, Analytics, API Routes, Architecture, Auth Middleware (`server/src/middleware/auth.ts`), Authentication, CI, Common Commands (+15 more)
 
-### Community 155 - "abstractBios"
+### Community 155 - "migrateMongoNaming.ts"
 Cohesion: 0.15
 Nodes (21): assertMongoNamingMigrationWriteAllowed(), buildMongoNamingMigrationOutput(), buildUserFieldSetStage(), COLLECTION_RENAMES, collectionExists(), CollectionRenameResult, main(), migrateMongoNaming() (+13 more)
 
-### Community 156 - "researchEntity.ts"
+### Community 156 - "repairProfileDescriptionBackfillConflicts.ts"
 Cohesion: 0.16
 Nodes (21): applyPlans(), assertRepairProfileDescriptionBackfillConflictsApplyAllowed(), buildProfileDescriptionConflictRepairPlan(), buildProfileDescriptionConflictRepairPlans(), chooseKeepObservation(), consumePath(), DESCRIPTION_FIELDS, __dirname (+13 more)
 
-### Community 157 - "researchQualitySearchReview.ts"
-Cohesion: 0.15
-Nodes (21): getProfileByNetid(), hasProfileDirectoryLabelContamination(), normalizePublicProfile(), PUBLIC_PROFILE_BASE_ARRAY_FIELDS, PUBLIC_PROFILE_BASE_TEXT_FIELDS, publicProfileBase(), publicProfileImageUrl(), publicProfileResearchEntity() (+13 more)
+### Community 157 - "normalizePublicProfile"
+Cohesion: 0.14
+Nodes (22): cleanPublicHttpUrl(), hasProfileDirectoryLabelContamination(), normalizePublicProfile(), PUBLIC_PROFILE_BASE_ARRAY_FIELDS, PUBLIC_PROFILE_BASE_TEXT_FIELDS, publicProfileBase(), publicProfileHttpUrls(), publicProfileImageUrl() (+14 more)
 
-### Community 158 - "{ container }"
+### Community 158 - "migrateSmartTitles.ts"
 Cohesion: 0.13
 Nodes (18): args, ARTS_DEPARTMENT_ABBRS, CATEGORY_PRIORITY, CATEGORY_SUFFIXES, DepartmentCategory, DepartmentDoc, determineSuffix(), escapeRegex() (+10 more)
 
-### Community 159 - "migrateResearchEntityCollections.ts"
-Cohesion: 0.16
-Nodes (20): publicProgramForReader(), publicProgramLinks(), publicProgramText(), publicProgramTextArray(), hasDirectContactInfo(), defaultRewriter(), cache, CourseTableCourse (+12 more)
+### Community 159 - "courseTableService.ts"
+Cohesion: 0.32
+Nodes (11): cache, CourseTableCourse, fetchAllSeasonCourses(), fetchCourseTableData(), getRecentSeasonCodes(), normalizeCourseTableProfessorName(), normalizeCourseTableSeason(), publicCourseTableCourse() (+3 more)
 
-### Community 160 - "researchGroupController.ts"
+### Community 160 - "betaSeedEnvironment.ts"
 Cohesion: 0.16
-Nodes (20): ScrapeJobLockInput, ScraperEnvironment, BetaSeedEnvironmentCliOptions, BetaSeedPlan, BetaSeedPlanStep, BetaSeedRunResult, BetaSeedTargetMetadata, buildBetaSeedPlan() (+12 more)
+Nodes (21): ScrapeJobLockInput, ScraperEnvironment, assertBetaSeedAllowed(), BetaSeedEnvironmentCliOptions, BetaSeedPlan, BetaSeedPlanStep, BetaSeedRunResult, BetaSeedTargetMetadata (+13 more)
 
-### Community 161 - "migrateSmartTitles.ts"
+### Community 161 - "agent-workflow.md"
 Cohesion: 0.10
 Nodes (15): Agent Workflow, Durable Notes, Read Order, Skill Index, Finishing work, Fold durable changes into docs, Refresh Graphify, Review the final diff (+7 more)
 
-### Community 162 - "externalIdsSchema"
-Cohesion: 0.16
-Nodes (19): Source, BETA_ROLLOUT_ORDER, BetaReadinessGateCliOptions, buildBetaReadinessCommands(), buildBetaReadinessGateOutput(), collectionCount(), describeMongoTarget(), __dirname (+11 more)
+### Community 162 - "betaReadinessGate.ts"
+Cohesion: 0.17
+Nodes (18): BETA_ROLLOUT_ORDER, BetaReadinessGateCliOptions, buildBetaReadinessCommands(), buildBetaReadinessGateOutput(), collectionCount(), describeMongoTarget(), __dirname, EXPECTED_SOURCE_NAMES (+10 more)
 
-### Community 163 - "studentDecisionExplanationService.ts"
-Cohesion: 0.16
-Nodes (21): cleanOfficialProfileDisplayName(), cleanOfficialProfileTitle(), clipOfficialProfileBio(), extractBio(), extractDepartments(), extractEmail(), extractImageUrl(), extractOfficialProfileIdentity() (+13 more)
+### Community 163 - "source.ts"
+Cohesion: 0.20
+Nodes (12): sourceSchema, SourceCoverageArtifactType, sourceCoverageArtifactTypes, sourceCoverageEvidenceCategories, SourceCoverageEvidenceCategory, SourceCoverageMetadata, SourceCoverageTier, sourceCoverageTiers (+4 more)
 
-### Community 164 - "disambiguateSurnameLabNames.ts"
+### Community 164 - "auditResearchEntityRename.ts"
 Cohesion: 0.18
 Nodes (19): buildLegacyResidueSummary(), buildResearchEntityRenameAuditOutput(), collectionExists(), countCollection(), countDanglingReferences(), countLegacyResidue(), LEGACY_RESIDUE_CHECKS, LegacyResidueCheck (+11 more)
 
-### Community 165 - "repairDuplicateAccessSignals.ts"
-Cohesion: 0.18
-Nodes (18): assertPostedOpportunityBackfillApplyAllowed(), buildPostedOpportunityBackfillOutput(), __dirname, __filename, main(), parsePositiveInteger(), parsePostedOpportunityBackfillArgs(), PostedOpportunityBackfillCliOptions (+10 more)
+### Community 165 - "resolveSafeJsonReportOutputPath"
+Cohesion: 0.13
+Nodes (28): assertPostedOpportunityBackfillApplyAllowed(), buildPostedOpportunityBackfillOutput(), __dirname, __filename, main(), parsePositiveInteger(), parsePostedOpportunityBackfillArgs(), PostedOpportunityBackfillCliOptions (+20 more)
 
-### Community 166 - "arxivPreprintScraper.ts"
+### Community 166 - "Session Notes"
 Cohesion: 0.10
 Nodes (19): 10) `/research` cluster profile links should avoid broken routes on malformed data, 11) Playwright interaction pass for research flows could not run in this environment, 12) `/research` was blocked by an unrelated Listings error modal, 13) `/research/:slug` repeated the same official source link across pathways, evidence, and CTAs, 14) Listings load failure used a blocking modal instead of inline recovery, 15) `/research` showed duplicate Neuroscience concepts and undersized touch targets, 16) `/research` hierarchy exposed clusters before student decisions, 1) `/research` search request ordering and cancellation (+11 more)
 
-### Community 167 - "EvidenceQualitySection"
+### Community 167 - "devDependencies"
+Cohesion: 0.18
+Nodes (11): devDependencies, ts-node, tsup, tsx, @types/cookie-session, @types/cors, @types/express, @types/node (+3 more)
+
+### Community 168 - "acceptedInputs.ts"
+Cohesion: 0.18
+Nodes (22): ACCEPTED_INPUT_FILE_EXTENSIONS, assertAcceptedInputPathRoot(), assertSafeAcceptedInputPathText(), defaultAdvisorResolver(), resolveSafeAcceptedInputPath(), resolveSafeAcceptedInputRoot(), assertAcceptedInputsApplyAllowed(), buildAcceptedInputsOutput() (+14 more)
+
+### Community 169 - "accessClaims.ts"
 Cohesion: 0.10
-Nodes (19): devDependencies, ts-node, tsup, tsx, @types/cookie-session, @types/cors, @types/express, @types/node (+11 more)
+Nodes (31): AccessSignalConfidence, AccessSignalType, CompensationType, EntryPathwayStatus, EntryPathwayType, EvidenceStrength, PostedOpportunityStatus, DerivedAccessSignal (+23 more)
 
-### Community 168 - "LIVE"
-Cohesion: 0.21
-Nodes (18): defaultAdvisorResolver(), resolveSafeAcceptedInputRoot(), assertAcceptedInputsApplyAllowed(), buildAcceptedInputsOutput(), CliOptions, COMMANDS_REQUIRING_DB, COMMANDS_SUPPORTING_APPLY, main() (+10 more)
-
-### Community 169 - "dependencies"
-Cohesion: 0.17
-Nodes (18): AccessSignalType, AccessArtifactCandidate, AccessArtifactType, buildClaimGateReport(), ClaimGateReport, ClaimGateStatus, ClaimValidationBundleResult, ClaimValidationResult (+10 more)
-
-### Community 170 - "normalizeOfficialProfileUrl"
+### Community 170 - "scraperIntegrityDuplicateReview.ts"
 Cohesion: 0.17
 Nodes (18): DuplicateAccessSignalGroup, DuplicateResearchPaperGroup, DuplicateAccessSignalRepairPlan, buildScraperIntegrityDuplicateReviewReport(), consumeValue(), __dirname, __filename, loadDuplicateAccessSignalReviewGroups() (+10 more)
 
-### Community 171 - "axios.ts"
+### Community 171 - "clearBetaStudentAnalytics.ts"
 Cohesion: 0.24
 Nodes (17): assertClearBetaStudentAnalyticsApplyAllowed(), buildBetaStudentAnalyticsEventFilter(), buildClearBetaStudentAnalyticsOutput(), loadCandidateSummary(), main(), runClearBetaStudentAnalytics(), writeClearBetaStudentAnalyticsOutput(), BETA_STUDENT_ANALYTICS_USER_TYPES (+9 more)
 
-### Community 172 - "programController.ts"
-Cohesion: 0.24
-Nodes (20): archivedResearchEntityRepairBlock(), attemptResearchActionEvidenceRepair(), attemptResearchRepair(), createEntitySourceActionEvidenceRepair(), createOfficialProfileActionEvidenceRepair(), entityActionEvidenceSourceUrl(), entityActionEvidenceSourceUrls(), findOfficialProfileUserMatch() (+12 more)
+### Community 172 - "ResearchAreaInput.tsx"
+Cohesion: 0.23
+Nodes (10): react-dom, colorKeyToTailwind, FieldSelectorModalProps, ResearchAreaInput(), ResearchAreaInputProps, createInitialResearchAreaInputState(), ResearchAreaInputAction, researchAreaInputReducer() (+2 more)
 
-### Community 173 - "seedDepartments.ts"
+### Community 173 - "Yale Research"
 Cohesion: 0.11
 Nodes (15): Core Rules, Default Task Loop, Implementation Rules, On-Demand Skills, Parallel Work, Yale Research - Agent Guide, Yale Research, Acknowledgements (+7 more)
 
-### Community 174 - "Active Detail Docs"
+### Community 174 - "adminListingsTableReducer.ts"
 Cohesion: 0.14
 Nodes (15): AdminListing, AdminListingsTable(), PAGE_SIZES, SORT_OPTIONS, SortField, TABLE_COLUMNS, AdminListingsFilter, AdminListingsSortField (+7 more)
 
-### Community 175 - "repairMismatchedPersonEmailsCore.ts"
+### Community 175 - "compilerOptions"
 Cohesion: 0.11
 Nodes (18): compilerOptions, allowJs, allowSyntheticDefaultImports, esModuleInterop, forceConsistentCasingInFileNames, isolatedModules, jsx, lib (+10 more)
 
-### Community 176 - "betaReadinessGate.ts"
+### Community 176 - "seedResearchAreas.ts"
 Cohesion: 0.14
 Nodes (18): assertResearchAreaSeedApplyAllowed(), buildResearchAreaSeedOutput(), buildResearchAreaSeedRows(), defaultResearchAreas, __dirname, fieldColorKeys, __filename, main() (+10 more)
 
-### Community 177 - "buildDescriptionLLMPrompt"
+### Community 177 - "Decisions"
 Cohesion: 0.11
 Nodes (19): 2026-05-07: Evolve Legacy ResearchGroup Conservatively, 2026-05-07: North Star Is Research Navigation, 2026-05-07: Replace Binary Acceptance With Access Signals, 2026-05-07: Separate EntryPathway From PostedOpportunity, 2026-05-07: Use Two Main Product Surfaces, 2026-05-11: Use Pathways As The Student Action Layer, 2026-05-14: Student-Facing Routes Should Not Use URL Versioning, 2026-05-25: Beta Operator Review Is An Automatic Repair State (+11 more)
 
-### Community 178 - "index.tsx"
+### Community 178 - "Research Data Pipeline"
 Cohesion: 0.13
 Nodes (14): Canonical Collections, Pipeline Shape, Promotion Invariants, Read-Only Control Plane, Research Data Pipeline, Retention Posture, Rollback Drill Expectations, Active Priority Queue (+6 more)
 
-### Community 179 - "callLLM"
+### Community 179 - "Research Model"
 Cohesion: 0.11
 Nodes (19): 2026-05-13 External Yale Validation, 2026-05-13 Model Audit, AccessSignal, Admin Review, ContactRoute, Current Implementation Context, EntryPathway, Migration Guidance (+11 more)
 
-### Community 180 - "adminAccessReviewService.ts"
-Cohesion: 0.28
-Nodes (15): AuthenticatedUser, canCreateListing(), canSubmitListingClaimRequest(), hasAdminAuthority(), hasAuthenticatedPrincipal(), isAdmin(), isAuthenticated(), isConfirmed() (+7 more)
+### Community 180 - "auth.ts"
+Cohesion: 0.17
+Nodes (21): AuthenticatedUser, canCreateListing(), canSubmitListingClaimRequest(), hasAdminAuthority(), hasAuthenticatedPrincipal(), isAdmin(), isAuthenticated(), isConfirmed() (+13 more)
 
-### Community 181 - "studentVisibilityRepairTargets.ts"
-Cohesion: 0.25
-Nodes (15): AdminGrant, adminGrantSchema, buildAuthenticatedSessionUser(), adminGrantCache, AdminGrantResponse, allowsLegacyAdminUserType(), assertValidNetid(), grantAdminAccess() (+7 more)
+### Community 181 - "adminGrantService.ts"
+Cohesion: 0.30
+Nodes (11): AdminGrant, adminGrantSchema, adminGrantCache, AdminGrantResponse, assertValidNetid(), grantAdminAccess(), listAdminGrants(), normalizeAdminGrantNote() (+3 more)
 
-### Community 182 - "scripts"
-Cohesion: 0.26
-Nodes (17): buildProfileImageQualitySummary(), DuplicateProfileImageFinding, isLikelyPublicProfileImageUrl(), isNonPersonProfileImageUrl(), isSharedProfileImageAcrossDifferentNames(), isTrustedPublicProfileImageHost(), normalizedIdentityKey(), normalizedName() (+9 more)
+### Community 182 - "profileImageQualityAudit.ts"
+Cohesion: 0.20
+Nodes (22): buildProfileImageQualityAuditOutput(), main(), parseNonNegativeInteger(), parseProfileImageQualityAuditArgs(), parseRequiredOutputPath(), ProfileImageQualityAuditCliOptions, writeProfileImageQualityAuditOutput(), buildProfileImageQualitySummary() (+14 more)
 
-### Community 183 - "v4MigrationUtils.ts"
+### Community 183 - "rebuildPathwaySearchIndex.ts"
 Cohesion: 0.22
 Nodes (16): assertRebuildPathwaySearchIndexAllowed(), buildRebuildPathwaySearchIndexOutput(), main(), parsePositiveInteger(), parseRebuildPathwaySearchIndexArgs(), parseRequiredOutputPath(), RebuildPathwaySearchIndexCliOptions, writeRebuildPathwaySearchIndexOutput() (+8 more)
 
-### Community 184 - "source.ts"
-Cohesion: 0.15
-Nodes (19): ADMIN_PROFILE_USER_TYPES, adminUpdateProfile(), boundedAdminProfileEmail(), boundedAdminProfileNumber(), boundedAdminProfileText(), boundedProfileString(), boundedProfileStringArray(), boundedProfileUrlKey() (+11 more)
+### Community 184 - "researchDetailSources.ts"
+Cohesion: 0.21
+Nodes (12): buildResearchDetailSources(), BuildResearchDetailSourcesInput, DetailSourceContactRoute, DetailSourceGroup, DetailSourcePathway, DetailSourcePostedOpportunity, DetailSourceSignal, isDepartmentRosterProvenanceUrl() (+4 more)
 
-### Community 185 - "cleanupLegacyMongoCollections.ts"
-Cohesion: 0.23
-Nodes (17): actionSet, cleanHttpUrl(), cleanText(), containsDirectEmail(), hasActivePostedOpportunity(), hasPublicOfficialApplicationRoute(), hasPublicRoute(), hasUndergraduateAccessEvidence() (+9 more)
+### Community 185 - "AdminListingEditModal.tsx"
+Cohesion: 0.24
+Nodes (10): AdminListing, AdminListingEditModal(), Props, AdminListingEditAction, adminListingEditReducer(), AdminListingEditState, AdminListingShape, createInitialAdminListingEditState() (+2 more)
 
-### Community 186 - "seedSources.ts"
+### Community 186 - "compilerOptions"
 Cohesion: 0.11
 Nodes (18): compilerOptions, esModuleInterop, forceConsistentCasingInFileNames, lib, module, moduleResolution, noImplicitAny, outDir (+10 more)
 
-### Community 187 - "AdminProfileEditModal.tsx"
-Cohesion: 0.16
-Nodes (14): AdminFacultyProfilesTable(), AdminProfile, getHIndex(), getPrimaryDepartment(), PAGE_SIZES, SortField, TABLE_COLUMNS, AdminFacultyProfilesFilter (+6 more)
+### Community 187 - "AdminFacultyProfilesTable.tsx"
+Cohesion: 0.18
+Nodes (10): AdminFacultyProfilesTable(), AdminProfile, getHIndex(), getPrimaryDepartment(), PAGE_SIZES, SortField, TABLE_COLUMNS, Tab (+2 more)
 
-### Community 188 - "configService.ts"
+### Community 188 - "generateKeywords.ts"
 Cohesion: 0.16
 Nodes (17): ALIAS_MAP, args, buildSystemPrompt(), buildUserPrompt(), callOpenAI(), classifyExistingAreas(), classifyNovelAreas(), classifyOnly (+9 more)
 
-### Community 189 - "publicResearchSeo.ts"
+### Community 189 - "Per-Source Audit Playbooks"
 Cohesion: 0.11
 Nodes (18): Audit Checklist, `department-undergrad-research`, `dept-faculty-roster`, Entity Discovery Sources, Funding And Publication Enrichment, `lab-microsite-description-llm`, `lab-microsite-undergrad-llm`, Mental Model (+10 more)
 
-### Community 190 - "migrateMongoNaming.ts"
-Cohesion: 0.20
-Nodes (15): fellowshipSchema, programCategories, ProgramCategory, ProgramEntryMode, programEntryModes, ProgramKind, programKinds, archiveReviewClassification() (+7 more)
+### Community 190 - "PublicationsTable.tsx"
+Cohesion: 0.22
+Nodes (9): PublicationsTableProps, SortField, createInitialPublicationsTableState(), PublicationsFilter, PublicationsSortField, PublicationsTableAction, publicationsTableReducer(), PublicationsTableState (+1 more)
 
-### Community 191 - "researchEntityPiDedupeCore.ts"
-Cohesion: 0.13
-Nodes (8): normalizeSeedNetid(), requireSeedToken(), router, SEED_USER_FIELDS, seedListingSummary(), seedUserPayload(), seedUserSummary(), tokensMatch()
+### Community 191 - "seed.ts"
+Cohesion: 0.11
+Nodes (14): normalizeSeedNetid(), requireLocalSeedRuntime(), requireSeedToken(), router, SEED_USER_FIELDS, seedListingSummary(), seedUserPayload(), seedUserSummary() (+6 more)
 
-### Community 192 - "staleObservationConflictReview.test.ts"
-Cohesion: 0.16
+### Community 192 - "backfillResearchDescriptions.ts"
+Cohesion: 0.15
 Nodes (17): getSourceByName(), defaultRewriter(), DESC_BLOCK_REASONS, DescriptionRewriter, __dirname, entityHttpUrls(), fetchGrantAbstract(), __filename (+9 more)
 
-### Community 193 - "launchTrustContract.ts"
+### Community 193 - "backfillResearchHomeOfficialUrls.ts"
 Cohesion: 0.18
 Nodes (16): candidateProfileUrls(), defaultVerifier(), DESC_BLOCK_REASONS, __dirname, __filename, isTrustedYaleProfileUrl(), LEAD_ROLES, main() (+8 more)
 
-### Community 194 - "EvidenceSourceRow.tsx"
-Cohesion: 0.21
-Nodes (15): buildProfessorBioCoverageAuditOutput(), buildProfessorBioCoverageInputs(), idValue(), main(), parseInteger(), parseProfessorBioCoverageAuditArgs(), parseRequiredOutputPath(), ProfessorBioCoverageAuditCliOptions (+7 more)
+### Community 194 - "scraperIntegrityGate.ts"
+Cohesion: 0.27
+Nodes (11): isIntegrityGateFailure(), PostMaterializationIntegritySummary, buildScraperIntegrityGateOutput(), consumeValue(), __dirname, __filename, main(), parseScraperIntegrityGateArgs() (+3 more)
 
-### Community 195 - "adminGrantService.ts"
-Cohesion: 0.25
-Nodes (16): addResearchEntityDetailAlias(), addResearchEntitySearchAliases(), departmentDisplayLabel(), normalizedDepartmentLabel(), OPERATOR_PUBLIC_RESEARCH_ENTITY_FIELDS, OPTIONAL_PUBLIC_RESEARCH_ENTITY_FIELDS, publicDepartmentArray(), publicHttpUrl() (+8 more)
+### Community 195 - "researchEntityDto.ts"
+Cohesion: 0.20
+Nodes (19): mapResearchGroupKindToEntityType(), addResearchEntityDetailAlias(), addResearchEntitySearchAliases(), departmentDisplayLabel(), normalizedDepartmentLabel(), OPERATOR_PUBLIC_RESEARCH_ENTITY_FIELDS, OPTIONAL_PUBLIC_RESEARCH_ENTITY_FIELDS, publicDepartmentArray() (+11 more)
 
-### Community 196 - "resolveSafeJsonReportOutputPath"
-Cohesion: 0.18
-Nodes (15): MaterializerObservationLike, CenterDirectorsBackfillCliOptions, CenterDirectorsBackfillResult, __dirname, __filename, findCenterDirectorCandidates(), LEAD_ROLES, main() (+7 more)
+### Community 196 - "serializedDocumentId"
+Cohesion: 0.27
+Nodes (13): ResearchGroupMember, ResolvedRelationshipMaterializationDeps, defaultCenterFinder(), findCenterDirectorCandidates(), findFacultyWaysInCandidates(), loadDuplicateCurrentMemberRows(), loadSamePiCandidateRows(), buildCurrentMemberOnArchivedEntityPipeline() (+5 more)
 
-### Community 197 - "dependencies"
-Cohesion: 0.22
-Nodes (17): isOfficialYalePersonPageUrl(), isOfficialYaleProfileUrl(), isPotentialDirectYalePersonPageUrl(), normalizeOfficialProfileUrl(), officialPersonUrlMatchesEntity(), officialProfileSlugMatchesGivenNameVariant(), officialProfileUrlsForUser(), personPageUrlMatchesUser() (+9 more)
+### Community 197 - "normalizeName"
+Cohesion: 0.13
+Nodes (32): memberObservationsForEntityKey(), entryToResearchEntityObservations(), entryToUserObservations(), isLikelyExplicitLabWebsite(), entityExpectedPeople(), entityNameAsUser(), generatedOfficialProfileUrlCandidatesForPerson(), isOfficialYalePersonPageUrl() (+24 more)
 
-### Community 198 - "users.ts"
-Cohesion: 0.26
-Nodes (15): arrayValue(), assertBetaRepairQueueApplyReviewedArtifact(), BetaRepairQueueApplyArtifactValidation, blockedReasonsForAttempt(), buildApplyFromArtifactOptions(), buildBetaRepairQueueOutput(), main(), objectValue() (+7 more)
+### Community 198 - "betaRepairQueue.ts"
+Cohesion: 0.24
+Nodes (16): arrayValue(), assertBetaRepairQueueApplyReviewedArtifact(), BetaRepairQueueApplyArtifactValidation, blockedReasonsForAttempt(), buildApplyFromArtifactOptions(), buildBetaRepairQueueOutput(), main(), objectValue() (+8 more)
 
-### Community 199 - "unified-research-search-audit.mjs"
-Cohesion: 0.22
-Nodes (15): buildClaimGateOutput(), ClaimGateCliOptions, ClaimGateCollection, consumeValue(), __dirname, __filename, loadResearchAccessArtifacts(), main() (+7 more)
+### Community 199 - "researchAccessTypes.ts"
+Cohesion: 0.06
+Nodes (50): allowedValues(), hasOversizedStringList(), isOversizedSearchRequest(), parseFilters(), parseSearchInput(), parseSort(), publicPathwayResearchEntity(), publicPathwaySearchResult() (+42 more)
 
-### Community 200 - "index.ts"
+### Community 200 - "pathwayRelevanceReview.ts"
 Cohesion: 0.21
 Nodes (15): buildPathwayRelevanceReviewOutput(), DEFAULT_REVIEW_CASES, __dirname, errorMessage(), __filename, main(), overlap(), parsePathwayRelevanceReviewArgs() (+7 more)
 
-### Community 201 - "userEmailHygiene.ts"
+### Community 201 - "accessSummaryService.ts"
 Cohesion: 0.21
 Nodes (14): AccessSummary, accessSummaryEntityId(), AccessSummaryStatus, bestNextStepFor(), boundedString(), computeStatus(), confidenceScore(), EMPTY_SUMMARY (+6 more)
 
-### Community 202 - "orcidWorksScraper.ts"
+### Community 202 - "sourceHealthService.ts"
 Cohesion: 0.24
 Nodes (15): betaCommand(), buildSourceHealthRows(), commandArg(), iso(), noRecentRunCommand(), reportCommand(), reportOutputPath(), reviewArtifactForRun() (+7 more)
 
-### Community 203 - "backfillResearchHomeOfficialUrls.ts"
-Cohesion: 0.18
-Nodes (13): AdminFellowshipsFilter, AdminFellowshipsSortField, AdminFellowshipsTableAction, adminFellowshipsTableReducer(), AdminFellowshipsTableState, AdminTableAction, AdminTableDefaults, adminTableReducer() (+5 more)
+### Community 203 - "adminFacultyProfilesTableReducer.ts"
+Cohesion: 0.09
+Nodes (22): AdminFellowshipsTable(), AdminFacultyProfilesFilter, AdminFacultyProfilesSortField, AdminFacultyProfilesTableAction, adminFacultyProfilesTableReducer(), AdminFacultyProfilesTableState, AdminFellowshipsFilter, AdminFellowshipsSortField (+14 more)
 
-### Community 204 - "backfillFacultyWaysIn.ts"
+### Community 204 - "resolutions"
 Cohesion: 0.12
 Nodes (16): resolutions, axios, brace-expansion, braces, encoding-sniffer, form-data, glob, ip-address (+8 more)
 
-### Community 205 - "publicationsTableReducer.ts"
+### Community 205 - "publicResearchSeo.ts"
 Cohesion: 0.26
 Nodes (14): sendPublicResearchIndex(), getResearchGroupBySlug(), buildPublicResearchSeoMetadata(), compact(), escapeHtml(), firstNonEmpty(), injectSeoMetadata(), joinList() (+6 more)
 
-### Community 206 - "AdminFacultyProfilesTable.tsx"
-Cohesion: 0.23
-Nodes (13): allowedValues(), hasOversizedStringList(), isOversizedSearchRequest(), parseFilters(), parseSearchInput(), parseSort(), publicPathwayResearchEntity(), publicPathwaySearchResult() (+5 more)
+### Community 206 - "devDependencies"
+Cohesion: 0.17
+Nodes (12): devDependencies, agentation, autoprefixer, jsdom, postcss, tailwindcss, @testing-library/dom, @testing-library/jest-dom (+4 more)
 
-### Community 207 - "meiliSyncService.ts"
-Cohesion: 0.18
-Nodes (15): VisibilityReleaseQueueCollection, visibilityReleaseQueueCollections, visibilityReleaseQueueItemSchema, VisibilityReleaseQueueStatus, visibilityReleaseQueueStatuses, VisibilityRepairStage, visibilityRepairStages, VisibilityRepairStatus (+7 more)
+### Community 207 - "visibilityReleaseQueueItem.ts"
+Cohesion: 0.13
+Nodes (23): StudentVisibilityTier, VisibilityReleaseQueueCollection, visibilityReleaseQueueCollections, visibilityReleaseQueueItemSchema, VisibilityReleaseQueueStatus, visibilityReleaseQueueStatuses, VisibilityRepairStage, visibilityRepairStages (+15 more)
 
-### Community 208 - "AdminOperatorBoard"
+### Community 208 - "users.ts"
 Cohesion: 0.19
 Nodes (8): getFavoriteIds(), logFavoriteEvent(), logProfileUpdateEvent(), normalizeFavoriteAnalyticsIds(), parseFavoriteAnalyticsResponse(), profileUpdateAnalyticsFields(), router, visibleFavoriteAnalyticsIdsFromResponse()
 
-### Community 209 - "departmentResolver.ts"
-Cohesion: 0.25
-Nodes (16): affiliationValuesFromProfiles(), canonicalResearchHomeName(), classifyResearchHome(), cleanProfileCardLabWebsiteLabel(), dedupeRepeatedProfileCardLabel(), disallowedProfileLinkedResearchHome(), extractOfficialProfileResearchHomes(), genericOrganizationName() (+8 more)
+### Community 209 - "fellowshipApplicationCycleEvidenceService.ts"
+Cohesion: 0.33
+Nodes (10): buildFellowshipApplicationCycleEvidence(), cleanHttpUrl(), cleanString(), dateStatus(), FellowshipApplicationCycleEvidence, hasApplicationRoute(), looksRecurring(), textForFellowship() (+2 more)
 
-### Community 210 - "isPublicHttpUrl"
+### Community 210 - "dependencies"
 Cohesion: 0.13
 Nodes (15): dependencies, axios, cheerio, cookie-session, cors, cross-env, dotenv, express (+7 more)
 
-### Community 211 - "repairProfileDescriptionBackfillConflicts.ts"
+### Community 211 - "dedupeExploratoryContactPathways.ts"
 Cohesion: 0.30
 Nodes (13): applyPlans(), assertDedupeExploratoryContactPathwaysApplyConfirmed(), buildDedupeExploratoryContactPathwaysOutput(), buildPlans(), countDedupeExploratoryContactPathwaysPlannedChanges(), DedupeExploratoryContactPathwaysCliOptions, idString(), main() (+5 more)
 
-### Community 212 - "clearBetaStudentAnalytics.ts"
+### Community 212 - "repairListingResearchEntityProfiles.ts"
 Cohesion: 0.30
 Nodes (13): applyRepairs(), assertRepairListingResearchEntityProfilesApplyAllowed(), buildRepairListingResearchEntityProfilesOutput(), main(), normalizeListingProfileRepairObjectId(), normalizeListingProfileRepairObjectIdString(), parsePositiveInteger(), parseRepairListingResearchEntityProfilesArgs() (+5 more)
 
-### Community 213 - "scraperIntegrityDuplicateReview.ts"
-Cohesion: 0.20
-Nodes (14): currentResearchEntityMemberFilter(), getResearchGroupById(), idEquals(), listMembersOfGroup(), listResearchEntityRelationshipPayload(), normalizeResearchGroupObjectId(), publicRelationshipForResearchDetail(), leanResult() (+6 more)
+### Community 213 - "resolutions"
+Cohesion: 0.18
+Nodes (11): resolutions, brace-expansion, form-data, glob, ip-address, minimatch, picomatch, postcss (+3 more)
 
-### Community 214 - "normalizePublicProfile"
+### Community 214 - "longText.ts"
 Cohesion: 0.30
 Nodes (11): LongText(), LongTextProps, LongTextOptions, longTextParagraphs(), normalizeCommonAcademicAbbreviations(), normalizeInlineWhitespace(), protectDots(), protectSentenceAbbreviations() (+3 more)
 
-### Community 215 - "departmentLeadRepairPlanCore.ts"
-Cohesion: 0.18
-Nodes (12): assertDepartmentMigrationApplyAllowed(), buildDepartmentMigrationOutput(), ChangeLog, DepartmentDoc, DepartmentMigrationCliOptions, DepartmentMigrationResult, __dirname, __filename (+4 more)
+### Community 215 - "csrfOriginGuard.ts"
+Cohesion: 0.31
+Nodes (6): csrfOriginGuard(), isTrustedUnsafeRequestOrigin(), originFromUrl(), SAFE_METHODS, allowedOrigins, ORIGINAL_ENV
 
-### Community 216 - "auditResearchEntityRename.ts"
+### Community 216 - "compilerOptions"
 Cohesion: 0.14
 Nodes (13): compilerOptions, esModuleInterop, forceConsistentCasingInFileNames, lib, module, outDir, resolveJsonModule, rootDir (+5 more)
 
-### Community 217 - "normalizeName"
+### Community 217 - "Environment Progression"
 Cohesion: 0.14
 Nodes (14): 1. Development Testing, 2. Beta Seeding, 3. Production Seeding, Environment Progression, Known Accepted Warnings To Recheck, Lane A: Accepted Beta Copy, Lane B: Guarded Production Delta, Local, VPN, And Render Constraints (+6 more)
 
-### Community 218 - "authorshipEvidence"
+### Community 218 - "ScrapeRun"
 Cohesion: 0.25
 Nodes (11): ScrapeRun, scrapeRunSchema, buildSupersededObservationPruneFilter(), findKeptRunIds(), nonNegativeInteger(), positiveInteger(), pruneSupersededObservations(), SupersededObservationPruneOptions (+3 more)
 
-### Community 219 - "actor"
+### Community 219 - "programs.ts"
 Cohesion: 0.22
 Nodes (9): buildProgramSearchFilters(), getStringParam(), hasProgramSearchFilters(), logProgramEvent(), logProgramSearchEvent(), parseFilterParam(), router, routeByPath() (+1 more)
 
-### Community 220 - "compilerOptions"
+### Community 220 - "backfillProgramClassifications.ts"
+Cohesion: 0.42
+Nodes (8): assertBackfillProgramClassificationsApplyAllowed(), BackfillProgramClassificationsCliOptions, buildBackfillProgramClassificationsOutput(), main(), parseBackfillProgramClassificationsArgs(), parsePositiveInteger(), parseRequiredOutputPath(), writeBackfillProgramClassificationsOutput()
+
+### Community 221 - "package.json"
+Cohesion: 0.22
+Nodes (8): engines, node, license, main, name, proxy, type, version
+
+### Community 222 - "classifyDuplicateEntityCluster"
 Cohesion: 0.25
-Nodes (14): DEPARTMENT_IDENTITY_STOPWORDS, departmentIdentityTokens(), findUserDocByOfficialProfileObservations(), identityTokens(), isLikelyYaleEmailLocalPart(), normalizeIdentityText(), observationValueForField(), observedUserDepartmentLabels() (+6 more)
+Nodes (9): DuplicateEntityCluster, buildDuplicateEntityReviewSummary(), classifyDuplicateEntityCluster(), distinctDepartmentCount(), hasSingleSharedWebsite(), isFullPersonResearchName(), isSingleSurnameLabName(), normalizedNameTokens() (+1 more)
 
-### Community 221 - "backfillPostedOpportunitiesFromListings.ts"
-Cohesion: 0.20
-Nodes (13): buildCrossSourceObservationConflictReviewOutput(), buildCrossSourceObservationDecisionTemplate(), CrossSourceObservationConflictSample, main(), normalizedObservationIdRows(), readCrossSourceObservationReviewDecisions(), runCrossSourceObservationConflictReview(), sameObservationIdsBySource() (+5 more)
-
-### Community 222 - "acronymExpansion"
-Cohesion: 0.17
-Nodes (8): AdminFellowship, AdminFellowshipsTable(), FellowshipLink, PAGE_SIZES, SortField, TABLE_COLUMNS, createInitialAdminFellowshipsTableState(), TestFellowship
-
-### Community 223 - "paperQualityService.ts"
+### Community 223 - "seo.ts"
 Cohesion: 0.32
 Nodes (11): applySeoMetadata(), buildDefaultSeoMetadata(), buildResearchSeoMetadata(), compact(), firstNonEmpty(), joinList(), SeoMetadata, stripHtml() (+3 more)
 
-### Community 224 - "dataOps.ts"
-Cohesion: 0.27
-Nodes (11): backfillV4StudentProfiles(), buildDepartmentMap(), compact(), departmentIdsFor(), __filename, graduationYear(), norm(), V4StudentProfileBackfillResult (+3 more)
+### Community 224 - "BackfillV4StudentProfiles.ts"
+Cohesion: 0.36
+Nodes (9): backfillV4StudentProfiles(), buildDepartmentMap(), compact(), departmentIdsFor(), __filename, graduationYear(), norm(), V4StudentProfileBackfillResult (+1 more)
 
-### Community 225 - "actionabilityMatch"
-Cohesion: 0.22
-Nodes (12): assertPublicationMigrationApplyAllowed(), buildPublicationMigrationOutput(), dedupeKey(), __dirname, EmbeddedPub, __filename, migratePublicationsToPapers(), parsePositiveInteger() (+4 more)
+### Community 225 - "assertScriptApplyAllowed"
+Cohesion: 0.09
+Nodes (27): assertPublicationMigrationApplyAllowed(), buildPublicationMigrationOutput(), dedupeKey(), __dirname, EmbeddedPub, __filename, migratePublicationsToPapers(), parsePositiveInteger() (+19 more)
 
-### Community 226 - "pathwayRelevanceReview.ts"
+### Community 226 - "Graphify repo memory"
 Cohesion: 0.15
 Nodes (11): Canonical Sources, Graphify Onboarding, Refresh Policy, Setup Tasks, Shared Output Policy, Committed vs ignored outputs, Graphify repo memory, Installation (+3 more)
 
-### Community 227 - "profileImageQualityAudit.ts"
+### Community 227 - "securityHeaders.ts"
 Cohesion: 0.27
 Nodes (11): buildContentSecurityPolicy(), CONNECT_SRC_ORIGINS, connectSrcDirective(), CONTENT_SECURITY_POLICY, IMG_SRC_ORIGINS, imgSrcDirective(), PERMISSIONS_POLICY, securityHeaders() (+3 more)
 
-### Community 228 - "researchGroupService.test.ts"
-Cohesion: 0.22
-Nodes (13): ADMIN_URL_CHECK_ALLOWED_PORTS, adminUrlCheckDisplayText(), adminUrlCheckDisplayUrl(), checkAdminUrlReachability(), requestHead(), ipv4ToNumber(), isIpv4InCidr(), isIpv6InCidr() (+5 more)
+### Community 228 - "ssrfGuard.ts"
+Cohesion: 0.32
+Nodes (10): ipv4ToNumber(), isAllowedPublicHttpPort(), isIpv4InCidr(), isIpv6InCidr(), isPrivateAddress(), isPublicHostname(), parseIpv6ToBigInt(), SsrfBlockedError (+2 more)
 
-### Community 229 - "programs.ts"
+### Community 229 - "listings.ts"
 Cohesion: 0.24
 Nodes (8): buildListingSearchFilters(), getStringParam(), hasListingSearchFilters(), logListingCreateEvent(), logListingEvent(), logSearchEvent(), parseFilterParam(), router
 
-### Community 230 - "bare"
+### Community 230 - "confidenceResolver.ts"
 Cohesion: 0.24
 Nodes (10): applyProseCompletenessBonus(), DEFAULTS, normalizedProse(), PROSE_COMPLETENESS_FIELDS, recencyDecay(), resolveField(), ResolverObservation, ResolverOptions (+2 more)
 
-### Community 231 - "crossrefFreeFullText"
-Cohesion: 0.27
-Nodes (12): addPostMaterializationMetrics(), buildInferredPiMemberUpsert(), countListingBackedPostedOpportunitiesForRun(), departmentValuesForInferredPiLookup(), emptyPostMaterializationMetrics(), materializeFromRun(), materializeInferredPiMembership(), normalizeMaterializerObjectId() (+4 more)
+### Community 231 - "refreshGateScorecards.ts"
+Cohesion: 0.28
+Nodes (8): argValue(), Feeder, FeederResult, FEEDERS, __filenameLocal, runFeeder(), runGateRefresh(), SERVER_ROOT
 
-### Community 232 - "compilerOptions"
+### Community 232 - "AdminOperatorBoard"
 Cohesion: 0.20
 Nodes (12): AdminOperatorBoard(), classifyReason(), formatCountList(), formatDate(), queueDecisionPrompt(), sourceConflictScopeText(), sourceReviewArtifactRollupLines(), sourceReviewCategoryText() (+4 more)
 
-### Community 233 - "seo.ts"
-Cohesion: 0.35
-Nodes (11): decodeHtmlEntities(), decodeNumericEntity(), isScholarlyLink(), LabPapersList(), LabPapersListProps, normalizeResearchActivityTitle(), ResearchActivityLink, resolveDisplayDate() (+3 more)
+### Community 233 - "scripts"
+Cohesion: 0.29
+Nodes (7): scripts, build, dev, preview, smoke:production-promotion, test, test:ci
 
-### Community 234 - "MigratePublicationsToPapers.ts"
-Cohesion: 0.32
-Nodes (11): backfillV4FacultyMembers(), buildDepartmentMap(), compact(), departmentIdsFor(), __filename, isFacultyTitle(), norm(), slugify() (+3 more)
+### Community 234 - "BackfillV4FacultyMembers.ts"
+Cohesion: 0.17
+Nodes (18): backfillV4FacultyMembers(), buildDepartmentMap(), compact(), departmentIdsFor(), __filename, isFacultyTitle(), norm(), slugify() (+10 more)
 
-### Community 235 - "sourceHealthService.ts"
-Cohesion: 0.27
-Nodes (8): app, getApiMode(), startApp(), __filenameLocal, gateRefreshIntervalMs(), SERVER_ROOT, startGateRefreshScheduler(), triggerRefresh()
+### Community 235 - "useFavorites.ts"
+Cohesion: 0.38
+Nodes (5): mockedAxios, mockedSwal, Endpoints, FavoritesKind, useFavorites()
 
-### Community 236 - "listings.ts"
+### Community 236 - "fellowships.ts"
 Cohesion: 0.26
 Nodes (7): buildFellowshipSearchFilters(), getStringParam(), hasFellowshipSearchFilters(), logFellowshipEvent(), logFellowshipSearchEvent(), parseFilterParam(), router
 
-### Community 237 - "confidenceResolver.ts"
+### Community 237 - "Auth and Security"
 Cohesion: 0.17
 Nodes (11): Auth and Security, Auth middleware, Authentication flow, Client, Environment variables, Error handling, Rate limits, Security middleware (+3 more)
 
-### Community 238 - "facultyResearch"
+### Community 238 - "Yale Research Product Context"
 Cohesion: 0.18
 Nodes (10): Author-Disambiguation Rules, Core Flows, Data-Quality Caveats, Not Optimizing For, Primary User Jobs, Product Thesis, Target User, Trust Constraints (+2 more)
 
-### Community 239 - "filterDuplicateRunObservations"
-Cohesion: 0.29
-Nodes (9): FellowshipEditModal(), AdminFellowshipFormAction, adminFellowshipFormReducer(), AdminFellowshipFormSource, AdminFellowshipFormState, createInitialAdminFellowshipFormState(), FellowshipLink, toDatetimeLocal() (+1 more)
+### Community 239 - "AdminFellowshipsTable.tsx"
+Cohesion: 0.16
+Nodes (14): AdminFellowship, FellowshipEditModal(), FellowshipLink, PAGE_SIZES, SortField, TABLE_COLUMNS, AdminFellowshipFormAction, adminFellowshipFormReducer() (+6 more)
 
-### Community 240 - "authenticatedRouteDoc"
-Cohesion: 0.25
-Nodes (9): assertUserMigrationApplyAllowed(), assertUserMigrationReplacementAllowed(), buildUserMigrationOutput(), __dirname, __filename, migrateUsers(), UserMigrationCliOptions, UserMigrationResult (+1 more)
+### Community 240 - "ScraperMetrics"
+Cohesion: 0.50
+Nodes (5): ReportScrapeRun, ScrapeRunReport, ScraperFetchMetrics, ScraperMetrics, WorkPlannerMetrics
 
-### Community 241 - "normalizeAcceptedDecisionValidation"
+### Community 241 - "Local Development Setup"
 Cohesion: 0.18
 Nodes (11): 1. Fresh machine setup, 2. Install dependencies, 3. Configure environment, 4. Start local Meilisearch, 5. Seed Meilisearch, 6. Start dev servers, 7. Verify setup, Dev login bypass (+3 more)
 
-### Community 242 - "isLocalHostValue"
+### Community 242 - "Product Context"
 Cohesion: 0.18
 Nodes (11): CTA Vocabulary, Entity Page Questions, Explore Research, Navigation Shape, North Star, Planning Context, Primary Surfaces, Product Context (+3 more)
 
@@ -1349,209 +1341,177 @@ Nodes (11): CTA Vocabulary, Entity Page Questions, Explore Research, Navigation 
 Cohesion: 0.18
 Nodes (11): Canonical Product Frame, Current Interface Shape, Graphify Grounding, `/listings`, Near-Term UX Moves, Open UX Questions, `/research`, `/research/:slug` (+3 more)
 
-### Community 244 - "LEGACY_EXPLORATORY_CONTACT_PATHWAY_DERIVATION_KEYS"
+### Community 244 - "ensure-server-build-fresh.mjs"
 Cohesion: 0.18
 Nodes (8): buildDir, buildEntrypoint, forbiddenBuildArtifacts, freshnessInputs, repoRoot, serverRoot, sourceFileExtensions, sourceMtimeMs
 
-### Community 245 - "firstSentence"
+### Community 245 - "corsOrigin.ts"
 Cohesion: 0.29
 Nodes (8): CorsOriginCallback, CorsOriginError, createCorsOriginHandler(), isAllowedCorsOrigin(), normalizeCorsOrigin(), allowedOrigins, HandlerResult, runOriginHandler()
 
-### Community 246 - "loadCandidateCollisions"
+### Community 246 - "sanitizeMongo.ts"
 Cohesion: 0.40
 Nodes (9): hasUnsafeMongoShape(), isPlainObject(), isUnsafeMongoKey(), PROTOTYPE_POLLUTION_KEYS, sanitizeMongo(), scrub(), invokeRejected(), invokeSanitize() (+1 more)
 
-### Community 247 - "entityMaterializer.test.ts"
+### Community 247 - "staleObservationConflictReview.test.ts"
 Cohesion: 0.25
 Nodes (8): assertStaleObservationConflictReviewApplyAllowed(), buildStaleObservationConflictReviewOutput(), buildStaleObservationDecisionTemplate(), main(), normalizeStaleObservationObjectId(), toObjectId(), writeStaleObservationConflictReviewOutput(), writeStaleObservationDecisionTemplate()
 
-### Community 248 - "backfillCenterDirectors.ts"
+### Community 248 - "Architecture"
 Cohesion: 0.18
 Nodes (10): Architecture, Commands, Environments, External integrations, Key services, Naming conventions, Repo map, Routes (+2 more)
 
-### Community 249 - "programClassifier.ts"
+### Community 249 - "listingFormReducer.ts"
 Cohesion: 0.31
 Nodes (7): createInitialListingFormState(), ListingFormAction, ListingFormErrors, listingFormReducer(), ListingFormState, researchAreasFromListing(), resolve()
 
-### Community 250 - "seed.ts"
+### Community 250 - "Scraper Deployment Runbook"
 Cohesion: 0.20
 Nodes (10): Compact Observation Retention, Cost Controls, Data Flow, Goal, Operating Model, Recurring Refresh, Report Checklist, Rollback (+2 more)
 
-### Community 251 - "index.ts"
+### Community 251 - "devDependencies"
 Cohesion: 0.20
 Nodes (10): devDependencies, eslint, eslint-config-prettier, eslint-plugin-react, eslint-plugin-react-hooks, globals, playwright, prettier (+2 more)
 
-### Community 252 - "seedResearchAreas.ts"
+### Community 252 - "resolutions"
 Cohesion: 0.20
 Nodes (10): resolutions, axios, brace-expansion, form-data, path-to-regexp, shell-quote, underscore, undici (+2 more)
 
-### Community 253 - "fellowships.tsx"
-Cohesion: 0.31
-Nodes (9): isPaperAuthorshipEvidence(), isPaperAuthorshipSource(), isPaperMetadataOnlySource(), normalizePaperAuthorshipEvidence(), PAPER_AUTHORSHIP_METHODS, PAPER_AUTHORSHIP_SOURCE_NAMES, PAPER_METADATA_ONLY_SOURCE_NAMES, PaperAuthorshipEvidence (+1 more)
+### Community 253 - "orcidWorksScraper.ts"
+Cohesion: 0.10
+Nodes (28): closeAll(), DEFAULT_EXCLUDED, flush(), main(), parseList(), isPaperAuthorshipEvidence(), isPaperAuthorshipSource(), isPaperMetadataOnlySource() (+20 more)
 
-### Community 254 - "securityHeaders.ts"
+### Community 254 - "importFaculty.ts"
 Cohesion: 0.31
 Nodes (9): cleanPrimaryDepartment(), cleanSecondaryDepartments(), hasPathPrefix(), importFaculty(), KNOWN_DEPARTMENTS, RawFacultyEntry, resolveSafeFacultyImportJsonPath(), SORTED_KNOWN_DEPTS (+1 more)
 
-### Community 255 - "dir"
-Cohesion: 0.38
-Nodes (7): buildLaunchAcquisitionReportOutput(), LaunchAcquisitionReportCliOptions, main(), parseLaunchAcquisitionReportArgs(), parsePositiveInteger(), writeLaunchAcquisitionReportOutput(), LaunchAcquisitionReportOptions
+### Community 255 - "launchAcquisitionReport.ts"
+Cohesion: 0.33
+Nodes (8): buildLaunchAcquisitionReportOutput(), LaunchAcquisitionReportCliOptions, main(), parseLaunchAcquisitionReportArgs(), parsePositiveInteger(), writeLaunchAcquisitionReportOutput(), LaunchAcquisitionReport, LaunchAcquisitionReportOptions
 
-### Community 256 - "leadMemberDisplayName"
-Cohesion: 0.31
-Nodes (8): cache, canonicalizeDepartment(), CanonicalizeResult, DepartmentRow, loadCache(), normalize(), registerDepartmentAlias(), tokenJaccard()
+### Community 256 - "Topic matching and search engagement"
+Cohesion: 0.50
+Nodes (3): Program topics, Search engagement, Topic matching and search engagement
 
-### Community 257 - "environment.ts"
+### Community 257 - "researchAreaResolver.ts"
 Cohesion: 0.31
 Nodes (8): cache, canonicalizeResearchArea(), CanonicalizeResult, loadCache(), normalize(), registerResearchAreaAlias(), ResearchAreaRow, tokenJaccard()
 
-### Community 258 - "sourceReviewDecisionHandoffs"
+### Community 258 - "EvidenceSourceRow.tsx"
 Cohesion: 0.39
 Nodes (7): EvidenceSourceRow(), EvidenceSourceRowProps, formatConfidence(), formatDate(), formatSourceType(), labelize(), EvidenceSourceRowData
 
-### Community 259 - "dependencies"
+### Community 259 - "buildCandidateSample"
 Cohesion: 0.22
 Nodes (9): buildCandidateSample(), buildReviewQueues(), compareObservationsByNewest(), formatOptionalDate(), observedAtMs(), previewValue(), reviewCategoryForField(), reviewQueueForCategory() (+1 more)
 
-### Community 260 - "sourceReviewDecisionValidationProbeCommands"
+### Community 260 - "buildStaleObservationConflictSummary"
 Cohesion: 0.22
 Nodes (9): buildCategoryCounts(), buildFieldCounts(), buildPolicyBucketCounts(), buildStaleObservationConflictSummary(), buildSupersessionPlan(), compareSamplesForReview(), matchesReviewFilters(), policyBucketForCategory() (+1 more)
 
-### Community 261 - "departmentGroundTruth.test.ts"
+### Community 261 - "testFixturePrivacy.test.ts"
 Cohesion: 0.31
 Nodes (8): localPartIsSynthetic(), REAL_FIXTURE_PATTERNS, ROOT, SELF, SOURCE_ROOTS, SYNTHETIC_YALE_TOKENS, testFiles(), walk()
 
-### Community 262 - "applyProfileResearchAreasForIndexDocument"
+### Community 262 - "manifest.json"
 Cohesion: 0.25
 Nodes (7): background_color, display, icons, name, short_name, start_url, theme_color
 
-### Community 263 - "csv"
+### Community 263 - "Available Scripts"
 Cohesion: 0.25
 Nodes (7): Available Scripts, Getting Started with Create React App, Learn More, `npm run build`, `npm run eject`, `npm start`, `npm test`
 
-### Community 264 - "entryToMemberObservations"
+### Community 264 - "departmentGroundTruth.test.ts"
 Cohesion: 0.32
 Nodes (6): DepartmentCategory, DepartmentCodeSystem, departmentSourceUrls, validateDepartmentRows(), __dirname, fixtureByUrl
 
-### Community 265 - "dir"
+### Community 265 - "package.json"
 Cohesion: 0.25
 Nodes (7): author, license, main, name, packageManager, repository, version
 
-### Community 266 - "repairListingResearchEntityProfiles.ts"
-Cohesion: 0.32
-Nodes (8): observation(), buildCandidateSample(), buildValuePreviewsBySource(), observedAtForResolver(), policyBucketForConflict(), previewValue(), reviewCategoryForField(), toResolverObservation()
+### Community 266 - "buildCandidateSample"
+Cohesion: 0.21
+Nodes (12): buildCandidateSample(), buildValuePreviewsBySource(), loadCrossSourceConflictGroups(), loadObservationsForGroupKey(), observationCollection(), observedAtForResolver(), policyBucketForConflict(), previewValue() (+4 more)
 
-### Community 267 - "CanonicalDepartmentListResult"
+### Community 267 - "itemOperations.ts"
 Cohesion: 0.46
 Nodes (5): addFavorite(), addView(), ItemMutationFilter, normalizeItemObjectId(), removeFavorite()
 
-### Community 268 - "ArtifactFreshnessStrip"
-Cohesion: 0.32
-Nodes (8): dedupeSameNameLeadMembers(), departmentMatchScore(), memberEvidenceScore(), normalizedMemberName(), normalizedWordsForMatch(), SAME_PERSON_LEAD_ROLE_PRIORITY, samePersonLeadRoleKey(), shouldCollapseSamePersonLeadRoles()
-
-### Community 269 - "MockBroadcastChannel"
+### Community 269 - "check-no-secrets-core.mjs"
 Cohesion: 0.43
 Nodes (5): findSecretFindings(), isAllowedPlaceholder(), lineNumberForIndex(), PLACEHOLDER_PATTERNS, SECRET_RULES
 
-### Community 270 - "Product Context"
+### Community 270 - "security-preflight.test.mjs"
 Cohesion: 0.29
 Nodes (6): ciWorkflow, keepAliveWorkflow, packageJson, productionSecuritySmokeWorkflow, renderBlueprint, yarnrc
 
-### Community 271 - "1. Admin And Search Gates"
+### Community 271 - "runStaleObservationConflictReview"
 Cohesion: 0.29
 Nodes (7): applyStaleObservationSupersessions(), buildMongoFieldFilter(), defaultStaleObservationApplyDeps(), loadSameSourceConflictGroups(), mongoFieldFilterForCategory(), runStaleObservationConflictReview(), stringifyId()
 
-### Community 272 - "apiBaseUrl.ts"
-Cohesion: 0.33
-Nodes (4): Filter, makeState(), Row, Sort
-
-### Community 274 - "sourceReviewDecisionValidationLines"
-Cohesion: 0.53
-Nodes (5): closeAll(), DEFAULT_EXCLUDED, flush(), main(), parseList()
-
-### Community 275 - "spreadsheetSafety.ts"
-Cohesion: 0.60
-Nodes (5): status(), blocked_reason(), fail(), is_blocked(), main()
-
-### Community 276 - "summary"
+### Community 276 - "parseStaleObservationConflictReviewArgs"
 Cohesion: 0.47
 Nodes (6): consumeValue(), parsePositiveIntegerValue(), parseRequiredString(), parseReviewCategory(), parseReviewQueue(), parseStaleObservationConflictReviewArgs()
 
-### Community 277 - "trustedLeadResearchHomeBioFallback"
+### Community 277 - "normalizeAcceptedDecisionValidation"
 Cohesion: 0.53
 Nodes (6): copyFiniteNumber(), normalizeAcceptedDecisionValidation(), normalizeDecisionHandoff(), normalizeDuplicateNamePreflight(), normalizeSamePiDedupeReview(), normalizeSamePiDedupeReviewBreakdown()
 
-### Community 278 - "README.md"
-Cohesion: 0.67
-Nodes (4): buildSafeSearchRegex(), escapeRegex(), normalizeRegexOptions(), SAFE_REGEX_OPTIONS
+### Community 278 - "researchAreas.ts"
+Cohesion: 0.17
+Nodes (9): hasDirectContactInfo(), router, invokeRouteHandler(), mocks, routesByPath(), buildSafeSearchRegex(), escapeRegex(), normalizeRegexOptions() (+1 more)
 
-### Community 279 - "paragraphs"
+### Community 279 - "Contributing: endpoints, pages, schema"
 Cohesion: 0.33
 Nodes (5): Adding a new endpoint, Adding a new page, Contributing: endpoints, pages, schema, General implementation rules, Modifying a schema
 
-### Community 280 - "opportunity.ts"
+### Community 280 - "Scrapers"
 Cohesion: 0.33
 Nodes (5): Active source scrapers (`server/src/scrapers/sources/`), Core rule: evidence-first, Infrastructure files, Safety rules (write guards), Scrapers
 
-### Community 281 - "README.md"
+### Community 281 - "Search and Data"
 Cohesion: 0.33
 Nodes (5): Data shape rules, Default `/research` ordering, Meilisearch indexes, Rebuild commands, Search and Data
 
-### Community 282 - "BackfillV4Grants.ts"
+### Community 282 - "checker.py"
 Cohesion: 0.60
 Nodes (4): load_env(), main(), normalize(), Lowercase, strip whitespace and punctuation for fuzzy matching.
 
-### Community 283 - "isLikelyPersonUrl"
+### Community 283 - "dependencies"
 Cohesion: 0.40
 Nodes (5): dependencies, concurrently, dotenv, mongoose, openai
 
-### Community 284 - "sanitizeMongo.ts"
-Cohesion: 0.70
-Nodes (5): asString(), asStringArray(), normalizeCrossSourceReviewDecision(), normalizeObservationIdsBySource(), optionalString()
-
-### Community 285 - "index.ts"
-Cohesion: 0.60
-Nodes (5): loadCrossSourceConflictGroups(), loadObservationsForGroupKey(), observationCollection(), serializeValue(), stringifyId()
-
-### Community 286 - "OfficialProfilePublicationValue"
+### Community 286 - "normalizeStaleObservationReviewDecision"
 Cohesion: 0.50
 Nodes (5): asString(), asStringArray(), normalizeStaleObservationReviewDecision(), optionalString(), readStaleObservationReviewDecisions()
 
-### Community 288 - ".run"
+### Community 288 - "with-playwright-libs.sh"
 Cohesion: 0.67
 Nodes (3): install_libs(), LD_LIBRARY_PATH, with-playwright-libs.sh script
 
-### Community 289 - "researchEntityRelationship.ts"
-Cohesion: 0.50
-Nodes (3): researchEntityRelationshipSchema, ResearchEntityRelationshipType, researchEntityRelationshipTypes
-
-### Community 290 - "corsOrigin.ts"
+### Community 290 - "validateStaleObservationReviewDecisions"
 Cohesion: 0.50
 Nodes (4): sameStringSet(), StaleObservationConflictObservation, validateStaleObservationReviewDecision(), validateStaleObservationReviewDecisions()
 
-### Community 300 - "testFixturePrivacy.test.ts"
-Cohesion: 0.67
-Nodes (3): asString(), asStringArray(), normalizeLoadedUser()
-
 ## Knowledge Gaps
-- **2205 isolated node(s):** `name`, `version`, `private`, `node`, `@emotion/react` (+2200 more)
+- **2208 isolated node(s):** `name`, `version`, `private`, `node`, `@emotion/react` (+2203 more)
   These have ≤1 connection - possible missing edges or undocumented components.
 - **38 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `sanitizeLogValue()` connect `security-preflight.test.mjs` to `labDetail.tsx`, `departmentRosterScraper.ts`, `labDetail.ts`, `researchGroupService.ts`, `UserContext.ts`, `index.ts`, `sanitizeLogValue`, `passport.ts`, `Navbar.tsx`, `undergradFellowshipRecipientScraper.ts`, `app.ts`, `admin.ts`, `researchDiscoveryAdapters.ts`, `advisees`, `launchAcquisitionReportService.ts`, `profileDataQualityAudit.ts`, `centersInstitutesScraper.ts`, `types.tsx`, `buildUserBioObservationScore`, `userService.ts`, `researchAnalytics.ts`, `betaDataQualityCore.ts`, `scripts`, `productionPromotionSmoke.mjs`, `opportunityDetailService.ts`, `staleObservationConflictReview.ts`, `betaDataQuality.ts`, `studentVisibilityTier.ts`, `listingController.ts`, `acceptedInputsCore.ts`, `serializedDocumentId`, `researchEntityEvidenceCoverage.ts`, `fellowshipMatchingService.ts`, `fellowshipInputs.ts`, `repairOfficialProfilePublicationPointers.ts`, `analytics.ts`, `SavedPathwaysSection.tsx`, `departmentUndergradResearchScraper.ts`, `pathwaySearchIndexService.ts`, `adminOperatorBoardService.ts`, `Listing`, `promoteAcceptedBetaCopy.ts`, `paperAuthorshipAudit.ts`, `Observation`, `devDependencies`, `Per-Source Audit Playbooks`, `assertPublicHttpUrl`, `studentDecisionLLMExtractor.ts`, `backfillProfileBiosFromOfficialUrls.ts`, `rebuildPathwaySearchIndex.ts`, `dedupeUsersByIdentityCore.ts`, `buildAdminOperatorBoard`, `analytics.tsx`, `officialProfilePiBackfillScraper.ts`, `pathwaySearchService.ts`, `renderedFetch.ts`, `BackfillV4FacultyMembers.ts`, `assessment`, `yaleCollegeFellowshipsOfficeScraper.ts`, `pathwayQualityAudit.ts`, `normalizeProfileUpdateForStorage`, `yaleResearchOfficialScraper.ts`, `fellowshipController.ts`, `ListingDetailModal.tsx`, `pathwayController.ts`, `dir`, `launchReviewExceptions.ts`, `adminRender`, `research-detail-professor-audit.mjs`, `ImportRootDataFiles.ts`, `candidateDescriptionCrawlUrls`, `applicationRoutePathwayBackfillCore.ts`, `generateKeywords.ts`, `profileBioCoverageAudit.ts`, `cli.ts`, `AdminFellowshipsTable.tsx`, `crossSourceObservationConflictReview.ts`, `migrateResearchEntities.ts`, `abstractBios`, `researchEntity.ts`, `migrateResearchEntityCollections.ts`, `researchGroupController.ts`, `externalIdsSchema`, `disambiguateSurnameLabNames.ts`, `repairDuplicateAccessSignals.ts`, `LIVE`, `normalizeOfficialProfileUrl`, `axios.ts`, `v4MigrationUtils.ts`, `researchEntityPiDedupeCore.ts`, `staleObservationConflictReview.test.ts`, `launchTrustContract.ts`, `EvidenceSourceRow.tsx`, `resolveSafeJsonReportOutputPath`, `users.ts`, `unified-research-search-audit.mjs`, `index.ts`, `AdminOperatorBoard`, `repairProfileDescriptionBackfillConflicts.ts`, `clearBetaStudentAnalytics.ts`, `actor`, `programs.ts`, `crossrefFreeFullText`, `sourceHealthService.ts`, `listings.ts`, `securityHeaders.ts`, `dir`?**
+- **Why does `sanitizeLogValue()` connect `sanitizeLogValue` to `ScraperContext`, `departmentRosterScraper.ts`, `labMicrositeUndergradLLMExtractor.ts`, `duplicateEntityNameReview.ts`, `listingController.ts`, `betaDataQuality.ts`, `auditProgramResearchRelevance.ts`, `dedupeResearchEntitiesByPi.ts`, `listingService.ts`, `profileDataQualityAudit.ts`, `researchQualitySearchReview.ts`, `passport.ts`, `labMicrositeDescriptionLLMExtractor.ts`, `sourceHealth.ts`, `analyticsService.ts`, `userService.ts`, `runReport.ts`, `User`, `scholarlyLinkSuppressionAudit.ts`, `admin.ts`, `officialProfilePiBackfillScraper.ts`, `yaleCollegeFellowshipsOfficeScraper.ts`, `paperAuthorshipAudit.ts`, `entryPathwayService.ts`, `applicationRoutePathwayBackfillCore.ts`, `backfillStudentVisibilityTiers.ts`, `entityMaterializer.ts`, `officialProfilePiBackfillScraper.test.ts`, `undergradFellowshipRecipientScraper.ts`, `crossSourceObservationConflictReview.ts`, `researchEntityMemberReferenceAudit.ts`, `seedSources.ts`, `repairOfficialProfilePublicationPointers.ts`, `configService.ts`, `backfillProfileBiosFromOfficialUrls.ts`, `departmentLeadRepairPlanCore.ts`, `scriptWriteGuards.ts`, `nihReporterScraper.ts`, `studentVisibilityRepairTargets.ts`, `redactDirectContactInfo`, `programController.ts`, `centersInstitutesScraper.ts`, `studentDecisionLLMExtractor.ts`, `dedupeUsersByIdentity.ts`, `researchEntityCoverageAudit.ts`, `renderedFetch.ts`, `analytics.ts`, `openAlexPaperScraper.ts`, `postedOpportunityService.ts`, `centerDirectorLLMExtractor.ts`, `launchTrustContractService.ts`, `pathwayQualityAudit.ts`, `promoteAcceptedBetaCopy.ts`, `profileController.ts`, `backfillCenterDirectors.ts`, `migrateResearchEntityCollections.ts`, `nsfAwardScraper.ts`, `migrateResearchEntities.ts`, `disambiguateSurnameLabNames.ts`, `repairDuplicateAccessSignals.ts`, `fellowshipController.ts`, `repairArchivedEntityArtifacts.ts`, `repairMismatchedPersonEmailsCore.ts`, `errorHandler.ts`, `cronRunner.ts`, `assertPublicHttpUrl`, `userEmailHygiene.ts`, `paperQualityService.ts`, `profileBioCoverageAudit.ts`, `logSanitizer.ts`, `staleObservationConflictReview.ts`, `researchGroupController.ts`, `cleanupLegacyMongoCollections.ts`, `launchReviewExceptions.ts`, `idSerialization.ts`, `migrateMongoNaming.ts`, `repairProfileDescriptionBackfillConflicts.ts`, `courseTableService.ts`, `betaSeedEnvironment.ts`, `betaReadinessGate.ts`, `auditResearchEntityRename.ts`, `resolveSafeJsonReportOutputPath`, `acceptedInputs.ts`, `scraperIntegrityDuplicateReview.ts`, `clearBetaStudentAnalytics.ts`, `auth.ts`, `profileImageQualityAudit.ts`, `rebuildPathwaySearchIndex.ts`, `seed.ts`, `backfillResearchDescriptions.ts`, `backfillResearchHomeOfficialUrls.ts`, `scraperIntegrityGate.ts`, `betaRepairQueue.ts`, `researchAccessTypes.ts`, `pathwayRelevanceReview.ts`, `users.ts`, `dedupeExploratoryContactPathways.ts`, `repairListingResearchEntityProfiles.ts`, `programs.ts`, `backfillProgramClassifications.ts`, `assertScriptApplyAllowed`, `listings.ts`, `refreshGateScorecards.ts`, `fellowships.ts`, `orcidWorksScraper.ts`, `importFaculty.ts`, `launchAcquisitionReport.ts`, `researchAreas.ts`?**
   _High betweenness centrality (0.128) - this node is a cross-community bridge._
-- **Why does `field()` connect `assertPublicHttpUrl` to `labDetail.tsx`, `sourceReviewDecisionValidationProbeCommands`, `labDetail.ts`, `applicationRoutePathwayBackfillCore.ts`, `types.ts`, `index.ts`, `integrityGate.ts`, `migrateResearchEntities.ts`, `researchDiscoveryAdapters.ts`, `researchQualitySearchReview.ts`, `advisees`, `profileDataQualityAudit.ts`, `centersInstitutesScraper.ts`, `buildUserBioObservationScore`, `userService.ts`, `normalizeOfficialProfileUrl`, `researchEntityCoverageAudit.ts`, `programController.ts`, `Active Detail Docs`, `scripts`, `staleObservationConflictReview.ts`, `AdminProfileEditModal.tsx`, `researchEntityEvidenceCoverage.ts`, `postedOpportunityService.ts`, `analytics.ts`, `acronymExpansion`, `dedupeUsersByIdentityCore.ts`, `BackfillV4FacultyMembers.ts`, `betaRepairQueue.ts`?**
-  _High betweenness centrality (0.080) - this node is a cross-community bridge._
-- **Why does `member()` connect `repairArchivedEntityArtifacts.ts` to `applyProfileResearchAreaFallback`, `backfillProfileBiosFromOfficialUrls.ts`, `EvidenceSourceRow.tsx`, `departmentRosterScraper.ts`, `AdminDepartments.tsx`, `ArtifactFreshnessStrip`, `researchEntitySearchIndexService.ts`, `accessMaterializer.ts`, `researchEntity.ts`, `crossSourceObservationConflictReview.ts`, `Yale Research - Developer Guide`, `app.ts`, `devDependencies`, `fellowshipController.ts`?**
-  _High betweenness centrality (0.076) - this node is a cross-community bridge._
+- **Why does `field()` connect `acceptedInputsCore.ts` to `ScraperContext`, `buildStaleObservationConflictSummary`, `labMicrositeUndergradLLMExtractor.ts`, `logSanitizer.ts`, `AdminProfileEditModal.tsx`, `betaDataQuality.ts`, `labMicrositeDescriptionLLMExtractor.ts`, `normalizePublicProfile`, `sourceHealth.ts`, `integrityGate.ts`, `analyticsService.ts`, `runReport.ts`, `User`, `scraperIntegrityDuplicateReview.ts`, `ImportRootDataFiles.ts`, `adminListingsTableReducer.ts`, `officialProfilePiBackfillScraper.ts`, `entryPathwayService.ts`, `AdminFacultyProfilesTable.tsx`, `entityMaterializer.ts`, `crossSourceObservationConflictReview.ts`, `fellowshipService.ts`, `adminFacultyProfilesTableReducer.ts`, `index.ts`, `dedupeUsersByIdentity.ts`, `openAlexPaperScraper.ts`, `promoteAcceptedBetaCopy.ts`, `visibilityRepairQueueService.ts`, `listingClaimRequestService.ts`, `orcidWorksScraper.ts`, `repairDuplicateAccessSignals.ts`?**
+  _High betweenness centrality (0.082) - this node is a cross-community bridge._
+- **Why does `member()` connect `visibilityRepairQueueService.ts` to `research-detail-professor-audit.mjs`, `departmentRosterScraper.ts`, `labDetail.ts`, `profileBioCoverageAudit.ts`, `labDetail.tsx`, `v4MigrationUtils.ts`, `studentVisibilityTier.ts`, `idSerialization.ts`, `researchEntitySearchIndexService.ts`, `researchGroupService.ts`, `researchQualitySearchReview.ts`, `centersInstitutesScraper.ts`, `disambiguateSurnameLabNames.ts`?**
+  _High betweenness centrality (0.075) - this node is a cross-community bridge._
 - **What connects `name`, `version`, `private` to the rest of the system?**
-  _2207 weakly-connected nodes found - possible documentation gaps or missing edges._
-- **Should `Decisions` be split into smaller, more focused modules?**
-  _Cohesion score 0.03947583947583948 - nodes in this community are weakly interconnected._
-- **Should `labDetail.tsx` be split into smaller, more focused modules?**
-  _Cohesion score 0.04728317659352142 - nodes in this community are weakly interconnected._
-- **Should `browsable.ts` be split into smaller, more focused modules?**
-  _Cohesion score 0.03753501400560224 - nodes in this community are weakly interconnected._
+  _2210 weakly-connected nodes found - possible documentation gaps or missing edges._
+- **Should `types.tsx` be split into smaller, more focused modules?**
+  _Cohesion score 0.06779661016949153 - nodes in this community are weakly interconnected._
+- **Should `ScraperContext` be split into smaller, more focused modules?**
+  _Cohesion score 0.08220211161387632 - nodes in this community are weakly interconnected._
+- **Should `UserContext.ts` be split into smaller, more focused modules?**
+  _Cohesion score 0.03815261044176707 - nodes in this community are weakly interconnected._

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,12 +1,12 @@
-# Graph Report - ylabs-fr8-fr11  (2026-07-10)
+# Graph Report - ylabs-fr5  (2026-07-10)
 
 ## Corpus Check
-- 849 files · ~1,320,846 words
+- 846 files · ~1,320,280 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8513 nodes · 21722 edges · 330 communities (292 shown, 38 thin omitted)
-- Extraction: 98% EXTRACTED · 2% INFERRED · 0% AMBIGUOUS · INFERRED: 480 edges (avg confidence: 0.63)
+- 8499 nodes · 21689 edges · 336 communities (298 shown, 38 thin omitted)
+- Extraction: 98% EXTRACTED · 2% INFERRED · 0% AMBIGUOUS · INFERRED: 479 edges (avg confidence: 0.63)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
@@ -16,7 +16,7 @@
 
 ## Community Hubs (Navigation)
 - [[_COMMUNITY_types.tsx|types.tsx]]
-- [[_COMMUNITY_ScraperContext|ScraperContext]]
+- [[_COMMUNITY_types.ts|types.ts]]
 - [[_COMMUNITY_UserContext.ts|UserContext.ts]]
 - [[_COMMUNITY_sanitizeLogValue|sanitizeLogValue]]
 - [[_COMMUNITY_departmentRosterScraper.ts|departmentRosterScraper.ts]]
@@ -30,10 +30,10 @@
 - [[_COMMUNITY_client|client]]
 - [[_COMMUNITY_duplicateEntityNameReview.ts|duplicateEntityNameReview.ts]]
 - [[_COMMUNITY_labDetail.tsx|labDetail.tsx]]
-- [[_COMMUNITY_v4MigrationUtils.ts|v4MigrationUtils.ts]]
+- [[_COMMUNITY_Observation|Observation]]
 - [[_COMMUNITY_listingController.ts|listingController.ts]]
 - [[_COMMUNITY_betaDataQuality.ts|betaDataQuality.ts]]
-- [[_COMMUNITY_auditProgramResearchRelevance.ts|auditProgramResearchRelevance.ts]]
+- [[_COMMUNITY_resolveSafeJsonReportOutputPath|resolveSafeJsonReportOutputPath]]
 - [[_COMMUNITY_acceptedInputsCore.ts|acceptedInputsCore.ts]]
 - [[_COMMUNITY_dedupeResearchEntitiesByPi.ts|dedupeResearchEntitiesByPi.ts]]
 - [[_COMMUNITY_listingService.ts|listingService.ts]]
@@ -56,7 +56,7 @@
 - [[_COMMUNITY_accessMaterializer.ts|accessMaterializer.ts]]
 - [[_COMMUNITY_User|User]]
 - [[_COMMUNITY_profileService.ts|profileService.ts]]
-- [[_COMMUNITY_labDetail.ts|labDetail.ts]]
+- [[_COMMUNITY_researchGroup.ts|researchGroup.ts]]
 - [[_COMMUNITY_SavedPathwaysSection.tsx|SavedPathwaysSection.tsx]]
 - [[_COMMUNITY_ImportRootDataFiles.ts|ImportRootDataFiles.ts]]
 - [[_COMMUNITY_scholarlyLinkSuppressionAudit.ts|scholarlyLinkSuppressionAudit.ts]]
@@ -69,13 +69,13 @@
 - [[_COMMUNITY_admin.ts|admin.ts]]
 - [[_COMMUNITY_officialProfilePiBackfillScraper.ts|officialProfilePiBackfillScraper.ts]]
 - [[_COMMUNITY_yaleCollegeFellowshipsOfficeScraper.ts|yaleCollegeFellowshipsOfficeScraper.ts]]
-- [[_COMMUNITY_fellowships.tsx|fellowships.tsx]]
+- [[_COMMUNITY_Navbar.tsx|Navbar.tsx]]
 - [[_COMMUNITY_pathwaySearchService.ts|pathwaySearchService.ts]]
 - [[_COMMUNITY_paperAuthorshipAudit.ts|paperAuthorshipAudit.ts]]
 - [[_COMMUNITY_entryPathwayService.ts|entryPathwayService.ts]]
-- [[_COMMUNITY_package.json|package.json]]
+- [[_COMMUNITY_devDependencies|devDependencies]]
 - [[_COMMUNITY_applicationRoutePathwayBackfillCore.ts|applicationRoutePathwayBackfillCore.ts]]
-- [[_COMMUNITY_backfillStudentVisibilityTiers.ts|backfillStudentVisibilityTiers.ts]]
+- [[_COMMUNITY_serializedDocumentId|serializedDocumentId]]
 - [[_COMMUNITY_entityMaterializer.ts|entityMaterializer.ts]]
 - [[_COMMUNITY_AdminOperatorBoard.tsx|AdminOperatorBoard.tsx]]
 - [[_COMMUNITY_researchEntity.ts|researchEntity.ts]]
@@ -89,7 +89,7 @@
 - [[_COMMUNITY_seedSources.ts|seedSources.ts]]
 - [[_COMMUNITY_repairOfficialProfilePublicationPointers.ts|repairOfficialProfilePublicationPointers.ts]]
 - [[_COMMUNITY_fellowshipService.ts|fellowshipService.ts]]
-- [[_COMMUNITY_researchGroup.ts|researchGroup.ts]]
+- [[_COMMUNITY_opportunityDetail.tsx|opportunityDetail.tsx]]
 - [[_COMMUNITY_index.ts|index.ts]]
 - [[_COMMUNITY_researchAnalytics.ts|researchAnalytics.ts]]
 - [[_COMMUNITY_analytics.tsx|analytics.tsx]]
@@ -98,45 +98,45 @@
 - [[_COMMUNITY_backfillProfileBiosFromOfficialUrls.ts|backfillProfileBiosFromOfficialUrls.ts]]
 - [[_COMMUNITY_departmentLeadRepairPlanCore.ts|departmentLeadRepairPlanCore.ts]]
 - [[_COMMUNITY_researchEntityEvidenceCoverage.ts|researchEntityEvidenceCoverage.ts]]
-- [[_COMMUNITY_scriptWriteGuards.ts|scriptWriteGuards.ts]]
-- [[_COMMUNITY_nihReporterScraper.ts|nihReporterScraper.ts]]
+- [[_COMMUNITY_cli.ts|cli.ts]]
+- [[_COMMUNITY_ScraperContext|ScraperContext]]
 - [[_COMMUNITY_studentVisibilityRepairTargets.ts|studentVisibilityRepairTargets.ts]]
 - [[_COMMUNITY_researchEntitySearchIndexService.ts|researchEntitySearchIndexService.ts]]
-- [[_COMMUNITY_redactDirectContactInfo|redactDirectContactInfo]]
+- [[_COMMUNITY_opportunityDetailService.ts|opportunityDetailService.ts]]
 - [[_COMMUNITY_programController.ts|programController.ts]]
 - [[_COMMUNITY_departmentUndergradResearchScraper.ts|departmentUndergradResearchScraper.ts]]
 - [[_COMMUNITY_centersInstitutesScraper.ts|centersInstitutesScraper.ts]]
 - [[_COMMUNITY_studentDecisionLLMExtractor.ts|studentDecisionLLMExtractor.ts]]
-- [[_COMMUNITY_dedupeUsersByIdentity.ts|dedupeUsersByIdentity.ts]]
+- [[_COMMUNITY_field|field]]
 - [[_COMMUNITY_researchEntityCoverageAudit.ts|researchEntityCoverageAudit.ts]]
 - [[_COMMUNITY_research.tsx|research.tsx]]
 - [[_COMMUNITY_isLikelyPersonUrl|isLikelyPersonUrl]]
 - [[_COMMUNITY_research-detail-professor-audit.mjs|research-detail-professor-audit.mjs]]
-- [[_COMMUNITY_renderedFetch.ts|renderedFetch.ts]]
+- [[_COMMUNITY_AdminAccessReview.tsx|AdminAccessReview.tsx]]
 - [[_COMMUNITY_analytics.ts|analytics.ts]]
 - [[_COMMUNITY_dedupeUsersByIdentityCore.ts|dedupeUsersByIdentityCore.ts]]
 - [[_COMMUNITY_openAlexPaperScraper.ts|openAlexPaperScraper.ts]]
 - [[_COMMUNITY_dependencies|dependencies]]
-- [[_COMMUNITY_getUniqueDepartmentLabels|getUniqueDepartmentLabels]]
+- [[_COMMUNITY_ProfileEditor.tsx|ProfileEditor.tsx]]
 - [[_COMMUNITY_apiBaseUrl.ts|apiBaseUrl.ts]]
 - [[_COMMUNITY_postedOpportunityService.ts|postedOpportunityService.ts]]
-- [[_COMMUNITY_ObservationInput|ObservationInput]]
-- [[_COMMUNITY_centerDirectorLLMExtractor.ts|centerDirectorLLMExtractor.ts]]
+- [[_COMMUNITY_assertPublicHttpUrl|assertPublicHttpUrl]]
+- [[_COMMUNITY_arxivPreprintScraper.ts|arxivPreprintScraper.ts]]
 - [[_COMMUNITY_launchTrustContractService.ts|launchTrustContractService.ts]]
 - [[_COMMUNITY_pathwayQualityAudit.ts|pathwayQualityAudit.ts]]
 - [[_COMMUNITY_promoteAcceptedBetaCopy.ts|promoteAcceptedBetaCopy.ts]]
-- [[_COMMUNITY_visibilityRepairQueueService.ts|visibilityRepairQueueService.ts]]
+- [[_COMMUNITY_textValue|textValue]]
 - [[_COMMUNITY_departmentGroundTruth.ts|departmentGroundTruth.ts]]
 - [[_COMMUNITY_app.ts|app.ts]]
 - [[_COMMUNITY_listingClaimRequestService.ts|listingClaimRequestService.ts]]
 - [[_COMMUNITY_profileController.ts|profileController.ts]]
-- [[_COMMUNITY_backfillCenterDirectors.ts|backfillCenterDirectors.ts]]
+- [[_COMMUNITY_logSanitizer.ts|logSanitizer.ts]]
 - [[_COMMUNITY_adminAccessReviewService.ts|adminAccessReviewService.ts]]
 - [[_COMMUNITY_migrateResearchEntityCollections.ts|migrateResearchEntityCollections.ts]]
 - [[_COMMUNITY_scholarlyLinkToPublicLink|scholarlyLinkToPublicLink]]
 - [[_COMMUNITY_UserContextProvider.tsx|UserContextProvider.tsx]]
-- [[_COMMUNITY_profile.tsx|profile.tsx]]
-- [[_COMMUNITY_nsfAwardScraper.ts|nsfAwardScraper.ts]]
+- [[_COMMUNITY_safeRouteSegment|safeRouteSegment]]
+- [[_COMMUNITY_betaDataQualityCore.test.ts|betaDataQualityCore.test.ts]]
 - [[_COMMUNITY_migrateResearchEntities.ts|migrateResearchEntities.ts]]
 - [[_COMMUNITY_buildAdminOperatorBoard|buildAdminOperatorBoard]]
 - [[_COMMUNITY_axios.ts|axios.ts]]
@@ -149,16 +149,16 @@
 - [[_COMMUNITY_repairMismatchedPersonEmailsCore.ts|repairMismatchedPersonEmailsCore.ts]]
 - [[_COMMUNITY_errorHandler.ts|errorHandler.ts]]
 - [[_COMMUNITY_researchEntityPiDedupeCore.ts|researchEntityPiDedupeCore.ts]]
-- [[_COMMUNITY_isPublicHttpUrl|isPublicHttpUrl]]
+- [[_COMMUNITY_listingResearchEntityProfile.ts|listingResearchEntityProfile.ts]]
 - [[_COMMUNITY_researchEntityQuality.ts|researchEntityQuality.ts]]
 - [[_COMMUNITY_cronRunner.ts|cronRunner.ts]]
-- [[_COMMUNITY_assertPublicHttpUrl|assertPublicHttpUrl]]
+- [[_COMMUNITY_entityMaterializer.test.ts|entityMaterializer.test.ts]]
 - [[_COMMUNITY_userEmailHygiene.ts|userEmailHygiene.ts]]
 - [[_COMMUNITY_paperQualityService.ts|paperQualityService.ts]]
 - [[_COMMUNITY_profileBioCoverageAudit.ts|profileBioCoverageAudit.ts]]
-- [[_COMMUNITY_logSanitizer.ts|logSanitizer.ts]]
+- [[_COMMUNITY_initializeConnections|initializeConnections]]
 - [[_COMMUNITY_staleObservationConflictReview.ts|staleObservationConflictReview.ts]]
-- [[_COMMUNITY_betaDataQualityCore.test.ts|betaDataQualityCore.test.ts]]
+- [[_COMMUNITY_visibilityRepairQueueService.test.ts|visibilityRepairQueueService.test.ts]]
 - [[_COMMUNITY_AdminProfileEditModal.tsx|AdminProfileEditModal.tsx]]
 - [[_COMMUNITY_seedDepartments.ts|seedDepartments.ts]]
 - [[_COMMUNITY_unified-research-search-audit.mjs|unified-research-search-audit.mjs]]
@@ -166,28 +166,28 @@
 - [[_COMMUNITY_yaleResearchOfficialScraper.ts|yaleResearchOfficialScraper.ts]]
 - [[_COMMUNITY_cleanupLegacyMongoCollections.ts|cleanupLegacyMongoCollections.ts]]
 - [[_COMMUNITY_launchReviewExceptions.ts|launchReviewExceptions.ts]]
-- [[_COMMUNITY_Observation|Observation]]
-- [[_COMMUNITY_idSerialization.ts|idSerialization.ts]]
-- [[_COMMUNITY_isNonBiographicalPublicBio|isNonBiographicalPublicBio]]
+- [[_COMMUNITY_profile.tsx|profile.tsx]]
+- [[_COMMUNITY_ResearchGroupMember|ResearchGroupMember]]
+- [[_COMMUNITY_materializePaperObservationsFromRun|materializePaperObservationsFromRun]]
 - [[_COMMUNITY_Yale Research - Developer Guide|Yale Research - Developer Guide]]
 - [[_COMMUNITY_migrateMongoNaming.ts|migrateMongoNaming.ts]]
 - [[_COMMUNITY_repairProfileDescriptionBackfillConflicts.ts|repairProfileDescriptionBackfillConflicts.ts]]
-- [[_COMMUNITY_normalizePublicProfile|normalizePublicProfile]]
+- [[_COMMUNITY_cleanPublicHttpUrl|cleanPublicHttpUrl]]
 - [[_COMMUNITY_migrateSmartTitles.ts|migrateSmartTitles.ts]]
-- [[_COMMUNITY_courseTableService.ts|courseTableService.ts]]
+- [[_COMMUNITY_redactDirectContactInfo|redactDirectContactInfo]]
 - [[_COMMUNITY_betaSeedEnvironment.ts|betaSeedEnvironment.ts]]
 - [[_COMMUNITY_agent-workflow|agent-workflow.md]]
 - [[_COMMUNITY_betaReadinessGate.ts|betaReadinessGate.ts]]
-- [[_COMMUNITY_source.ts|source.ts]]
+- [[_COMMUNITY_textValue|textValue]]
 - [[_COMMUNITY_auditResearchEntityRename.ts|auditResearchEntityRename.ts]]
-- [[_COMMUNITY_resolveSafeJsonReportOutputPath|resolveSafeJsonReportOutputPath]]
+- [[_COMMUNITY_backfillPostedOpportunitiesFromListings.ts|backfillPostedOpportunitiesFromListings.ts]]
 - [[_COMMUNITY_Session Notes|Session Notes]]
 - [[_COMMUNITY_devDependencies|devDependencies]]
 - [[_COMMUNITY_acceptedInputs.ts|acceptedInputs.ts]]
-- [[_COMMUNITY_accessClaims.ts|accessClaims.ts]]
+- [[_COMMUNITY_claimGate.ts|claimGate.ts]]
 - [[_COMMUNITY_scraperIntegrityDuplicateReview.ts|scraperIntegrityDuplicateReview.ts]]
 - [[_COMMUNITY_clearBetaStudentAnalytics.ts|clearBetaStudentAnalytics.ts]]
-- [[_COMMUNITY_ResearchAreaInput.tsx|ResearchAreaInput.tsx]]
+- [[_COMMUNITY_visibilityRepairQueueService.ts|visibilityRepairQueueService.ts]]
 - [[_COMMUNITY_Yale Research|Yale Research]]
 - [[_COMMUNITY_adminListingsTableReducer.ts|adminListingsTableReducer.ts]]
 - [[_COMMUNITY_compilerOptions|compilerOptions]]
@@ -195,67 +195,67 @@
 - [[_COMMUNITY_Decisions|Decisions]]
 - [[_COMMUNITY_Research Data Pipeline|Research Data Pipeline]]
 - [[_COMMUNITY_Research Model|Research Model]]
-- [[_COMMUNITY_auth.ts|auth.ts]]
+- [[_COMMUNITY_index.ts|index.ts]]
 - [[_COMMUNITY_adminGrantService.ts|adminGrantService.ts]]
-- [[_COMMUNITY_profileImageQualityAudit.ts|profileImageQualityAudit.ts]]
-- [[_COMMUNITY_rebuildPathwaySearchIndex.ts|rebuildPathwaySearchIndex.ts]]
-- [[_COMMUNITY_researchDetailSources.ts|researchDetailSources.ts]]
-- [[_COMMUNITY_AdminListingEditModal.tsx|AdminListingEditModal.tsx]]
+- [[_COMMUNITY_profileImageQualityAuditCore.ts|profileImageQualityAuditCore.ts]]
+- [[_COMMUNITY_assertScriptApplyAllowed|assertScriptApplyAllowed]]
+- [[_COMMUNITY_updateOwnProfile|updateOwnProfile]]
+- [[_COMMUNITY_studentDecisionExplanationService.ts|studentDecisionExplanationService.ts]]
 - [[_COMMUNITY_compilerOptions|compilerOptions]]
 - [[_COMMUNITY_AdminFacultyProfilesTable.tsx|AdminFacultyProfilesTable.tsx]]
 - [[_COMMUNITY_generateKeywords.ts|generateKeywords.ts]]
 - [[_COMMUNITY_Per-Source Audit Playbooks|Per-Source Audit Playbooks]]
-- [[_COMMUNITY_PublicationsTable.tsx|PublicationsTable.tsx]]
-- [[_COMMUNITY_seed.ts|seed.ts]]
+- [[_COMMUNITY_fellowship.ts|fellowship.ts]]
+- [[_COMMUNITY_materializeEntity|materializeEntity]]
 - [[_COMMUNITY_backfillResearchDescriptions.ts|backfillResearchDescriptions.ts]]
 - [[_COMMUNITY_backfillResearchHomeOfficialUrls.ts|backfillResearchHomeOfficialUrls.ts]]
-- [[_COMMUNITY_scraperIntegrityGate.ts|scraperIntegrityGate.ts]]
+- [[_COMMUNITY_smartTitle.ts|smartTitle.ts]]
 - [[_COMMUNITY_researchEntityDto.ts|researchEntityDto.ts]]
-- [[_COMMUNITY_serializedDocumentId|serializedDocumentId]]
-- [[_COMMUNITY_normalizeName|normalizeName]]
+- [[_COMMUNITY_backfillCenterDirectors.ts|backfillCenterDirectors.ts]]
+- [[_COMMUNITY_normalizeOfficialProfileUrl|normalizeOfficialProfileUrl]]
 - [[_COMMUNITY_betaRepairQueue.ts|betaRepairQueue.ts]]
-- [[_COMMUNITY_researchAccessTypes.ts|researchAccessTypes.ts]]
+- [[_COMMUNITY_sanitizeProfileResearchTerms|sanitizeProfileResearchTerms]]
 - [[_COMMUNITY_pathwayRelevanceReview.ts|pathwayRelevanceReview.ts]]
 - [[_COMMUNITY_accessSummaryService.ts|accessSummaryService.ts]]
 - [[_COMMUNITY_sourceHealthService.ts|sourceHealthService.ts]]
-- [[_COMMUNITY_adminFacultyProfilesTableReducer.ts|adminFacultyProfilesTableReducer.ts]]
+- [[_COMMUNITY_adminFellowshipsTableReducer.ts|adminFellowshipsTableReducer.ts]]
 - [[_COMMUNITY_resolutions|resolutions]]
 - [[_COMMUNITY_publicResearchSeo.ts|publicResearchSeo.ts]]
-- [[_COMMUNITY_devDependencies|devDependencies]]
+- [[_COMMUNITY_researchEntity.ts|researchEntity.ts]]
 - [[_COMMUNITY_visibilityReleaseQueueItem.ts|visibilityReleaseQueueItem.ts]]
 - [[_COMMUNITY_users.ts|users.ts]]
-- [[_COMMUNITY_fellowshipApplicationCycleEvidenceService.ts|fellowshipApplicationCycleEvidenceService.ts]]
+- [[_COMMUNITY_extractOfficialProfileResearchHomes|extractOfficialProfileResearchHomes]]
 - [[_COMMUNITY_dependencies|dependencies]]
 - [[_COMMUNITY_dedupeExploratoryContactPathways.ts|dedupeExploratoryContactPathways.ts]]
 - [[_COMMUNITY_repairListingResearchEntityProfiles.ts|repairListingResearchEntityProfiles.ts]]
-- [[_COMMUNITY_resolutions|resolutions]]
-- [[_COMMUNITY_longText.ts|longText.ts]]
-- [[_COMMUNITY_csrfOriginGuard.ts|csrfOriginGuard.ts]]
+- [[_COMMUNITY_scraperIntegrityGate.ts|scraperIntegrityGate.ts]]
+- [[_COMMUNITY_isPublicHttpUrl|isPublicHttpUrl]]
+- [[_COMMUNITY_MigrateDepartments.ts|MigrateDepartments.ts]]
 - [[_COMMUNITY_compilerOptions|compilerOptions]]
 - [[_COMMUNITY_Environment Progression|Environment Progression]]
 - [[_COMMUNITY_ScrapeRun|ScrapeRun]]
 - [[_COMMUNITY_programs.ts|programs.ts]]
-- [[_COMMUNITY_backfillProgramClassifications.ts|backfillProgramClassifications.ts]]
-- [[_COMMUNITY_package.json|package.json]]
-- [[_COMMUNITY_classifyDuplicateEntityCluster|classifyDuplicateEntityCluster]]
+- [[_COMMUNITY_csrfOriginGuard.ts|csrfOriginGuard.ts]]
+- [[_COMMUNITY_main|main]]
+- [[_COMMUNITY_AdminFellowshipsTable.tsx|AdminFellowshipsTable.tsx]]
 - [[_COMMUNITY_seo.ts|seo.ts]]
 - [[_COMMUNITY_BackfillV4StudentProfiles.ts|BackfillV4StudentProfiles.ts]]
-- [[_COMMUNITY_assertScriptApplyAllowed|assertScriptApplyAllowed]]
+- [[_COMMUNITY_backfillProgramClassifications.ts|backfillProgramClassifications.ts]]
 - [[_COMMUNITY_Graphify repo memory|Graphify repo memory]]
 - [[_COMMUNITY_securityHeaders.ts|securityHeaders.ts]]
-- [[_COMMUNITY_ssrfGuard.ts|ssrfGuard.ts]]
+- [[_COMMUNITY_package.json|package.json]]
 - [[_COMMUNITY_listings.ts|listings.ts]]
 - [[_COMMUNITY_confidenceResolver.ts|confidenceResolver.ts]]
-- [[_COMMUNITY_refreshGateScorecards.ts|refreshGateScorecards.ts]]
+- [[_COMMUNITY_OfficialProfilePublicationValue|OfficialProfilePublicationValue]]
 - [[_COMMUNITY_AdminOperatorBoard|AdminOperatorBoard]]
-- [[_COMMUNITY_scripts|scripts]]
+- [[_COMMUNITY_labDetail.ts|labDetail.ts]]
 - [[_COMMUNITY_BackfillV4FacultyMembers.ts|BackfillV4FacultyMembers.ts]]
-- [[_COMMUNITY_useFavorites.ts|useFavorites.ts]]
+- [[_COMMUNITY_refreshGateScorecards.ts|refreshGateScorecards.ts]]
 - [[_COMMUNITY_fellowships.ts|fellowships.ts]]
 - [[_COMMUNITY_Auth and Security|Auth and Security]]
 - [[_COMMUNITY_Yale Research Product Context|Yale Research Product Context]]
-- [[_COMMUNITY_AdminFellowshipsTable.tsx|AdminFellowshipsTable.tsx]]
-- [[_COMMUNITY_ScraperMetrics|ScraperMetrics]]
+- [[_COMMUNITY_adminFellowshipFormReducer.ts|adminFellowshipFormReducer.ts]]
+- [[_COMMUNITY_MigrateUsers.ts|MigrateUsers.ts]]
 - [[_COMMUNITY_Local Development Setup|Local Development Setup]]
 - [[_COMMUNITY_Product Context|Product Context]]
 - [[_COMMUNITY_UIUX Direction|UI/UX Direction]]
@@ -268,10 +268,10 @@
 - [[_COMMUNITY_Scraper Deployment Runbook|Scraper Deployment Runbook]]
 - [[_COMMUNITY_devDependencies|devDependencies]]
 - [[_COMMUNITY_resolutions|resolutions]]
-- [[_COMMUNITY_orcidWorksScraper.ts|orcidWorksScraper.ts]]
+- [[_COMMUNITY_paperAuthorshipPolicy.ts|paperAuthorshipPolicy.ts]]
 - [[_COMMUNITY_importFaculty.ts|importFaculty.ts]]
 - [[_COMMUNITY_launchAcquisitionReport.ts|launchAcquisitionReport.ts]]
-- [[_COMMUNITY_Topic matching and search engagement|Topic matching and search engagement]]
+- [[_COMMUNITY_departmentResolver.ts|departmentResolver.ts]]
 - [[_COMMUNITY_researchAreaResolver.ts|researchAreaResolver.ts]]
 - [[_COMMUNITY_EvidenceSourceRow.tsx|EvidenceSourceRow.tsx]]
 - [[_COMMUNITY_buildCandidateSample|buildCandidateSample]]
@@ -281,12 +281,16 @@
 - [[_COMMUNITY_Available Scripts|Available Scripts]]
 - [[_COMMUNITY_departmentGroundTruth.test.ts|departmentGroundTruth.test.ts]]
 - [[_COMMUNITY_package.json|package.json]]
-- [[_COMMUNITY_buildCandidateSample|buildCandidateSample]]
-- [[_COMMUNITY_itemOperations.ts|itemOperations.ts]]
+- [[_COMMUNITY_observation|observation]]
+- [[_COMMUNITY_researchGroupFilters.ts|researchGroupFilters.ts]]
+- [[_COMMUNITY_useFavorites.ts|useFavorites.ts]]
 - [[_COMMUNITY_check-no-secrets-core.mjs|check-no-secrets-core.mjs]]
 - [[_COMMUNITY_security-preflight.test.mjs|security-preflight.test.mjs]]
-- [[_COMMUNITY_runStaleObservationConflictReview|runStaleObservationConflictReview]]
+- [[_COMMUNITY_contactEmail.ts|contactEmail.ts]]
+- [[_COMMUNITY_adminTableReducer.test.ts|adminTableReducer.test.ts]]
 - [[_COMMUNITY_MockBroadcastChannel|MockBroadcastChannel]]
+- [[_COMMUNITY_copyBetaToProd.ts|copyBetaToProd.ts]]
+- [[_COMMUNITY_main|main]]
 - [[_COMMUNITY_parseStaleObservationConflictReviewArgs|parseStaleObservationConflictReviewArgs]]
 - [[_COMMUNITY_normalizeAcceptedDecisionValidation|normalizeAcceptedDecisionValidation]]
 - [[_COMMUNITY_researchAreas.ts|researchAreas.ts]]
@@ -295,9 +299,11 @@
 - [[_COMMUNITY_Search and Data|Search and Data]]
 - [[_COMMUNITY_checker.py|checker.py]]
 - [[_COMMUNITY_dependencies|dependencies]]
+- [[_COMMUNITY_normalizeCrossSourceReviewDecision|normalizeCrossSourceReviewDecision]]
+- [[_COMMUNITY_loadCrossSourceConflictGroups|loadCrossSourceConflictGroups]]
 - [[_COMMUNITY_normalizeStaleObservationReviewDecision|normalizeStaleObservationReviewDecision]]
 - [[_COMMUNITY_with-playwright-libs.sh|with-playwright-libs.sh]]
-- [[_COMMUNITY_validateStaleObservationReviewDecisions|validateStaleObservationReviewDecisions]]
+- [[_COMMUNITY_runStaleObservationConflictReview|runStaleObservationConflictReview]]
 - [[_COMMUNITY_dataMigrationPackageScripts.test.ts|dataMigrationPackageScripts.test.ts]]
 - [[_COMMUNITY_dataMigrationV4GrantBackfill.test.ts|dataMigrationV4GrantBackfill.test.ts]]
 - [[_COMMUNITY_departmentMigrationCliSafety.test.ts|departmentMigrationCliSafety.test.ts]]
@@ -363,95 +369,95 @@
 ## Import Cycles
 - None detected.
 
-## Communities (330 total, 38 thin omitted)
+## Communities (336 total, 38 thin omitted)
 
 ### Community 0 - "types.tsx"
-Cohesion: 0.07
-Nodes (36): AdminFellowshipEditModal(), Props, fellowship, renderModal(), COLUMNS, FellowshipKanbanBoardProps, defaultFellowshipSearchContext, FellowshipSearchContextType (+28 more)
+Cohesion: 0.05
+Nodes (49): AdminFellowshipEditModal(), Props, fellowship, renderModal(), sortOptions, defaultFellowshipSearchContext, FellowshipSearchContextType, dateValue() (+41 more)
 
-### Community 1 - "ScraperContext"
-Cohesion: 0.08
-Nodes (28): ScraperOrchestrator, CrossrefFetcher, CrossrefMessage, crossrefMessageToObservations(), CrossrefPaperScraper, CrossrefPaperScraperOptions, dateFromParts(), normalizeDoi() (+20 more)
+### Community 1 - "types.ts"
+Cohesion: 0.05
+Nodes (53): ScrapeSnapshot, scrapeSnapshotSchema, ScraperOrchestrator, getCached(), invalidateCache(), CrossrefFetcher, CrossrefMessage, crossrefMessageToObservations() (+45 more)
 
 ### Community 2 - "UserContext.ts"
 Cohesion: 0.04
-Nodes (55): baseProfile, renderProfileHeader(), fellowship, item, renderAdmin(), listing, renderModal(), listing (+47 more)
+Nodes (53): baseProfile, renderProfileHeader(), fellowship, item, renderAdmin(), listing, renderModal(), listing (+45 more)
 
 ### Community 3 - "sanitizeLogValue"
-Cohesion: 0.11
-Nodes (52): mocks, privateProgram, addFavFellowships(), addFavListings(), addFavPathways(), addSavedPrograms(), addSavedResearchPlans(), ALLOWED_SELF_USER_TYPES (+44 more)
+Cohesion: 0.09
+Nodes (74): mocks, privateProgram, addFavFellowships(), addFavListings(), addFavPathways(), addSavedPrograms(), addSavedResearchPlans(), ALLOWED_SELF_USER_TYPES (+66 more)
 
 ### Community 4 - "departmentRosterScraper.ts"
 Cohesion: 0.09
-Nodes (59): summarizeFetchMetrics, absolutize(), canonicalProfileUrlFromHtml(), cleanProfileSectionText(), cleanText(), csFacultyDataExtractor(), csJsRenderedStub(), csRenderedExtractor() (+51 more)
+Nodes (60): absolutize(), canonicalProfileUrlFromHtml(), cleanProfileSectionText(), cleanText(), csFacultyDataExtractor(), csJsRenderedStub(), csRenderedExtractor(), decodeHtmlEntities() (+52 more)
 
 ### Community 5 - "labMicrositeUndergradLLMExtractor.ts"
-Cohesion: 0.09
-Nodes (38): RenderedFetcher, buildLLMPrompt(), CallLLMFn, candidateCrawlUrls(), CandidateLab, candidateLabFromResearchEntityDoc(), candidateSubPageUrls(), cleanResearchSummary() (+30 more)
+Cohesion: 0.05
+Nodes (68): average(), boundedRenderedFetchTimeout(), buildFetchAttemptMetrics(), createScraplingRenderedFetcher(), currentMemoryBytes(), DEFAULT_BRIDGE_PATH, defaultRenderedSeedRedirectCheck(), execFileAsync (+60 more)
 
 ### Community 6 - "scripts"
 Cohesion: 0.03
 Nodes (75): scripts, accepted-inputs, access-signals:repair-duplicates, application-routes:backfill-pathways, beta:clear-student-analytics, beta:data-quality, beta:readiness, beta:repair-queue (+67 more)
 
 ### Community 7 - "researchEntityDescriptionQuality.ts"
-Cohesion: 0.06
-Nodes (89): actionSet, cleanHttpUrl(), cleanText(), containsDirectEmail(), hasActivePostedOpportunity(), hasPublicOfficialApplicationRoute(), hasPublicRoute(), hasUndergraduateAccessEvidence() (+81 more)
+Cohesion: 0.08
+Nodes (71): activeAreasOfResearchSummary(), assessResearchEntityDescriptionQuality(), deriveShortDescriptionFromFullDescription(), DescriptionQualityFlag, FieldQuality, fullDescriptionQuality(), hasBrokenTemplate(), hasDuplicatedLongFragment() (+63 more)
 
 ### Community 8 - "App.tsx"
 Cohesion: 0.05
-Nodes (37): PlanningOverview(), PlanningOverviewProps, pluralize(), scrollPositions, ScrollToTop(), normalizeReturnPath(), SignInButton(), SignInButtonProps (+29 more)
+Nodes (35): PlanningOverview(), PlanningOverviewProps, pluralize(), scrollPositions, ScrollToTop(), normalizeReturnPath(), SignInButton(), SignInButtonProps (+27 more)
 
 ### Community 9 - "safeHttpUrl"
-Cohesion: 0.07
-Nodes (47): AccessReviewCounts, AccessReviewDetail, AccessReviewEntitySummary, AccessSignal, AdminAccessReview(), ContactRoute, EntryPathway, evidenceIds() (+39 more)
+Cohesion: 0.06
+Nodes (54): SourceLinks(), DeveloperCard(), DeveloperCardProps, FellowshipModal(), FellowshipModalProps, RichText(), trackFellowshipApplyClick(), LabInquireModal() (+46 more)
 
 ### Community 10 - "researchDiscoveryAdapters.ts"
-Cohesion: 0.06
-Nodes (65): directoryFirstNextStep(), directoryFirstPathwayLabel(), formatDate(), PathwayActionCard(), PathwayActionCardProps, emptyGroupedResults(), PathwayActionability, PathwayBestNextStepCategory (+57 more)
+Cohesion: 0.07
+Nodes (55): directoryFirstNextStep(), directoryFirstPathwayLabel(), formatDate(), PathwayActionCard(), buildCompleteContextSummary(), buildGroupedSearchResults(), buildIdentityConfidenceRecords(), buildPathwayEvidenceRows() (+47 more)
 
 ### Community 11 - "index.ts"
-Cohesion: 0.07
-Nodes (35): FacultyMember, facultyMemberSchema, Grant, grantSchema, fieldProvenanceSchema, opennessSignalSchema, Paper, paperSchema (+27 more)
+Cohesion: 0.06
+Nodes (44): AccessSignal, accessSignalSchema, ContactRoute, contactRouteSchema, categoryColorKeys, Department, DepartmentCodeSystem, departmentSchema (+36 more)
 
 ### Community 12 - "client"
 Cohesion: 0.06
-Nodes (56): csvCell(), dateFormatter, deadlineEndOfUtcDay(), FavoritesManager(), FavoritesManagerProps, fellowshipToBrowsable(), savedProgramDeadlineSummary(), validDeadlineDate() (+48 more)
+Nodes (58): csvCell(), dateFormatter, deadlineEndOfUtcDay(), FavoritesManager(), FavoritesManagerProps, fellowshipToBrowsable(), savedProgramDeadlineSummary(), validDeadlineDate() (+50 more)
 
 ### Community 13 - "duplicateEntityNameReview.ts"
 Cohesion: 0.06
-Nodes (66): DuplicateEntityReviewCategory, DuplicateEntityReviewEntity, DuplicateEntityReviewSummary, applyResearchEntityDedupeGroupsSequentially, ACTIVE_FILTER, assertDuplicateEntityNameReviewApplyAllowed(), asString(), asStringArray() (+58 more)
+Nodes (67): DuplicateEntityReviewCategory, DuplicateEntityReviewEntity, DuplicateEntityReviewSummary, applyResearchEntityDedupeGroupsSequentially, ResearchEntityDedupeMergeGroup, ACTIVE_FILTER, assertDuplicateEntityNameReviewApplyAllowed(), asString() (+59 more)
 
 ### Community 14 - "labDetail.tsx"
 Cohesion: 0.06
-Nodes (63): copy, FirstSaveCallout(), FirstSaveCalloutProps, adminQualityNotes(), AffiliatedResearchEntitiesSection(), compactDepartmentLabels(), decisionNextStep(), DecisionSummary() (+55 more)
+Nodes (66): copy, FirstSaveCallout(), FirstSaveCalloutProps, adminQualityNotes(), AffiliatedResearchEntitiesSection(), compactDepartmentLabels(), decisionNextStep(), DecisionSummary() (+58 more)
 
-### Community 15 - "v4MigrationUtils.ts"
-Cohesion: 0.12
-Nodes (31): backfillV4Grants(), buildV4GrantBackfillOutput(), __dirname, __filename, normalizeAgency(), V4GrantBackfillResult, writeV4GrantBackfillOutput(), backfillV4PaperGraph() (+23 more)
+### Community 15 - "Observation"
+Cohesion: 0.07
+Nodes (53): backfillV4Grants(), buildV4GrantBackfillOutput(), __dirname, __filename, normalizeAgency(), V4GrantBackfillResult, writeV4GrantBackfillOutput(), backfillV4PaperGraph() (+45 more)
 
 ### Community 16 - "listingController.ts"
 Cohesion: 0.07
-Nodes (56): addViewToListing(), archiveListingForCurrentUser(), boundedListingSearchQuery(), buildListingOutreachEvent(), buildMongoFilterMatch(), buildRobustFilterMatch(), createListingForCurrentUser(), deleteListingForCurrentUser() (+48 more)
+Nodes (58): addViewToListing(), archiveListingForCurrentUser(), boundedListingSearchQuery(), buildListingOutreachEvent(), buildMongoFilterMatch(), buildRobustFilterMatch(), createListingForCurrentUser(), escapeMeiliFilterValue() (+50 more)
 
 ### Community 17 - "betaDataQuality.ts"
-Cohesion: 0.10
-Nodes (44): ACTIVE_FILTER, asString(), asStringArray(), buildBetaDataQualityScorecard(), buildCollectionCounts(), buildDescriptionQuality(), buildDuplicateEntityNames(), buildLiveLinkCheck() (+36 more)
+Cohesion: 0.09
+Nodes (50): ACTIVE_FILTER, asString(), asStringArray(), buildCollectionCounts(), buildDescriptionQuality(), buildDuplicateEntityNames(), buildEmailHygiene(), buildOpportunityState() (+42 more)
 
-### Community 18 - "auditProgramResearchRelevance.ts"
-Cohesion: 0.15
-Nodes (22): CliOptions, main(), parseArgs(), assertStudentVisibilityGateApplyConfirmed(), buildStudentVisibilityGateOutput(), main(), parsePositiveInteger(), parseStudentVisibilityGateArgs() (+14 more)
+### Community 18 - "resolveSafeJsonReportOutputPath"
+Cohesion: 0.19
+Nodes (20): CliOptions, main(), parseArgs(), BackfillEntry, CliOptions, DEFAULT_INPUT, isCommunityForcePortal(), isHttpUrl() (+12 more)
 
 ### Community 19 - "acceptedInputsCore.ts"
 Cohesion: 0.07
-Nodes (63): AcceptedInputIssue, AcceptedInputUser, applyOrcidCrosswalkCsv(), ArxivResolvedTarget, ArxivValidationResult, asString(), asStringArray(), buildAcceptedInputsStatus() (+55 more)
+Nodes (60): AcceptedInputIssue, AcceptedInputUser, applyOrcidCrosswalkCsv(), applyScholarAcceptedCsv(), ArxivResolvedTarget, ArxivValidationResult, asString(), asStringArray() (+52 more)
 
 ### Community 20 - "dedupeResearchEntitiesByPi.ts"
 Cohesion: 0.07
-Nodes (58): applyDeleteModeArtifactPlan(), applyResearchEntityDedupeMergeGroup(), applyResearchEntityPiDedupeGroupsSequentially(), archiveOrDeleteDuplicateDocument(), ARRAY_REFERENCE_SPECS, ARTIFACT_SPECS, assertResearchEntityPiDedupeApplyAllowed(), assertResearchEntityPiDedupeApplyBounded() (+50 more)
+Nodes (60): applyDeleteModeArtifactPlan(), applyResearchEntityDedupeMergeGroup(), applyResearchEntityPiDedupeGroupsSequentially(), archiveOrDeleteDuplicateDocument(), ARRAY_REFERENCE_SPECS, ARTIFACT_SPECS, assertResearchEntityPiDedupeApplyAllowed(), assertResearchEntityPiDedupeApplyBounded() (+52 more)
 
 ### Community 21 - "listingService.ts"
 Cohesion: 0.11
-Nodes (45): getListingModel(), addFavorite(), addView(), archiveListing(), boundedListingDate(), boundedListingNetid(), boundedListingNetidArray(), boundedListingNumber() (+37 more)
+Nodes (38): deleteListingForCurrentUser(), getListingModel(), addFavorite(), boundedListingDate(), boundedListingNetid(), boundedListingNetidArray(), boundedListingNumber(), boundedListingString() (+30 more)
 
 ### Community 22 - "profileDataQualityAudit.ts"
 Cohesion: 0.10
@@ -459,43 +465,43 @@ Nodes (58): auditProfileRecord(), candidateOfficialProfileUrls(), candidateProfi
 
 ### Community 23 - "researchGroupService.ts"
 Cohesion: 0.04
-Nodes (109): defaultOwnerToGroupSlug(), addPublicMemberField(), addPublicMemberInternalProfilePath(), addPublicMemberProfileUrls(), addPublicPaperField(), boundedResearchFilterValues(), boundedResearchSearchQuery(), buildLeadPiOutreachContactRoute() (+101 more)
+Nodes (112): getResearchGroupBySlug(), addPublicMemberField(), addPublicMemberInternalProfilePath(), addPublicMemberProfileUrls(), addPublicPaperField(), boundedResearchFilterValues(), boundedResearchSearchQuery(), buildLeadPiOutreachContactRoute() (+104 more)
 
 ### Community 24 - "researchQualitySearchReview.ts"
 Cohesion: 0.07
 Nodes (54): addMapSet(), aggregateCountAndTypes(), aggregateCountMap(), buildLexicalReasons(), buildResearchQualitySearchReviewOutput(), buildReview(), collectSearchCandidates(), countMap() (+46 more)
 
 ### Community 25 - "browsable.ts"
-Cohesion: 0.05
-Nodes (65): FellowshipModal(), FellowshipModalProps, trackFellowshipApplyClick(), ArchivedBadge(), BrowseCard, BrowseCardProps, BrowseGrid(), BrowseGridProps (+57 more)
+Cohesion: 0.06
+Nodes (56): ArchivedBadge(), BrowseCard, BrowseCardProps, BrowseGrid(), BrowseGridProps, BrowseListItem, BrowseListItemProps, FavoriteButton (+48 more)
 
 ### Community 26 - "passport.ts"
-Cohesion: 0.07
-Nodes (48): authConfig, authDebug(), AuthenticatedSessionUser, buildDirectoryUpdate(), casLogin(), DEV_LOGIN_PROFILES, ensureDevLoginUser(), findOrCreateUser() (+40 more)
+Cohesion: 0.06
+Nodes (51): authConfig, authDebug(), AuthenticatedSessionUser, buildAuthenticatedSessionUser(), buildDirectoryUpdate(), casLogin(), DEV_LOGIN_PROFILES, ensureDevLoginUser() (+43 more)
 
 ### Community 27 - "launchAcquisitionReportService.ts"
 Cohesion: 0.09
-Nodes (53): AccessRecordCounts, ActionEvidenceGroups, addGroup(), buildActionGroups(), buildActionManifestRow(), buildLaunchAcquisitionReport(), buildManifestRow(), buildPiGroups() (+45 more)
+Nodes (54): AccessRecordCounts, ActionEvidenceGroups, addGroup(), buildActionGroups(), buildActionManifestRow(), buildLaunchAcquisitionReport(), buildManifestRow(), buildPiGroups() (+46 more)
 
 ### Community 28 - "labMicrositeDescriptionLLMExtractor.ts"
 Cohesion: 0.08
-Nodes (52): ObservedEntityType, CallDescriptionLLMFn, CandidateDescriptionLab, CandidateDescriptionLabDoc, candidateDescriptionLabsFromDocs(), candidateKeyMatches(), candidateUrlsForDoc(), defaultCallLLM() (+44 more)
+Nodes (50): ObservedEntityType, CallDescriptionLLMFn, CandidateDescriptionLab, CandidateDescriptionLabDoc, candidateDescriptionLabsFromDocs(), candidateKeyMatches(), candidateUrlsForDoc(), defaultCallLLM() (+42 more)
 
 ### Community 29 - "betaDataQualityCore.ts"
-Cohesion: 0.07
-Nodes (43): BETA_CHECK_OPERATOR_METADATA, betaCommand(), BetaDataQualityCheck, BetaDataQualityDiagnostics, BetaDataQualityProgressEvent, BetaDataQualitySeverity, BetaDataQualitySummary, BetaDataQualitySummaryInput (+35 more)
+Cohesion: 0.06
+Nodes (53): DuplicateEntityCluster, BETA_CHECK_OPERATOR_METADATA, betaCommand(), BetaDataQualityCheck, BetaDataQualityDiagnostics, BetaDataQualityProgressEvent, BetaDataQualitySeverity, BetaDataQualitySummary (+45 more)
 
 ### Community 30 - "sourceHealth.ts"
-Cohesion: 0.06
-Nodes (57): buildSourceHealthSummary(), classifySourceWarning(), AcceptedDecisionValidationCommandInput, attachAcceptedDecisionValidationSummary(), attachReviewArtifactSummary(), buildCrossSourceObservationReviewCommand(), buildReviewArtifactRollups(), buildReviewArtifactStatus() (+49 more)
+Cohesion: 0.07
+Nodes (55): AcceptedDecisionValidationCommandInput, attachAcceptedDecisionValidationSummary(), attachReviewArtifactSummary(), buildCrossSourceObservationReviewCommand(), buildReviewArtifactRollups(), buildReviewArtifactStatus(), buildReviewDecisionValidationStatus(), buildReviewQueues() (+47 more)
 
 ### Community 31 - "ysmAtoZScraper.ts"
-Cohesion: 0.11
-Nodes (32): absoluteUrl(), cleanDescription(), cleanProfileTitle(), clippedDescription(), decodeHtmlEntities(), escapeRegex(), extractLabHomepageDescription(), extractProfileContactWidgetProfile() (+24 more)
+Cohesion: 0.12
+Nodes (31): absoluteUrl(), cleanDescription(), cleanProfileTitle(), clippedDescription(), decodeHtmlEntities(), escapeRegex(), extractLabHomepageDescription(), extractProfileContactWidgetProfile() (+23 more)
 
 ### Community 32 - "integrityGate.ts"
 Cohesion: 0.09
-Nodes (36): ActiveArtifactOnArchivedEntity, buildDuplicateResearchPaperGroupsFromRows(), BuildPostMaterializationIntegrityInput, buildPostMaterializationIntegritySummary(), buildSamePiNameDuplicateGroupsFromDedupeRows(), CurrentMemberOnArchivedEntity, DuplicateCurrentMemberGroup, DuplicateExploratoryContactPathwayGroup (+28 more)
+Nodes (35): ActiveArtifactOnArchivedEntity, BuildPostMaterializationIntegrityInput, buildPostMaterializationIntegritySummary(), buildSamePiNameDuplicateGroupsFromDedupeRows(), CurrentMemberOnArchivedEntity, DuplicateCurrentMemberGroup, DuplicateExploratoryContactPathwayGroup, enrichIntegrityWarnings() (+27 more)
 
 ### Community 33 - "analyticsService.ts"
 Cohesion: 0.07
@@ -503,35 +509,35 @@ Nodes (62): AnalyticsEvent, ActionNeededAnalytics, ANALYTICS_EVENT_TYPES, ANALYT
 
 ### Community 34 - "userService.ts"
 Cohesion: 0.07
-Nodes (75): getFavPathwayFundingMatches(), getFavPathwayIds(), getFavPathways(), getSavedResearchPlanIds(), getSavedResearchPlans(), normalizeStoredPathwayIdsForAccountRead(), confirmListing(), readListing() (+67 more)
+Nodes (60): escapeCsvCell(), confirmListing(), readListing(), unconfirmListing(), updateListing(), addDepartments(), addOwnListings(), assertSafeUserUpdateDocument() (+52 more)
 
 ### Community 35 - "studentVisibilityGateService.ts"
-Cohesion: 0.08
-Nodes (46): actionRepairReasons, buildNameOnlyVisibilityDedupeRows(), buildSamePiVisibilityDedupeRows(), countByEntityId(), defaultGateDeps, entityDuplicateUrls(), evidenceReasons, exactDuplicateCanonicalScore() (+38 more)
+Cohesion: 0.07
+Nodes (52): actionRepairReasons, applyStudentVisibilityGatePlans(), buildNameOnlyVisibilityDedupeRows(), buildSamePiVisibilityDedupeRows(), countByEntityId(), defaultGateDeps, entityDuplicateUrls(), evidenceReasons (+44 more)
 
 ### Community 36 - "AdminDepartments.tsx"
-Cohesion: 0.09
-Nodes (30): AdminDepartments(), CATEGORY_COLORS, DEPARTMENT_CATEGORIES, DepartmentAction, DepartmentDoc, DepartmentState, EditDraft, INITIAL_NEW_DRAFT (+22 more)
+Cohesion: 0.06
+Nodes (42): AdminDepartments(), CATEGORY_COLORS, DEPARTMENT_CATEGORIES, DepartmentAction, DepartmentDoc, DepartmentState, EditDraft, INITIAL_NEW_DRAFT (+34 more)
 
 ### Community 37 - "runReport.ts"
 Cohesion: 0.07
-Nodes (46): ACCESS_ARTIFACT_TYPES, ACCESS_EVIDENCE_CONFLICT_FIELDS, ADDITIVE_METADATA_CONFLICT_FIELDS, buildCoverageFetchSummary(), buildCoverageSourceSummary(), buildMaterializationConflictEntityClauses(), buildMaterializationConflictReview(), buildPostMaterializationSummary() (+38 more)
+Nodes (51): ACCESS_ARTIFACT_TYPES, ACCESS_EVIDENCE_CONFLICT_FIELDS, ADDITIVE_METADATA_CONFLICT_FIELDS, buildCoverageFetchSummary(), buildCoverageSourceSummary(), buildMaterializationConflictEntityClauses(), buildMaterializationConflictReview(), buildPostMaterializationSummary() (+43 more)
 
 ### Community 38 - "accessMaterializer.ts"
-Cohesion: 0.09
-Nodes (50): ContactPolicy, ContactRouteVisibility, accessArtifactCandidatesFromDerived(), AccessMaterializationResult, AccessObservation, bestObservation(), confidenceLabel(), contactSignalExcerpt() (+42 more)
+Cohesion: 0.08
+Nodes (54): AccessSignalConfidence, ContactPolicy, ContactRouteVisibility, accessArtifactCandidatesFromDerived(), AccessMaterializationResult, AccessObservation, bestObservation(), confidenceLabel() (+46 more)
 
 ### Community 39 - "User"
 Cohesion: 0.06
-Nodes (42): normalizeUserType(), publicationSchema, User, userSchema, ProfileBackedFacultyResearchAreaMemberDeps, arxivEntryToObservations(), ArxivFetcher, ArxivPreprintScraper (+34 more)
+Nodes (37): publicationSchema, User, userSchema, ArxivPreprintScraperOptions, entityKeyForResult(), EUROPE_PMC_SOURCE_CONFIG, EuropePmcFetcher, EuropePmcPaperScraper (+29 more)
 
 ### Community 40 - "profileService.ts"
-Cohesion: 0.06
-Nodes (67): ADMIN_PROFILE_USER_TYPES, ADMIN_UPDATE_FIELDS, adminUpdateProfile(), ALLOWED_SELF_UPDATE_FIELDS, boundedAdminProfileEmail(), boundedAdminProfileNumber(), boundedAdminProfileText(), boundedProfileString() (+59 more)
+Cohesion: 0.09
+Nodes (50): ADMIN_UPDATE_FIELDS, ALLOWED_SELF_UPDATE_FIELDS, appointmentTitleCount(), capitalizeSentenceStart(), cleanPublicProfileBio(), cleanResearchHomeSummaryForBio(), clipPublicProfileBio(), dedupeProfileResearchEntities() (+42 more)
 
-### Community 41 - "labDetail.ts"
+### Community 41 - "researchGroup.ts"
 Cohesion: 0.07
-Nodes (45): LabInquireModalProps, LabMembersList(), LabMembersListProps, ROLE_LABELS, ROLE_ORDER, ROLE_PILL_CLASSES, decodeHtmlEntities(), decodeNumericEntity() (+37 more)
+Nodes (41): LabHeader(), LabHeaderProps, normalizeActionUrl(), LabInquireModalProps, baseGroup, baseGroup, LabContactRoute, AccessSummary (+33 more)
 
 ### Community 42 - "SavedPathwaysSection.tsx"
 Cohesion: 0.09
@@ -539,51 +545,51 @@ Nodes (44): CHECKLIST_TEMPLATES, daysUntil(), DeadlineReminder, deadlineReminder
 
 ### Community 43 - "ImportRootDataFiles.ts"
 Cohesion: 0.09
-Nodes (48): LabHeaderProps, ResearchGroup, asPlainObject(), assertRootDataImportApplyAllowed(), buildDepartmentMap(), buildRootDataImportOutput(), cleanText(), confidenceFor() (+40 more)
+Nodes (46): asPlainObject(), assertRootDataImportApplyAllowed(), buildDepartmentMap(), buildRootDataImportOutput(), cleanText(), confidenceFor(), countCsvRows(), DEFAULT_OPTIONS (+38 more)
 
 ### Community 44 - "scholarlyLinkSuppressionAudit.ts"
-Cohesion: 0.09
-Nodes (38): assertScholarlyLinkProvenanceAuditApplyAllowed(), buildScholarlyLinkProvenanceAuditOutput(), __filename, main(), nullTargetAttributionFilter, orphanAttributionIds(), ownerlessLinkFilter, parseNonNegativeInteger() (+30 more)
+Cohesion: 0.11
+Nodes (32): assertScholarlyLinkProvenanceAuditApplyAllowed(), buildScholarlyLinkProvenanceAuditOutput(), __filename, main(), nullTargetAttributionFilter, orphanAttributionIds(), ownerlessLinkFilter, parseNonNegativeInteger() (+24 more)
 
 ### Community 45 - "pathwaySearchIndexService.ts"
 Cohesion: 0.10
 Nodes (43): anyFilter(), boundedFilterValues(), boundedSearchQuery(), buildPathwayMeiliFilter(), buildPathwayMeiliSort(), buildPathwaySearchIndexDocument(), buildPathwaySearchIndexDocuments(), configurePathwaySearchIndex() (+35 more)
 
 ### Community 46 - "studentVisibilityTier.ts"
-Cohesion: 0.11
-Nodes (35): computeProgramStudentVisibility(), computeResearchEntityStudentVisibility(), entityUrls(), ENTRY_PROGRAM_KINDS, ENTRY_PROGRAM_MODES, FORMALIZATION_PROGRAM_KINDS, genericDirectoryUrlPathPatterns, hasAnyHttpUrl() (+27 more)
+Cohesion: 0.09
+Nodes (41): classifyProgramResearchRelevance(), ProgramResearchRelevanceInput, ProgramResearchRelevanceResult, RESEARCH_PROGRAM_KINDS, RESEARCH_PURPOSES, text(), computeProgramStudentVisibility(), computeResearchEntityStudentVisibility() (+33 more)
 
 ### Community 47 - "dataOps.ts"
 Cohesion: 0.11
 Nodes (41): assertDestinationMatchesTarget(), assertExplicitCsvForExecute(), assertMeilisearchTargetMatches(), assertMongoTargetMatches(), assertSafeWrite(), DataOpsDestinations, DataOpsOptions, DataOpsTarget (+33 more)
 
 ### Community 48 - "fellowshipInputs.ts"
-Cohesion: 0.10
-Nodes (36): acceptedPath(), AdvisorResolution, AdvisorResolver, candidateRowsFromText(), coerceReviewRow(), escapeCsvCell(), escapeRegex(), exportAcceptedFellowshipRows() (+28 more)
+Cohesion: 0.09
+Nodes (42): ACCEPTED_INPUT_FILE_EXTENSIONS, acceptedPath(), AdvisorResolution, AdvisorResolver, assertAcceptedInputPathRoot(), assertSafeAcceptedInputPathText(), candidateRowsFromText(), coerceReviewRow() (+34 more)
 
 ### Community 49 - "adminOperatorBoardService.ts"
 Cohesion: 0.06
-Nodes (44): BetaRepairQueueGateArtifact, buildQueueSummaries(), buildReleaseQueueSummary(), buildRepairQueueSummary(), buildSourceFreshness(), classifyOperatorQueueReason(), compactProgramSample(), compactResearchSample() (+36 more)
+Nodes (42): BetaRepairQueueGateArtifact, buildQueueSummaries(), buildReleaseQueueSummary(), buildSourceFreshness(), classifyOperatorQueueReason(), compactProgramSample(), compactResearchSample(), countByTier() (+34 more)
 
 ### Community 50 - "Listing"
-Cohesion: 0.11
-Nodes (23): ListingEditor(), VennDiagramToggle(), VennDiagramToggleProps, CombinedFilterDropdown(), CombinedFilterDropdownProps, FilterTabConfig, COLUMNS, KanbanBoardProps (+15 more)
+Cohesion: 0.09
+Nodes (29): ListingEditor(), DepartmentInput(), DepartmentInputProps, VennDiagramToggle(), VennDiagramToggleProps, CombinedFilterDropdown(), CombinedFilterDropdownProps, FilterTabConfig (+21 more)
 
 ### Community 51 - "admin.ts"
-Cohesion: 0.07
-Nodes (44): ACCESS_REVIEW_RECORD_TYPES, ADMIN_FELLOWSHIP_SORT_FIELDS, ADMIN_LISTING_SORT_FIELDS, ADMIN_PROFILE_SORT_FIELDS, ADMIN_SEARCH_ERROR_MESSAGES, ADMIN_URL_CHECK_ALLOWED_PORTS, adminAccessReviewLockedFields(), adminAccessReviewRecordUpdateDto() (+36 more)
+Cohesion: 0.06
+Nodes (52): ACCESS_REVIEW_RECORD_TYPES, ADMIN_FELLOWSHIP_SORT_FIELDS, ADMIN_LISTING_SORT_FIELDS, ADMIN_PROFILE_SORT_FIELDS, ADMIN_SEARCH_ERROR_MESSAGES, ADMIN_URL_CHECK_ALLOWED_PORTS, adminAccessReviewLockedFields(), adminAccessReviewRecordUpdateDto() (+44 more)
 
 ### Community 52 - "officialProfilePiBackfillScraper.ts"
-Cohesion: 0.06
-Nodes (81): absolutize(), affiliationValuesFromProfiles(), canonicalLegacyResearchHomeUrl(), canonicalResearchHomeName(), canonicalUrlFromHtml(), classifyResearchHome(), cleanInterestForBio(), cleanOfficialProfileDisplayName() (+73 more)
+Cohesion: 0.08
+Nodes (43): absolutize(), canonicalLegacyResearchHomeUrl(), canonicalUrlFromHtml(), cleanInterestForBio(), derivedBioFromOfficialProfile(), derivedBioFromOfficialProfileInterests(), entityExpectedPeople(), entityLeadDirectWebsiteToObservations() (+35 more)
 
 ### Community 53 - "yaleCollegeFellowshipsOfficeScraper.ts"
-Cohesion: 0.09
-Nodes (51): ProgramCategory, ProgramEntryMode, ProgramKind, absoluteUrl(), bestDeadlineText(), candidateFromDetailPage(), candidateFromLink(), candidateToObservations() (+43 more)
+Cohesion: 0.11
+Nodes (41): absoluteUrl(), bestDeadlineText(), candidateFromDetailPage(), candidateFromLink(), candidateToObservations(), compactTitleIdentity(), DEFAULT_PAGE_URLS, existingKeyForCandidate() (+33 more)
 
-### Community 54 - "fellowships.tsx"
-Cohesion: 0.05
-Nodes (29): AboutButton(), AnalyticsButton(), FeedbackButton(), getAcademicDisciplineColor(), getResearchAreaChipColor(), listingQuickFilters, Navbar(), NavbarSearchBar() (+21 more)
+### Community 54 - "Navbar.tsx"
+Cohesion: 0.06
+Nodes (22): AboutButton(), AnalyticsButton(), FeedbackButton(), getAcademicDisciplineColor(), getResearchAreaChipColor(), listingQuickFilters, Navbar(), NavbarSearchBar() (+14 more)
 
 ### Community 55 - "pathwaySearchService.ts"
 Cohesion: 0.10
@@ -591,55 +597,55 @@ Nodes (33): BestNextStepSnapshot, boundedFilterValues(), boundedSearchQuery(), b
 
 ### Community 56 - "paperAuthorshipAudit.ts"
 Cohesion: 0.11
-Nodes (39): PaperAuthor, applyCleanup(), applyIntegrityCleanup(), assertPaperAuthorshipAuditApplyAllowed(), AUTHORSHIP_METHODS, AUTHORSHIP_SOURCES, backfillOpenAlexPaperAuthors(), buildPaperAuthorshipAudit() (+31 more)
+Nodes (41): Paper, PaperAuthor, CrossrefPaperScraperOptions, applyCleanup(), applyIntegrityCleanup(), assertPaperAuthorshipAuditApplyAllowed(), AUTHORSHIP_METHODS, AUTHORSHIP_SOURCES (+33 more)
 
 ### Community 57 - "entryPathwayService.ts"
-Cohesion: 0.11
-Nodes (34): AccessSignalServiceDeps, AccessSignalUpsertResult, compactObject(), getAccessSignalModel(), toStoredId(), toStoredObjectId(), upsertAccessSignal(), compactObject() (+26 more)
+Cohesion: 0.12
+Nodes (31): AccessSignalServiceDeps, AccessSignalUpsertResult, compactObject(), getAccessSignalModel(), toStoredId(), toStoredObjectId(), upsertAccessSignal(), compactObject() (+23 more)
 
-### Community 58 - "package.json"
-Cohesion: 0.17
-Nodes (11): browserslist, development, production, engines, node, eslintConfig, extends, name (+3 more)
+### Community 58 - "devDependencies"
+Cohesion: 0.05
+Nodes (41): browserslist, development, production, devDependencies, agentation, autoprefixer, jsdom, postcss (+33 more)
 
 ### Community 59 - "applicationRoutePathwayBackfillCore.ts"
-Cohesion: 0.12
-Nodes (37): ContactRouteType, applicationRouteBackfillDerivationKey(), ApplicationRoutePathwayBackfillDeps, ApplicationRoutePathwayBackfillEntity, ApplicationRoutePathwayBackfillOptions, ApplicationRoutePathwayBackfillResult, ApplicationRoutePathwayBackfillRoute, backfillApplicationRoutePathways() (+29 more)
+Cohesion: 0.11
+Nodes (37): applicationRouteBackfillDerivationKey(), ApplicationRoutePathwayBackfillDeps, ApplicationRoutePathwayBackfillEntity, ApplicationRoutePathwayBackfillOptions, ApplicationRoutePathwayBackfillResult, ApplicationRoutePathwayBackfillRoute, backfillApplicationRoutePathways(), classifyApplicationRoutePathway() (+29 more)
 
-### Community 60 - "backfillStudentVisibilityTiers.ts"
-Cohesion: 0.13
-Nodes (30): applyProgramUpdates(), applyResearchUpdates(), assertStudentVisibilityBackfillApplyAllowed(), buildNameOnlyVisibilityDedupeRows(), buildSamePiVisibilityDedupeRows(), buildStudentVisibilityBackfillOutput(), countByEntityId(), FORMALIZATION_ONLY_ENTRY_PATHWAY_TYPES (+22 more)
+### Community 60 - "serializedDocumentId"
+Cohesion: 0.08
+Nodes (43): StudentVisibilityTier, normalizeSeedNetid(), requireSeedToken(), SEED_USER_FIELDS, seedListingSummary(), seedUserPayload(), seedUserSummary(), tokensMatch() (+35 more)
 
 ### Community 61 - "entityMaterializer.ts"
-Cohesion: 0.05
-Nodes (118): resolveAllFields(), ResolvedField, addPostMaterializationMetrics(), addUniqueValuesToSet(), authorshipEvidenceFromPaperObservations(), buildInferredPiMemberUpsert(), buildOfficialProfileScholarlyLinkUpserts(), buildPaperUpdateFromObservations() (+110 more)
+Cohesion: 0.11
+Nodes (35): ResolvedField, buildOfficialProfileScholarlyLinkUpserts(), cleanScholarlyHttpUrl(), cleanScholarlyText(), DEPARTMENT_IDENTITY_STOPWORDS, departmentIdentityTokens(), findUserDocByOfficialProfileObservations(), identityTokens() (+27 more)
 
 ### Community 62 - "AdminOperatorBoard.tsx"
 Cohesion: 0.05
 Nodes (33): DataQualityDuplicateNamePreflight, DataQualitySamePiDedupeReview, DataQualitySuspiciousUserEmailCopy, decisionLaneCopy, evidenceReasons, GATE_LABELS, GateArtifactFreshness, LaunchReviewExceptionDecisionValidation (+25 more)
 
 ### Community 63 - "researchEntity.ts"
-Cohesion: 0.13
-Nodes (29): MaybeResearchEntityDetailPayload, NormalizedResearchEntitySearchResponse, normalizeResearchEntity(), normalizeSearchMatch(), normalizeStudentDecisionExplanation(), ResearchEntityDescriptionState, ResearchEntityLeadState, ResearchEntityQualitySummary (+21 more)
+Cohesion: 0.09
+Nodes (38): createInitialLabDetailState(), LabDetailAction, labDetailReducer(), LabDetailState, otherPayload, sampleGroup, sampleListing, samplePayload (+30 more)
 
 ### Community 64 - "scripts"
 Cohesion: 0.05
 Nodes (40): dependencies, csv-parse, dotenv, meilisearch, mongoose, openai, description, devDependencies (+32 more)
 
 ### Community 65 - "officialProfilePiBackfillScraper.test.ts"
-Cohesion: 0.14
-Nodes (35): annotateEntitiesWithLeadUsers(), annotateEntitiesWithSourceObservationUrls(), annotateProfileDescriptionPreferredSourceEvidence(), entityLeadDirectWebsiteToObservations(), entityResearchHomeToObservations(), firstNonDuplicateLeadDirectWebsiteUrl(), identityToResearchEntityDescriptionObservations(), identityToResearchEntityPiKeyObservations() (+27 more)
+Cohesion: 0.12
+Nodes (38): annotateEntitiesWithLeadUsers(), annotateEntitiesWithSourceObservationUrls(), annotateProfileDescriptionPreferredSourceEvidence(), entityResearchHomeToObservations(), firstNonDuplicateLeadDirectWebsiteUrl(), generatedOfficialProfileUrlCandidatesForPerson(), identityToResearchEntityDescriptionObservations(), identityToResearchEntityPiKeyObservations() (+30 more)
 
 ### Community 66 - "undergradFellowshipRecipientScraper.ts"
-Cohesion: 0.11
-Nodes (32): AdvisorAggregateRow, buildObservationsForAdvisor(), DEFAULT_ACCEPTED_FELLOWSHIP_RECIPIENT_PDF_DIR, DEFAULT_PROGRAM_CONFIGS, drupalRecipientRowExtractor(), escapeRegex(), ExtractorCtx, FellowshipRecipient (+24 more)
+Cohesion: 0.06
+Nodes (66): memberObservationsForEntityKey(), entryToUserObservations(), awardToRecord(), buildCoPiObservations(), buildPiUserObservations(), buildResearchGroupObservations(), defaultDateStart(), findUserForPi() (+58 more)
 
 ### Community 67 - "crossSourceObservationConflictReview.ts"
-Cohesion: 0.06
-Nodes (58): ACCESS_EVIDENCE_CONFLICT_FIELDS, ADDITIVE_METADATA_CONFLICT_FIELDS, AggregatedCrossSourceObservationConflictGroup, asString(), asStringArray(), buildCategoryCounts(), buildConflictPlan(), buildCrossSourceObservationConflictReviewOutput() (+50 more)
+Cohesion: 0.07
+Nodes (40): ACCESS_EVIDENCE_CONFLICT_FIELDS, ADDITIVE_METADATA_CONFLICT_FIELDS, AggregatedCrossSourceObservationConflictGroup, buildCategoryCounts(), buildConflictPlan(), buildCrossSourceObservationConflictSummary(), buildFieldCounts(), buildPolicyBucketCounts() (+32 more)
 
 ### Community 68 - "researchEntityMemberReferenceAudit.ts"
-Cohesion: 0.14
-Nodes (33): applyMemberReferenceRepairs(), buildExistingMemberMatchQuery(), buildOrphanMemberUserReferencePipeline(), CURRENT_MEMBER_ON_ARCHIVED_ENTITY_STAGES, escapeRegExp(), exactCaseInsensitive(), main(), normalizeMemberReferenceObjectId() (+25 more)
+Cohesion: 0.12
+Nodes (38): applyMemberReferenceRepairs(), buildCurrentMemberOnArchivedEntityPipeline(), buildExistingMemberMatchQuery(), buildOrphanMemberUserReferencePipeline(), CURRENT_MEMBER_ON_ARCHIVED_ENTITY_STAGES, escapeRegExp(), exactCaseInsensitive(), loadCandidateUsers() (+30 more)
 
 ### Community 69 - "productionPromotionSmoke.mjs"
 Cohesion: 0.13
@@ -650,28 +656,28 @@ Cohesion: 0.09
 Nodes (30): EvidenceRail(), formatEvidenceDate(), getEvidenceHost(), getSafeEvidenceUrl(), ListingDetailModal(), ListingDetailModalProps, MockIntersectionObserver, TestScroller() (+22 more)
 
 ### Community 71 - "seedSources.ts"
-Cohesion: 0.13
-Nodes (19): assertSeedSourcesWriteAllowed(), buildSeedSourcesOutput(), __dirname, __filename, main(), parseRequiredOutputPath(), parseSeedSourcesArgs(), RETIRED_SOURCE_NAMES (+11 more)
+Cohesion: 0.08
+Nodes (31): sourceSchema, SourceCoverageArtifactType, sourceCoverageArtifactTypes, sourceCoverageEvidenceCategories, SourceCoverageEvidenceCategory, SourceCoverageMetadata, SourceCoverageTier, sourceCoverageTiers (+23 more)
 
 ### Community 72 - "repairOfficialProfilePublicationPointers.ts"
 Cohesion: 0.15
 Nodes (37): absolutize(), archivePointerRow(), assertOfficialProfilePublicationPointerRepairApplyAllowed(), candidateRepairUrls(), cleanText(), crawlFeaturedPublications(), createRepairPageReader(), ExtractedFeaturedPublication (+29 more)
 
 ### Community 73 - "fellowshipService.ts"
-Cohesion: 0.07
-Nodes (53): Fellowship, fellowshipSchema, programCategories, programEntryModes, programKinds, publicSafeStudentVisibilityTiers, publicStudentVisibilityTiers, studentVisibilityFields (+45 more)
+Cohesion: 0.10
+Nodes (42): addFavorite(), addView(), adminFellowshipDate(), adminFellowshipLinks(), adminFellowshipNumber(), adminFellowshipStringArray(), adminFellowshipText(), archiveFellowship() (+34 more)
 
-### Community 74 - "researchGroup.ts"
+### Community 74 - "opportunityDetail.tsx"
 Cohesion: 0.09
-Nodes (28): LabHeader(), normalizeActionUrl(), baseGroup, AccessSummary, IndependentStudyCourse, PastUndergradAdvisee, RecentGrant, ResearchEntityType (+20 more)
+Nodes (23): PrivateRoute(), PrivateRouteProps, InfiniteScrollLoadingDots(), InfiniteScrollLoadingDotsProps, LoadingSpinner(), LoadingSpinnerProps, sizeMap, applicationStateTone() (+15 more)
 
 ### Community 75 - "index.ts"
-Cohesion: 0.11
-Nodes (14): asyncHandler(), compactPositiveInteger(), requireBody(), requireFields(), validateNetid(), validateObjectId(), validatePagination(), validateQuery() (+6 more)
+Cohesion: 0.14
+Nodes (6): asyncHandler(), router, router, router, router, router
 
 ### Community 76 - "researchAnalytics.ts"
-Cohesion: 0.10
-Nodes (32): analyticsEventSchema, AnalyticsEventType, RESEARCH_ENTITY_TYPES, ResearchEntityType, AnalyticsUserEvent, LogEventParams, AnalyticsUser, buildResearchEvent() (+24 more)
+Cohesion: 0.09
+Nodes (33): analyticsEventSchema, AnalyticsEventType, RESEARCH_ENTITY_TYPES, ResearchEntityType, AnalyticsUserEvent, LogEventParams, AnalyticsUser, buildResearchEvent() (+25 more)
 
 ### Community 77 - "analytics.tsx"
 Cohesion: 0.09
@@ -682,12 +688,12 @@ Cohesion: 0.06
 Nodes (36): scripts, audit:research-detail-professors, audit:unified-research, build, build:client, build:server, clean:all, dev:client (+28 more)
 
 ### Community 79 - "configService.ts"
-Cohesion: 0.06
-Nodes (40): categoryColorKeys, Department, DepartmentCategory, DepartmentCodeSystem, departmentSchema, sourceRecordSchema, buildDeploymentFingerprint(), ConfigData (+32 more)
+Cohesion: 0.15
+Nodes (17): ResearchField, router, routeHandlerNames(), routesByPath(), buildDeploymentFingerprint(), ConfigData, DeploymentEnv, DeploymentEnvKey (+9 more)
 
 ### Community 80 - "backfillProfileBiosFromOfficialUrls.ts"
-Cohesion: 0.12
-Nodes (36): articleForFacultyTitle(), BioBackfillCandidate, BioBackfillDecision, buildCandidates(), composeTitleLedBio(), decideBioBackfill(), defaultFetcher(), defaultRewriter() (+28 more)
+Cohesion: 0.13
+Nodes (34): articleForFacultyTitle(), BioBackfillCandidate, BioBackfillDecision, buildCandidates(), composeTitleLedBio(), decideBioBackfill(), detectFieldMismatch(), __dirname (+26 more)
 
 ### Community 81 - "departmentLeadRepairPlanCore.ts"
 Cohesion: 0.11
@@ -695,15 +701,15 @@ Nodes (32): escapeRegExp(), main(), normalizeEmail(), parseDepartmentLeadRepairP
 
 ### Community 82 - "researchEntityEvidenceCoverage.ts"
 Cohesion: 0.11
-Nodes (33): observation(), assessResearchEntityEvidenceCoverage(), buildEvidenceCoverageImpact(), buildEvidenceCoverageImpactReportForObservations(), descriptionObservationSources(), descriptionState(), entityIdentifierKey(), EvidenceClaimState (+25 more)
+Nodes (32): assessResearchEntityEvidenceCoverage(), buildEvidenceCoverageImpact(), buildEvidenceCoverageImpactReportForObservations(), descriptionObservationSources(), descriptionState(), entityIdentifierKey(), EvidenceClaimState, EvidenceCoverageAssessment (+24 more)
 
-### Community 83 - "scriptWriteGuards.ts"
-Cohesion: 0.09
-Nodes (40): assertDepartmentMigrationApplyAllowed(), buildDepartmentMigrationOutput(), ChangeLog, DepartmentDoc, DepartmentMigrationCliOptions, DepartmentMigrationResult, __dirname, __filename (+32 more)
+### Community 83 - "cli.ts"
+Cohesion: 0.14
+Nodes (28): __dirname, __filename, main(), BOOLEAN_FLAGS, buildCronOutputPayload(), buildMaterializeOutputPayload(), buildScraperCliOutputPayload(), buildScraperCliPreflight() (+20 more)
 
-### Community 84 - "nihReporterScraper.ts"
+### Community 84 - "ScraperContext"
 Cohesion: 0.11
-Nodes (28): canonicalPiName(), DEFAULT_FISCAL_YEARS, escapeRegex(), FetchPageOpts, findUserForPi(), grantToRecord(), groupGrantsByPi(), NihAgencyAdmin (+20 more)
+Nodes (30): canonicalPiName(), DEFAULT_FISCAL_YEARS, escapeRegex(), fetchPage(), FetchPageOpts, findUserForPi(), grantToRecord(), groupGrantsByPi() (+22 more)
 
 ### Community 85 - "studentVisibilityRepairTargets.ts"
 Cohesion: 0.12
@@ -711,91 +717,91 @@ Nodes (31): buildBucket(), buildStudentVisibilityRepairTargetReport(), compactSa
 
 ### Community 86 - "researchEntitySearchIndexService.ts"
 Cohesion: 0.11
-Nodes (33): addUniqueSearchTerm(), buildResearchEntitySearchIndexDocument(), buildResearchEntitySearchIndexDocuments(), buildResearchEntitySearchIndexDocumentsWithMemberNames(), buildStudentSearchTerms(), cleanPersonName(), emptyMemberNameFields(), facultyDisplayName() (+25 more)
+Nodes (32): addUniqueSearchTerm(), buildResearchEntitySearchIndexDocument(), buildResearchEntitySearchIndexDocuments(), buildResearchEntitySearchIndexDocumentsWithMemberNames(), buildStudentSearchTerms(), cleanPersonName(), emptyMemberNameFields(), facultyDisplayName() (+24 more)
 
-### Community 87 - "redactDirectContactInfo"
-Cohesion: 0.10
-Nodes (30): getOpportunityById(), normalizeOpportunityIdParam(), mocks, compactStrings(), evidenceExcerpt(), firstEvidenceText(), getOpportunityApplicationLabel(), getOpportunityApplicationState() (+22 more)
+### Community 87 - "opportunityDetailService.ts"
+Cohesion: 0.11
+Nodes (27): getOpportunityById(), normalizeOpportunityIdParam(), mocks, compactStrings(), evidenceExcerpt(), firstEvidenceText(), getOpportunityApplicationLabel(), getOpportunityApplicationState() (+19 more)
 
 ### Community 88 - "programController.ts"
-Cohesion: 0.10
-Nodes (32): getFellowshipById(), addFavoriteToProgram(), addViewToProgram(), boundedSearchQuery(), getProgramById(), numericSearchParam(), OPERATOR_PROGRAM_SORT_FIELDS, parseFilter() (+24 more)
+Cohesion: 0.12
+Nodes (29): getFellowshipById(), addFavoriteToProgram(), addViewToProgram(), boundedSearchQuery(), getProgramById(), numericSearchParam(), OPERATOR_PROGRAM_SORT_FIELDS, parseFilter() (+21 more)
 
 ### Community 89 - "departmentUndergradResearchScraper.ts"
-Cohesion: 0.14
-Nodes (31): ResearchGroupKind, absoluteUrl(), bestApplicationUrl(), conciseText(), DEFAULT_DEPARTMENT_UNDERGRAD_RESEARCH_PAGES, departmentEntityKey(), departmentGuidanceDescription(), DepartmentUndergradResearchPageConfig (+23 more)
+Cohesion: 0.16
+Nodes (28): absoluteUrl(), bestApplicationUrl(), conciseText(), DEFAULT_DEPARTMENT_UNDERGRAD_RESEARCH_PAGES, departmentEntityKey(), departmentGuidanceDescription(), DepartmentUndergradResearchPageConfig, DepartmentUndergradResearchParser (+20 more)
 
 ### Community 90 - "centersInstitutesScraper.ts"
 Cohesion: 0.07
 Nodes (45): affiliationExtractionToObservations(), CallCenterAffiliationLLMFn, CandidateCenter, CenterAffiliationExtraction, CenterAffiliationLLMExtractor, CenterAffiliationLLMExtractorDeps, CenterAffiliationPerson, CenterFinderFn (+37 more)
 
 ### Community 91 - "studentDecisionLLMExtractor.ts"
-Cohesion: 0.10
-Nodes (34): ScrapeSnapshot, scrapeSnapshotSchema, getCached(), invalidateCache(), buildStudentDecisionPrompt(), candidateMatchesOnly(), clean(), compactSourceUrls() (+26 more)
+Cohesion: 0.17
+Nodes (22): buildStudentDecisionPrompt(), candidateMatchesOnly(), clean(), compactSourceUrls(), DecisionCandidateLoader, DecisionCandidateSelectionOptions, decisionExtractionToObservation(), defaultCandidateLoader() (+14 more)
 
-### Community 92 - "dedupeUsersByIdentity.ts"
-Cohesion: 0.10
-Nodes (33): applyUserIdentityDedupeGroups(), archiveDuplicateUniqueUserReferences(), assertDedupeUsersByIdentityApplyAllowed(), buildDedupeUsersByIdentityOutput(), buildUserIdentityCollisionPipeline(), IDENTITY_FIELDS, isMissing(), loadCollisions() (+25 more)
+### Community 92 - "field"
+Cohesion: 0.11
+Nodes (35): buildDuplicateAccessSignalGroupsFromRows(), loadDuplicateAccessSignalGroups(), field(), normalizedHeader(), applyUserIdentityDedupeGroups(), archiveDuplicateUniqueUserReferences(), assertDedupeUsersByIdentityApplyAllowed(), buildDedupeUsersByIdentityOutput() (+27 more)
 
 ### Community 93 - "researchEntityCoverageAudit.ts"
 Cohesion: 0.13
 Nodes (29): aggregateCountMap(), AuditEntityRecord, buildBulkAudit(), buildObservationFlags(), buildResearchEntityCoverageAuditOutput(), buildSlugAudit(), countMap(), __dirname (+21 more)
 
 ### Community 94 - "research.tsx"
-Cohesion: 0.09
-Nodes (26): ActiveResearchSearchRequest, buildDepartmentSearchTargets(), DepartmentResearchHomeConfig, DepartmentSearchTarget, hasStructuredFilters(), isResearchEntitySearchExhausted(), pluralize(), QUALITY_FILTER_OPTIONS (+18 more)
+Cohesion: 0.06
+Nodes (38): PathwayActionCardProps, ActiveResearchSearchRequest, buildDepartmentSearchTargets(), DepartmentResearchHomeConfig, DepartmentSearchTarget, emptyGroupedResults(), hasStructuredFilters(), isResearchEntitySearchExhausted() (+30 more)
 
 ### Community 95 - "isLikelyPersonUrl"
-Cohesion: 0.24
-Nodes (17): initial(), allNameTokens(), allowsLastNameOnlyPersonUrl(), cleanProfileUrlsForPerson(), compoundLastNameMatchedTokens(), entityNameMatchesUser(), givenNameAliasMatches(), hasPartialCompoundLastNameProfilePath() (+9 more)
+Cohesion: 0.25
+Nodes (16): initial(), allNameTokens(), allowsLastNameOnlyPersonUrl(), compoundLastNameMatchedTokens(), entityNameMatchesUser(), givenNameAliasMatches(), hasPartialCompoundLastNameProfilePath(), hasSurnameOnlyProfilePath() (+8 more)
 
 ### Community 96 - "research-detail-professor-audit.mjs"
 Cohesion: 0.11
 Nodes (27): absoluteApiUrl(), absoluteClientUrl(), addFinding(), artifacts, auditEntity(), auditProfileLink(), clientBase, collectResearchEntities() (+19 more)
 
-### Community 97 - "renderedFetch.ts"
-Cohesion: 0.09
-Nodes (29): average(), boundedRenderedFetchTimeout(), buildFetchAttemptMetrics(), createScraplingRenderedFetcher(), currentMemoryBytes(), DEFAULT_BRIDGE_PATH, defaultRenderedSeedRedirectCheck(), execFileAsync (+21 more)
+### Community 97 - "AdminAccessReview.tsx"
+Cohesion: 0.11
+Nodes (23): AccessReviewCounts, AccessReviewDetail, AccessReviewEntitySummary, AccessSignal, AdminAccessReview(), ContactRoute, EntryPathway, evidenceIds() (+15 more)
 
 ### Community 98 - "analytics.ts"
-Cohesion: 0.09
-Nodes (13): ANALYTICS_SORT_DIRECTIONS, ANALYTICS_USER_SORTS, AnalyticsRequestError, parseAnalyticsSortDirection(), parseAnalyticsUserSort(), router, invokeRouteHandler(), mocks (+5 more)
+Cohesion: 0.10
+Nodes (12): ANALYTICS_SORT_DIRECTIONS, ANALYTICS_USER_SORTS, AnalyticsRequestError, parseAnalyticsSortDirection(), parseAnalyticsUserSort(), router, invokeRouteHandler(), mocks (+4 more)
 
 ### Community 99 - "dedupeUsersByIdentityCore.ts"
-Cohesion: 0.15
-Nodes (26): buildUserIdentityDedupePlan(), buildUserIdentityDedupeSummary(), canonicalScore(), chooseCanonicalUser(), clusterUsersByCompatibleName(), comparePlannedGroups(), compareStrings(), compareWarningGroups() (+18 more)
+Cohesion: 0.12
+Nodes (31): DuplicatePersonGroup, buildUserIdentityDedupePlan(), buildUserIdentityDedupeSummary(), canonicalScore(), chooseCanonicalUser(), clusterUsersByCompatibleName(), comparePlannedGroups(), compareStrings() (+23 more)
 
 ### Community 100 - "openAlexPaperScraper.ts"
 Cohesion: 0.12
 Nodes (30): arxivIdFromUrl(), buildExternalIds(), buildOpenAlexAuthorshipEvidence(), extractArxivId(), FacultyRecord, fetchPage(), HttpFetcher, isExactNameMatch() (+22 more)
 
 ### Community 101 - "dependencies"
-Cohesion: 0.11
-Nodes (18): dependencies, axios, @emotion/react, @emotion/styled, @mui/material, react, react-router-dom, react-spinners (+10 more)
+Cohesion: 0.08
+Nodes (28): dependencies, axios, @emotion/react, @emotion/styled, @mui/material, react, react-dom, react-router-dom (+20 more)
 
-### Community 102 - "getUniqueDepartmentLabels"
-Cohesion: 0.09
-Nodes (34): DepartmentInput(), DepartmentInputProps, ProfileEditor(), ProfileEditorProps, orcidHref(), ProfileHeader(), ProfileHeaderProps, profileLinkDedupeKey() (+26 more)
+### Community 102 - "ProfileEditor.tsx"
+Cohesion: 0.23
+Nodes (12): ProfileEditor(), ProfileEditorProps, ProfileHeaderProps, createInitialProfileEditorState(), hydrateFromProfile(), ProfileEditorAction, profileEditorReducer(), ProfileEditorState (+4 more)
 
 ### Community 103 - "apiBaseUrl.ts"
-Cohesion: 0.11
-Nodes (22): AdminRoute(), AdminRouteProps, getLocalAdminDevLoginUrl(), getSafeLocalAdminRedirectTarget(), PrivateRoute(), PrivateRouteProps, InfiniteScrollLoadingDots(), InfiniteScrollLoadingDotsProps (+14 more)
+Cohesion: 0.22
+Nodes (13): AdminRoute(), AdminRouteProps, getLocalAdminDevLoginUrl(), getSafeLocalAdminRedirectTarget(), SignOutButton(), storeLogoutReturnPath(), buildApiUrl(), getApiBaseUrl() (+5 more)
 
 ### Community 104 - "postedOpportunityService.ts"
 Cohesion: 0.14
-Nodes (28): activeListingBackfillFilter(), backfillPostedOpportunitiesFromListings(), BackfillPostedOpportunitiesFromListingsOptions, BackfillPostedOpportunitiesFromListingsResult, compactObject(), firstUrl(), getEntryPathwayModel(), getEntryPathwayStatusForPostedOpportunity() (+20 more)
+Nodes (27): activeListingBackfillFilter(), backfillPostedOpportunitiesFromListings(), BackfillPostedOpportunitiesFromListingsOptions, BackfillPostedOpportunitiesFromListingsResult, compactObject(), firstUrl(), getEntryPathwayModel(), getEntryPathwayStatusForPostedOpportunity() (+19 more)
 
-### Community 105 - "ObservationInput"
-Cohesion: 0.22
-Nodes (17): ACCESS_DETAIL_CONFIGS, accessObservationsForEntity(), cleanName(), entityToObservations(), inferKind(), normalizeUrl(), pageText(), parseCenters() (+9 more)
+### Community 105 - "assertPublicHttpUrl"
+Cohesion: 0.08
+Nodes (45): defaultFetchUrl(), setCached(), defaultFetchPage(), CallCenterDirectorLLMFn, CandidateCenter, CenterDirector, CenterDirectorExtraction, CenterDirectorLLMExtractor (+37 more)
 
-### Community 106 - "centerDirectorLLMExtractor.ts"
-Cohesion: 0.15
-Nodes (18): CallCenterDirectorLLMFn, CandidateCenter, CenterDirector, CenterDirectorExtraction, CenterDirectorLLMExtractor, CenterDirectorLLMExtractorDeps, CenterFinderFn, defaultCallLLM() (+10 more)
+### Community 106 - "arxivPreprintScraper.ts"
+Cohesion: 0.11
+Nodes (22): arxivEntryToObservations(), ArxivFetcher, ArxivPreprintScraper, buildAuthorSearchQuery(), normalizeArxivId(), normalizeArxivText(), parseArxivFeed(), ParsedArxivEntry (+14 more)
 
 ### Community 107 - "launchTrustContractService.ts"
 Cohesion: 0.10
-Nodes (29): LaunchReviewExceptionCliOptions, buildLaunchTrustContractOutput(), CliOptions, __filename, main(), parseLaunchTrustContractArgs(), parsePositiveInteger(), parseRequiredValue() (+21 more)
+Nodes (30): LaunchReviewExceptionCliOptions, buildLaunchTrustContractOutput(), CliOptions, __filename, main(), parseLaunchTrustContractArgs(), parsePositiveInteger(), parseRequiredValue() (+22 more)
 
 ### Community 108 - "pathwayQualityAudit.ts"
 Cohesion: 0.13
@@ -805,9 +811,9 @@ Nodes (28): activeListingFilter(), aggregateCountMap(), buildEntityContexts(), b
 Cohesion: 0.11
 Nodes (30): applyCopy(), assertPromotionSummaryCanApply(), assertSafeOptions(), buildApplyBlockers(), buildPlan(), buildPromotionSummary(), COLLECTION_CATEGORY_ORDER, CollectionCategorySummary (+22 more)
 
-### Community 110 - "visibilityRepairQueueService.ts"
-Cohesion: 0.10
-Nodes (68): member(), actionReasons, archivedResearchEntityRepairBlock(), attemptProgramRepair(), attemptResearchActionEvidenceRepair(), attemptResearchRepair(), attemptVisibilityRepair(), buildResearchSourceDescriptionPatch() (+60 more)
+### Community 110 - "textValue"
+Cohesion: 0.15
+Nodes (36): member(), buildResearchSourceDescriptionPatch(), cleanResearchInterest(), entityPersonDisplayName(), hasHttpUrl(), interestCorroboratedByBio(), isDescriptionEligibleSourceUrl(), isLeadMember() (+28 more)
 
 ### Community 111 - "departmentGroundTruth.ts"
 Cohesion: 0.14
@@ -815,19 +821,19 @@ Nodes (29): addSourceRecord(), buildDepartmentGroundTruth(), buildResolverKeys()
 
 ### Community 112 - "app.ts"
 Cohesion: 0.08
-Nodes (22): allowList, apiLimiter, app, bypassRuntimeSecurity, clientDistPath, clientIndexPath, corsOptions, deployedBrowserOrigins (+14 more)
+Nodes (21): allowList, apiLimiter, bypassRuntimeSecurity, clientDistPath, clientIndexPath, corsOptions, deployedBrowserOrigins, __dirname (+13 more)
 
 ### Community 113 - "listingClaimRequestService.ts"
-Cohesion: 0.11
-Nodes (30): getAdminListingClaimRequest(), listAdminListingClaimRequests(), reviewAdminListingClaimRequest(), submitListingClaimRequest(), ListingClaimRequest, listingClaimRequestSchema, ListingClaimRequestStatus, ListingClaimRequestType (+22 more)
+Cohesion: 0.14
+Nodes (26): getAdminListingClaimRequest(), listAdminListingClaimRequests(), reviewAdminListingClaimRequest(), submitListingClaimRequest(), ListingClaimRequest, listingClaimRequestSchema, ListingClaimRequestStatus, ListingClaimRequestType (+18 more)
 
 ### Community 114 - "profileController.ts"
-Cohesion: 0.13
-Nodes (24): addIfDefined(), getProfile(), getProfileCourses(), getProfileListings(), getPublications(), normalizePublicationPagination(), PUBLICATION_SORT_FIELDS, publicationSortValue() (+16 more)
+Cohesion: 0.12
+Nodes (26): addIfDefined(), getProfile(), getProfileCourses(), getProfileListings(), getPublications(), normalizePublicationPagination(), PUBLICATION_SORT_FIELDS, publicationSortValue() (+18 more)
 
-### Community 115 - "backfillCenterDirectors.ts"
-Cohesion: 0.07
-Nodes (36): MaterializerObservationLike, BrowseRankBackfillCliOptions, BrowseRankBackfillResult, __dirname, __filename, main(), parseBrowseRankBackfillArgs(), parsePositiveInt() (+28 more)
+### Community 115 - "logSanitizer.ts"
+Cohesion: 0.09
+Nodes (26): BrowseRankBackfillCliOptions, BrowseRankBackfillResult, __dirname, __filename, main(), parseBrowseRankBackfillArgs(), parsePositiveInt(), runBrowseRankBackfill() (+18 more)
 
 ### Community 116 - "adminAccessReviewService.ts"
 Cohesion: 0.14
@@ -838,20 +844,20 @@ Cohesion: 0.14
 Nodes (30): assertResearchEntityCollectionMigrationWriteAllowed(), buildCollectionMigrationLiveFilter(), buildCollectionMigrationTargetReferenceFilter(), buildResearchEntityCollectionMigrationOutput(), COLLECTION_MIGRATIONS, collectionExists(), CollectionMigration, collectionMigrationModeWrites() (+22 more)
 
 ### Community 118 - "scholarlyLinkToPublicLink"
-Cohesion: 0.12
-Nodes (25): buildProfileResearchMembershipFilter(), cleanScholarlyTitle(), cleanUrl(), dateToIso(), isDatasetLikeScholarlyLink(), isGeneratedOfficialProfilePublicationAnchor(), isOfficialProfileScholarlyLink(), isOfficialProfileSourcePagePublicationPointer() (+17 more)
+Cohesion: 0.09
+Nodes (30): buildProfileResearchMembershipFilter(), cleanPublicSourceLabel(), cleanScholarlyTitle(), cleanUrl(), dateToIso(), hasInspectableOpenAlexDestination(), isDatasetLikeScholarlyLink(), isGeneratedOfficialProfilePublicationAnchor() (+22 more)
 
 ### Community 119 - "UserContextProvider.tsx"
 Cohesion: 0.11
 Nodes (16): ListingEditorProps, ErrorBoundary, ErrorBoundaryProps, ErrorBoundaryState, container, root, UserContextProvider(), sampleUser (+8 more)
 
-### Community 120 - "profile.tsx"
-Cohesion: 0.07
-Nodes (41): cleanResearchInterest(), ResearchInterests(), ResearchInterestsProps, SOURCE_CHROME_PATTERNS, splitCleanResearchInterest(), adminQualityLabels(), contextLabelClass(), countLabel() (+33 more)
+### Community 120 - "safeRouteSegment"
+Cohesion: 0.09
+Nodes (32): cleanResearchInterest(), ResearchInterests(), ResearchInterestsProps, SOURCE_CHROME_PATTERNS, splitCleanResearchInterest(), adminQualityLabels(), contextLabelClass(), countLabel() (+24 more)
 
-### Community 121 - "nsfAwardScraper.ts"
-Cohesion: 0.13
-Nodes (26): awardToRecord(), buildCoPiObservations(), buildPiUserObservations(), buildResearchGroupObservations(), defaultDateStart(), fetchPage(), findUserForPi(), groupAwardsByPi() (+18 more)
+### Community 121 - "betaDataQualityCore.test.ts"
+Cohesion: 0.15
+Nodes (20): buildBetaDataQualityScorecard(), buildLiveLinkCheck(), buildUrlHygiene(), collectLinkCandidateInputs(), describeMongoTarget(), main(), BetaDataQualityScorecard, buildBetaDataQualityDiagnostics() (+12 more)
 
 ### Community 122 - "migrateResearchEntities.ts"
 Cohesion: 0.13
@@ -862,28 +868,28 @@ Cohesion: 0.16
 Nodes (27): betaTargetCommand(), buildAdminOperatorBoard(), buildGateArtifactFreshness(), buildRecommendedNextActions(), deriveDataQualityGate(), deriveLaunchAcquisitionGate(), deriveLaunchTrustGate(), derivePromotionCopyGate() (+19 more)
 
 ### Community 124 - "axios.ts"
-Cohesion: 0.05
-Nodes (36): mockedAxios, HttpStatusNotifier(), CourseTableCourse, CourseTableSection(), CourseTableSectionProps, formatSeason(), ProfileListingsProps, SearchResponse (+28 more)
+Cohesion: 0.07
+Nodes (20): mockedAxios, HttpStatusNotifier(), CourseTableCourse, CourseTableSection(), CourseTableSectionProps, formatSeason(), ProfileListingsProps, SearchResponse (+12 more)
 
 ### Community 125 - "disambiguateSurnameLabNames.ts"
 Cohesion: 0.12
 Nodes (27): ACTIVE_FILTER, applyPlans(), ApplyResult, assertDisambiguateSurnameLabApplyAllowed(), buildSurnameLabDisambiguationPlans(), cleanNamePart(), consumeValue(), __dirname (+19 more)
 
 ### Community 126 - "repairDuplicateAccessSignals.ts"
-Cohesion: 0.12
-Nodes (30): buildDuplicateAccessSignalGroupsFromRows(), loadDuplicateAccessSignalGroups(), applyPlans(), assertDuplicateAccessSignalRepairApplyAllowed(), BlockedDuplicateAccessSignalRepairGroup, buildDuplicateAccessSignalRepairPlans(), __dirname, DuplicateAccessSignalPathwayContext (+22 more)
+Cohesion: 0.14
+Nodes (27): applyPlans(), assertDuplicateAccessSignalRepairApplyAllowed(), BlockedDuplicateAccessSignalRepairGroup, buildDuplicateAccessSignalRepairPlans(), __dirname, DuplicateAccessSignalPathwayContext, DuplicateAccessSignalRecord, DuplicateAccessSignalRepairPlanResult (+19 more)
 
 ### Community 127 - "fellowshipMatchingService.ts"
-Cohesion: 0.17
-Nodes (20): publicFellowshipApplicationCycleEvidence, FellowshipMatch, FellowshipMatchingDeps, FellowshipMatchStrength, hasFellowshipCompatibleEvidence(), matchFellowshipsForPathways(), matchStrength(), overlapCount() (+12 more)
+Cohesion: 0.14
+Nodes (24): buildFellowshipApplicationCycleEvidence(), cleanHttpUrl(), cleanString(), dateStatus(), FellowshipApplicationCycleEvidence, hasApplicationRoute(), looksRecurring(), publicFellowshipApplicationCycleEvidence (+16 more)
 
 ### Community 128 - "fellowshipController.ts"
-Cohesion: 0.17
-Nodes (18): addFavoriteToFellowship(), addViewToFellowship(), boundedSearchQuery(), getFellowshipFilterOptions(), numericSearchParam(), parseFilter(), PUBLIC_FELLOWSHIP_SORT_FIELDS, publicFellowshipPage() (+10 more)
+Cohesion: 0.18
+Nodes (17): addFavoriteToFellowship(), addViewToFellowship(), boundedSearchQuery(), getFellowshipFilterOptions(), numericSearchParam(), parseFilter(), PUBLIC_FELLOWSHIP_SORT_FIELDS, publicFellowshipPage() (+9 more)
 
 ### Community 129 - "environment.ts"
-Cohesion: 0.31
-Nodes (13): allowsNonProductionSecurityBypass(), isCI(), isDevelopment(), isLocalDevelopmentRuntime(), isLocalHostValue(), isProduction(), isTest(), LOCAL_DEV_HOSTS (+5 more)
+Cohesion: 0.28
+Nodes (14): requireLocalSeedRuntime(), allowsNonProductionSecurityBypass(), isCI(), isDevelopment(), isLocalDevelopmentRuntime(), isLocalHostValue(), isProduction(), isTest() (+6 more)
 
 ### Community 130 - "repairArchivedEntityArtifacts.ts"
 Cohesion: 0.15
@@ -894,16 +900,16 @@ Cohesion: 0.15
 Nodes (25): applyRepairs(), assertRepairMismatchedPersonEmailsApplyAllowed(), loadUsers(), main(), runRepairMismatchedPersonEmails(), writeOutput(), buildMismatchedExternalIdentityRepairs(), buildMismatchedPersonEmailRepairPlan() (+17 more)
 
 ### Community 132 - "errorHandler.ts"
-Cohesion: 0.18
-Nodes (13): triggerReconnect(), AsyncRequestHandler, clientErrorStatus(), errorHandler(), notFoundHandler(), publicClientErrorMessage(), ORIGINAL_ENV, IncorrectPermissionsError (+5 more)
+Cohesion: 0.08
+Nodes (29): app, getApiMode(), triggerReconnect(), startApp(), AsyncRequestHandler, clientErrorStatus(), errorHandler(), notFoundHandler() (+21 more)
 
 ### Community 133 - "researchEntityPiDedupeCore.ts"
-Cohesion: 0.17
-Nodes (27): buildFundingGroupFromCluster(), buildFundingResearchEntityDedupePlan(), buildGroupFromCluster(), buildOfficialLabUrlResearchEntityDedupePlan(), buildProfileAreaShellDuplicateGroup(), buildResearchEntityPiDedupePlan(), canonicalScore(), cleanMergedResearchAreas() (+19 more)
+Cohesion: 0.19
+Nodes (26): buildFundingGroupFromCluster(), buildFundingResearchEntityDedupePlan(), buildGroupFromCluster(), buildOfficialLabUrlResearchEntityDedupePlan(), buildProfileAreaShellDuplicateGroup(), buildResearchEntityPiDedupePlan(), canonicalScore(), cleanMergedResearchAreas() (+18 more)
 
-### Community 134 - "isPublicHttpUrl"
-Cohesion: 0.16
-Nodes (22): buildListingResearchEntityProfilePatch(), hasText(), isHttpUrl(), ListingResearchEntityProfileInput, looksLikeOwnerTitle(), looksLikePublicationBlurb(), missingArray(), missingText() (+14 more)
+### Community 134 - "listingResearchEntityProfile.ts"
+Cohesion: 0.28
+Nodes (14): buildListingResearchEntityProfilePatch(), hasText(), isHttpUrl(), ListingResearchEntityProfileInput, looksLikeOwnerTitle(), looksLikePublicationBlurb(), missingArray(), missingText() (+6 more)
 
 ### Community 135 - "researchEntityQuality.ts"
 Cohesion: 0.14
@@ -913,13 +919,13 @@ Nodes (21): ACCESS_SIGNAL_POINTS, accessPoints(), computeResearchEntityBrowseRan
 Cohesion: 0.17
 Nodes (20): ScrapeJobLock, scrapeJobLockSchema, createCronOwnerId(), createCronRunnerDependencies(), CronRunnerDependencies, loadCronSource(), runScraperCron(), RunScraperCronResult (+12 more)
 
-### Community 137 - "assertPublicHttpUrl"
-Cohesion: 0.22
-Nodes (22): defaultFetchUrl(), setCached(), defaultFetchPage(), defaultFetchPage(), fetchHtml(), fetchDeptData(), fetchHtml(), defaultFetchHtml() (+14 more)
+### Community 137 - "entityMaterializer.test.ts"
+Cohesion: 0.13
+Nodes (31): addPostMaterializationMetrics(), buildInferredPiMemberUpsert(), buildResearchGroupMemberUpsert(), centerRelationshipTypeForResolvedTarget(), countListingBackedPostedOpportunitiesForRun(), emptyPostMaterializationMetrics(), findExistingResearchEntityByFacultyResearchAreaIdentity(), findUniqueUserIdByPersonName() (+23 more)
 
 ### Community 138 - "userEmailHygiene.ts"
-Cohesion: 0.18
-Nodes (23): buildEmailHygiene(), buildSuspiciousUserEmailScorecardSummary(), isInvalidOptionalEmail(), assertUserEmailHygieneApplyAllowed(), buildSuspiciousUserEmailFilter(), buildUserEmailHygieneOutput(), loadSuspiciousUsers(), main() (+15 more)
+Cohesion: 0.22
+Nodes (17): assertUserEmailHygieneApplyAllowed(), buildSuspiciousUserEmailFilter(), buildUserEmailHygieneOutput(), loadSuspiciousUsers(), main(), runUserEmailHygiene(), writeUserEmailHygieneOutput(), buildUserEmailHygieneSummary() (+9 more)
 
 ### Community 139 - "paperQualityService.ts"
 Cohesion: 0.14
@@ -929,21 +935,21 @@ Nodes (22): buildPaperQualityAuditOutput(), __filename, main(), PaperQualityAudi
 Cohesion: 0.10
 Nodes (40): buildProfessorBioCoverageAuditOutput(), buildProfessorBioCoverageInputs(), idValue(), main(), parseInteger(), parseProfessorBioCoverageAuditArgs(), parseRequiredOutputPath(), ProfessorBioCoverageAuditCliOptions (+32 more)
 
-### Community 141 - "logSanitizer.ts"
-Cohesion: 0.08
-Nodes (27): ApiMode, getApiMode(), initializeConnections(), mongoOptions, startApp(), CliOptions, FILTER, main() (+19 more)
+### Community 141 - "initializeConnections"
+Cohesion: 0.11
+Nodes (23): ApiMode, initializeConnections(), mongoOptions, CliOptions, FILTER, main(), parseArgs(), buildProfileImageQualityAuditOutput() (+15 more)
 
 ### Community 142 - "staleObservationConflictReview.ts"
-Cohesion: 0.08
-Nodes (25): ACCESS_EVIDENCE_CONFLICT_FIELDS, ADDITIVE_METADATA_CONFLICT_FIELDS, AggregatedObservationConflictGroup, ALL_KNOWN_CONFLICT_FIELDS, CONTENT_CONFLICT_FIELDS, __filename, FUNDING_CONTEXT_CONFLICT_FIELDS, IDENTITY_OR_ROUTING_CONFLICT_FIELDS (+17 more)
+Cohesion: 0.07
+Nodes (29): ACCESS_EVIDENCE_CONFLICT_FIELDS, ADDITIVE_METADATA_CONFLICT_FIELDS, AggregatedObservationConflictGroup, ALL_KNOWN_CONFLICT_FIELDS, buildMongoFieldFilter(), CONTENT_CONFLICT_FIELDS, __filename, FUNDING_CONTEXT_CONFLICT_FIELDS (+21 more)
 
-### Community 143 - "betaDataQualityCore.test.ts"
-Cohesion: 0.15
-Nodes (19): buildReferenceAuditSamples(), buildUrlHygiene(), main(), BetaDataQualityScorecard, buildArrayRefOrphanSamplePipeline(), buildBetaDataQualityOutput(), buildBetaDataQualityRecommendedCommands(), buildBetaDataQualityRetentionOptions() (+11 more)
+### Community 143 - "visibilityRepairQueueService.test.ts"
+Cohesion: 0.36
+Nodes (7): buildRepairQueueSummary(), buildVisibilityRepairPiMemberUpsert(), buildVisibilityRepairPlan(), buildVisibilityRepairPlans(), classifyVisibilityRepairStage(), repairActionForStage(), runVisibilityRepairQueue()
 
 ### Community 144 - "AdminProfileEditModal.tsx"
-Cohesion: 0.21
-Nodes (14): AdminProfile, AdminProfileEditModal(), AdminProfileEditModalProps, PublicationsTable(), AdminProfileEditAction, adminProfileEditReducer(), AdminProfileEditState, AdminProfileShape (+6 more)
+Cohesion: 0.25
+Nodes (12): AdminProfile, AdminProfileEditModal(), AdminProfileEditModalProps, AdminProfileEditAction, adminProfileEditReducer(), AdminProfileEditState, AdminProfileShape, createInitialAdminProfileEditState() (+4 more)
 
 ### Community 145 - "seedDepartments.ts"
 Cohesion: 0.12
@@ -954,32 +960,32 @@ Cohesion: 0.12
 Nodes (22): artifacts, assert(), assertTextExcludes(), assertTextIncludes(), assertTextMatches(), audit(), bodyText(), clientBase (+14 more)
 
 ### Community 147 - "researchGroupController.ts"
-Cohesion: 0.12
-Nodes (23): getResearchGroupBySlug(), hasOversizedStringList(), isOversizedSearchRequest(), OPERATOR_ALLOWED_SORT_FIELDS, parseFilters(), parsePositiveIntegerParam(), parseQualityFilters(), parseStudentVisibilityTiers() (+15 more)
+Cohesion: 0.15
+Nodes (19): hasOversizedStringList(), isOversizedSearchRequest(), OPERATOR_ALLOWED_SORT_FIELDS, parseFilters(), parsePositiveIntegerParam(), parseQualityFilters(), parseStudentVisibilityTiers(), PUBLIC_ALLOWED_SORT_FIELDS (+11 more)
 
 ### Community 148 - "yaleResearchOfficialScraper.ts"
-Cohesion: 0.15
-Nodes (22): ResearchEntityType, absoluteUrl(), cleanText(), DEFAULT_YALE_RESEARCH_DIRECTORY_CONFIGS, entityFromRecord(), entityToObservations(), inferResearchYaleKind(), pageUrlForIndex() (+14 more)
+Cohesion: 0.18
+Nodes (19): absoluteUrl(), cleanText(), DEFAULT_YALE_RESEARCH_DIRECTORY_CONFIGS, entityFromRecord(), entityToObservations(), inferResearchYaleKind(), pageUrlForIndex(), parseDirectory() (+11 more)
 
 ### Community 149 - "cleanupLegacyMongoCollections.ts"
 Cohesion: 0.17
 Nodes (23): assertLegacyCleanupWriteAllowed(), buildLegacyCleanupOutput(), collectionExists(), copyApplications(), countCollection(), countMissingStudentApplications(), createStudentApplicationIndexes(), dropLegacyCollections() (+15 more)
 
 ### Community 150 - "launchReviewExceptions.ts"
-Cohesion: 0.15
-Nodes (21): buildLaunchReviewExceptionCandidates(), buildLaunchReviewExceptionDecisionTemplate(), buildLaunchReviewExceptionOutput(), buildLaunchReviewExceptionPlan(), buildLaunchReviewExceptionReview(), __filename, isStudentReadyLaunchViolation(), LAUNCH_REVIEW_EXCEPTION_DECISION_VALUES (+13 more)
+Cohesion: 0.14
+Nodes (23): buildLaunchReviewExceptionCandidates(), buildLaunchReviewExceptionDecisionTemplate(), buildLaunchReviewExceptionOutput(), buildLaunchReviewExceptionPlan(), buildLaunchReviewExceptionReview(), __filename, isStudentReadyLaunchViolation(), LAUNCH_REVIEW_EXCEPTION_DECISION_VALUES (+15 more)
 
-### Community 151 - "Observation"
-Cohesion: 0.21
-Nodes (15): entityKeyFor(), GroupRow, LATEST_WINS, Result, run(), Observation, observationSchema, ListingPostedOpportunityMetricDeps (+7 more)
+### Community 151 - "profile.tsx"
+Cohesion: 0.13
+Nodes (22): LongText(), LongTextProps, formatRoleLabel(), Profile(), ROLE_LABELS, Tab, VALID_TABS, createInitialProfilePageState() (+14 more)
 
-### Community 152 - "idSerialization.ts"
-Cohesion: 0.15
-Nodes (17): deleteFromIndex(), ENTITY_REGISTRY, EntityIndexConfig, getConfig(), MaybePromise, stripInternalFields(), SyncableEntityType, syncEntities() (+9 more)
+### Community 152 - "ResearchGroupMember"
+Cohesion: 0.14
+Nodes (21): ResearchGroupMember, ProfileBackedFacultyResearchAreaMemberDeps, ResolvedRelationshipMaterializationDeps, deleteFromIndex(), ENTITY_REGISTRY, EntityIndexConfig, getConfig(), isSyncableEntityType() (+13 more)
 
-### Community 153 - "isNonBiographicalPublicBio"
-Cohesion: 0.15
-Nodes (18): appointmentTitleCount(), degreeTokenCount(), hasPublicProfileEmail(), hasResearchDescriptionVerb(), isAffiliationOnlyResearchSummary(), isAppointmentListOnlyProfileBio(), isAppointmentOnlyProfileBio(), isCitationLikePublicationList() (+10 more)
+### Community 153 - "materializePaperObservationsFromRun"
+Cohesion: 0.35
+Nodes (13): findEntityDocByIdentifier(), findPaperForObservationGroup(), isArxivPaperKey(), isDoiPaperKey(), mapExistingPapers(), materializePaperAuthorEvidenceFromGroups(), materializePaperObservationsFromRun(), normalizeDoiForMaterialization() (+5 more)
 
 ### Community 154 - "Yale Research - Developer Guide"
 Cohesion: 0.09
@@ -993,21 +999,21 @@ Nodes (21): assertMongoNamingMigrationWriteAllowed(), buildMongoNamingMigrationO
 Cohesion: 0.16
 Nodes (21): applyPlans(), assertRepairProfileDescriptionBackfillConflictsApplyAllowed(), buildProfileDescriptionConflictRepairPlan(), buildProfileDescriptionConflictRepairPlans(), chooseKeepObservation(), consumePath(), DESCRIPTION_FIELDS, __dirname (+13 more)
 
-### Community 157 - "normalizePublicProfile"
-Cohesion: 0.14
-Nodes (22): cleanPublicHttpUrl(), hasProfileDirectoryLabelContamination(), normalizePublicProfile(), PUBLIC_PROFILE_BASE_ARRAY_FIELDS, PUBLIC_PROFILE_BASE_TEXT_FIELDS, publicProfileBase(), publicProfileHttpUrls(), publicProfileImageUrl() (+14 more)
+### Community 157 - "cleanPublicHttpUrl"
+Cohesion: 0.13
+Nodes (22): cleanProfileUrlsForPerson(), cleanPublicHttpUrl(), hasPersonScopedYaleDirectoryPath(), hasProfileDirectoryLabelContamination(), isLabOrResearchGroupUrl(), isOfficialYaleProfileUrlForUser(), isYaleHost(), officialYaleProfileUrlForUser() (+14 more)
 
 ### Community 158 - "migrateSmartTitles.ts"
 Cohesion: 0.13
 Nodes (18): args, ARTS_DEPARTMENT_ABBRS, CATEGORY_PRIORITY, CATEGORY_SUFFIXES, DepartmentCategory, DepartmentDoc, determineSuffix(), escapeRegex() (+10 more)
 
-### Community 159 - "courseTableService.ts"
-Cohesion: 0.32
-Nodes (11): cache, CourseTableCourse, fetchAllSeasonCourses(), fetchCourseTableData(), getRecentSeasonCodes(), normalizeCourseTableProfessorName(), normalizeCourseTableSeason(), publicCourseTableCourse() (+3 more)
+### Community 159 - "redactDirectContactInfo"
+Cohesion: 0.20
+Nodes (16): publicProgramLinks(), publicProgramText(), publicProgramTextArray(), defaultRewriter(), cache, CourseTableCourse, fetchAllSeasonCourses(), fetchCourseTableData() (+8 more)
 
 ### Community 160 - "betaSeedEnvironment.ts"
-Cohesion: 0.16
-Nodes (21): ScrapeJobLockInput, ScraperEnvironment, assertBetaSeedAllowed(), BetaSeedEnvironmentCliOptions, BetaSeedPlan, BetaSeedPlanStep, BetaSeedRunResult, BetaSeedTargetMetadata (+13 more)
+Cohesion: 0.18
+Nodes (19): ScrapeJobLockInput, ScraperEnvironment, BetaSeedEnvironmentCliOptions, BetaSeedPlan, BetaSeedPlanStep, BetaSeedRunResult, BetaSeedTargetMetadata, buildBetaSeedPlan() (+11 more)
 
 ### Community 161 - "agent-workflow.md"
 Cohesion: 0.10
@@ -1017,17 +1023,17 @@ Nodes (15): Agent Workflow, Durable Notes, Read Order, Skill Index, Finishing wo
 Cohesion: 0.17
 Nodes (18): BETA_ROLLOUT_ORDER, BetaReadinessGateCliOptions, buildBetaReadinessCommands(), buildBetaReadinessGateOutput(), collectionCount(), describeMongoTarget(), __dirname, EXPECTED_SOURCE_NAMES (+10 more)
 
-### Community 163 - "source.ts"
-Cohesion: 0.20
-Nodes (12): sourceSchema, SourceCoverageArtifactType, sourceCoverageArtifactTypes, sourceCoverageEvidenceCategories, SourceCoverageEvidenceCategory, SourceCoverageMetadata, SourceCoverageTier, sourceCoverageTiers (+4 more)
+### Community 163 - "textValue"
+Cohesion: 0.16
+Nodes (21): cleanOfficialProfileDisplayName(), cleanOfficialProfileTitle(), clipOfficialProfileBio(), extractBio(), extractDepartments(), extractEmail(), extractImageUrl(), extractOfficialProfileIdentity() (+13 more)
 
 ### Community 164 - "auditResearchEntityRename.ts"
 Cohesion: 0.18
 Nodes (19): buildLegacyResidueSummary(), buildResearchEntityRenameAuditOutput(), collectionExists(), countCollection(), countDanglingReferences(), countLegacyResidue(), LEGACY_RESIDUE_CHECKS, LegacyResidueCheck (+11 more)
 
-### Community 165 - "resolveSafeJsonReportOutputPath"
-Cohesion: 0.13
-Nodes (28): assertPostedOpportunityBackfillApplyAllowed(), buildPostedOpportunityBackfillOutput(), __dirname, __filename, main(), parsePositiveInteger(), parsePostedOpportunityBackfillArgs(), PostedOpportunityBackfillCliOptions (+20 more)
+### Community 165 - "backfillPostedOpportunitiesFromListings.ts"
+Cohesion: 0.18
+Nodes (18): assertPostedOpportunityBackfillApplyAllowed(), buildPostedOpportunityBackfillOutput(), __dirname, __filename, main(), parsePositiveInteger(), parsePostedOpportunityBackfillArgs(), PostedOpportunityBackfillCliOptions (+10 more)
 
 ### Community 166 - "Session Notes"
 Cohesion: 0.10
@@ -1038,24 +1044,24 @@ Cohesion: 0.18
 Nodes (11): devDependencies, ts-node, tsup, tsx, @types/cookie-session, @types/cors, @types/express, @types/node (+3 more)
 
 ### Community 168 - "acceptedInputs.ts"
-Cohesion: 0.18
-Nodes (22): ACCEPTED_INPUT_FILE_EXTENSIONS, assertAcceptedInputPathRoot(), assertSafeAcceptedInputPathText(), defaultAdvisorResolver(), resolveSafeAcceptedInputPath(), resolveSafeAcceptedInputRoot(), assertAcceptedInputsApplyAllowed(), buildAcceptedInputsOutput() (+14 more)
+Cohesion: 0.22
+Nodes (17): defaultAdvisorResolver(), assertAcceptedInputsApplyAllowed(), buildAcceptedInputsOutput(), CliOptions, COMMANDS_REQUIRING_DB, COMMANDS_SUPPORTING_APPLY, main(), parseAcceptedInputsArgs() (+9 more)
 
-### Community 169 - "accessClaims.ts"
-Cohesion: 0.10
-Nodes (31): AccessSignalConfidence, AccessSignalType, CompensationType, EntryPathwayStatus, EntryPathwayType, EvidenceStrength, PostedOpportunityStatus, DerivedAccessSignal (+23 more)
+### Community 169 - "claimGate.ts"
+Cohesion: 0.09
+Nodes (37): AccessSignalType, ContactRouteType, PostedOpportunityStatus, buildClaimGateOutput(), ClaimGateCliOptions, ClaimGateCollection, consumeValue(), __dirname (+29 more)
 
 ### Community 170 - "scraperIntegrityDuplicateReview.ts"
 Cohesion: 0.17
-Nodes (18): DuplicateAccessSignalGroup, DuplicateResearchPaperGroup, DuplicateAccessSignalRepairPlan, buildScraperIntegrityDuplicateReviewReport(), consumeValue(), __dirname, __filename, loadDuplicateAccessSignalReviewGroups() (+10 more)
+Nodes (18): buildDuplicateResearchPaperGroupsFromRows(), DuplicateAccessSignalGroup, DuplicateResearchPaperGroup, DuplicateAccessSignalRepairPlan, buildScraperIntegrityDuplicateReviewReport(), consumeValue(), __dirname, __filename (+10 more)
 
 ### Community 171 - "clearBetaStudentAnalytics.ts"
 Cohesion: 0.24
 Nodes (17): assertClearBetaStudentAnalyticsApplyAllowed(), buildBetaStudentAnalyticsEventFilter(), buildClearBetaStudentAnalyticsOutput(), loadCandidateSummary(), main(), runClearBetaStudentAnalytics(), writeClearBetaStudentAnalyticsOutput(), BETA_STUDENT_ANALYTICS_USER_TYPES (+9 more)
 
-### Community 172 - "ResearchAreaInput.tsx"
-Cohesion: 0.23
-Nodes (10): react-dom, colorKeyToTailwind, FieldSelectorModalProps, ResearchAreaInput(), ResearchAreaInputProps, createInitialResearchAreaInputState(), ResearchAreaInputAction, researchAreaInputReducer() (+2 more)
+### Community 172 - "visibilityRepairQueueService.ts"
+Cohesion: 0.15
+Nodes (32): actionReasons, archivedResearchEntityRepairBlock(), attemptProgramRepair(), attemptResearchActionEvidenceRepair(), attemptResearchRepair(), attemptVisibilityRepair(), createEntitySourceActionEvidenceRepair(), createOfficialProfileActionEvidenceRepair() (+24 more)
 
 ### Community 173 - "Yale Research"
 Cohesion: 0.11
@@ -1085,37 +1091,37 @@ Nodes (14): Canonical Collections, Pipeline Shape, Promotion Invariants, Read-On
 Cohesion: 0.11
 Nodes (19): 2026-05-13 External Yale Validation, 2026-05-13 Model Audit, AccessSignal, Admin Review, ContactRoute, Current Implementation Context, EntryPathway, Migration Guidance (+11 more)
 
-### Community 180 - "auth.ts"
-Cohesion: 0.17
-Nodes (21): AuthenticatedUser, canCreateListing(), canSubmitListingClaimRequest(), hasAdminAuthority(), hasAuthenticatedPrincipal(), isAdmin(), isAuthenticated(), isConfirmed() (+13 more)
+### Community 180 - "index.ts"
+Cohesion: 0.16
+Nodes (24): AuthenticatedUser, canCreateListing(), canSubmitListingClaimRequest(), hasAdminAuthority(), hasAuthenticatedPrincipal(), isAdmin(), isAuthenticated(), isConfirmed() (+16 more)
 
 ### Community 181 - "adminGrantService.ts"
-Cohesion: 0.30
-Nodes (11): AdminGrant, adminGrantSchema, adminGrantCache, AdminGrantResponse, assertValidNetid(), grantAdminAccess(), listAdminGrants(), normalizeAdminGrantNote() (+3 more)
+Cohesion: 0.29
+Nodes (12): AdminGrant, adminGrantSchema, adminGrantCache, AdminGrantResponse, assertValidNetid(), grantAdminAccess(), hasActiveAdminGrant(), listAdminGrants() (+4 more)
 
-### Community 182 - "profileImageQualityAudit.ts"
-Cohesion: 0.20
-Nodes (22): buildProfileImageQualityAuditOutput(), main(), parseNonNegativeInteger(), parseProfileImageQualityAuditArgs(), parseRequiredOutputPath(), ProfileImageQualityAuditCliOptions, writeProfileImageQualityAuditOutput(), buildProfileImageQualitySummary() (+14 more)
+### Community 182 - "profileImageQualityAuditCore.ts"
+Cohesion: 0.26
+Nodes (17): buildProfileImageQualitySummary(), DuplicateProfileImageFinding, isLikelyPublicProfileImageUrl(), isNonPersonProfileImageUrl(), isSharedProfileImageAcrossDifferentNames(), isTrustedPublicProfileImageHost(), normalizedIdentityKey(), normalizedName() (+9 more)
 
-### Community 183 - "rebuildPathwaySearchIndex.ts"
-Cohesion: 0.22
-Nodes (16): assertRebuildPathwaySearchIndexAllowed(), buildRebuildPathwaySearchIndexOutput(), main(), parsePositiveInteger(), parseRebuildPathwaySearchIndexArgs(), parseRequiredOutputPath(), RebuildPathwaySearchIndexCliOptions, writeRebuildPathwaySearchIndexOutput() (+8 more)
+### Community 183 - "assertScriptApplyAllowed"
+Cohesion: 0.09
+Nodes (36): assertPublicationMigrationApplyAllowed(), buildPublicationMigrationOutput(), dedupeKey(), __dirname, EmbeddedPub, __filename, migratePublicationsToPapers(), parsePositiveInteger() (+28 more)
 
-### Community 184 - "researchDetailSources.ts"
-Cohesion: 0.21
-Nodes (12): buildResearchDetailSources(), BuildResearchDetailSourcesInput, DetailSourceContactRoute, DetailSourceGroup, DetailSourcePathway, DetailSourcePostedOpportunity, DetailSourceSignal, isDepartmentRosterProvenanceUrl() (+4 more)
+### Community 184 - "updateOwnProfile"
+Cohesion: 0.15
+Nodes (19): ADMIN_PROFILE_USER_TYPES, adminUpdateProfile(), boundedAdminProfileEmail(), boundedAdminProfileNumber(), boundedAdminProfileText(), boundedProfileString(), boundedProfileStringArray(), boundedProfileUrlKey() (+11 more)
 
-### Community 185 - "AdminListingEditModal.tsx"
-Cohesion: 0.24
-Nodes (10): AdminListing, AdminListingEditModal(), Props, AdminListingEditAction, adminListingEditReducer(), AdminListingEditState, AdminListingShape, createInitialAdminListingEditState() (+2 more)
+### Community 185 - "studentDecisionExplanationService.ts"
+Cohesion: 0.23
+Nodes (17): actionSet, cleanHttpUrl(), cleanText(), containsDirectEmail(), hasActivePostedOpportunity(), hasPublicOfficialApplicationRoute(), hasPublicRoute(), hasUndergraduateAccessEvidence() (+9 more)
 
 ### Community 186 - "compilerOptions"
 Cohesion: 0.11
 Nodes (18): compilerOptions, esModuleInterop, forceConsistentCasingInFileNames, lib, module, moduleResolution, noImplicitAny, outDir (+10 more)
 
 ### Community 187 - "AdminFacultyProfilesTable.tsx"
-Cohesion: 0.18
-Nodes (10): AdminFacultyProfilesTable(), AdminProfile, getHIndex(), getPrimaryDepartment(), PAGE_SIZES, SortField, TABLE_COLUMNS, Tab (+2 more)
+Cohesion: 0.16
+Nodes (14): AdminFacultyProfilesTable(), AdminProfile, getHIndex(), getPrimaryDepartment(), PAGE_SIZES, SortField, TABLE_COLUMNS, AdminFacultyProfilesFilter (+6 more)
 
 ### Community 188 - "generateKeywords.ts"
 Cohesion: 0.16
@@ -1125,45 +1131,45 @@ Nodes (17): ALIAS_MAP, args, buildSystemPrompt(), buildUserPrompt(), callOpenAI(
 Cohesion: 0.11
 Nodes (18): Audit Checklist, `department-undergrad-research`, `dept-faculty-roster`, Entity Discovery Sources, Funding And Publication Enrichment, `lab-microsite-description-llm`, `lab-microsite-undergrad-llm`, Mental Model (+10 more)
 
-### Community 190 - "PublicationsTable.tsx"
-Cohesion: 0.22
-Nodes (9): PublicationsTableProps, SortField, createInitialPublicationsTableState(), PublicationsFilter, PublicationsSortField, PublicationsTableAction, publicationsTableReducer(), PublicationsTableState (+1 more)
+### Community 190 - "fellowship.ts"
+Cohesion: 0.20
+Nodes (15): fellowshipSchema, programCategories, ProgramCategory, ProgramEntryMode, programEntryModes, ProgramKind, programKinds, archiveReviewClassification() (+7 more)
 
-### Community 191 - "seed.ts"
-Cohesion: 0.11
-Nodes (14): normalizeSeedNetid(), requireLocalSeedRuntime(), requireSeedToken(), router, SEED_USER_FIELDS, seedListingSummary(), seedUserPayload(), seedUserSummary() (+6 more)
+### Community 191 - "materializeEntity"
+Cohesion: 0.16
+Nodes (20): normalizeUserType(), addUniqueValuesToSet(), buildPaperUpdateFromObservations(), DISCOVERY_ONLY_ACCESS_FIELD_SOURCES, entityModelFor(), hasRequiredFieldsForCreate(), isOfficialProfileBioChromeObservation(), isResearchEntityObservationType() (+12 more)
 
 ### Community 192 - "backfillResearchDescriptions.ts"
-Cohesion: 0.15
+Cohesion: 0.16
 Nodes (17): getSourceByName(), defaultRewriter(), DESC_BLOCK_REASONS, DescriptionRewriter, __dirname, entityHttpUrls(), fetchGrantAbstract(), __filename (+9 more)
 
 ### Community 193 - "backfillResearchHomeOfficialUrls.ts"
 Cohesion: 0.18
 Nodes (16): candidateProfileUrls(), defaultVerifier(), DESC_BLOCK_REASONS, __dirname, __filename, isTrustedYaleProfileUrl(), LEAD_ROLES, main() (+8 more)
 
-### Community 194 - "scraperIntegrityGate.ts"
-Cohesion: 0.27
-Nodes (11): isIntegrityGateFailure(), PostMaterializationIntegritySummary, buildScraperIntegrityGateOutput(), consumeValue(), __dirname, __filename, main(), parseScraperIntegrityGateArgs() (+3 more)
+### Community 194 - "smartTitle.ts"
+Cohesion: 0.18
+Nodes (16): DepartmentCategory, ARTS_DEPARTMENT_ABBRS, buildDepartmentLookup(), CATEGORY_PRIORITY, CATEGORY_SUFFIXES, DepartmentDoc, determineSuffix(), escapeRegex() (+8 more)
 
 ### Community 195 - "researchEntityDto.ts"
-Cohesion: 0.20
-Nodes (19): mapResearchGroupKindToEntityType(), addResearchEntityDetailAlias(), addResearchEntitySearchAliases(), departmentDisplayLabel(), normalizedDepartmentLabel(), OPERATOR_PUBLIC_RESEARCH_ENTITY_FIELDS, OPTIONAL_PUBLIC_RESEARCH_ENTITY_FIELDS, publicDepartmentArray() (+11 more)
+Cohesion: 0.21
+Nodes (18): addResearchEntityDetailAlias(), addResearchEntitySearchAliases(), departmentDisplayLabel(), normalizedDepartmentLabel(), OPERATOR_PUBLIC_RESEARCH_ENTITY_FIELDS, OPTIONAL_PUBLIC_RESEARCH_ENTITY_FIELDS, publicDepartmentArray(), publicHttpUrl() (+10 more)
 
-### Community 196 - "serializedDocumentId"
-Cohesion: 0.27
-Nodes (13): ResearchGroupMember, ResolvedRelationshipMaterializationDeps, defaultCenterFinder(), findCenterDirectorCandidates(), findFacultyWaysInCandidates(), loadDuplicateCurrentMemberRows(), loadSamePiCandidateRows(), buildCurrentMemberOnArchivedEntityPipeline() (+5 more)
+### Community 196 - "backfillCenterDirectors.ts"
+Cohesion: 0.18
+Nodes (15): MaterializerObservationLike, CenterDirectorsBackfillCliOptions, CenterDirectorsBackfillResult, __dirname, __filename, findCenterDirectorCandidates(), LEAD_ROLES, main() (+7 more)
 
-### Community 197 - "normalizeName"
-Cohesion: 0.13
-Nodes (32): memberObservationsForEntityKey(), entryToResearchEntityObservations(), entryToUserObservations(), isLikelyExplicitLabWebsite(), entityExpectedPeople(), entityNameAsUser(), generatedOfficialProfileUrlCandidatesForPerson(), isOfficialYalePersonPageUrl() (+24 more)
+### Community 197 - "normalizeOfficialProfileUrl"
+Cohesion: 0.22
+Nodes (17): isOfficialYalePersonPageUrl(), isOfficialYaleProfileUrl(), isPotentialDirectYalePersonPageUrl(), normalizeOfficialProfileUrl(), officialPersonUrlMatchesEntity(), officialProfileSlugMatchesGivenNameVariant(), officialProfileUrlsForUser(), personPageUrlMatchesUser() (+9 more)
 
 ### Community 198 - "betaRepairQueue.ts"
-Cohesion: 0.24
-Nodes (16): arrayValue(), assertBetaRepairQueueApplyReviewedArtifact(), BetaRepairQueueApplyArtifactValidation, blockedReasonsForAttempt(), buildApplyFromArtifactOptions(), buildBetaRepairQueueOutput(), main(), objectValue() (+8 more)
+Cohesion: 0.26
+Nodes (15): arrayValue(), assertBetaRepairQueueApplyReviewedArtifact(), BetaRepairQueueApplyArtifactValidation, blockedReasonsForAttempt(), buildApplyFromArtifactOptions(), buildBetaRepairQueueOutput(), main(), objectValue() (+7 more)
 
-### Community 199 - "researchAccessTypes.ts"
-Cohesion: 0.06
-Nodes (50): allowedValues(), hasOversizedStringList(), isOversizedSearchRequest(), parseFilters(), parseSearchInput(), parseSort(), publicPathwayResearchEntity(), publicPathwaySearchResult() (+42 more)
+### Community 199 - "sanitizeProfileResearchTerms"
+Cohesion: 0.23
+Nodes (12): expandedResearchAreasPublicBio(), formatPublicBioList(), hasOfficialYaleProfileUrl(), officialProfileResearchInterestTermsBio(), publicProfileDisplayName(), supportedPublicProfileTopics(), cleanResearchTerm(), extractExplicitResearchInterestPhrases() (+4 more)
 
 ### Community 200 - "pathwayRelevanceReview.ts"
 Cohesion: 0.21
@@ -1177,9 +1183,9 @@ Nodes (14): AccessSummary, accessSummaryEntityId(), AccessSummaryStatus, bestNex
 Cohesion: 0.24
 Nodes (15): betaCommand(), buildSourceHealthRows(), commandArg(), iso(), noRecentRunCommand(), reportCommand(), reportOutputPath(), reviewArtifactForRun() (+7 more)
 
-### Community 203 - "adminFacultyProfilesTableReducer.ts"
-Cohesion: 0.09
-Nodes (22): AdminFellowshipsTable(), AdminFacultyProfilesFilter, AdminFacultyProfilesSortField, AdminFacultyProfilesTableAction, adminFacultyProfilesTableReducer(), AdminFacultyProfilesTableState, AdminFellowshipsFilter, AdminFellowshipsSortField (+14 more)
+### Community 203 - "adminFellowshipsTableReducer.ts"
+Cohesion: 0.18
+Nodes (13): AdminFellowshipsFilter, AdminFellowshipsSortField, AdminFellowshipsTableAction, adminFellowshipsTableReducer(), AdminFellowshipsTableState, AdminTableAction, AdminTableDefaults, adminTableReducer() (+5 more)
 
 ### Community 204 - "resolutions"
 Cohesion: 0.12
@@ -1189,21 +1195,21 @@ Nodes (16): resolutions, axios, brace-expansion, braces, encoding-sniffer, form-
 Cohesion: 0.26
 Nodes (14): sendPublicResearchIndex(), getResearchGroupBySlug(), buildPublicResearchSeoMetadata(), compact(), escapeHtml(), firstNonEmpty(), injectSeoMetadata(), joinList() (+6 more)
 
-### Community 206 - "devDependencies"
-Cohesion: 0.17
-Nodes (12): devDependencies, agentation, autoprefixer, jsdom, postcss, tailwindcss, @testing-library/dom, @testing-library/jest-dom (+4 more)
+### Community 206 - "researchEntity.ts"
+Cohesion: 0.08
+Nodes (38): allowedValues(), hasOversizedStringList(), isOversizedSearchRequest(), parseFilters(), parseSearchInput(), parseSort(), publicPathwayResearchEntity(), publicPathwaySearchResult() (+30 more)
 
 ### Community 207 - "visibilityReleaseQueueItem.ts"
-Cohesion: 0.13
-Nodes (23): StudentVisibilityTier, VisibilityReleaseQueueCollection, visibilityReleaseQueueCollections, visibilityReleaseQueueItemSchema, VisibilityReleaseQueueStatus, visibilityReleaseQueueStatuses, VisibilityRepairStage, visibilityRepairStages (+15 more)
+Cohesion: 0.18
+Nodes (15): VisibilityReleaseQueueCollection, visibilityReleaseQueueCollections, visibilityReleaseQueueItemSchema, VisibilityReleaseQueueStatus, visibilityReleaseQueueStatuses, VisibilityRepairStage, visibilityRepairStages, VisibilityRepairStatus (+7 more)
 
 ### Community 208 - "users.ts"
 Cohesion: 0.19
 Nodes (8): getFavoriteIds(), logFavoriteEvent(), logProfileUpdateEvent(), normalizeFavoriteAnalyticsIds(), parseFavoriteAnalyticsResponse(), profileUpdateAnalyticsFields(), router, visibleFavoriteAnalyticsIdsFromResponse()
 
-### Community 209 - "fellowshipApplicationCycleEvidenceService.ts"
-Cohesion: 0.33
-Nodes (10): buildFellowshipApplicationCycleEvidence(), cleanHttpUrl(), cleanString(), dateStatus(), FellowshipApplicationCycleEvidence, hasApplicationRoute(), looksRecurring(), textForFellowship() (+2 more)
+### Community 209 - "extractOfficialProfileResearchHomes"
+Cohesion: 0.25
+Nodes (16): affiliationValuesFromProfiles(), canonicalResearchHomeName(), classifyResearchHome(), cleanProfileCardLabWebsiteLabel(), dedupeRepeatedProfileCardLabel(), disallowedProfileLinkedResearchHome(), extractOfficialProfileResearchHomes(), genericOrganizationName() (+8 more)
 
 ### Community 210 - "dependencies"
 Cohesion: 0.13
@@ -1217,17 +1223,17 @@ Nodes (13): applyPlans(), assertDedupeExploratoryContactPathwaysApplyConfirmed()
 Cohesion: 0.30
 Nodes (13): applyRepairs(), assertRepairListingResearchEntityProfilesApplyAllowed(), buildRepairListingResearchEntityProfilesOutput(), main(), normalizeListingProfileRepairObjectId(), normalizeListingProfileRepairObjectIdString(), parsePositiveInteger(), parseRepairListingResearchEntityProfilesArgs() (+5 more)
 
-### Community 213 - "resolutions"
+### Community 213 - "scraperIntegrityGate.ts"
+Cohesion: 0.27
+Nodes (11): isIntegrityGateFailure(), PostMaterializationIntegritySummary, buildScraperIntegrityGateOutput(), consumeValue(), __dirname, __filename, main(), parseScraperIntegrityGateArgs() (+3 more)
+
+### Community 214 - "isPublicHttpUrl"
+Cohesion: 0.33
+Nodes (9): ipv4ToNumber(), isAllowedPublicHttpPort(), isIpv4InCidr(), isPrivateOrLocalHostname(), isPublicHttpUrl(), PRIVATE_HOSTNAME_SUFFIXES, PRIVATE_IPV4_CIDRS, publicHttpUrl() (+1 more)
+
+### Community 215 - "MigrateDepartments.ts"
 Cohesion: 0.18
-Nodes (11): resolutions, brace-expansion, form-data, glob, ip-address, minimatch, picomatch, postcss (+3 more)
-
-### Community 214 - "longText.ts"
-Cohesion: 0.30
-Nodes (11): LongText(), LongTextProps, LongTextOptions, longTextParagraphs(), normalizeCommonAcademicAbbreviations(), normalizeInlineWhitespace(), protectDots(), protectSentenceAbbreviations() (+3 more)
-
-### Community 215 - "csrfOriginGuard.ts"
-Cohesion: 0.31
-Nodes (6): csrfOriginGuard(), isTrustedUnsafeRequestOrigin(), originFromUrl(), SAFE_METHODS, allowedOrigins, ORIGINAL_ENV
+Nodes (12): assertDepartmentMigrationApplyAllowed(), buildDepartmentMigrationOutput(), ChangeLog, DepartmentDoc, DepartmentMigrationCliOptions, DepartmentMigrationResult, __dirname, __filename (+4 more)
 
 ### Community 216 - "compilerOptions"
 Cohesion: 0.14
@@ -1245,29 +1251,29 @@ Nodes (11): ScrapeRun, scrapeRunSchema, buildSupersededObservationPruneFilter(),
 Cohesion: 0.22
 Nodes (9): buildProgramSearchFilters(), getStringParam(), hasProgramSearchFilters(), logProgramEvent(), logProgramSearchEvent(), parseFilterParam(), router, routeByPath() (+1 more)
 
-### Community 220 - "backfillProgramClassifications.ts"
-Cohesion: 0.42
-Nodes (8): assertBackfillProgramClassificationsApplyAllowed(), BackfillProgramClassificationsCliOptions, buildBackfillProgramClassificationsOutput(), main(), parseBackfillProgramClassificationsArgs(), parsePositiveInteger(), parseRequiredOutputPath(), writeBackfillProgramClassificationsOutput()
+### Community 220 - "csrfOriginGuard.ts"
+Cohesion: 0.31
+Nodes (6): csrfOriginGuard(), isTrustedUnsafeRequestOrigin(), originFromUrl(), SAFE_METHODS, allowedOrigins, ORIGINAL_ENV
 
-### Community 221 - "package.json"
-Cohesion: 0.22
-Nodes (8): engines, node, license, main, name, proxy, type, version
+### Community 221 - "main"
+Cohesion: 0.20
+Nodes (13): buildCrossSourceObservationConflictReviewOutput(), buildCrossSourceObservationDecisionTemplate(), CrossSourceObservationConflictSample, main(), normalizedObservationIdRows(), readCrossSourceObservationReviewDecisions(), runCrossSourceObservationConflictReview(), sameObservationIdsBySource() (+5 more)
 
-### Community 222 - "classifyDuplicateEntityCluster"
-Cohesion: 0.25
-Nodes (9): DuplicateEntityCluster, buildDuplicateEntityReviewSummary(), classifyDuplicateEntityCluster(), distinctDepartmentCount(), hasSingleSharedWebsite(), isFullPersonResearchName(), isSingleSurnameLabName(), normalizedNameTokens() (+1 more)
+### Community 222 - "AdminFellowshipsTable.tsx"
+Cohesion: 0.17
+Nodes (8): AdminFellowship, AdminFellowshipsTable(), FellowshipLink, PAGE_SIZES, SortField, TABLE_COLUMNS, createInitialAdminFellowshipsTableState(), TestFellowship
 
 ### Community 223 - "seo.ts"
 Cohesion: 0.32
 Nodes (11): applySeoMetadata(), buildDefaultSeoMetadata(), buildResearchSeoMetadata(), compact(), firstNonEmpty(), joinList(), SeoMetadata, stripHtml() (+3 more)
 
 ### Community 224 - "BackfillV4StudentProfiles.ts"
-Cohesion: 0.36
-Nodes (9): backfillV4StudentProfiles(), buildDepartmentMap(), compact(), departmentIdsFor(), __filename, graduationYear(), norm(), V4StudentProfileBackfillResult (+1 more)
+Cohesion: 0.27
+Nodes (11): backfillV4StudentProfiles(), buildDepartmentMap(), compact(), departmentIdsFor(), __filename, graduationYear(), norm(), V4StudentProfileBackfillResult (+3 more)
 
-### Community 225 - "assertScriptApplyAllowed"
-Cohesion: 0.09
-Nodes (27): assertPublicationMigrationApplyAllowed(), buildPublicationMigrationOutput(), dedupeKey(), __dirname, EmbeddedPub, __filename, migratePublicationsToPapers(), parsePositiveInteger() (+19 more)
+### Community 225 - "backfillProgramClassifications.ts"
+Cohesion: 0.42
+Nodes (8): assertBackfillProgramClassificationsApplyAllowed(), BackfillProgramClassificationsCliOptions, buildBackfillProgramClassificationsOutput(), main(), parseBackfillProgramClassificationsArgs(), parsePositiveInteger(), parseRequiredOutputPath(), writeBackfillProgramClassificationsOutput()
 
 ### Community 226 - "Graphify repo memory"
 Cohesion: 0.15
@@ -1277,9 +1283,9 @@ Nodes (11): Canonical Sources, Graphify Onboarding, Refresh Policy, Setup Tasks,
 Cohesion: 0.27
 Nodes (11): buildContentSecurityPolicy(), CONNECT_SRC_ORIGINS, connectSrcDirective(), CONTENT_SECURITY_POLICY, IMG_SRC_ORIGINS, imgSrcDirective(), PERMISSIONS_POLICY, securityHeaders() (+3 more)
 
-### Community 228 - "ssrfGuard.ts"
-Cohesion: 0.32
-Nodes (10): ipv4ToNumber(), isAllowedPublicHttpPort(), isIpv4InCidr(), isIpv6InCidr(), isPrivateAddress(), isPublicHostname(), parseIpv6ToBigInt(), SsrfBlockedError (+2 more)
+### Community 228 - "package.json"
+Cohesion: 0.22
+Nodes (8): engines, node, license, main, name, proxy, type, version
 
 ### Community 229 - "listings.ts"
 Cohesion: 0.24
@@ -1287,27 +1293,27 @@ Nodes (8): buildListingSearchFilters(), getStringParam(), hasListingSearchFilter
 
 ### Community 230 - "confidenceResolver.ts"
 Cohesion: 0.24
-Nodes (10): applyProseCompletenessBonus(), DEFAULTS, normalizedProse(), PROSE_COMPLETENESS_FIELDS, recencyDecay(), resolveField(), ResolverObservation, ResolverOptions (+2 more)
+Nodes (11): applyProseCompletenessBonus(), DEFAULTS, normalizedProse(), PROSE_COMPLETENESS_FIELDS, recencyDecay(), resolveAllFields(), resolveField(), ResolverObservation (+3 more)
 
-### Community 231 - "refreshGateScorecards.ts"
-Cohesion: 0.28
-Nodes (8): argValue(), Feeder, FeederResult, FEEDERS, __filenameLocal, runFeeder(), runGateRefresh(), SERVER_ROOT
+### Community 231 - "OfficialProfilePublicationValue"
+Cohesion: 0.15
+Nodes (16): compactPersonName(), comparableObservationValue(), departmentValuesForInferredPiLookup(), deptUserNameFilters(), escapeRegex(), escapeRegExp(), fieldProvenanceForResolvedObservation(), findUniqueUserByPersonName() (+8 more)
 
 ### Community 232 - "AdminOperatorBoard"
 Cohesion: 0.20
 Nodes (12): AdminOperatorBoard(), classifyReason(), formatCountList(), formatDate(), queueDecisionPrompt(), sourceConflictScopeText(), sourceReviewArtifactRollupLines(), sourceReviewCategoryText() (+4 more)
 
-### Community 233 - "scripts"
-Cohesion: 0.29
-Nodes (7): scripts, build, dev, preview, smoke:production-promotion, test, test:ci
+### Community 233 - "labDetail.ts"
+Cohesion: 0.09
+Nodes (31): LabMembersList(), LabMembersListProps, ROLE_LABELS, ROLE_ORDER, ROLE_PILL_CLASSES, decodeHtmlEntities(), decodeNumericEntity(), isScholarlyLink() (+23 more)
 
 ### Community 234 - "BackfillV4FacultyMembers.ts"
-Cohesion: 0.17
-Nodes (18): backfillV4FacultyMembers(), buildDepartmentMap(), compact(), departmentIdsFor(), __filename, isFacultyTitle(), norm(), slugify() (+10 more)
+Cohesion: 0.32
+Nodes (11): backfillV4FacultyMembers(), buildDepartmentMap(), compact(), departmentIdsFor(), __filename, isFacultyTitle(), norm(), slugify() (+3 more)
 
-### Community 235 - "useFavorites.ts"
-Cohesion: 0.38
-Nodes (5): mockedAxios, mockedSwal, Endpoints, FavoritesKind, useFavorites()
+### Community 235 - "refreshGateScorecards.ts"
+Cohesion: 0.28
+Nodes (8): argValue(), Feeder, FeederResult, FEEDERS, __filenameLocal, runFeeder(), runGateRefresh(), SERVER_ROOT
 
 ### Community 236 - "fellowships.ts"
 Cohesion: 0.26
@@ -1321,13 +1327,13 @@ Nodes (11): Auth and Security, Auth middleware, Authentication flow, Client, Env
 Cohesion: 0.18
 Nodes (10): Author-Disambiguation Rules, Core Flows, Data-Quality Caveats, Not Optimizing For, Primary User Jobs, Product Thesis, Target User, Trust Constraints (+2 more)
 
-### Community 239 - "AdminFellowshipsTable.tsx"
-Cohesion: 0.16
-Nodes (14): AdminFellowship, FellowshipEditModal(), FellowshipLink, PAGE_SIZES, SortField, TABLE_COLUMNS, AdminFellowshipFormAction, adminFellowshipFormReducer() (+6 more)
+### Community 239 - "adminFellowshipFormReducer.ts"
+Cohesion: 0.29
+Nodes (9): FellowshipEditModal(), AdminFellowshipFormAction, adminFellowshipFormReducer(), AdminFellowshipFormSource, AdminFellowshipFormState, createInitialAdminFellowshipFormState(), FellowshipLink, toDatetimeLocal() (+1 more)
 
-### Community 240 - "ScraperMetrics"
-Cohesion: 0.50
-Nodes (5): ReportScrapeRun, ScrapeRunReport, ScraperFetchMetrics, ScraperMetrics, WorkPlannerMetrics
+### Community 240 - "MigrateUsers.ts"
+Cohesion: 0.25
+Nodes (9): assertUserMigrationApplyAllowed(), assertUserMigrationReplacementAllowed(), buildUserMigrationOutput(), __dirname, __filename, migrateUsers(), UserMigrationCliOptions, UserMigrationResult (+1 more)
 
 ### Community 241 - "Local Development Setup"
 Cohesion: 0.18
@@ -1377,21 +1383,21 @@ Nodes (10): devDependencies, eslint, eslint-config-prettier, eslint-plugin-react
 Cohesion: 0.20
 Nodes (10): resolutions, axios, brace-expansion, form-data, path-to-regexp, shell-quote, underscore, undici (+2 more)
 
-### Community 253 - "orcidWorksScraper.ts"
-Cohesion: 0.10
-Nodes (28): closeAll(), DEFAULT_EXCLUDED, flush(), main(), parseList(), isPaperAuthorshipEvidence(), isPaperAuthorshipSource(), isPaperMetadataOnlySource() (+20 more)
+### Community 253 - "paperAuthorshipPolicy.ts"
+Cohesion: 0.27
+Nodes (10): authorshipEvidenceFromPaperObservations(), isPaperAuthorshipEvidence(), isPaperAuthorshipSource(), isPaperMetadataOnlySource(), normalizePaperAuthorshipEvidence(), PAPER_AUTHORSHIP_METHODS, PAPER_AUTHORSHIP_SOURCE_NAMES, PAPER_METADATA_ONLY_SOURCE_NAMES (+2 more)
 
 ### Community 254 - "importFaculty.ts"
 Cohesion: 0.31
 Nodes (9): cleanPrimaryDepartment(), cleanSecondaryDepartments(), hasPathPrefix(), importFaculty(), KNOWN_DEPARTMENTS, RawFacultyEntry, resolveSafeFacultyImportJsonPath(), SORTED_KNOWN_DEPTS (+1 more)
 
 ### Community 255 - "launchAcquisitionReport.ts"
-Cohesion: 0.33
-Nodes (8): buildLaunchAcquisitionReportOutput(), LaunchAcquisitionReportCliOptions, main(), parseLaunchAcquisitionReportArgs(), parsePositiveInteger(), writeLaunchAcquisitionReportOutput(), LaunchAcquisitionReport, LaunchAcquisitionReportOptions
+Cohesion: 0.38
+Nodes (7): buildLaunchAcquisitionReportOutput(), LaunchAcquisitionReportCliOptions, main(), parseLaunchAcquisitionReportArgs(), parsePositiveInteger(), writeLaunchAcquisitionReportOutput(), LaunchAcquisitionReportOptions
 
-### Community 256 - "Topic matching and search engagement"
-Cohesion: 0.50
-Nodes (3): Program topics, Search engagement, Topic matching and search engagement
+### Community 256 - "departmentResolver.ts"
+Cohesion: 0.31
+Nodes (8): cache, canonicalizeDepartment(), CanonicalizeResult, DepartmentRow, loadCache(), normalize(), registerDepartmentAlias(), tokenJaccard()
 
 ### Community 257 - "researchAreaResolver.ts"
 Cohesion: 0.31
@@ -1429,13 +1435,17 @@ Nodes (6): DepartmentCategory, DepartmentCodeSystem, departmentSourceUrls, valid
 Cohesion: 0.25
 Nodes (7): author, license, main, name, packageManager, repository, version
 
-### Community 266 - "buildCandidateSample"
-Cohesion: 0.21
-Nodes (12): buildCandidateSample(), buildValuePreviewsBySource(), loadCrossSourceConflictGroups(), loadObservationsForGroupKey(), observationCollection(), observedAtForResolver(), policyBucketForConflict(), previewValue() (+4 more)
+### Community 266 - "observation"
+Cohesion: 0.32
+Nodes (8): observation(), buildCandidateSample(), buildValuePreviewsBySource(), observedAtForResolver(), policyBucketForConflict(), previewValue(), reviewCategoryForField(), toResolverObservation()
 
-### Community 267 - "itemOperations.ts"
-Cohesion: 0.46
-Nodes (5): addFavorite(), addView(), ItemMutationFilter, normalizeItemObjectId(), removeFavorite()
+### Community 267 - "researchGroupFilters.ts"
+Cohesion: 0.33
+Nodes (6): acceptanceLevelClauses(), AcceptanceLevelInput, buildResearchGroupFilterString(), escapeMeiliFilterValue(), orEqualsClause(), ResearchGroupFilterInput
+
+### Community 268 - "useFavorites.ts"
+Cohesion: 0.38
+Nodes (5): mockedAxios, mockedSwal, Endpoints, FavoritesKind, useFavorites()
 
 ### Community 269 - "check-no-secrets-core.mjs"
 Cohesion: 0.43
@@ -1445,9 +1455,21 @@ Nodes (5): findSecretFindings(), isAllowedPlaceholder(), lineNumberForIndex(), P
 Cohesion: 0.29
 Nodes (6): ciWorkflow, keepAliveWorkflow, packageJson, productionSecuritySmokeWorkflow, renderBlueprint, yarnrc
 
-### Community 271 - "runStaleObservationConflictReview"
-Cohesion: 0.29
-Nodes (7): applyStaleObservationSupersessions(), buildMongoFieldFilter(), defaultStaleObservationApplyDeps(), loadSameSourceConflictGroups(), mongoFieldFilterForCategory(), runStaleObservationConflictReview(), stringifyId()
+### Community 271 - "contactEmail.ts"
+Cohesion: 0.70
+Nodes (3): isPublicInstitutionalEmailDomain(), PUBLIC_CONTACT_EMAIL_DOMAINS, publicContactEmail()
+
+### Community 272 - "adminTableReducer.test.ts"
+Cohesion: 0.33
+Nodes (4): Filter, makeState(), Row, Sort
+
+### Community 274 - "copyBetaToProd.ts"
+Cohesion: 0.53
+Nodes (5): closeAll(), DEFAULT_EXCLUDED, flush(), main(), parseList()
+
+### Community 275 - "main"
+Cohesion: 0.60
+Nodes (5): status(), blocked_reason(), fail(), is_blocked(), main()
 
 ### Community 276 - "parseStaleObservationConflictReviewArgs"
 Cohesion: 0.47
@@ -1481,6 +1503,14 @@ Nodes (4): load_env(), main(), normalize(), Lowercase, strip whitespace and punc
 Cohesion: 0.40
 Nodes (5): dependencies, concurrently, dotenv, mongoose, openai
 
+### Community 284 - "normalizeCrossSourceReviewDecision"
+Cohesion: 0.70
+Nodes (5): asString(), asStringArray(), normalizeCrossSourceReviewDecision(), normalizeObservationIdsBySource(), optionalString()
+
+### Community 285 - "loadCrossSourceConflictGroups"
+Cohesion: 0.60
+Nodes (5): loadCrossSourceConflictGroups(), loadObservationsForGroupKey(), observationCollection(), serializeValue(), stringifyId()
+
 ### Community 286 - "normalizeStaleObservationReviewDecision"
 Cohesion: 0.50
 Nodes (5): asString(), asStringArray(), normalizeStaleObservationReviewDecision(), optionalString(), readStaleObservationReviewDecisions()
@@ -1489,29 +1519,29 @@ Nodes (5): asString(), asStringArray(), normalizeStaleObservationReviewDecision(
 Cohesion: 0.67
 Nodes (3): install_libs(), LD_LIBRARY_PATH, with-playwright-libs.sh script
 
-### Community 290 - "validateStaleObservationReviewDecisions"
-Cohesion: 0.50
-Nodes (4): sameStringSet(), StaleObservationConflictObservation, validateStaleObservationReviewDecision(), validateStaleObservationReviewDecisions()
+### Community 290 - "runStaleObservationConflictReview"
+Cohesion: 0.29
+Nodes (7): applyStaleObservationSupersessions(), defaultStaleObservationApplyDeps(), runStaleObservationConflictReview(), sameStringSet(), StaleObservationConflictObservation, validateStaleObservationReviewDecision(), validateStaleObservationReviewDecisions()
 
 ## Knowledge Gaps
-- **2208 isolated node(s):** `name`, `version`, `private`, `node`, `@emotion/react` (+2203 more)
+- **2205 isolated node(s):** `name`, `version`, `private`, `node`, `@emotion/react` (+2200 more)
   These have ≤1 connection - possible missing edges or undocumented components.
 - **38 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `sanitizeLogValue()` connect `sanitizeLogValue` to `ScraperContext`, `departmentRosterScraper.ts`, `labMicrositeUndergradLLMExtractor.ts`, `duplicateEntityNameReview.ts`, `listingController.ts`, `betaDataQuality.ts`, `auditProgramResearchRelevance.ts`, `dedupeResearchEntitiesByPi.ts`, `listingService.ts`, `profileDataQualityAudit.ts`, `researchQualitySearchReview.ts`, `passport.ts`, `labMicrositeDescriptionLLMExtractor.ts`, `sourceHealth.ts`, `analyticsService.ts`, `userService.ts`, `runReport.ts`, `User`, `scholarlyLinkSuppressionAudit.ts`, `admin.ts`, `officialProfilePiBackfillScraper.ts`, `yaleCollegeFellowshipsOfficeScraper.ts`, `paperAuthorshipAudit.ts`, `entryPathwayService.ts`, `applicationRoutePathwayBackfillCore.ts`, `backfillStudentVisibilityTiers.ts`, `entityMaterializer.ts`, `officialProfilePiBackfillScraper.test.ts`, `undergradFellowshipRecipientScraper.ts`, `crossSourceObservationConflictReview.ts`, `researchEntityMemberReferenceAudit.ts`, `seedSources.ts`, `repairOfficialProfilePublicationPointers.ts`, `configService.ts`, `backfillProfileBiosFromOfficialUrls.ts`, `departmentLeadRepairPlanCore.ts`, `scriptWriteGuards.ts`, `nihReporterScraper.ts`, `studentVisibilityRepairTargets.ts`, `redactDirectContactInfo`, `programController.ts`, `centersInstitutesScraper.ts`, `studentDecisionLLMExtractor.ts`, `dedupeUsersByIdentity.ts`, `researchEntityCoverageAudit.ts`, `renderedFetch.ts`, `analytics.ts`, `openAlexPaperScraper.ts`, `postedOpportunityService.ts`, `centerDirectorLLMExtractor.ts`, `launchTrustContractService.ts`, `pathwayQualityAudit.ts`, `promoteAcceptedBetaCopy.ts`, `profileController.ts`, `backfillCenterDirectors.ts`, `migrateResearchEntityCollections.ts`, `nsfAwardScraper.ts`, `migrateResearchEntities.ts`, `disambiguateSurnameLabNames.ts`, `repairDuplicateAccessSignals.ts`, `fellowshipController.ts`, `repairArchivedEntityArtifacts.ts`, `repairMismatchedPersonEmailsCore.ts`, `errorHandler.ts`, `cronRunner.ts`, `assertPublicHttpUrl`, `userEmailHygiene.ts`, `paperQualityService.ts`, `profileBioCoverageAudit.ts`, `logSanitizer.ts`, `staleObservationConflictReview.ts`, `researchGroupController.ts`, `cleanupLegacyMongoCollections.ts`, `launchReviewExceptions.ts`, `idSerialization.ts`, `migrateMongoNaming.ts`, `repairProfileDescriptionBackfillConflicts.ts`, `courseTableService.ts`, `betaSeedEnvironment.ts`, `betaReadinessGate.ts`, `auditResearchEntityRename.ts`, `resolveSafeJsonReportOutputPath`, `acceptedInputs.ts`, `scraperIntegrityDuplicateReview.ts`, `clearBetaStudentAnalytics.ts`, `auth.ts`, `profileImageQualityAudit.ts`, `rebuildPathwaySearchIndex.ts`, `seed.ts`, `backfillResearchDescriptions.ts`, `backfillResearchHomeOfficialUrls.ts`, `scraperIntegrityGate.ts`, `betaRepairQueue.ts`, `researchAccessTypes.ts`, `pathwayRelevanceReview.ts`, `users.ts`, `dedupeExploratoryContactPathways.ts`, `repairListingResearchEntityProfiles.ts`, `programs.ts`, `backfillProgramClassifications.ts`, `assertScriptApplyAllowed`, `listings.ts`, `refreshGateScorecards.ts`, `fellowships.ts`, `orcidWorksScraper.ts`, `importFaculty.ts`, `launchAcquisitionReport.ts`, `researchAreas.ts`?**
-  _High betweenness centrality (0.128) - this node is a cross-community bridge._
-- **Why does `field()` connect `acceptedInputsCore.ts` to `ScraperContext`, `buildStaleObservationConflictSummary`, `labMicrositeUndergradLLMExtractor.ts`, `logSanitizer.ts`, `AdminProfileEditModal.tsx`, `betaDataQuality.ts`, `labMicrositeDescriptionLLMExtractor.ts`, `normalizePublicProfile`, `sourceHealth.ts`, `integrityGate.ts`, `analyticsService.ts`, `runReport.ts`, `User`, `scraperIntegrityDuplicateReview.ts`, `ImportRootDataFiles.ts`, `adminListingsTableReducer.ts`, `officialProfilePiBackfillScraper.ts`, `entryPathwayService.ts`, `AdminFacultyProfilesTable.tsx`, `entityMaterializer.ts`, `crossSourceObservationConflictReview.ts`, `fellowshipService.ts`, `adminFacultyProfilesTableReducer.ts`, `index.ts`, `dedupeUsersByIdentity.ts`, `openAlexPaperScraper.ts`, `promoteAcceptedBetaCopy.ts`, `visibilityRepairQueueService.ts`, `listingClaimRequestService.ts`, `orcidWorksScraper.ts`, `repairDuplicateAccessSignals.ts`?**
-  _High betweenness centrality (0.082) - this node is a cross-community bridge._
-- **Why does `member()` connect `visibilityRepairQueueService.ts` to `research-detail-professor-audit.mjs`, `departmentRosterScraper.ts`, `labDetail.ts`, `profileBioCoverageAudit.ts`, `labDetail.tsx`, `v4MigrationUtils.ts`, `studentVisibilityTier.ts`, `idSerialization.ts`, `researchEntitySearchIndexService.ts`, `researchGroupService.ts`, `researchQualitySearchReview.ts`, `centersInstitutesScraper.ts`, `disambiguateSurnameLabNames.ts`?**
+- **Why does `sanitizeLogValue()` connect `sanitizeLogValue` to `types.ts`, `departmentRosterScraper.ts`, `labMicrositeUndergradLLMExtractor.ts`, `duplicateEntityNameReview.ts`, `listingController.ts`, `betaDataQuality.ts`, `resolveSafeJsonReportOutputPath`, `dedupeResearchEntitiesByPi.ts`, `listingService.ts`, `profileDataQualityAudit.ts`, `researchGroupService.ts`, `researchQualitySearchReview.ts`, `passport.ts`, `labMicrositeDescriptionLLMExtractor.ts`, `sourceHealth.ts`, `analyticsService.ts`, `userService.ts`, `runReport.ts`, `User`, `scholarlyLinkSuppressionAudit.ts`, `admin.ts`, `officialProfilePiBackfillScraper.ts`, `yaleCollegeFellowshipsOfficeScraper.ts`, `paperAuthorshipAudit.ts`, `entryPathwayService.ts`, `applicationRoutePathwayBackfillCore.ts`, `serializedDocumentId`, `entityMaterializer.ts`, `officialProfilePiBackfillScraper.test.ts`, `undergradFellowshipRecipientScraper.ts`, `crossSourceObservationConflictReview.ts`, `researchEntityMemberReferenceAudit.ts`, `seedSources.ts`, `repairOfficialProfilePublicationPointers.ts`, `configService.ts`, `backfillProfileBiosFromOfficialUrls.ts`, `departmentLeadRepairPlanCore.ts`, `cli.ts`, `ScraperContext`, `studentVisibilityRepairTargets.ts`, `opportunityDetailService.ts`, `programController.ts`, `centersInstitutesScraper.ts`, `studentDecisionLLMExtractor.ts`, `field`, `researchEntityCoverageAudit.ts`, `analytics.ts`, `openAlexPaperScraper.ts`, `postedOpportunityService.ts`, `assertPublicHttpUrl`, `arxivPreprintScraper.ts`, `launchTrustContractService.ts`, `pathwayQualityAudit.ts`, `promoteAcceptedBetaCopy.ts`, `profileController.ts`, `logSanitizer.ts`, `migrateResearchEntityCollections.ts`, `migrateResearchEntities.ts`, `disambiguateSurnameLabNames.ts`, `repairDuplicateAccessSignals.ts`, `fellowshipController.ts`, `repairArchivedEntityArtifacts.ts`, `repairMismatchedPersonEmailsCore.ts`, `errorHandler.ts`, `cronRunner.ts`, `entityMaterializer.test.ts`, `userEmailHygiene.ts`, `paperQualityService.ts`, `profileBioCoverageAudit.ts`, `initializeConnections`, `staleObservationConflictReview.ts`, `researchGroupController.ts`, `cleanupLegacyMongoCollections.ts`, `launchReviewExceptions.ts`, `ResearchGroupMember`, `materializePaperObservationsFromRun`, `migrateMongoNaming.ts`, `repairProfileDescriptionBackfillConflicts.ts`, `redactDirectContactInfo`, `betaSeedEnvironment.ts`, `betaReadinessGate.ts`, `auditResearchEntityRename.ts`, `backfillPostedOpportunitiesFromListings.ts`, `acceptedInputs.ts`, `claimGate.ts`, `scraperIntegrityDuplicateReview.ts`, `clearBetaStudentAnalytics.ts`, `assertScriptApplyAllowed`, `materializeEntity`, `backfillResearchDescriptions.ts`, `backfillResearchHomeOfficialUrls.ts`, `backfillCenterDirectors.ts`, `betaRepairQueue.ts`, `pathwayRelevanceReview.ts`, `users.ts`, `dedupeExploratoryContactPathways.ts`, `repairListingResearchEntityProfiles.ts`, `scraperIntegrityGate.ts`, `programs.ts`, `backfillProgramClassifications.ts`, `listings.ts`, `refreshGateScorecards.ts`, `fellowships.ts`, `importFaculty.ts`, `launchAcquisitionReport.ts`, `researchAreas.ts`?**
+  _High betweenness centrality (0.129) - this node is a cross-community bridge._
+- **Why does `field()` connect `field` to `types.ts`, `buildStaleObservationConflictSummary`, `labMicrositeUndergradLLMExtractor.ts`, `safeHttpUrl`, `initializeConnections`, `betaDataQuality.ts`, `acceptedInputsCore.ts`, `labMicrositeDescriptionLLMExtractor.ts`, `cleanPublicHttpUrl`, `sourceHealth.ts`, `integrityGate.ts`, `analyticsService.ts`, `runReport.ts`, `User`, `scraperIntegrityDuplicateReview.ts`, `ImportRootDataFiles.ts`, `visibilityRepairQueueService.ts`, `adminListingsTableReducer.ts`, `index.ts`, `officialProfilePiBackfillScraper.ts`, `entryPathwayService.ts`, `AdminFacultyProfilesTable.tsx`, `materializeEntity`, `crossSourceObservationConflictReview.ts`, `fellowshipService.ts`, `AdminFellowshipsTable.tsx`, `openAlexPaperScraper.ts`, `confidenceResolver.ts`, `arxivPreprintScraper.ts`, `promoteAcceptedBetaCopy.ts`, `listingClaimRequestService.ts`, `betaDataQualityCore.test.ts`?**
+  _High betweenness centrality (0.081) - this node is a cross-community bridge._
+- **Why does `member()` connect `textValue` to `research-detail-professor-audit.mjs`, `departmentRosterScraper.ts`, `labDetail.ts`, `profileBioCoverageAudit.ts`, `labDetail.tsx`, `Observation`, `studentVisibilityTier.ts`, `ResearchGroupMember`, `researchEntitySearchIndexService.ts`, `researchGroupService.ts`, `researchQualitySearchReview.ts`, `centersInstitutesScraper.ts`, `disambiguateSurnameLabNames.ts`?**
   _High betweenness centrality (0.075) - this node is a cross-community bridge._
 - **What connects `name`, `version`, `private` to the rest of the system?**
-  _2210 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _2207 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `types.tsx` be split into smaller, more focused modules?**
-  _Cohesion score 0.06779661016949153 - nodes in this community are weakly interconnected._
-- **Should `ScraperContext` be split into smaller, more focused modules?**
-  _Cohesion score 0.08220211161387632 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.04647160068846816 - nodes in this community are weakly interconnected._
+- **Should `types.ts` be split into smaller, more focused modules?**
+  _Cohesion score 0.05092592592592592 - nodes in this community are weakly interconnected._
 - **Should `UserContext.ts` be split into smaller, more focused modules?**
-  _Cohesion score 0.03815261044176707 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.04245614035087719 - nodes in this community are weakly interconnected._

--- a/scripts/security-preflight.test.mjs
+++ b/scripts/security-preflight.test.mjs
@@ -3017,10 +3017,15 @@ test('program and fellowship search bound query and filter inputs before search 
   assert.match(fellowshipService, /PUBLIC_FELLOWSHIP_PRIMITIVE_FIELDS/);
   assert.match(fellowshipService, /const safeQuery = boundedSearchQuery\(query\)/);
   assert.match(fellowshipService, /const safeYearOfStudy = boundedSearchFilterValues\(yearOfStudy\)/);
-  assert.match(fellowshipService, /filter\.\$text = \{ \$search: safeQuery \}/);
+  assert.match(fellowshipService, /const querySubjects = resolveTopicSubjects\(\[safeQuery\]\)/);
+  assert.match(fellowshipService, /const searchTerms = \[safeQuery, \.\.\.queryTopicAliases\]\.filter\(Boolean\)/);
+  assert.match(fellowshipService, /filter\.\$text = \{ \$search: searchTerms\.join\(' '\) \}/);
   assert.match(fellowshipService, /const adminFellowshipText = \(value: unknown\): string \| undefined =>/);
   assert.match(fellowshipService, /const adminFellowshipStringArray = \(value: unknown\): string\[\] \| undefined => \{/);
-  assert.match(fellowshipService, /const adminFellowshipLinks = \(value: unknown\): Array<\{ label\?: string; url: string \}> \| undefined =>/);
+  assert.match(
+    fellowshipService,
+    /const adminFellowshipLinks = \(\s*value: unknown,?\s*\): Array<\{ label\?: string; url: string \}> \| undefined =>/,
+  );
   assert.match(fellowshipService, /if \('links' in update\) \{/);
   assert.match(fellowshipService, /if \('hoursPerWeek' in update\) \{/);
   assert.match(fellowshipService, /!isStudentVisibilityTier\(update\[field\]\)/);

--- a/server/src/controllers/programController.ts
+++ b/server/src/controllers/programController.ts
@@ -73,7 +73,9 @@ const MAX_PROGRAM_SEARCH_PAGINATION_PARAM_LENGTH = 16;
 const POSITIVE_INTEGER_PARAM_RE = /^[1-9]\d*$/;
 
 const publicProgramSortField = (value: unknown, includeOperatorFields = false): string => {
-  const allowedFields = includeOperatorFields ? OPERATOR_PROGRAM_SORT_FIELDS : PUBLIC_PROGRAM_SORT_FIELDS;
+  const allowedFields = includeOperatorFields
+    ? OPERATOR_PROGRAM_SORT_FIELDS
+    : PUBLIC_PROGRAM_SORT_FIELDS;
   return typeof value === 'string' && allowedFields.has(value)
     ? value
     : DEFAULT_PUBLIC_PROGRAM_SORT_FIELD;
@@ -94,7 +96,8 @@ const numericSearchParam = (value: unknown): number | undefined => {
   return Number.isSafeInteger(parsed) ? parsed : undefined;
 };
 
-const publicProgramSortOrder = (value: unknown): 1 | -1 => (numericSearchParam(value) === 1 ? 1 : -1);
+const publicProgramSortOrder = (value: unknown): 1 | -1 =>
+  numericSearchParam(value) === 1 ? 1 : -1;
 const publicProgramPage = (value: unknown): number =>
   Math.min(MAX_SEARCH_PAGE, Math.max(1, Math.floor(numericSearchParam(value) || 1)));
 const publicProgramPageSize = (value: unknown): number =>
@@ -117,6 +120,7 @@ export const searchProgramsController = async (request: Request, response: Respo
       programKind,
       entryMode,
       studentFacingCategory,
+      subjects,
       studentVisibilityTier,
       includeOperatorReview,
       includeSuppressed,
@@ -141,6 +145,7 @@ export const searchProgramsController = async (request: Request, response: Respo
       programKind: parseFilter(programKind),
       entryMode: parseFilter(entryMode),
       studentFacingCategory: parseFilter(studentFacingCategory),
+      subjects: parseFilter(subjects),
       includeNonPublic: hasAdminAuthority,
       studentVisibilityTier: hasAdminAuthority
         ? parseStudentVisibilityFilter(studentVisibilityTier)
@@ -174,8 +179,7 @@ export const getProgramById = async (request: Request, response: Response) => {
     const program = await readProgram(request.params.id, {
       includeNonPublic: hasAdminAuthority,
     });
-    const publicProgram =
-      hasAdminAuthority ? program : publicProgramForReader(program);
+    const publicProgram = hasAdminAuthority ? program : publicProgramForReader(program);
     response.status(200).json({ program: publicProgram, fellowship: publicProgram });
   } catch (error: any) {
     sendProgramError(response, error, 'Failed to fetch program');

--- a/server/src/routes/programs.ts
+++ b/server/src/routes/programs.ts
@@ -40,6 +40,7 @@ const buildProgramSearchFilters = (query: Request['query']) => ({
   programKind: parseFilterParam(query.programKind),
   entryMode: parseFilterParam(query.entryMode),
   studentFacingCategory: parseFilterParam(query.studentFacingCategory),
+  subjects: parseFilterParam(query.subjects),
   studentVisibilityTier: parseFilterParam(query.studentVisibilityTier),
 });
 
@@ -53,6 +54,7 @@ const hasProgramSearchFilters = (filters: ReturnType<typeof buildProgramSearchFi
   filters.programKind.length > 0 ||
   filters.entryMode.length > 0 ||
   filters.studentFacingCategory.length > 0 ||
+  filters.subjects.length > 0 ||
   filters.studentVisibilityTier.length > 0;
 
 const logProgramSearchEvent = async (req: Request, res: Response, next: NextFunction) => {
@@ -88,7 +90,9 @@ const logProgramSearchEvent = async (req: Request, res: Response, next: NextFunc
             pageSize: data?.pageSize,
             totalPages: data?.totalPages,
           },
-        }).catch((err) => console.error('Error logging program search event:', sanitizeLogValue(err)));
+        }).catch((err) =>
+          console.error('Error logging program search event:', sanitizeLogValue(err)),
+        );
       }
     }
 
@@ -119,7 +123,9 @@ const logProgramEvent = (eventType: AnalyticsEventType) => {
               entityType: 'program',
               programId,
             },
-          }).catch((err: unknown) => console.error(`Error logging ${eventType} event:`, sanitizeLogValue(err)));
+          }).catch((err: unknown) =>
+            console.error(`Error logging ${eventType} event:`, sanitizeLogValue(err)),
+          );
         }
       }
 

--- a/server/src/services/__tests__/analyticsService.test.ts
+++ b/server/src/services/__tests__/analyticsService.test.ts
@@ -114,6 +114,7 @@ describe('search engagement attribution', () => {
     expect(JSON.stringify(lookup)).toContain('$$searchNetid');
     expect(JSON.stringify(lookup)).toContain('amount":30');
     expect(JSON.stringify(pipeline)).toContain('nextSearchAt');
+    expect(JSON.stringify(pipeline)).toContain('$resultCount');
   });
 });
 

--- a/server/src/services/__tests__/analyticsService.test.ts
+++ b/server/src/services/__tests__/analyticsService.test.ts
@@ -55,6 +55,7 @@ import {
   combineAnalyticsUserTypeCounts,
   getUserAnalytics,
   getUserAnalyticsDrilldown,
+  getSearchQualityAnalytics,
   logEvent,
   normalizeAnalyticsUserTypeBucket,
   shouldSuppressBetaAnalyticsEvent,
@@ -65,14 +66,54 @@ describe('analytics user type normalization', () => {
   it('combines professor and faculty into the canonical professor bucket', () => {
     expect(normalizeAnalyticsUserTypeBucket('professor')).toBe('professor');
     expect(normalizeAnalyticsUserTypeBucket('faculty')).toBe('professor');
-    expect(combineAnalyticsUserTypeCounts([
-      { userType: 'professor', count: 10755 },
-      { userType: 'faculty', count: 6701 },
-      { userType: 'undergraduate', count: 1340 },
-    ])).toEqual([
+    expect(
+      combineAnalyticsUserTypeCounts([
+        { userType: 'professor', count: 10755 },
+        { userType: 'faculty', count: 6701 },
+        { userType: 'undergraduate', count: 1340 },
+      ]),
+    ).toEqual([
       { userType: 'professor', count: 17456 },
       { userType: 'undergraduate', count: 1340 },
     ]);
+  });
+});
+
+describe('search engagement attribution', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reports action-aware success and uses a bounded same-user attribution lookup', async () => {
+    mocks.analyticsAggregate.mockResolvedValueOnce([
+      {
+        overall: [
+          {
+            totalSearches: 10,
+            zeroResultSearches: 2,
+            uniqueSearchers: 4,
+            engagedSearches: 3,
+            returnedButIgnoredSearches: 5,
+          },
+        ],
+        byQueryAndEntityType: [],
+      },
+    ]);
+
+    await expect(getSearchQualityAnalytics()).resolves.toMatchObject({
+      totalSearches: 10,
+      engagedSearches: 3,
+      returnedButIgnoredSearches: 5,
+      engagementRate: 0.3,
+      attributionWindowMinutes: 30,
+    });
+
+    const pipeline = mocks.analyticsAggregate.mock.calls[0][0];
+    const lookup = pipeline.find((stage: any) => stage.$lookup)?.$lookup;
+    expect(lookup.from).toBe('analytics_events');
+    expect(JSON.stringify(lookup)).toContain('$$searchNetid');
+    expect(JSON.stringify(lookup)).toContain('amount":30');
+    expect(JSON.stringify(pipeline)).toContain('nextSearchAt');
   });
 });
 
@@ -84,7 +125,9 @@ describe('shouldSuppressBetaAnalyticsEvent', () => {
   it('suppresses real student analytics in Beta', () => {
     vi.stubEnv('SCRAPER_ENV', 'beta');
 
-    expect(shouldSuppressBetaAnalyticsEvent({ netid: 'aa3246', userType: 'undergraduate' })).toBe(true);
+    expect(shouldSuppressBetaAnalyticsEvent({ netid: 'aa3246', userType: 'undergraduate' })).toBe(
+      true,
+    );
     expect(shouldSuppressBetaAnalyticsEvent({ netid: 'aa3246', userType: 'student' })).toBe(true);
     expect(shouldSuppressBetaAnalyticsEvent({ netid: 'aa3246', userType: 'graduate' })).toBe(true);
   });
@@ -93,14 +136,18 @@ describe('shouldSuppressBetaAnalyticsEvent', () => {
     vi.stubEnv('SCRAPER_ENV', 'beta');
 
     expect(shouldSuppressBetaAnalyticsEvent({ netid: 'qz285', userType: 'admin' })).toBe(false);
-    expect(shouldSuppressBetaAnalyticsEvent({ netid: 'devadmin', userType: 'undergraduate' })).toBe(false);
+    expect(shouldSuppressBetaAnalyticsEvent({ netid: 'devadmin', userType: 'undergraduate' })).toBe(
+      false,
+    );
     expect(shouldSuppressBetaAnalyticsEvent({ netid: 'test123', userType: 'student' })).toBe(false);
   });
 
   it('does not suppress production analytics', () => {
     vi.stubEnv('SCRAPER_ENV', 'production');
 
-    expect(shouldSuppressBetaAnalyticsEvent({ netid: 'aa3246', userType: 'undergraduate' })).toBe(false);
+    expect(shouldSuppressBetaAnalyticsEvent({ netid: 'aa3246', userType: 'undergraduate' })).toBe(
+      false,
+    );
   });
 });
 
@@ -167,7 +214,9 @@ describe('logEvent', () => {
       }),
     );
     expect(JSON.stringify(mocks.analyticsCreate.mock.calls[0][0])).not.toContain('ada@example.edu');
-    expect(JSON.stringify(mocks.analyticsCreate.mock.calls[0][0])).not.toContain('hidden@example.edu');
+    expect(JSON.stringify(mocks.analyticsCreate.mock.calls[0][0])).not.toContain(
+      'hidden@example.edu',
+    );
     expect(JSON.stringify(mocks.analyticsCreate.mock.calls[0][0])).not.toContain('203-555');
   });
 

--- a/server/src/services/__tests__/fellowshipMatchingService.test.ts
+++ b/server/src/services/__tests__/fellowshipMatchingService.test.ts
@@ -27,16 +27,20 @@ const pathway = (overrides: Partial<PathwaySearchHit> = {}): PathwaySearchHit =>
 
 describe('fellowshipMatchingService', () => {
   it('scores source-backed fellowship project matches with reasons and caveats', () => {
-    const match = scoreFellowshipForPathway(pathway(), {
-      _id: 'fellowship-1',
-      title: 'Summer RNA Research Fellowship',
-      summary: 'Supports undergraduate research projects in RNA biology.',
-      purpose: ['Research'],
-      isAcceptingApplications: true,
-      deadline: '2026-06-01T00:00:00.000Z',
-      applicationLink: 'https://example.edu/apply',
-      contactEmail: 'fellowships@example.edu',
-    }, new Date('2026-05-12T00:00:00.000Z'));
+    const match = scoreFellowshipForPathway(
+      pathway(),
+      {
+        _id: 'fellowship-1',
+        title: 'Summer RNA Research Fellowship',
+        summary: 'Supports undergraduate research projects in RNA biology.',
+        purpose: ['Research'],
+        isAcceptingApplications: true,
+        deadline: '2026-06-01T00:00:00.000Z',
+        applicationLink: 'https://example.edu/apply',
+        contactEmail: 'fellowships@example.edu',
+      },
+      new Date('2026-05-12T00:00:00.000Z'),
+    );
 
     expect(match).toMatchObject({
       fellowshipId: 'fellowship-1',
@@ -67,16 +71,20 @@ describe('fellowshipMatchingService', () => {
   });
 
   it('redacts direct contact text from public fellowship funding matches', () => {
-    const match = scoreFellowshipForPathway(pathway(), {
-      _id: 'fellowship-contact',
-      title: 'Summer RNA Research Fellowship',
-      summary: 'Supports undergraduate research projects in RNA biology.',
-      purpose: ['Research'],
-      applicationLink: 'https://example.edu/apply',
-      contactOffice: 'Office contact: fellowships@example.edu or 203-555-1212.',
-      isAcceptingApplications: true,
-      deadline: '2026-06-01T00:00:00.000Z',
-    }, new Date('2026-05-12T00:00:00.000Z'));
+    const match = scoreFellowshipForPathway(
+      pathway(),
+      {
+        _id: 'fellowship-contact',
+        title: 'Summer RNA Research Fellowship',
+        summary: 'Supports undergraduate research projects in RNA biology.',
+        purpose: ['Research'],
+        applicationLink: 'https://example.edu/apply',
+        contactOffice: 'Office contact: fellowships@example.edu or 203-555-1212.',
+        isAcceptingApplications: true,
+        deadline: '2026-06-01T00:00:00.000Z',
+      },
+      new Date('2026-05-12T00:00:00.000Z'),
+    );
 
     expect(match?.contactOffice).toBe('Office contact: [email redacted] or [phone redacted].');
     expect(match?.applicationCycle.contactOffice).toBe(
@@ -85,14 +93,18 @@ describe('fellowshipMatchingService', () => {
   });
 
   it('does not mark high-scoring matches as source-confirmed without a source URL', () => {
-    const match = scoreFellowshipForPathway(pathway(), {
-      _id: 'fellowship-no-source',
-      title: 'Summer RNA Research Fellowship',
-      summary: 'Supports undergraduate research projects in RNA biology.',
-      purpose: ['Research'],
-      isAcceptingApplications: true,
-      deadline: '2026-06-01T00:00:00.000Z',
-    }, new Date('2026-05-12T00:00:00.000Z'));
+    const match = scoreFellowshipForPathway(
+      pathway(),
+      {
+        _id: 'fellowship-no-source',
+        title: 'Summer RNA Research Fellowship',
+        summary: 'Supports undergraduate research projects in RNA biology.',
+        purpose: ['Research'],
+        isAcceptingApplications: true,
+        deadline: '2026-06-01T00:00:00.000Z',
+      },
+      new Date('2026-05-12T00:00:00.000Z'),
+    );
 
     expect(match).toMatchObject({
       fellowshipId: 'fellowship-no-source',
@@ -109,18 +121,22 @@ describe('fellowshipMatchingService', () => {
   });
 
   it('uses official link rows as fellowship source URLs', () => {
-    const match = scoreFellowshipForPathway(pathway(), {
-      _id: 'fellowship-links',
-      title: 'Summer RNA Research Fellowship',
-      summary: 'Supports undergraduate research projects in RNA biology.',
-      purpose: ['Research'],
-      links: [
-        { label: 'Program page', url: 'https://example.edu/program' },
-        { label: 'Duplicate', url: 'https://example.edu/program' },
-      ],
-      isAcceptingApplications: true,
-      deadline: '2026-06-01T00:00:00.000Z',
-    }, new Date('2026-05-12T00:00:00.000Z'));
+    const match = scoreFellowshipForPathway(
+      pathway(),
+      {
+        _id: 'fellowship-links',
+        title: 'Summer RNA Research Fellowship',
+        summary: 'Supports undergraduate research projects in RNA biology.',
+        purpose: ['Research'],
+        links: [
+          { label: 'Program page', url: 'https://example.edu/program' },
+          { label: 'Duplicate', url: 'https://example.edu/program' },
+        ],
+        isAcceptingApplications: true,
+        deadline: '2026-06-01T00:00:00.000Z',
+      },
+      new Date('2026-05-12T00:00:00.000Z'),
+    );
 
     expect(match?.sourceUrls).toEqual(['https://example.edu/program']);
     expect(match?.applicationCycle.sourceUrls).toEqual(['https://example.edu/program']);
@@ -128,16 +144,20 @@ describe('fellowshipMatchingService', () => {
   });
 
   it('does not return unsafe raw fellowship application links in matches', () => {
-    const match = scoreFellowshipForPathway(pathway(), {
-      _id: 'fellowship-unsafe-application',
-      title: 'Summer RNA Research Fellowship',
-      summary: 'Supports undergraduate research projects in RNA biology.',
-      purpose: ['Research'],
-      applicationLink: 'javascript:alert(document.cookie)',
-      links: [{ label: 'Program page', url: 'https://example.edu/program' }],
-      isAcceptingApplications: true,
-      deadline: '2026-06-01T00:00:00.000Z',
-    }, new Date('2026-05-12T00:00:00.000Z'));
+    const match = scoreFellowshipForPathway(
+      pathway(),
+      {
+        _id: 'fellowship-unsafe-application',
+        title: 'Summer RNA Research Fellowship',
+        summary: 'Supports undergraduate research projects in RNA biology.',
+        purpose: ['Research'],
+        applicationLink: 'javascript:alert(document.cookie)',
+        links: [{ label: 'Program page', url: 'https://example.edu/program' }],
+        isAcceptingApplications: true,
+        deadline: '2026-06-01T00:00:00.000Z',
+      },
+      new Date('2026-05-12T00:00:00.000Z'),
+    );
 
     expect(match?.sourceUrls).toEqual(['https://example.edu/program']);
     expect(match?.applicationCycle.applicationLink).toBeUndefined();
@@ -210,15 +230,19 @@ describe('fellowshipMatchingService', () => {
   });
 
   it('keeps expired official cycles as next-cycle planning candidates', () => {
-    const match = scoreFellowshipForPathway(pathway(), {
-      _id: 'fellowship-expired',
-      title: 'Summer RNA Research Fellowship',
-      summary: 'Supports undergraduate research projects in RNA biology.',
-      purpose: ['Research'],
-      applicationLink: 'https://example.edu/apply',
-      isAcceptingApplications: true,
-      deadline: '2026-05-01T00:00:00.000Z',
-    }, new Date('2026-05-12T00:00:00.000Z'));
+    const match = scoreFellowshipForPathway(
+      pathway(),
+      {
+        _id: 'fellowship-expired',
+        title: 'Summer RNA Research Fellowship',
+        summary: 'Supports undergraduate research projects in RNA biology.',
+        purpose: ['Research'],
+        applicationLink: 'https://example.edu/apply',
+        isAcceptingApplications: true,
+        deadline: '2026-05-01T00:00:00.000Z',
+      },
+      new Date('2026-05-12T00:00:00.000Z'),
+    );
 
     expect(match).toMatchObject({
       fellowshipId: 'fellowship-expired',
@@ -254,6 +278,33 @@ describe('fellowshipMatchingService', () => {
     );
 
     expect(match).toBeNull();
+  });
+
+  it('uses canonical topic aliases to match an AI plan to an AI award', () => {
+    const match = scoreFellowshipForPathway(
+      pathway({
+        compensation: 'VOLUNTEER',
+        researchEntity: {
+          _id: 'entity-ai',
+          slug: 'intelligent-systems',
+          name: 'Intelligent Systems Lab',
+          departments: ['Computer Science'],
+          researchAreas: ['Machine learning systems'],
+        },
+      }),
+      {
+        _id: 'schmidt-ai',
+        title: 'Schmidt Artificial Intelligence Award',
+        summary: 'Funding for AI projects across disciplines.',
+        applicationLink: 'https://example.edu/schmidt-ai',
+        isAcceptingApplications: true,
+        deadline: '2026-09-01T00:00:00.000Z',
+      },
+      new Date('2026-07-01T00:00:00.000Z'),
+    );
+
+    expect(match?.reasons).toContain('Topic match: Artificial Intelligence.');
+    expect(match?.score).toBeGreaterThanOrEqual(45);
   });
 
   it('returns top matches grouped by pathway id', async () => {

--- a/server/src/services/__tests__/programTopicService.test.ts
+++ b/server/src/services/__tests__/programTopicService.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { inferProgramSubjects, resolveTopicSubjects } from '../programTopicService';
+import {
+  inferProgramSubjects,
+  resolveTopicSubjects,
+  topicRegexForSubjects,
+} from '../programTopicService';
 
 describe('programTopicService', () => {
   it('normalizes short and long AI topic aliases to canonical subjects', () => {
@@ -7,6 +11,14 @@ describe('programTopicService', () => {
       'Artificial Intelligence',
       'Language and Text',
     ]);
+  });
+
+  it('keeps short aliases token-boundary aware in database facets', () => {
+    const pattern = new RegExp(topicRegexForSubjects(['Artificial Intelligence']), 'i');
+
+    expect(pattern.test('AI and machine learning research')).toBe(true);
+    expect(pattern.test('Application details are available')).toBe(false);
+    expect(pattern.test('Contact by email')).toBe(false);
   });
 
   it('infers subjects only from supported program text', () => {

--- a/server/src/services/__tests__/programTopicService.test.ts
+++ b/server/src/services/__tests__/programTopicService.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { inferProgramSubjects, resolveTopicSubjects } from '../programTopicService';
+
+describe('programTopicService', () => {
+  it('normalizes short and long AI topic aliases to canonical subjects', () => {
+    expect(resolveTopicSubjects(['AI systems and NLP'])).toEqual([
+      'Artificial Intelligence',
+      'Language and Text',
+    ]);
+  });
+
+  it('infers subjects only from supported program text', () => {
+    expect(
+      inferProgramSubjects({
+        title: 'Schmidt Program for Artificial Intelligence',
+        summary: 'Supports machine learning research in health and medicine.',
+      }),
+    ).toEqual(['Artificial Intelligence', 'Health and Medicine']);
+    expect(inferProgramSubjects({ title: 'General Research Award' })).toEqual([]);
+  });
+});

--- a/server/src/services/analyticsService.ts
+++ b/server/src/services/analyticsService.ts
@@ -1,11 +1,7 @@
 /**
  * Analytics event logging and aggregation service.
  */
-import {
-  AnalyticsEvent,
-  AnalyticsEventType,
-  RESEARCH_ENTITY_TYPES,
-} from '../models/analytics';
+import { AnalyticsEvent, AnalyticsEventType, RESEARCH_ENTITY_TYPES } from '../models/analytics';
 import { User, ResearchEntity } from '../models/index';
 import { getListingModel } from '../db/connections';
 import { Types, type PipelineStage } from 'mongoose';
@@ -72,10 +68,7 @@ const sanitizeAnalyticsMetadataKey = (key: string): string | undefined => {
   return trimmed;
 };
 
-const sanitizeAnalyticsMetadata = (
-  value: unknown,
-  depth = 0,
-): unknown => {
+const sanitizeAnalyticsMetadata = (value: unknown, depth = 0): unknown => {
   if (typeof value === 'string') return sanitizeAnalyticsText(value);
   if (typeof value === 'number') return Number.isFinite(value) ? value : undefined;
   if (typeof value === 'boolean' || value === null) return value;
@@ -222,6 +215,10 @@ export interface SearchQualityAnalytics {
   byQueryAndEntityType: SearchQualityQueryAnalytics[];
   topZeroResultQueries: SearchQualityQueryAnalytics[];
   topQueries: SearchQualityQueryAnalytics[];
+  engagedSearches: number;
+  returnedButIgnoredSearches: number;
+  engagementRate: number;
+  attributionWindowMinutes: number;
 }
 
 export interface SearchQuerySearcherAnalytics {
@@ -310,7 +307,10 @@ const appUserAccountMatch = (): PipelineStage.Match['$match'] => ({
 });
 
 export const normalizeAnalyticsUserTypeBucket = (userType?: string | null): string => {
-  const normalized = String(userType || 'unknown').trim().toLowerCase() || 'unknown';
+  const normalized =
+    String(userType || 'unknown')
+      .trim()
+      .toLowerCase() || 'unknown';
   return LEGACY_ACADEMIC_USER_TYPES.includes(normalized)
     ? CANONICAL_ACADEMIC_USER_TYPE
     : normalized;
@@ -370,7 +370,9 @@ const isFixtureNetid = (netid: string): boolean => {
   );
 };
 
-export const shouldSuppressBetaAnalyticsEvent = (params: Pick<LogEventParams, 'netid' | 'userType'>): boolean => {
+export const shouldSuppressBetaAnalyticsEvent = (
+  params: Pick<LogEventParams, 'netid' | 'userType'>,
+): boolean => {
   if (!isBetaRuntime()) {
     return false;
   }
@@ -379,7 +381,11 @@ export const shouldSuppressBetaAnalyticsEvent = (params: Pick<LogEventParams, 'n
     return false;
   }
 
-  return BETA_STUDENT_USER_TYPES.has(String(params.userType || '').trim().toLowerCase());
+  return BETA_STUDENT_USER_TYPES.has(
+    String(params.userType || '')
+      .trim()
+      .toLowerCase(),
+  );
 };
 
 const escapeRegex = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -649,7 +655,9 @@ export const getUserAnalytics = async (
   query: AnalyticsUsersQuery = {},
 ): Promise<AnalyticsUsersResult> => {
   const limit = clampLimit(query.limit, 50, 200);
-  const [result] = await AnalyticsEvent.aggregate(userSummaryPipeline(undefined, { ...query, limit }));
+  const [result] = await AnalyticsEvent.aggregate(
+    userSummaryPipeline(undefined, { ...query, limit }),
+  );
 
   return {
     users: result?.users ?? [],
@@ -766,6 +774,94 @@ export const getSearchQualityAnalytics = async (
       },
     },
     {
+      $lookup: {
+        from: 'analytics_events',
+        let: { searchNetid: '$netid', searchAt: '$timestamp' },
+        pipeline: [
+          {
+            $match: {
+              $expr: {
+                $and: [
+                  { $eq: ['$netid', '$$searchNetid'] },
+                  { $gt: ['$timestamp', '$$searchAt'] },
+                  {
+                    $lte: [
+                      '$timestamp',
+                      { $dateAdd: { startDate: '$$searchAt', unit: 'minute', amount: 30 } },
+                    ],
+                  },
+                  {
+                    $in: [
+                      '$eventType',
+                      [
+                        AnalyticsEventType.SEARCH,
+                        AnalyticsEventType.LISTING_VIEW,
+                        AnalyticsEventType.LISTING_FAVORITE,
+                        AnalyticsEventType.FELLOWSHIP_VIEW,
+                        AnalyticsEventType.FELLOWSHIP_FAVORITE,
+                        AnalyticsEventType.RESEARCH_VIEW,
+                        AnalyticsEventType.PATHWAY_SAVE,
+                      ],
+                    ],
+                  },
+                ],
+              },
+            },
+          },
+          { $sort: { timestamp: 1 } },
+        ],
+        as: 'attributionEvents',
+      },
+    },
+    {
+      $addFields: {
+        nextSearchAt: {
+          $min: {
+            $map: {
+              input: {
+                $filter: {
+                  input: '$attributionEvents',
+                  as: 'event',
+                  cond: { $eq: ['$$event.eventType', AnalyticsEventType.SEARCH] },
+                },
+              },
+              as: 'event',
+              in: '$$event.timestamp',
+            },
+          },
+        },
+      },
+    },
+    {
+      $addFields: {
+        hasAttributedAction: {
+          $gt: [
+            {
+              $size: {
+                $filter: {
+                  input: '$attributionEvents',
+                  as: 'event',
+                  cond: {
+                    $and: [
+                      { $ne: ['$$event.eventType', AnalyticsEventType.SEARCH] },
+                      {
+                        $or: [
+                          { $eq: [{ $type: '$nextSearchAt' }, 'missing'] },
+                          { $eq: ['$nextSearchAt', null] },
+                          { $lt: ['$$event.timestamp', '$nextSearchAt'] },
+                        ],
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+            0,
+          ],
+        },
+      },
+    },
+    {
       $facet: {
         overall: [
           {
@@ -776,6 +872,16 @@ export const getSearchQualityAnalytics = async (
                 $sum: { $cond: [{ $lte: ['$resultCount', 0] }, 1, 0] },
               },
               uniqueSearchers: { $addToSet: '$netid' },
+              engagedSearches: { $sum: { $cond: ['$hasAttributedAction', 1, 0] } },
+              returnedButIgnoredSearches: {
+                $sum: {
+                  $cond: [
+                    { $and: [{ $gt: ['$resultCount', 0] }, { $not: ['$hasAttributedAction'] }] },
+                    1,
+                    0,
+                  ],
+                },
+              },
             },
           },
           {
@@ -784,6 +890,8 @@ export const getSearchQualityAnalytics = async (
               totalSearches: 1,
               zeroResultSearches: 1,
               uniqueSearchers: { $size: '$uniqueSearchers' },
+              engagedSearches: 1,
+              returnedButIgnoredSearches: 1,
             },
           },
         ],
@@ -824,8 +932,11 @@ export const getSearchQualityAnalytics = async (
     totalSearches: 0,
     zeroResultSearches: 0,
     uniqueSearchers: 0,
+    engagedSearches: 0,
+    returnedButIgnoredSearches: 0,
   };
-  const byQueryAndEntityType = (result?.byQueryAndEntityType ?? []) as SearchQualityQueryAnalytics[];
+  const byQueryAndEntityType = (result?.byQueryAndEntityType ??
+    []) as SearchQualityQueryAnalytics[];
   const topQueries = byQueryAndEntityType.slice(0, 10);
   const topZeroResultQueries = [...byQueryAndEntityType]
     .filter((query) => query.zeroResultSearches > 0)
@@ -848,6 +959,13 @@ export const getSearchQualityAnalytics = async (
     byQueryAndEntityType,
     topZeroResultQueries,
     topQueries,
+    engagedSearches: overall.engagedSearches,
+    returnedButIgnoredSearches: overall.returnedButIgnoredSearches,
+    engagementRate:
+      overall.totalSearches > 0
+        ? Number((overall.engagedSearches / overall.totalSearches).toFixed(4))
+        : 0,
+    attributionWindowMinutes: 30,
   };
 };
 
@@ -2064,7 +2182,9 @@ export const getAnalytics = async () => {
     .lean();
   const trendingListingsById = new Map(
     trendingListingsData
-      .map((listing: any) => [normalizeAnalyticsStoredObjectIdString(listing._id), listing] as const)
+      .map(
+        (listing: any) => [normalizeAnalyticsStoredObjectIdString(listing._id), listing] as const,
+      )
       .filter(([id]) => Boolean(id)),
   );
   const enrichedTrending = engagement.trendingListings.map((t: any) => {

--- a/server/src/services/analyticsService.ts
+++ b/server/src/services/analyticsService.ts
@@ -872,7 +872,15 @@ export const getSearchQualityAnalytics = async (
                 $sum: { $cond: [{ $lte: ['$resultCount', 0] }, 1, 0] },
               },
               uniqueSearchers: { $addToSet: '$netid' },
-              engagedSearches: { $sum: { $cond: ['$hasAttributedAction', 1, 0] } },
+              engagedSearches: {
+                $sum: {
+                  $cond: [
+                    { $and: [{ $gt: ['$resultCount', 0] }, '$hasAttributedAction'] },
+                    1,
+                    0,
+                  ],
+                },
+              },
               returnedButIgnoredSearches: {
                 $sum: {
                   $cond: [

--- a/server/src/services/fellowshipMatchingService.ts
+++ b/server/src/services/fellowshipMatchingService.ts
@@ -6,6 +6,7 @@ import {
 } from './fellowshipApplicationCycleEvidenceService';
 import { getPathwaysByIds, type PathwaySearchHit } from './pathwaySearchService';
 import { serializedDocumentId } from '../utils/idSerialization';
+import { inferProgramSubjects, resolveTopicSubjects } from './programTopicService';
 
 const MAX_FELLOWSHIP_MATCH_TEXT_LENGTH = 5000;
 const MAX_FELLOWSHIP_MATCH_ARRAY_ITEMS = 50;
@@ -122,9 +123,7 @@ function matchStrength(
 }
 
 function hasFellowshipCompatibleEvidence(pathway: PathwaySearchHit): boolean {
-  return (pathway.evidence || []).some(
-    (item) => item.signalType === 'FELLOWSHIP_COMPATIBLE',
-  );
+  return (pathway.evidence || []).some((item) => item.signalType === 'FELLOWSHIP_COMPATIBLE');
 }
 
 export function scoreFellowshipForPathway(
@@ -147,7 +146,9 @@ export function scoreFellowshipForPathway(
 
   if (hasFellowshipCompatibleEvidence(pathway)) {
     score += 25;
-    reasons.push('Saved pathway has evidence that past student projects were fellowship-compatible.');
+    reasons.push(
+      'Saved pathway has evidence that past student projects were fellowship-compatible.',
+    );
   }
   if (['FELLOWSHIP', 'FELLOWSHIP_ELIGIBLE', 'STIPEND'].includes(pathway.compensation || '')) {
     score += 20;
@@ -167,6 +168,19 @@ export function scoreFellowshipForPathway(
   if (departmentMatches > 0) {
     score += Math.min(16, departmentMatches * 8);
     reasons.push('Fellowship text overlaps with the host department.');
+  }
+
+  const pathwaySubjects = resolveTopicSubjects([
+    ...(pathway.researchEntity?.researchAreas || []).slice(0, MAX_FELLOWSHIP_MATCH_ARRAY_ITEMS),
+    pathway.researchEntity?.name,
+    pathway.researchEntity?.displayName,
+    pathway.researchEntity?.kind,
+  ]);
+  const fellowshipSubjects = inferProgramSubjects(fellowship);
+  const topicMatches = pathwaySubjects.filter((subject) => fellowshipSubjects.includes(subject));
+  if (topicMatches.length > 0 && researchAreaMatches === 0) {
+    score += Math.min(36, topicMatches.length * 18);
+    reasons.push(`Topic match: ${topicMatches.join(', ')}.`);
   }
 
   if (
@@ -199,8 +213,12 @@ export function scoreFellowshipForPathway(
   } else if (applicationCycle.deadlineHasNotPassed === false) {
     if (applicationCycle.nextCycleSignal) {
       score -= 8;
-      reasons.push('Past deadline still provides evidence for a likely recurring application cycle.');
-      caveats.push('Current fellowship deadline appears to have passed; verify the next cycle before applying.');
+      reasons.push(
+        'Past deadline still provides evidence for a likely recurring application cycle.',
+      );
+      caveats.push(
+        'Current fellowship deadline appears to have passed; verify the next cycle before applying.',
+      );
     } else {
       score -= 20;
       caveats.push('Fellowship deadline appears to have passed.');
@@ -253,17 +271,17 @@ export async function matchFellowshipsForPathways(
     deps.fellowshipReader ||
     (async () => Fellowship.find({ archived: false }).sort({ deadline: 1, updatedAt: -1 }).lean());
 
-  const [pathways, fellowships] = await Promise.all([
-    pathwayReader(uniqueIds),
-    fellowshipReader(),
-  ]);
+  const [pathways, fellowships] = await Promise.all([pathwayReader(uniqueIds), fellowshipReader()]);
 
   const matchesByPathway: Record<string, FellowshipMatch[]> = {};
   for (const pathway of pathways) {
     const matches = fellowships
       .map((fellowship) => scoreFellowshipForPathway(pathway, fellowship))
       .filter((match): match is FellowshipMatch => !!match)
-      .sort((a, b) => b.score - a.score || String(a.deadline || '').localeCompare(String(b.deadline || '')))
+      .sort(
+        (a, b) =>
+          b.score - a.score || String(a.deadline || '').localeCompare(String(b.deadline || '')),
+      )
       .slice(0, 5);
     matchesByPathway[pathway._id] = matches;
   }

--- a/server/src/services/fellowshipService.ts
+++ b/server/src/services/fellowshipService.ts
@@ -23,6 +23,7 @@ import {
   PROGRAM_TOPIC_TAXONOMY,
   resolveTopicSubjects,
   topicAliasesForSubjects,
+  topicRegexForSubjects,
 } from './programTopicService';
 
 export interface FellowshipReadOptions {
@@ -55,7 +56,6 @@ const MAX_FELLOWSHIP_ID_READS = 100;
 const MAX_ADMIN_FELLOWSHIP_NUMBER = 1_000_000;
 const MONGO_OBJECT_ID_RE = /^[a-fA-F0-9]{24}$/;
 const POSITIVE_INTEGER_PARAM_RE = /^[1-9]\d*$/;
-const escapeSearchRegex = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 const PROGRAM_CATEGORIES = new Set<string>(programCategories);
 const PROGRAM_KINDS = new Set<string>(programKinds);
 const PROGRAM_ENTRY_MODES = new Set<string>(programEntryModes);
@@ -697,8 +697,7 @@ export const searchFellowships = async (params: {
     filter.$text = { $search: searchTerms.join(' ') };
   }
   if (safeSubjects.length > 0) {
-    const subjectAliases = topicAliasesForSubjects(safeSubjects);
-    const subjectPattern = subjectAliases.map(escapeSearchRegex).join('|');
+    const subjectPattern = topicRegexForSubjects(safeSubjects);
     filter.$or = [
       'title',
       'competitionType',

--- a/server/src/services/fellowshipService.ts
+++ b/server/src/services/fellowshipService.ts
@@ -18,6 +18,12 @@ import * as itemOps from './itemOperations';
 import { redactDirectContactInfo } from '../utils/contactRedaction';
 import { serializedDocumentId } from '../utils/idSerialization';
 import { publicHttpUrl } from '../utils/urlSafety';
+import {
+  inferProgramSubjects,
+  PROGRAM_TOPIC_TAXONOMY,
+  resolveTopicSubjects,
+  topicAliasesForSubjects,
+} from './programTopicService';
 
 export interface FellowshipReadOptions {
   includeNonPublic?: boolean;
@@ -49,6 +55,7 @@ const MAX_FELLOWSHIP_ID_READS = 100;
 const MAX_ADMIN_FELLOWSHIP_NUMBER = 1_000_000;
 const MONGO_OBJECT_ID_RE = /^[a-fA-F0-9]{24}$/;
 const POSITIVE_INTEGER_PARAM_RE = /^[1-9]\d*$/;
+const escapeSearchRegex = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 const PROGRAM_CATEGORIES = new Set<string>(programCategories);
 const PROGRAM_KINDS = new Set<string>(programKinds);
 const PROGRAM_ENTRY_MODES = new Set<string>(programEntryModes);
@@ -59,7 +66,9 @@ const normalizeFellowshipObjectId = (id: unknown): string | undefined => {
 };
 
 const publicFellowshipSortField = (value: unknown, includeNonPublic = false): string => {
-  const allowedFields = includeNonPublic ? OPERATOR_FELLOWSHIP_SORT_FIELDS : PUBLIC_FELLOWSHIP_SORT_FIELDS;
+  const allowedFields = includeNonPublic
+    ? OPERATOR_FELLOWSHIP_SORT_FIELDS
+    : PUBLIC_FELLOWSHIP_SORT_FIELDS;
   return typeof value === 'string' && allowedFields.has(value)
     ? value
     : DEFAULT_PUBLIC_FELLOWSHIP_SORT_FIELD;
@@ -80,7 +89,8 @@ const numericSearchParam = (value: unknown): number | undefined => {
   return Number.isSafeInteger(parsed) ? parsed : undefined;
 };
 
-const publicFellowshipSortOrder = (value: unknown): 1 | -1 => (numericSearchParam(value) === 1 ? 1 : -1);
+const publicFellowshipSortOrder = (value: unknown): 1 | -1 =>
+  numericSearchParam(value) === 1 ? 1 : -1;
 
 const boundedSearchQuery = (value: unknown): string => {
   if (typeof value !== 'string') return '';
@@ -105,9 +115,7 @@ const boundedSearchFilterValues = (values?: unknown[]): string[] => {
 };
 
 const publicFellowshipFilter = (options: FellowshipReadOptions = {}) =>
-  options.includeNonPublic
-    ? {}
-    : { studentVisibilityTier: { $in: publicStudentVisibilityTiers } };
+  options.includeNonPublic ? {} : { studentVisibilityTier: { $in: publicStudentVisibilityTiers } };
 
 const PUBLIC_FELLOWSHIP_TEXT_FIELDS = new Set([
   'compensationSummary',
@@ -198,9 +206,10 @@ const publicFellowshipLinks = (links: unknown): Array<{ label?: string; url: str
         const record = link as Record<string, unknown>;
         const url = publicHttpUrl(record.url);
         if (!url) return [];
-        const label = typeof record.label === 'string' && boundedPublicText(record.label)
-          ? redactDirectContactInfo(boundedPublicText(record.label))
-          : undefined;
+        const label =
+          typeof record.label === 'string' && boundedPublicText(record.label)
+            ? redactDirectContactInfo(boundedPublicText(record.label))
+            : undefined;
         return [{ ...(label ? { label } : {}), url }];
       })
     : [];
@@ -216,7 +225,9 @@ const adminFellowshipStringArray = (value: unknown): string[] | undefined => {
   });
 };
 
-const adminFellowshipLinks = (value: unknown): Array<{ label?: string; url: string }> | undefined =>
+const adminFellowshipLinks = (
+  value: unknown,
+): Array<{ label?: string; url: string }> | undefined =>
   Array.isArray(value) ? publicFellowshipLinks(value) : undefined;
 
 const adminFellowshipDate = (value: unknown): Date | undefined => {
@@ -229,7 +240,8 @@ const adminFellowshipNumber = (
   value: unknown,
   { min = 0, max = MAX_ADMIN_FELLOWSHIP_NUMBER }: { min?: number; max?: number } = {},
 ): number | undefined => {
-  const number = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
+  const number =
+    typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
   if (!Number.isFinite(number) || number < min || number > max) return undefined;
   return Math.trunc(number);
 };
@@ -246,19 +258,22 @@ const publicFellowshipField = (field: string, value: unknown): unknown => {
   }
 
   if (field === 'prepSteps' && Array.isArray(value)) {
-    return value.slice(0, MAX_PUBLIC_FELLOWSHIP_ARRAY_ITEMS).flatMap((item) =>
-      typeof item === 'string' ? [redactDirectContactInfo(boundedPublicText(item))] : [],
-    );
+    return value
+      .slice(0, MAX_PUBLIC_FELLOWSHIP_ARRAY_ITEMS)
+      .flatMap((item) =>
+        typeof item === 'string' ? [redactDirectContactInfo(boundedPublicText(item))] : [],
+      );
   }
 
   if (PUBLIC_FELLOWSHIP_PRIMITIVE_FIELDS.has(field)) {
     if (field === '_id') return serializedDocumentId(value);
     if (typeof value === 'string') return boundedPublicText(value);
-    if (typeof value === 'number' || typeof value === 'boolean' || value instanceof Date) return value;
+    if (typeof value === 'number' || typeof value === 'boolean' || value instanceof Date)
+      return value;
     if (Array.isArray(value)) {
-      return value.slice(0, MAX_PUBLIC_FELLOWSHIP_ARRAY_ITEMS).flatMap((item) =>
-        typeof item === 'string' ? [boundedPublicText(item)] : [],
-      );
+      return value
+        .slice(0, MAX_PUBLIC_FELLOWSHIP_ARRAY_ITEMS)
+        .flatMap((item) => (typeof item === 'string' ? [boundedPublicText(item)] : []));
     }
     return undefined;
   }
@@ -304,12 +319,10 @@ export const readFellowship = async (id: any, options: FellowshipReadOptions = {
 
 export const readFellowships = async (ids: any[], options: FellowshipReadOptions = {}) => {
   const validIds = Array.isArray(ids)
-    ? ids
-        .slice(0, MAX_FELLOWSHIP_ID_READS)
-        .flatMap((id) => {
-          const safeId = normalizeFellowshipObjectId(id);
-          return safeId ? [safeId] : [];
-        })
+    ? ids.slice(0, MAX_FELLOWSHIP_ID_READS).flatMap((id) => {
+        const safeId = normalizeFellowshipObjectId(id);
+        return safeId ? [safeId] : [];
+      })
     : [];
   if (validIds.length === 0) return [];
 
@@ -319,9 +332,7 @@ export const readFellowships = async (ids: any[], options: FellowshipReadOptions
     ...publicFellowshipFilter(options),
   });
   const rawFellowships = fellowships.map((fellowship: any) => fellowship.toObject());
-  return options.includeNonPublic
-    ? rawFellowships
-    : rawFellowships.map(publicFellowshipForStudent);
+  return options.includeNonPublic ? rawFellowships : rawFellowships.map(publicFellowshipForStudent);
 };
 
 export const readAllFellowships = async () => {
@@ -448,7 +459,15 @@ const filterFellowshipUpdate = (data: any): Record<string, any> => {
     }
   }
 
-  for (const field of ['prepSteps', 'yearOfStudy', 'termOfAward', 'purpose', 'globalRegions', 'citizenshipStatus', 'studentVisibilityReasons']) {
+  for (const field of [
+    'prepSteps',
+    'yearOfStudy',
+    'termOfAward',
+    'purpose',
+    'globalRegions',
+    'citizenshipStatus',
+    'studentVisibilityReasons',
+  ]) {
     if (field in update) {
       const values = adminFellowshipStringArray(update[field]);
       if (values !== undefined) update[field] = values;
@@ -480,7 +499,14 @@ const filterFellowshipUpdate = (data: any): Record<string, any> => {
     else delete update.hoursPerWeek;
   }
 
-  for (const field of ['applicationOpenDate', 'deadline', 'sourceLastVerifiedAt', 'sourceLastChangedAt', 'studentVisibilityComputedAt', 'studentVisibilityReviewedAt']) {
+  for (const field of [
+    'applicationOpenDate',
+    'deadline',
+    'sourceLastVerifiedAt',
+    'sourceLastChangedAt',
+    'studentVisibilityComputedAt',
+    'studentVisibilityReviewedAt',
+  ]) {
     if (field in update) {
       const date = adminFellowshipDate(update[field]);
       if (date !== undefined) update[field] = date;
@@ -488,11 +514,16 @@ const filterFellowshipUpdate = (data: any): Record<string, any> => {
     }
   }
 
-  for (const field of ['studentVisibilityTier', 'studentVisibilityComputedTier', 'studentVisibilityOverrideTier']) {
+  for (const field of [
+    'studentVisibilityTier',
+    'studentVisibilityComputedTier',
+    'studentVisibilityOverrideTier',
+  ]) {
     if (field in update && !isStudentVisibilityTier(update[field])) delete update[field];
   }
 
-  if ('programCategory' in update && !PROGRAM_CATEGORIES.has(update.programCategory)) delete update.programCategory;
+  if ('programCategory' in update && !PROGRAM_CATEGORIES.has(update.programCategory))
+    delete update.programCategory;
   if ('programKind' in update && !PROGRAM_KINDS.has(update.programKind)) delete update.programKind;
   if ('entryMode' in update && !PROGRAM_ENTRY_MODES.has(update.entryMode)) delete update.entryMode;
 
@@ -587,6 +618,7 @@ export const searchFellowships = async (params: {
   programKind?: string[];
   entryMode?: string[];
   studentFacingCategory?: string[];
+  subjects?: string[];
   requiresMentorBeforeApply?: boolean;
   mentorMatching?: boolean;
   undergraduateOnly?: boolean;
@@ -611,6 +643,7 @@ export const searchFellowships = async (params: {
     programKind = [],
     entryMode = [],
     studentFacingCategory = [],
+    subjects = [],
     requiresMentorBeforeApply,
     mentorMatching,
     undergraduateOnly,
@@ -630,9 +663,11 @@ export const searchFellowships = async (params: {
   const safeProgramKind = boundedSearchFilterValues(programKind);
   const safeEntryMode = boundedSearchFilterValues(entryMode);
   const safeStudentFacingCategory = boundedSearchFilterValues(studentFacingCategory);
-  const safeStudentVisibilityTier = boundedSearchFilterValues(studentVisibilityTier).filter(
-    isStudentVisibilityTier,
+  const safeSubjects = boundedSearchFilterValues(subjects).filter((subject) =>
+    PROGRAM_TOPIC_TAXONOMY.some((topic) => topic.subject === subject),
   );
+  const safeStudentVisibilityTier =
+    boundedSearchFilterValues(studentVisibilityTier).filter(isStudentVisibilityTier);
   const page = Math.min(
     MAX_SEARCH_PAGE,
     Math.max(1, Math.floor(numericSearchParam(requestedPage) || 1)),
@@ -655,8 +690,27 @@ export const searchFellowships = async (params: {
     filter.studentVisibilityTier = { $in: publicStudentVisibilityTiers };
   }
 
+  const querySubjects = resolveTopicSubjects([safeQuery]);
+  const queryTopicAliases = topicAliasesForSubjects(querySubjects);
   if (safeQuery) {
-    filter.$text = { $search: safeQuery };
+    const searchTerms = [safeQuery, ...queryTopicAliases].filter(Boolean);
+    filter.$text = { $search: searchTerms.join(' ') };
+  }
+  if (safeSubjects.length > 0) {
+    const subjectAliases = topicAliasesForSubjects(safeSubjects);
+    const subjectPattern = subjectAliases.map(escapeSearchRegex).join('|');
+    filter.$or = [
+      'title',
+      'competitionType',
+      'summary',
+      'description',
+      'applicationInformation',
+      'eligibility',
+      'restrictionsToUseOfAward',
+      'additionalInformation',
+      'purpose',
+      'studentFacingCategory',
+    ].map((field) => ({ [field]: { $regex: subjectPattern, $options: 'i' } }));
   }
 
   if (safeYearOfStudy.length > 0) {
@@ -703,7 +757,8 @@ export const searchFellowships = async (params: {
   if (safeQuery) {
     sortOptions.score = { $meta: 'textScore' };
   }
-  sortOptions[publicFellowshipSortField(sortBy, includeNonPublic)] = publicFellowshipSortOrder(sortOrder);
+  sortOptions[publicFellowshipSortField(sortBy, includeNonPublic)] =
+    publicFellowshipSortOrder(sortOrder);
 
   const skip = (page - 1) * pageSize;
 
@@ -719,7 +774,9 @@ export const searchFellowships = async (params: {
   ]);
 
   return {
-    fellowships: includeNonPublic ? fellowships : fellowships.map(publicFellowshipForStudent),
+    fellowships: (includeNonPublic ? fellowships : fellowships.map(publicFellowshipForStudent)).map(
+      (fellowship) => ({ ...fellowship, inferredSubjects: inferProgramSubjects(fellowship) }),
+    ),
     total,
     page,
     pageSize,
@@ -764,6 +821,7 @@ export const getFilterOptions = async () => {
     programKind: programKindOptions.filter(Boolean).sort(),
     entryMode: entryModeOptions.filter(Boolean).sort(),
     studentFacingCategory: studentFacingCategoryOptions.filter(Boolean).sort(),
+    subjects: PROGRAM_TOPIC_TAXONOMY.map((topic) => topic.subject),
   };
 };
 

--- a/server/src/services/programTopicService.ts
+++ b/server/src/services/programTopicService.ts
@@ -1,0 +1,124 @@
+const MAX_TOPIC_TEXT_LENGTH = 20_000;
+
+export interface ProgramTopicDefinition {
+  subject: string;
+  aliases: string[];
+}
+
+// Intentionally small and explicit. These labels are derived from source-backed
+// program/profile text; they are not claims that a program has curated tags.
+export const PROGRAM_TOPIC_TAXONOMY: ProgramTopicDefinition[] = [
+  {
+    subject: 'Artificial Intelligence',
+    aliases: [
+      'artificial intelligence',
+      'machine learning',
+      'deep learning',
+      'neural network',
+      ' ai ',
+      ' ml ',
+    ],
+  },
+  {
+    subject: 'Data Science',
+    aliases: ['data science', 'data analysis', 'statistics', 'statistical', 'computational'],
+  },
+  {
+    subject: 'Computer Vision',
+    aliases: ['computer vision', 'image processing', 'medical imaging'],
+  },
+  {
+    subject: 'Language and Text',
+    aliases: [
+      'natural language processing',
+      ' nlp ',
+      'linguistics',
+      'language model',
+      'text analysis',
+    ],
+  },
+  {
+    subject: 'Health and Medicine',
+    aliases: ['health', 'medicine', 'medical', 'clinical', 'biomedical', 'public health'],
+  },
+  {
+    subject: 'Biology',
+    aliases: ['biology', 'biological', 'genomics', 'genetics', 'neuroscience', 'ecology'],
+  },
+  {
+    subject: 'Engineering',
+    aliases: ['engineering', 'robotics', 'materials science', 'mechanical', 'electrical'],
+  },
+  {
+    subject: 'Environment and Climate',
+    aliases: ['environment', 'climate', 'sustainability', 'conservation'],
+  },
+  {
+    subject: 'Humanities and Arts',
+    aliases: ['humanities', 'history', 'literature', 'arts', 'archive', 'museum'],
+  },
+  {
+    subject: 'Social Sciences',
+    aliases: [
+      'social science',
+      'political science',
+      'economics',
+      'sociology',
+      'psychology',
+      'policy',
+    ],
+  },
+];
+
+const normalizedText = (value: unknown): string => {
+  const parts = Array.isArray(value) ? value : [value];
+  return ` ${parts
+    .flatMap((part) => (typeof part === 'string' ? [part] : []))
+    .join(' ')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .slice(0, MAX_TOPIC_TEXT_LENGTH)} `;
+};
+
+const topicText = (record: any): string =>
+  normalizedText([
+    record?.title,
+    record?.competitionType,
+    record?.summary,
+    record?.description,
+    record?.applicationInformation,
+    record?.eligibility,
+    record?.restrictionsToUseOfAward,
+    record?.additionalInformation,
+    record?.purpose,
+    record?.studentFacingCategory,
+  ]);
+
+const aliasMatches = (text: string, alias: string): boolean =>
+  text.includes(
+    ` ${alias
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, ' ')} `,
+  );
+
+export const inferProgramSubjects = (program: any): string[] => {
+  const text = topicText(program);
+  return PROGRAM_TOPIC_TAXONOMY.filter((topic) =>
+    topic.aliases.some((alias) => aliasMatches(text, alias)),
+  ).map((topic) => topic.subject);
+};
+
+export const resolveTopicSubjects = (values: unknown[]): string[] => {
+  const text = normalizedText(values);
+  return PROGRAM_TOPIC_TAXONOMY.filter(
+    (topic) =>
+      aliasMatches(text, topic.subject) || topic.aliases.some((alias) => aliasMatches(text, alias)),
+  ).map((topic) => topic.subject);
+};
+
+export const topicAliasesForSubjects = (subjects: string[]): string[] =>
+  PROGRAM_TOPIC_TAXONOMY.filter((topic) => subjects.includes(topic.subject))
+    .flatMap((topic) => [topic.subject, ...topic.aliases])
+    .map((value) => value.trim())
+    .filter((value) => value.length >= 2);

--- a/server/src/services/programTopicService.ts
+++ b/server/src/services/programTopicService.ts
@@ -122,3 +122,10 @@ export const topicAliasesForSubjects = (subjects: string[]): string[] =>
     .flatMap((topic) => [topic.subject, ...topic.aliases])
     .map((value) => value.trim())
     .filter((value) => value.length >= 2);
+
+const escapeRegex = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+export const topicRegexForSubjects = (subjects: string[]): string => {
+  const aliases = topicAliasesForSubjects(subjects).map(escapeRegex);
+  return aliases.length > 0 ? `(?:^|[^a-z0-9])(?:${aliases.join('|')})(?:$|[^a-z0-9])` : '';
+};


### PR DESCRIPTION
## Summary

- add a documented canonical topic taxonomy and synonym layer for program search and fellowship matching
- expose an inferred Subject facet without claiming unpopulated curated tags
- make search success depend on a same-user view or save within 30 minutes and before the next search
- report returned-but-ignored searches alongside existing zero-result diagnostics

## Topic design

Subjects are inferred only from supported program text and saved-plan research-home fields.
Short aliases such as AI and ML use token-boundary-aware matching.
Topic overlap supplements existing compensation, evidence, source, deadline, and minimum-score safeguards.

## Metric definition

A search is successful only when it returned at least one result and the same signed-in user viewed or saved a result within 30 minutes and before their next search.
No query text or contact data is copied onto action events.

## Validation

- server: 219 files, 2,530 tests passed
- client: 94 files, 761 tests passed
- focused server typecheck and review-fix tests passed
- focused ESLint: no errors
- secrets scan passed
- Graphify outputs refreshed

## Baseline limitations

- repository-wide ESLint remains blocked by 24 pre-existing errors on `beta`
- `yarn security:policy` remains blocked by a pre-existing syntax error in `scripts/security-preflight.test.mjs` on `beta`
