### PR TITLE
Clear repository ESLint errors

### DIFF
--- a/client/src/components/SignInButton.tsx
+++ b/client/src/components/SignInButton.tsx
@@ -5,6 +5,7 @@ import Button from '@mui/material/Button';
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { buildApiUrl } from '../utils/apiBaseUrl';
+import { isAsciiControlCode } from '../utils/asciiControl';
 
 const MAX_CAS_RETURN_PATH_LENGTH = 2048;
 
@@ -12,7 +13,13 @@ const normalizeReturnPath = (value?: string | null): string => {
   if (!value) return '';
   const trimmed = value.trim();
   if (!trimmed || trimmed.length > MAX_CAS_RETURN_PATH_LENGTH) return '';
-  if (/[\u0000-\u0020\u007f\\]/.test(trimmed)) return '';
+  if (
+    Array.from(trimmed).some((character) => {
+      const code = character.charCodeAt(0);
+      return isAsciiControlCode(code) || code === 0x20 || character === '\\';
+    })
+  )
+    return '';
 
   try {
     const url = new URL(trimmed, window.location.origin);

--- a/client/src/utils/__tests__/googleSheets.test.ts
+++ b/client/src/utils/__tests__/googleSheets.test.ts
@@ -1,6 +1,6 @@
-// @ts-ignore - Vitest executes this browser-oriented test in Node.
+// @ts-expect-error - Vitest executes this browser-oriented test in Node.
 import { readFileSync } from 'fs';
-// @ts-ignore - The client tsconfig does not include Node ambient types.
+// @ts-expect-error - The client tsconfig does not include Node ambient types.
 import { resolve } from 'path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -255,7 +255,12 @@ describe('Google Sheets OAuth popup', () => {
       close: vi.fn(),
     };
 
-    const runCallback = new Function('window', 'URLSearchParams', 'BroadcastChannel', callbackScript);
+    const runCallback = new Function(
+      'window',
+      'URLSearchParams',
+      'BroadcastChannel',
+      callbackScript,
+    );
     runCallback(fakeWindow, URLSearchParams, MockBroadcastChannel);
 
     expect(MockBroadcastChannel.channels[0].messages).toContainEqual({
@@ -264,11 +269,7 @@ describe('Google Sheets OAuth popup', () => {
       state: 'callback-state',
     });
     expect(MockBroadcastChannel.channels[0].name).toBe('google-oauth-token:callback-state');
-    expect(fakeWindow.history.replaceState).toHaveBeenCalledWith(
-      null,
-      '',
-      '/oauth-callback.html',
-    );
+    expect(fakeWindow.history.replaceState).toHaveBeenCalledWith(null, '', '/oauth-callback.html');
     expect(fakeWindow.close).toHaveBeenCalled();
   });
 
@@ -290,18 +291,18 @@ describe('Google Sheets OAuth popup', () => {
       close: vi.fn(),
     };
 
-    const runCallback = new Function('window', 'URLSearchParams', 'BroadcastChannel', callbackScript);
+    const runCallback = new Function(
+      'window',
+      'URLSearchParams',
+      'BroadcastChannel',
+      callbackScript,
+    );
     runCallback(fakeWindow, URLSearchParams, MockBroadcastChannel);
 
     expect(MockBroadcastChannel.channels).toEqual([]);
-    expect(fakeWindow.history.replaceState).toHaveBeenCalledWith(
-      null,
-      '',
-      '/oauth-callback.html',
-    );
+    expect(fakeWindow.history.replaceState).toHaveBeenCalledWith(null, '', '/oauth-callback.html');
     expect(fakeWindow.close).toHaveBeenCalled();
   });
-
 
   it('neutralizes formula-like headers and cells before writing to Google Sheets', async () => {
     vi.useFakeTimers();

--- a/client/src/utils/apiBaseUrl.ts
+++ b/client/src/utils/apiBaseUrl.ts
@@ -1,7 +1,11 @@
 const LOCAL_SERVER_ORIGIN = 'http://localhost:4000';
 const PRODUCTION_SERVER_ORIGIN = 'https://yalelabs.io';
 const MAX_BACKEND_ORIGIN_LENGTH = 2048;
-const UNSAFE_BACKEND_ORIGIN_CHAR_RE = /[\u0000-\u0020\u007f\\]/;
+const hasUnsafeBackendOriginCharacter = (value: string): boolean =>
+  Array.from(value).some((character) => {
+    const code = character.charCodeAt(0);
+    return isAsciiControlCode(code) || code === 0x20 || character === '\\';
+  });
 
 const trimTrailingSlashes = (value: string) => value.replace(/\/+$/, '');
 
@@ -12,15 +16,12 @@ export const isProductionWebHost = (host: string): boolean => {
   return hostname === 'yalelabs.io' || hostname === 'www.yalelabs.io';
 };
 
-export const normalizeBackendOrigin = (
-  value: unknown,
-  fallback = LOCAL_SERVER_ORIGIN,
-): string => {
+export const normalizeBackendOrigin = (value: unknown, fallback = LOCAL_SERVER_ORIGIN): string => {
   if (typeof value !== 'string') return fallback;
   const trimmed = trimTrailingSlashes(value.trim());
   if (!trimmed) return fallback;
   if (trimmed.length > MAX_BACKEND_ORIGIN_LENGTH) return fallback;
-  if (UNSAFE_BACKEND_ORIGIN_CHAR_RE.test(trimmed)) return fallback;
+  if (hasUnsafeBackendOriginCharacter(trimmed)) return fallback;
 
   try {
     const parsed = new URL(trimmed);
@@ -48,3 +49,4 @@ export const buildApiUrl = (path: string) => {
   const normalizedPath = path.startsWith('/') ? path : `/${path}`;
   return `${getApiBaseUrl()}${normalizedPath}`;
 };
+import { isAsciiControlCode } from './asciiControl';

--- a/client/src/utils/asciiControl.ts
+++ b/client/src/utils/asciiControl.ts
@@ -1,0 +1,9 @@
+export const isAsciiControlCode = (code: number): boolean => code <= 0x1f || code === 0x7f;
+
+export const containsAsciiControl = (value: string): boolean =>
+  Array.from(value).some((character) => isAsciiControlCode(character.charCodeAt(0)));
+
+export const replaceAsciiControls = (value: string, replacement: string): string =>
+  Array.from(value, (character) =>
+    isAsciiControlCode(character.charCodeAt(0)) ? replacement : character,
+  ).join('');

--- a/client/src/utils/googleSheets.ts
+++ b/client/src/utils/googleSheets.ts
@@ -11,7 +11,7 @@ const OAUTH_CHANNEL_NAME = 'google-oauth-token';
 const OAUTH_POPUP_NAME_PREFIX = 'google-auth';
 const OAUTH_POPUP_FEATURES = 'popup,width=500,height=600,noopener,noreferrer';
 const OAUTH_STATE_PATTERN = /^[A-Za-z0-9._~-]{1,128}$/;
-const ACCESS_TOKEN_PATTERN = /^[A-Za-z0-9._~+\/-]+=*$/;
+const ACCESS_TOKEN_PATTERN = /^[A-Za-z0-9._~+/-]+=*$/;
 const MAX_ACCESS_TOKEN_LENGTH = 4096;
 const MAX_SHEET_TITLE_LENGTH = 120;
 const MAX_SHEET_HEADERS = 50;
@@ -38,7 +38,9 @@ function oauthChannelNameForState(state: string): string {
 }
 
 function oauthPopupNameForState(state: string): string {
-  return OAUTH_STATE_PATTERN.test(state) ? `${OAUTH_POPUP_NAME_PREFIX}-${state}` : OAUTH_POPUP_NAME_PREFIX;
+  return OAUTH_STATE_PATTERN.test(state)
+    ? `${OAUTH_POPUP_NAME_PREFIX}-${state}`
+    : OAUTH_POPUP_NAME_PREFIX;
 }
 
 function openOAuthPopup(state: string): Window | null {
@@ -54,7 +56,9 @@ export function safeSheetCell(value: string): string {
 }
 
 function safeSheetTitle(value: unknown): string {
-  const title = String(value || 'Yale Research Export').trim().slice(0, MAX_SHEET_TITLE_LENGTH);
+  const title = String(value || 'Yale Research Export')
+    .trim()
+    .slice(0, MAX_SHEET_TITLE_LENGTH);
   return title || 'Yale Research Export';
 }
 
@@ -111,7 +115,13 @@ function getAccessToken(clientId: string): Promise<string> {
     }
 
     let settled = false;
-    let checkClosed: ReturnType<typeof setInterval>;
+    const checkClosed = setInterval(() => {
+      if (popup.closed && !settled) {
+        settled = true;
+        cleanup();
+        reject(new Error('Google sign-in was cancelled'));
+      }
+    }, 500);
     const cleanup = () => {
       channel.close();
       clearInterval(checkClosed);
@@ -134,14 +144,6 @@ function getAccessToken(clientId: string): Promise<string> {
     channel.onmessage = (event) => handleMessage(event.data);
 
     popup.location.href = authUrl;
-
-    checkClosed = setInterval(() => {
-      if (popup.closed && !settled) {
-        settled = true;
-        cleanup();
-        reject(new Error('Google sign-in was cancelled'));
-      }
-    }, 500);
   });
 }
 

--- a/client/src/utils/spreadsheetSafety.ts
+++ b/client/src/utils/spreadsheetSafety.ts
@@ -1,6 +1,20 @@
-const SPREADSHEET_FORMULA_PREFIX = /^[\s\u0000-\u001f]*[=+\-@]/;
+import { isAsciiControlCode } from './asciiControl';
+
+const startsWithSpreadsheetFormula = (value: string): boolean => {
+  const prefixIndex = Array.from(value).findIndex((character) => {
+    const code = character.charCodeAt(0);
+    return !isAsciiControlCode(code) && !/\s/.test(character);
+  });
+  const firstContentCharacter = prefixIndex === -1 ? '' : Array.from(value)[prefixIndex];
+  return (
+    firstContentCharacter === '=' ||
+    firstContentCharacter === '+' ||
+    firstContentCharacter === '-' ||
+    firstContentCharacter === '@'
+  );
+};
 
 export function safeSpreadsheetCell(value: unknown): string {
   const text = String(value ?? '');
-  return SPREADSHEET_FORMULA_PREFIX.test(text) ? `'${text}` : text;
+  return startsWithSpreadsheetFormula(text) ? `'${text}` : text;
 }

--- a/client/src/utils/url.ts
+++ b/client/src/utils/url.ts
@@ -2,7 +2,11 @@
  * URL construction utilities for API endpoints.
  */
 const SAFE_URL_SCHEMES = new Set(['http:', 'https:', 'mailto:']);
-const UNSAFE_RAW_URL_CHAR_RE = /[\u0000-\u0020\u007f\\]/;
+const hasUnsafeRawUrlCharacter = (value: string): boolean =>
+  Array.from(value).some((character) => {
+    const code = character.charCodeAt(0);
+    return isAsciiControlCode(code) || code === 0x20 || character === '\\';
+  });
 const EMAIL_ADDRESS_PATTERN =
   /^[a-z0-9.!#$&'*+/=?^_`{|}~-]+@[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$/i;
 const DOI_PATTERN = /^10\.\d{4,9}\/[a-z0-9._;()/:+-]+$/i;
@@ -90,7 +94,7 @@ export const safeUrl = (raw: unknown): string => {
   const trimmed = raw.trim();
   if (!trimmed) return '';
   if (trimmed.length > MAX_SAFE_URL_LENGTH) return '';
-  if (UNSAFE_RAW_URL_CHAR_RE.test(trimmed)) return '';
+  if (hasUnsafeRawUrlCharacter(trimmed)) return '';
   const withScheme = /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(trimmed) ? trimmed : `https://${trimmed}`;
   try {
     const parsed = new URL(withScheme);
@@ -126,7 +130,7 @@ export const safeImageSrc = (raw: unknown): string => {
   if (trimmed.length > MAX_SAFE_URL_LENGTH) return '';
 
   if (trimmed.startsWith('/') && !trimmed.startsWith('//')) {
-    if (/[\u0000-\u001f\u007f<>`"\\]/.test(trimmed)) return '';
+    if (containsAsciiControl(trimmed) || /[<>`"\\]/.test(trimmed)) return '';
     return trimmed;
   }
 
@@ -139,16 +143,28 @@ const safeUrlListValues = (values: unknown): unknown[] =>
   Array.isArray(values) ? values.slice(0, MAX_SAFE_URL_LIST_ITEMS) : [];
 
 export const safeUrlList = (values: unknown): string[] =>
-  Array.from(new Set(safeUrlListValues(values).map((value) => safeUrl(value)).filter(Boolean)));
+  Array.from(
+    new Set(
+      safeUrlListValues(values)
+        .map((value) => safeUrl(value))
+        .filter(Boolean),
+    ),
+  );
 
 export const safeHttpUrlList = (values: unknown): string[] =>
-  Array.from(new Set(safeUrlListValues(values).map((value) => safeHttpUrl(value)).filter(Boolean)));
+  Array.from(
+    new Set(
+      safeUrlListValues(values)
+        .map((value) => safeHttpUrl(value))
+        .filter(Boolean),
+    ),
+  );
 
 export const safeRouteSegment = (raw: unknown): string => {
   if (typeof raw !== 'string') return '';
   const trimmed = raw.trim();
   if (!trimmed || trimmed.length > MAX_SAFE_ROUTE_SEGMENT_LENGTH) return '';
-  if (/[\u0000-\u001f\u007f]/.test(trimmed)) return '';
+  if (containsAsciiControl(trimmed)) return '';
   if (trimmed === '.' || trimmed === '..') return '';
   if (/^%(?:2e)(?:%(?:2e))?$/i.test(trimmed)) return '';
   return encodeURIComponent(trimmed);
@@ -162,7 +178,10 @@ export const safeMailtoHref = (
   if (!email) return '';
 
   const query = new URLSearchParams();
-  if (typeof params.subject === 'string' && params.subject.length <= MAX_SAFE_MAILTO_SUBJECT_LENGTH) {
+  if (
+    typeof params.subject === 'string' &&
+    params.subject.length <= MAX_SAFE_MAILTO_SUBJECT_LENGTH
+  ) {
     query.set('subject', params.subject);
   }
   if (typeof params.body === 'string' && params.body.length <= MAX_SAFE_MAILTO_BODY_LENGTH) {
@@ -192,3 +211,4 @@ export const openSafeUrlInNewTab = (raw: unknown): Window | null => {
   if (opened) opened.opener = null;
   return opened;
 };
+import { containsAsciiControl, isAsciiControlCode } from './asciiControl';

--- a/scripts/security-preflight.test.mjs
+++ b/scripts/security-preflight.test.mjs
@@ -499,10 +499,8 @@ test('client dynamic internal route segments are encoded before rendering', () =
     new URL('../client/src/components/research/ResearchHomeCard.tsx', import.meta.url),
     'utf8',
   );
-  assert.match(urlSource, /const UNSAFE_RAW_URL_CHAR_RE = \/\[\\u0000-\\u0020\\u007f\\\\\]\//);
-  assert.match(urlSource, /if \(UNSAFE_RAW_URL_CHAR_RE\.test\(trimmed\)\) return ''/);
-  assert.match(serverUrlSafetySource, /const UNSAFE_RAW_PUBLIC_URL_CHAR_RE = \/\[\\u0000-\\u0020\\u007f\\\\\]\//);
-  assert.match(serverUrlSafetySource, /if \(UNSAFE_RAW_PUBLIC_URL_CHAR_RE\.test\(trimmed\)\) return false/);
+  assert.match(urlSource, /hasUnsafeRawUrlCharacter\(trimmed\)/);
+  assert.match(serverUrlSafetySource, /hasUnsafeRawPublicUrlCharacter\(trimmed\)/);
   assert.match(urlSource, /export const safeRouteSegment = \(raw: unknown\): string => \{/);
   assert.match(urlSource, /if \(trimmed === '\.' \|\| trimmed === '\.\.'\) return ''/);
   assert.match(urlSource, /\^%\(\?:2e\)\(\?:%\(\?:2e\)\)\?\$/i);
@@ -1654,16 +1652,15 @@ test('admin URL reachability helpers bound inputs before parsing or DNS work', (
   const source = fs.readFileSync(new URL('../server/src/routes/admin.ts', import.meta.url), 'utf8');
 
   assert.match(source, /export const MAX_ADMIN_URL_CHECK_URL_LENGTH = 2048/);
-  assert.match(source, /const ADMIN_URL_CHECK_DISPLAY_CONTROL_RE = \/\[\\u0000-\\u001f\\u007f\]\/g/);
-  assert.match(source, /const ADMIN_URL_CHECK_UNSAFE_INPUT_RE = \/\[\\u0000-\\u001f\\u007f\\s\\\\\]\/;/);
+  assert.match(source, /containsAsciiControl\(value\) \|\| \/\[\\s\\\\\]\/\.test\(value\)/);
   assert.match(source, /const adminUrlCheckDisplayText = \(value: string\): string =>/);
-  assert.match(source, /\.replace\(ADMIN_URL_CHECK_DISPLAY_CONTROL_RE, ''\)/);
+  assert.match(source, /replaceAsciiControls\(value, ''\)/);
   assert.match(source, /\.slice\(0, MAX_ADMIN_URL_CHECK_URL_LENGTH\)/);
   assert.match(source, /trimmed\.length === 0 \|\| trimmed\.length > MAX_ADMIN_URL_CHECK_URL_LENGTH/);
   assert.match(source, /const trimmedUrl = url\.trim\(\)/);
   assert.match(source, /trimmedUrl\.length === 0 \|\| url\.length > MAX_ADMIN_URL_CHECK_URL_LENGTH/);
-  assert.match(source, /ADMIN_URL_CHECK_UNSAFE_INPUT_RE\.test\(trimmedUrl\)/);
-  assert.match(source, /ADMIN_URL_CHECK_UNSAFE_INPUT_RE\.test\(trimmed\)/);
+  assert.match(source, /hasUnsafeAdminUrlInput\(trimmedUrl\)/);
+  assert.match(source, /hasUnsafeAdminUrlInput\(trimmed\)/);
   assert.match(source, /Each URL must be a canonical HTTP\(S\) URL/);
   assert.match(source, /return \{ url: displayUrl, status: 0, reachable: false, error: 'URL too long' \}/);
   assert.doesNotMatch(source, /return url;\n\s*\}/);
@@ -1767,7 +1764,7 @@ test('admin taxonomy write routes bound labels and category arrays before persis
   assert.doesNotMatch(source, /res\.json\(\{ department: dept \}\)/);
   assert.doesNotMatch(researchAreaClientSource, /addedBy/);
   assert.match(source, /rawValues\.length === 0 \|\| rawValues\.length > MAX_ADMIN_DEPARTMENT_CATEGORIES/);
-  assert.match(source, /update\.name = normalizeAdminTaxonomyLabel\(name, 'research area name', MAX_RESEARCH_AREA_NAME_LENGTH\)/);
+  assert.match(source, /update\.name = normalizeAdminTaxonomyLabel\(\s*name,\s*'research area name',\s*MAX_RESEARCH_AREA_NAME_LENGTH,?\s*\)/);
   assert.match(source, /const normalizedAbbreviation = normalizeAdminTaxonomyLabel/);
   assert.match(source, /const normalizedCategories = normalizeAdminDepartmentCategories/);
   assert.match(source, /update\.categories = normalizeAdminDepartmentCategories\(categories\)/);
@@ -2727,9 +2724,9 @@ test('client API base URL builder rejects hostile backend origins', () => {
   assert.doesNotMatch(source, /window\.location\.host\.includes\('yalelabs\.io'\)/);
   assert.match(source, /export const normalizeBackendOrigin = \(/);
   assert.match(source, /const MAX_BACKEND_ORIGIN_LENGTH = 2048/);
-  assert.match(source, /const UNSAFE_BACKEND_ORIGIN_CHAR_RE = \/\[\\u0000-\\u0020\\u007f\\\\\]\//);
+  assert.match(source, /const hasUnsafeBackendOriginCharacter/);
   assert.match(source, /trimmed\.length > MAX_BACKEND_ORIGIN_LENGTH/);
-  assert.match(source, /UNSAFE_BACKEND_ORIGIN_CHAR_RE\.test\(trimmed\)/);
+  assert.match(source, /hasUnsafeBackendOriginCharacter\(trimmed\)/);
   assert.match(source, /parsed\.protocol !== 'http:' && parsed\.protocol !== 'https:'/);
   assert.match(source, /parsed\.username \|\| parsed\.password/);
   assert.match(source, /return `\$\{parsed\.origin\}\$\{pathPrefix === '\/' \? '' : pathPrefix\}`/);
@@ -3519,12 +3516,12 @@ test('shared SSRF guard bounds public URL shape before outbound fetches', () => 
   );
 
   assert.match(source, /const MAX_SSRF_PUBLIC_HTTP_URL_LENGTH = 2048/);
-  assert.match(source, /const UNSAFE_SSRF_PUBLIC_HTTP_URL_RE = \/\[\\u0000-\\u001f\\u007f\\s\\\\\]\/;/);
+  assert.match(source, /const hasUnsafePublicHttpUrlCharacter/);
   assert.match(source, /const isAllowedPublicHttpPort = \(url: URL\): boolean =>/);
   assert.match(source, /if \(typeof rawUrl !== 'string'\)/);
   assert.match(source, /const trimmed = rawUrl\.trim\(\)/);
   assert.match(source, /if \(!trimmed \|\| trimmed\.length > MAX_SSRF_PUBLIC_HTTP_URL_LENGTH\)/);
-  assert.match(source, /UNSAFE_SSRF_PUBLIC_HTTP_URL_RE\.test\(trimmed\)/);
+  assert.match(source, /hasUnsafePublicHttpUrlCharacter\(trimmed\)/);
   assert.match(source, /parsed = new URL\(trimmed\)/);
   assert.match(source, /if \(!isAllowedPublicHttpPort\(parsed\)\)/);
   assert.match(source, /throw new SsrfBlockedError\('URL port is not allowed'\)/);
@@ -3598,7 +3595,7 @@ test('shared research-area creation normalizes labels and rejects direct contact
 
   assert.match(source, /import \{ redactDirectContactInfo \} from '\.\.\/utils\/contactRedaction'/);
   assert.match(source, /const normalizeResearchAreaLabel = \(value: string\): string =>/);
-  assert.match(source, /replace\(\/\[\\u0000-\\u001f\\u007f\]\/g, ' '\)/);
+  assert.match(source, /replaceAsciiControls\(value, ' '\)/);
   assert.match(source, /const hasDirectContactInfo = \(value: string\): boolean => redactDirectContactInfo\(value\) !== value/);
   assert.match(source, /const trimmedName = normalizeResearchAreaLabel\(name\)/);
   assert.match(source, /Research area name cannot include contact information/);
@@ -4483,10 +4480,10 @@ test('public config serializes taxonomy through bounded contact-redacted fields'
   assert.match(source, /const publicDepartmentColorKey = \(value: unknown\): number =>/);
   assert.match(source, /const publicResearchAreaColorKey = \(value: unknown, fallback: unknown\): string =>/);
   assert.match(source, /name: publicConfigText\(area\.name\)/);
-  assert.match(source, /colorKey: publicResearchAreaColorKey\(area\.colorKey, fieldColorKeys\[area\.field as ResearchField\]\)/);
+  assert.match(source, /colorKey: publicResearchAreaColorKey\(\s*area\.colorKey,\s*fieldColorKeys\[area\.field as ResearchField\],?\s*\)/);
   assert.match(source, /aliases: publicConfigTextArray\(/);
   assert.match(source, /categories: publicDepartmentCategories\(dept\.categories\)/);
-  assert.match(source, /primaryCategory: publicDepartmentCategories\(\[dept\.primaryCategory\]\)\[0\]/);
+  assert.match(source, /primaryCategory:\s*publicDepartmentCategories\(\[dept\.primaryCategory\]\)\[0\]/);
   assert.doesNotMatch(source, /aliases: dept\.aliases \|\| \[\]/);
   assert.doesNotMatch(source, /categories: dept\.categories/);
 });
@@ -4729,7 +4726,7 @@ test('unsafe request origin headers are bounded before parsing', () => {
   assert.match(passportSource, /const MAX_AUTH_ORIGIN_HEADER_LENGTH = 2048/);
   assert.match(passportSource, /function originFromUrl\(value: string \| undefined\): string \{/);
   assert.match(passportSource, /value\.length > MAX_AUTH_ORIGIN_HEADER_LENGTH/);
-  assert.match(passportSource, /if \(\/\[\\u0000-\\u0020\\u007f\\\\\]\/\.test\(value\)\) return ''/);
+  assert.match(passportSource, /isAsciiControlCode\(code\) \|\| code === 0x20 \|\| character === '\\\\'/);
   assert.match(passportSource, /if \(parsed\.username \|\| parsed\.password\) return ''/);
   assert.match(csrfSource, /const MAX_CSRF_ORIGIN_HEADER_LENGTH = 2048/);
   assert.match(csrfSource, /const originFromUrl = \(value: string \| undefined\): string => \{/);
@@ -4738,7 +4735,7 @@ test('unsafe request origin headers are bounded before parsing', () => {
   assert.match(csrfSource, /args\.writeLikeSafeMethodPaths\?\.has\(args\.path\)/);
   assert.match(csrfSource, /if \(SAFE_METHODS\.has\(method\) && !isWriteLikeSafeMethodPath\) return true/);
   assert.match(csrfSource, /value\.length > MAX_CSRF_ORIGIN_HEADER_LENGTH/);
-  assert.match(csrfSource, /if \(\/\[\\u0000-\\u0020\\u007f\\\\\]\/\.test\(value\)\) return ''/);
+  assert.match(csrfSource, /isAsciiControlCode\(code\) \|\| code === 0x20 \|\| character === '\\\\'/);
   assert.match(csrfSource, /if \(parsed\.username \|\| parsed\.password\) return ''/);
   assert.match(csrfSource, /if \(args\.origin !== undefined\) \{/);
   assert.match(csrfSource, /return Boolean\(origin && args\.allowedOrigins\.has\(origin\)\)/);
@@ -4757,10 +4754,10 @@ test('CORS origin headers are bounded before allowlist comparison', () => {
   );
 
   assert.match(source, /const MAX_CORS_ORIGIN_LENGTH = 2048/);
-  assert.match(source, /const UNSAFE_CORS_ORIGIN_RE = \/\[\\u0000-\\u0020\\u007f\\\\\]\//);
+  assert.match(source, /const hasUnsafeCorsOriginCharacter/);
   assert.match(source, /const normalizeCorsOrigin = \(origin: string \| undefined\): string => \{/);
   assert.match(source, /origin\.length > MAX_CORS_ORIGIN_LENGTH/);
-  assert.match(source, /UNSAFE_CORS_ORIGIN_RE\.test\(origin\)/);
+  assert.match(source, /hasUnsafeCorsOriginCharacter\(origin\)/);
   assert.match(source, /parsed\.username \|\| parsed\.password/);
   assert.match(source, /parsed\.origin !== origin/);
   assert.match(source, /const normalizedOrigin = normalizeCorsOrigin\(origin\)/);
@@ -5534,7 +5531,7 @@ test('shared URL sanitizers bound values before parsing', () => {
   assert.match(clientUrlSource, /Array\.isArray\(values\) \? values\.slice\(0, MAX_SAFE_URL_LIST_ITEMS\) : \[\]/);
   assert.match(clientUrlSource, /trimmed\.length > MAX_SAFE_EMAIL_LENGTH/);
   assert.match(clientUrlSource, /withoutMailto\.length > MAX_SAFE_EMAIL_LENGTH/);
-  assert.match(clientUrlSource, /typeof params\.subject === 'string' && params\.subject\.length <= MAX_SAFE_MAILTO_SUBJECT_LENGTH/);
+  assert.match(clientUrlSource, /typeof params\.subject === 'string' &&\s*params\.subject\.length <= MAX_SAFE_MAILTO_SUBJECT_LENGTH/);
   assert.match(clientUrlSource, /typeof params\.body === 'string' && params\.body\.length <= MAX_SAFE_MAILTO_BODY_LENGTH/);
   assert.match(clientUrlSource, /rawDoi\.trim\(\)\.length > MAX_SAFE_DOI_LENGTH/);
   assert.match(serverUrlSource, /MAX_PUBLIC_HTTP_URL_LENGTH = 2048/);
@@ -5728,8 +5725,8 @@ test('spreadsheet exports neutralize formula-like cell values', () => {
     'utf8',
   );
 
-  assert.match(spreadsheetSafetySource, /SPREADSHEET_FORMULA_PREFIX/);
-  assert.match(spreadsheetSafetySource, /\[\\s\\u0000-\\u001f\]\*\[=\+\\-@\]/);
+  assert.match(spreadsheetSafetySource, /startsWithSpreadsheetFormula/);
+  assert.match(spreadsheetSafetySource, /isAsciiControlCode\(code\)/);
   assert.match(googleSheetsSource, /safeSheetCell/);
   assert.match(googleSheetsSource, /normalizeOAuthAccessToken/);
   assert.match(googleSheetsSource, /ACCESS_TOKEN_PATTERN/);

--- a/server/src/acceptedInputs/fellowshipInputs.ts
+++ b/server/src/acceptedInputs/fellowshipInputs.ts
@@ -13,6 +13,7 @@ import {
 import { normalizeName, splitName } from '../scrapers/utils/scraperHelpers';
 import { normalizeOrcid } from '../utils/orcid';
 import { assertPublicHttpUrl, ssrfSafeAgents } from '../utils/ssrfGuard';
+import { containsAsciiControl } from '../utils/asciiControl';
 
 export const DEFAULT_ACCEPTED_INPUT_ROOT = '/tmp/ylabs-accepted-inputs';
 export const FELLOWSHIP_REVIEW_DIR = 'fellowship-review';
@@ -95,7 +96,7 @@ function assertSafeAcceptedInputPathText(value: string, flag: string): string {
   if (!trimmed || trimmed.startsWith('--')) {
     throw new Error(`${flag} requires a path`);
   }
-  if (/[\u0000-\u001f\u007f]/.test(trimmed)) {
+  if (containsAsciiControl(trimmed)) {
     throw new Error(`${flag} path contains invalid characters`);
   }
   return trimmed;
@@ -117,7 +118,10 @@ export function resolveSafeAcceptedInputRoot(value = DEFAULT_ACCEPTED_INPUT_ROOT
   );
 }
 
-export function resolveSafeAcceptedInputPath(filePath: string, flag = 'accepted input path'): string {
+export function resolveSafeAcceptedInputPath(
+  filePath: string,
+  flag = 'accepted input path',
+): string {
   const resolved = assertAcceptedInputPathRoot(
     path.resolve(assertSafeAcceptedInputPathText(filePath, flag)),
     flag,
@@ -260,18 +264,27 @@ function coerceReviewRow(row: Record<string, string>, config?: ProgramConfig): F
   };
 }
 
-async function readReviewRows(filePath: string, config?: ProgramConfig): Promise<FellowshipReviewRow[]> {
+async function readReviewRows(
+  filePath: string,
+  config?: ProgramConfig,
+): Promise<FellowshipReviewRow[]> {
   const body = await fs.readFile(resolveSafeAcceptedInputPath(filePath), 'utf8');
   return parseCsv(body).map((row) => coerceReviewRow(row, config));
 }
 
-async function writeRows(filePath: string, rows: FellowshipReviewRow[], headers: readonly string[]) {
+async function writeRows(
+  filePath: string,
+  rows: FellowshipReviewRow[],
+  headers: readonly string[],
+) {
   const safePath = resolveSafeAcceptedInputPath(filePath);
   await fs.mkdir(path.dirname(safePath), { recursive: true });
   await fs.writeFile(safePath, `${stringifyCsv(rows, headers)}\n`, 'utf8');
 }
 
-export async function defaultFetchUrl(url: string): Promise<{ body: Buffer; contentType?: string }> {
+export async function defaultFetchUrl(
+  url: string,
+): Promise<{ body: Buffer; contentType?: string }> {
   const parsedUrl = await assertPublicHttpUrl(url);
   const { httpAgent, httpsAgent } = ssrfSafeAgents();
   const response = await axios.get<ArrayBuffer>(parsedUrl.toString(), {
@@ -418,7 +431,10 @@ function htmlCandidateRows(
   return candidateRowsFromText(text, config, sourceUrl, defaultYear);
 }
 
-function manualRequiredRow(config: ProgramConfig, sourceUrl = config.urls[0] || ''): FellowshipReviewRow {
+function manualRequiredRow(
+  config: ProgramConfig,
+  sourceUrl = config.urls[0] || '',
+): FellowshipReviewRow {
   return {
     reviewStatus: 'manual-required',
     programKey: config.programKey,
@@ -446,7 +462,12 @@ export async function generateFellowshipCandidates(
   const configs = deps.configs || DEFAULT_PROGRAM_CONFIGS;
   const fetchUrl = deps.fetchUrl || defaultFetchUrl;
   const pdfTextExtractor = deps.pdfTextExtractor || extractPdfText;
-  const summaries: Array<{ programKey: string; status: string; candidateCount: number; path: string }> = [];
+  const summaries: Array<{
+    programKey: string;
+    status: string;
+    candidateCount: number;
+    path: string;
+  }> = [];
 
   for (const config of configs) {
     const rows: FellowshipReviewRow[] = [];
@@ -458,12 +479,7 @@ export async function generateFellowshipCandidates(
           ? fetched.body
           : Buffer.from(String(fetched.body), 'utf8');
         const sourceRows = isPdfSource(sourceUrl, fetched.contentType)
-          ? candidateRowsFromText(
-              await pdfTextExtractor(body),
-              config,
-              sourceUrl,
-              defaultYear,
-            )
+          ? candidateRowsFromText(await pdfTextExtractor(body), config, sourceUrl, defaultYear)
           : htmlCandidateRows(body.toString('utf8'), config, sourceUrl, defaultYear);
         rows.push(...sourceRows);
       } catch (error: any) {
@@ -549,7 +565,9 @@ export async function exportAcceptedFellowshipRows(
   programKey: string,
   deps: FellowshipInputDeps = {},
 ) {
-  const config = (deps.configs || DEFAULT_PROGRAM_CONFIGS).find((item) => item.programKey === programKey);
+  const config = (deps.configs || DEFAULT_PROGRAM_CONFIGS).find(
+    (item) => item.programKey === programKey,
+  );
   if (!config) throw new Error(`Unknown fellowship program "${programKey}"`);
   const inputPath = reviewPath(root, programKey);
   const rows = (await readReviewRows(inputPath, config)).filter(
@@ -670,15 +688,21 @@ async function findUserByName(advisorName: string): Promise<AdvisorResolution> {
 
   const queries: Record<string, unknown>[] = [];
   if (first) {
-    queries.push({ lname, fname: new RegExp(`^${escapeRegex(first)}$`, 'i'), userType: facultyTypes });
-    queries.push({ lname, fname: new RegExp(`^${escapeRegex(first.charAt(0))}`, 'i'), userType: facultyTypes });
+    queries.push({
+      lname,
+      fname: new RegExp(`^${escapeRegex(first)}$`, 'i'),
+      userType: facultyTypes,
+    });
+    queries.push({
+      lname,
+      fname: new RegExp(`^${escapeRegex(first.charAt(0))}`, 'i'),
+      userType: facultyTypes,
+    });
   }
   queries.push({ lname, userType: facultyTypes });
 
   for (const query of queries) {
-    const matches = await User.find(query, { fname: 1, lname: 1, netid: 1 })
-      .limit(2)
-      .lean();
+    const matches = await User.find(query, { fname: 1, lname: 1, netid: 1 }).limit(2).lean();
     if (matches.length === 1) {
       const match = matches[0] as any;
       return {
@@ -698,7 +722,10 @@ export async function defaultAdvisorResolver(row: FellowshipReviewRow): Promise<
   const advisorOrcid = normalizeOrcid(row.advisorOrcid);
   const facultyTypes = { $in: ['professor', 'faculty', 'admin'] };
   if (advisorOrcid) {
-    const matches = await User.find({ orcid: advisorOrcid, userType: facultyTypes }, { fname: 1, lname: 1, netid: 1 })
+    const matches = await User.find(
+      { orcid: advisorOrcid, userType: facultyTypes },
+      { fname: 1, lname: 1, netid: 1 },
+    )
       .limit(2)
       .lean();
     if (matches.length === 1) {

--- a/server/src/middleware/corsOrigin.ts
+++ b/server/src/middleware/corsOrigin.ts
@@ -1,6 +1,10 @@
 const CORS_ORIGIN_ERROR_MESSAGE = 'Not allowed by CORS';
 const MAX_CORS_ORIGIN_LENGTH = 2048;
-const UNSAFE_CORS_ORIGIN_RE = /[\u0000-\u0020\u007f\\]/;
+const hasUnsafeCorsOriginCharacter = (value: string): boolean =>
+  Array.from(value).some((character) => {
+    const code = character.charCodeAt(0);
+    return isAsciiControlCode(code) || code === 0x20 || character === '\\';
+  });
 
 export class CorsOriginError extends Error {
   status = 403;
@@ -17,7 +21,7 @@ type CorsOriginCallback = (error: Error | null, allow?: boolean) => void;
 const normalizeCorsOrigin = (origin: string | undefined): string => {
   if (origin === undefined) return '';
   if (origin.length > MAX_CORS_ORIGIN_LENGTH) return '';
-  if (UNSAFE_CORS_ORIGIN_RE.test(origin)) return '';
+  if (hasUnsafeCorsOriginCharacter(origin)) return '';
 
   try {
     const parsed = new URL(origin);
@@ -67,3 +71,4 @@ export const createCorsOriginHandler = (
     callback(new CorsOriginError());
   };
 };
+import { isAsciiControlCode } from '../utils/asciiControl';

--- a/server/src/middleware/csrfOriginGuard.ts
+++ b/server/src/middleware/csrfOriginGuard.ts
@@ -1,5 +1,6 @@
 import type { NextFunction, Request, Response } from 'express';
 import { allowsNonProductionSecurityBypass, isProduction } from '../utils/environment';
+import { isAsciiControlCode } from '../utils/asciiControl';
 
 const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
 const MAX_CSRF_ORIGIN_HEADER_LENGTH = 2048;
@@ -7,7 +8,13 @@ const MAX_CSRF_ORIGIN_HEADER_LENGTH = 2048;
 const originFromUrl = (value: string | undefined): string => {
   if (!value) return '';
   if (value.length > MAX_CSRF_ORIGIN_HEADER_LENGTH) return '';
-  if (/[\u0000-\u0020\u007f\\]/.test(value)) return '';
+  if (
+    Array.from(value).some((character) => {
+      const code = character.charCodeAt(0);
+      return isAsciiControlCode(code) || code === 0x20 || character === '\\';
+    })
+  )
+    return '';
   try {
     const parsed = new URL(value);
     if (parsed.username || parsed.password) return '';
@@ -29,8 +36,7 @@ export function isTrustedUnsafeRequestOrigin(args: {
 }): boolean {
   const method = args.method.toUpperCase();
   const isWriteLikeSafeMethodPath =
-    SAFE_METHODS.has(method) &&
-    Boolean(args.path && args.writeLikeSafeMethodPaths?.has(args.path));
+    SAFE_METHODS.has(method) && Boolean(args.path && args.writeLikeSafeMethodPaths?.has(args.path));
   if (SAFE_METHODS.has(method) && !isWriteLikeSafeMethodPath) return true;
 
   const allowUnsafeOriginBypass = args.allowUnsafeOriginBypass ?? !args.production;

--- a/server/src/passport.ts
+++ b/server/src/passport.ts
@@ -14,10 +14,7 @@ import {
   requiresDeployedRuntimeSecurity,
 } from './utils/environment';
 import { isPrivateOrLocalHostname } from './utils/urlSafety';
-import {
-  allowsLegacyAdminUserType,
-  hasActiveAdminGrant,
-} from './services/adminGrantService';
+import { allowsLegacyAdminUserType, hasActiveAdminGrant } from './services/adminGrantService';
 import { sanitizeLogValue } from './utils/logSanitizer';
 import { triggerReconnect } from './db/connections';
 
@@ -101,7 +98,13 @@ function safeRedirectTarget(raw: unknown): string | null {
 function originFromUrl(value: string | undefined): string {
   if (!value) return '';
   if (value.length > MAX_AUTH_ORIGIN_HEADER_LENGTH) return '';
-  if (/[\u0000-\u0020\u007f\\]/.test(value)) return '';
+  if (
+    Array.from(value).some((character) => {
+      const code = character.charCodeAt(0);
+      return isAsciiControlCode(code) || code === 0x20 || character === '\\';
+    })
+  )
+    return '';
   try {
     const parsed = new URL(value);
     if (parsed.username || parsed.password) return '';
@@ -218,7 +221,9 @@ function normalizedHeaderValue(value: string | string[] | undefined): string | u
 // dev/local-bypass tooling defaults to 'undergraduate' to match reality.
 function normalizeDevUserType(value: unknown): string {
   const normalized = typeof value === 'string' ? value.trim().toLowerCase() : '';
-  return ['admin', 'undergraduate', 'graduate', 'professor', 'faculty', 'unknown'].includes(normalized)
+  return ['admin', 'undergraduate', 'graduate', 'professor', 'faculty', 'unknown'].includes(
+    normalized,
+  )
     ? normalized
     : 'undergraduate';
 }
@@ -536,73 +541,81 @@ const casLogin = function (
   next: express.NextFunction,
 ) {
   setPrivateAuthResponseHeaders(res);
-  passport.authenticate('cas', function (
-    err: Error | null,
-    user: AuthenticatedSessionUser | false | null | undefined,
-    info: PassportAuthInfo = {},
-  ) {
-    if (err) {
-      console.log('Error in authenticate function');
-      console.error('Authentication error details:', sanitizeLogValue(err));
-
-      const errorRedirect = safeRedirectTarget(req.query?.error);
-      if (errorRedirect) {
-        return res.redirect(errorRedirect);
-      }
-
-      // VError 1.x exposes cause as .cause() method, not a property.
-      // Walk the chain via both APIs to catch the wrapped MongoNotConnectedError.
-      const isInfraError = (function checkInfra(e: any): boolean {
-        if (!e) return false;
-        if (e.name === 'MongoNotConnectedError') return true;
-        if (typeof e.message === 'string' && e.message.includes('Client must be connected before running operations')) return true;
-        const cause = typeof e.cause === 'function' ? e.cause() : e.cause;
-        return checkInfra(cause);
-      })(err);
-      if (isInfraError) {
-        triggerReconnect();
-        return res.status(503).json({ error: 'Service temporarily unavailable, please try again' });
-      }
-
-      return res.status(401).json({ error: 'Error in authentication' });
-    }
-
-    if (!user) {
-      console.log('CAS auth but no user');
-      return res.status(401).json({ error: 'CAS auth but no user' });
-    }
-
-    req.logIn(user, async function (err) {
+  passport.authenticate(
+    'cas',
+    function (
+      err: Error | null,
+      user: AuthenticatedSessionUser | false | null | undefined,
+      info: PassportAuthInfo = {},
+    ) {
       if (err) {
-        console.error('CAS login failed during session creation');
-        return next(err);
+        console.log('Error in authenticate function');
+        console.error('Authentication error details:', sanitizeLogValue(err));
+
+        const errorRedirect = safeRedirectTarget(req.query?.error);
+        if (errorRedirect) {
+          return res.redirect(errorRedirect);
+        }
+
+        // VError 1.x exposes cause as .cause() method, not a property.
+        // Walk the chain via both APIs to catch the wrapped MongoNotConnectedError.
+        const isInfraError = (function checkInfra(e: any): boolean {
+          if (!e) return false;
+          if (e.name === 'MongoNotConnectedError') return true;
+          if (
+            typeof e.message === 'string' &&
+            e.message.includes('Client must be connected before running operations')
+          )
+            return true;
+          const cause = typeof e.cause === 'function' ? e.cause() : e.cause;
+          return checkInfra(cause);
+        })(err);
+        if (isInfraError) {
+          triggerReconnect();
+          return res
+            .status(503)
+            .json({ error: 'Service temporarily unavailable, please try again' });
+        }
+
+        return res.status(401).json({ error: 'Error in authentication' });
       }
 
-      try {
-        await logEvent({
-          eventType: AnalyticsEventType.LOGIN,
-          netid: user.netId,
-          userType: user.userType || 'unknown',
-          metadata: {
-            timestamp: new Date(),
-            loginMethod: 'CAS',
-          },
-        });
-        authDebug('Login event logged to analytics');
-      } catch (analyticsError) {
-        console.error('Error logging analytics event:', sanitizeLogValue(analyticsError));
+      if (!user) {
+        console.log('CAS auth but no user');
+        return res.status(401).json({ error: 'CAS auth but no user' });
       }
 
-      const safeTarget = safeRedirectTarget(req.query?.redirect);
-      if (safeTarget) {
-        return res.redirect(safeTarget);
-      }
+      req.logIn(user, async function (err) {
+        if (err) {
+          console.error('CAS login failed during session creation');
+          return next(err);
+        }
 
-      const defaultRedirect =
-        isLocalDevelopmentRuntime() ? 'http://localhost:3000' : '/';
-      return res.redirect(defaultRedirect);
-    });
-  })(req, res, next);
+        try {
+          await logEvent({
+            eventType: AnalyticsEventType.LOGIN,
+            netid: user.netId,
+            userType: user.userType || 'unknown',
+            metadata: {
+              timestamp: new Date(),
+              loginMethod: 'CAS',
+            },
+          });
+          authDebug('Login event logged to analytics');
+        } catch (analyticsError) {
+          console.error('Error logging analytics event:', sanitizeLogValue(analyticsError));
+        }
+
+        const safeTarget = safeRedirectTarget(req.query?.redirect);
+        if (safeTarget) {
+          return res.redirect(safeTarget);
+        }
+
+        const defaultRedirect = isLocalDevelopmentRuntime() ? 'http://localhost:3000' : '/';
+        return res.redirect(defaultRedirect);
+      });
+    },
+  )(req, res, next);
 };
 
 const router = express.Router();
@@ -648,7 +661,11 @@ router.get('/check', (req, res) => {
 
 router.get('/cas', casLogin);
 
-const logoutRouteHandler: express.RequestHandler = async (req, res, next) => {
+const logoutRouteHandler = async (
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction,
+): Promise<void | express.Response> => {
   setPrivateAuthResponseHeaders(res);
 
   if (req.method !== 'GET') {
@@ -664,19 +681,19 @@ const logoutRouteHandler: express.RequestHandler = async (req, res, next) => {
 
   if (req.user) {
     const user = req.user as any;
-      try {
-        await logEvent({
+    try {
+      await logEvent({
         eventType: AnalyticsEventType.LOGOUT,
         netid: user.netId,
         userType: user.userType || 'unknown',
         metadata: {
           timestamp: new Date(),
         },
-        });
-        authDebug('Logout event logged to analytics');
-      } catch (analyticsError) {
-        console.error('Error logging analytics event:', sanitizeLogValue(analyticsError));
-      }
+      });
+      authDebug('Logout event logged to analytics');
+    } catch (analyticsError) {
+      console.error('Error logging analytics event:', sanitizeLogValue(analyticsError));
+    }
   }
 
   const casLogoutUrl = `${authConfig.ssoBaseURL}/logout`;
@@ -700,7 +717,9 @@ const logoutRouteHandler: express.RequestHandler = async (req, res, next) => {
   });
 };
 
-router.get('/logout', logoutRouteHandler);
+router.get('/logout', (req, res, next) => {
+  void logoutRouteHandler(req, res, next).catch(next);
+});
 
 if (isDevLoginAllowed()) {
   router.get('/dev-login', async (req, res) => {
@@ -731,7 +750,10 @@ if (isDevLoginAllowed()) {
           });
           authDebug('Dev login event logged to analytics');
         } catch (analyticsError) {
-          console.error('Error logging dev login analytics event:', sanitizeLogValue(analyticsError));
+          console.error(
+            'Error logging dev login analytics event:',
+            sanitizeLogValue(analyticsError),
+          );
         }
 
         const redirectUrl = safeRedirectTarget(req.query?.redirect) ?? 'http://localhost:3000';
@@ -757,3 +779,4 @@ export {
 };
 export { router as passportRoutes };
 export default passport;
+import { isAsciiControlCode } from './utils/asciiControl';

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -6,6 +6,7 @@ import mongoose from 'mongoose';
 import http from 'http';
 import https from 'https';
 import { isPrivateAddress, isPublicHostname, ssrfSafeLookup } from '../utils/ssrfGuard';
+import { containsAsciiControl, replaceAsciiControls } from '../utils/asciiControl';
 // Re-exported for back-compat with existing imports/tests that reference these from this module.
 export { isPrivateAddress, isPublicHostname, ssrfSafeLookup };
 import { isAuthenticated, isAdmin, validateObjectId, validateNetid } from '../middleware/index';
@@ -64,8 +65,8 @@ router.use(setPrivateAdminCacheHeaders, isAuthenticated, isAdmin);
 export const MAX_ADMIN_URL_CHECK_URLS = 25;
 export const MAX_ADMIN_URL_CHECK_URL_LENGTH = 2048;
 export const ADMIN_URL_CHECK_TIMEOUT_MS = 10000;
-const ADMIN_URL_CHECK_DISPLAY_CONTROL_RE = /[\u0000-\u001f\u007f]/g;
-const ADMIN_URL_CHECK_UNSAFE_INPUT_RE = /[\u0000-\u001f\u007f\s\\]/;
+const hasUnsafeAdminUrlInput = (value: string): boolean =>
+  containsAsciiControl(value) || /[\s\\]/.test(value);
 const MAX_ADMIN_LIST_PAGE = 1000;
 const MAX_ADMIN_LIST_PAGE_SIZE = 100;
 const ADMIN_OBJECT_ID_RE = /^[a-f0-9]{24}$/i;
@@ -104,7 +105,9 @@ const adminProfilePublications = (value: unknown) =>
 
 export const adminProfileDto = (user: any, includePublications = false) => {
   const ownListings = Array.isArray(user?.ownListings) ? user.ownListings : [];
-  const secondaryDepartments = Array.isArray(user?.secondaryDepartments) ? user.secondaryDepartments : [];
+  const secondaryDepartments = Array.isArray(user?.secondaryDepartments)
+    ? user.secondaryDepartments
+    : [];
   const researchInterests = Array.isArray(user?.researchInterests) ? user.researchInterests : [];
   const topics = Array.isArray(user?.topics) ? user.topics : [];
   const profileUrls =
@@ -161,13 +164,11 @@ const adminPayloadId = (value: unknown): string => {
 
 const adminAccessReviewLockedFields = (value: unknown): string[] =>
   Array.isArray(value)
-    ? value
-        .slice(0, MAX_ADMIN_ACCESS_REVIEW_LOCKED_FIELDS)
-        .flatMap((field) => {
-          if (typeof field !== 'string') return [];
-          const text = field.trim().slice(0, MAX_ADMIN_ACCESS_REVIEW_LOCKED_FIELD_LENGTH);
-          return text ? [text] : [];
-        })
+    ? value.slice(0, MAX_ADMIN_ACCESS_REVIEW_LOCKED_FIELDS).flatMap((field) => {
+        if (typeof field !== 'string') return [];
+        const text = field.trim().slice(0, MAX_ADMIN_ACCESS_REVIEW_LOCKED_FIELD_LENGTH);
+        return text ? [text] : [];
+      })
     : [];
 
 export const adminAccessReviewRecordUpdateDto = (record: any) => {
@@ -216,27 +217,22 @@ const MAX_ADMIN_LISTING_ARRAY_ITEMS = 100;
 const adminListingText = (
   value: unknown,
   maxLength = MAX_ADMIN_LISTING_TEXT_LENGTH,
-): string | undefined =>
-  typeof value === 'string' ? value.trim().slice(0, maxLength) : undefined;
+): string | undefined => (typeof value === 'string' ? value.trim().slice(0, maxLength) : undefined);
 
 const adminListingTextArray = (value: unknown): string[] =>
   Array.isArray(value)
-    ? value
-        .slice(0, MAX_ADMIN_LISTING_ARRAY_ITEMS)
-        .flatMap((item) => {
-          const text = adminListingText(item, MAX_ADMIN_LISTING_SHORT_TEXT_LENGTH);
-          return text ? [text] : [];
-        })
+    ? value.slice(0, MAX_ADMIN_LISTING_ARRAY_ITEMS).flatMap((item) => {
+        const text = adminListingText(item, MAX_ADMIN_LISTING_SHORT_TEXT_LENGTH);
+        return text ? [text] : [];
+      })
     : [];
 
 const adminListingUrlArray = (value: unknown): string[] =>
   Array.isArray(value)
-    ? value
-        .slice(0, MAX_ADMIN_LISTING_ARRAY_ITEMS)
-        .flatMap((item) => {
-          const url = publicHttpUrl(item);
-          return url ? [url] : [];
-        })
+    ? value.slice(0, MAX_ADMIN_LISTING_ARRAY_ITEMS).flatMap((item) => {
+        const url = publicHttpUrl(item);
+        return url ? [url] : [];
+      })
     : [];
 
 const adminListingNumber = (value: unknown, fallback = 0): number => {
@@ -300,36 +296,30 @@ const MAX_ADMIN_FELLOWSHIP_LINKS = 100;
 const adminFellowshipText = (
   value: unknown,
   maxLength = MAX_ADMIN_FELLOWSHIP_TEXT_LENGTH,
-): string | undefined =>
-  typeof value === 'string' ? value.trim().slice(0, maxLength) : undefined;
+): string | undefined => (typeof value === 'string' ? value.trim().slice(0, maxLength) : undefined);
 
 const adminFellowshipStringArray = (value: unknown): string[] =>
   Array.isArray(value)
-    ? value
-        .slice(0, MAX_ADMIN_FELLOWSHIP_ARRAY_ITEMS)
-        .flatMap((item) => {
-          const text = adminFellowshipText(item, MAX_ADMIN_FELLOWSHIP_SHORT_TEXT_LENGTH);
-          return text ? [text] : [];
-        })
+    ? value.slice(0, MAX_ADMIN_FELLOWSHIP_ARRAY_ITEMS).flatMap((item) => {
+        const text = adminFellowshipText(item, MAX_ADMIN_FELLOWSHIP_SHORT_TEXT_LENGTH);
+        return text ? [text] : [];
+      })
     : [];
 
 const adminFellowshipLinks = (value: unknown): Array<{ label: string; url: string }> =>
   Array.isArray(value)
-    ? value
-        .slice(0, MAX_ADMIN_FELLOWSHIP_LINKS)
-        .flatMap((item) => {
-          if (!item || typeof item !== 'object') return [];
-          const record = item as Record<string, unknown>;
-          const url = publicHttpUrl(record.url);
-          if (!url) return [];
-          return [
-            {
-              label:
-                adminFellowshipText(record.label, MAX_ADMIN_FELLOWSHIP_SHORT_TEXT_LENGTH) || '',
-              url,
-            },
-          ];
-        })
+    ? value.slice(0, MAX_ADMIN_FELLOWSHIP_LINKS).flatMap((item) => {
+        if (!item || typeof item !== 'object') return [];
+        const record = item as Record<string, unknown>;
+        const url = publicHttpUrl(record.url);
+        if (!url) return [];
+        return [
+          {
+            label: adminFellowshipText(record.label, MAX_ADMIN_FELLOWSHIP_SHORT_TEXT_LENGTH) || '',
+            url,
+          },
+        ];
+      })
     : [];
 
 const adminFellowshipNumber = (value: unknown, fallback = 0): number => {
@@ -410,10 +400,7 @@ interface AdminUrlCheckResult {
 }
 
 const adminUrlCheckDisplayText = (value: string): string =>
-  value
-    .replace(ADMIN_URL_CHECK_DISPLAY_CONTROL_RE, '')
-    .trim()
-    .slice(0, MAX_ADMIN_URL_CHECK_URL_LENGTH);
+  replaceAsciiControls(value, '').trim().slice(0, MAX_ADMIN_URL_CHECK_URL_LENGTH);
 
 const adminUrlCheckDisplayUrl = (url: string, parsed?: URL): string => {
   const candidate = parsed
@@ -469,10 +456,7 @@ export const normalizeAdminPagination = (
 
   return {
     page: Math.min(MAX_ADMIN_LIST_PAGE, parseCompactPositiveInteger(page, 1)),
-    pageSize: Math.min(
-      MAX_ADMIN_LIST_PAGE_SIZE,
-      parseCompactPositiveInteger(pageSize, 25),
-    ),
+    pageSize: Math.min(MAX_ADMIN_LIST_PAGE_SIZE, parseCompactPositiveInteger(pageSize, 25)),
   };
 };
 
@@ -507,8 +491,12 @@ export const normalizeAdminTaxonomyLabel = (
     throw new Error(`Invalid ${fieldName}`);
   }
 
-  const normalized = value.replace(/[\u0000-\u001f\u007f]/g, ' ').replace(/\s+/g, ' ').trim();
-  if (!normalized || normalized.length > maxLength || redactDirectContactInfo(normalized) !== normalized) {
+  const normalized = replaceAsciiControls(value, ' ').replace(/\s+/g, ' ').trim();
+  if (
+    !normalized ||
+    normalized.length > maxLength ||
+    redactDirectContactInfo(normalized) !== normalized
+  ) {
     throw new Error(`Invalid ${fieldName}`);
   }
 
@@ -526,7 +514,8 @@ export const normalizeAdminDepartmentCategories = (
   value: unknown,
   fallbackPrimaryCategory?: DepartmentCategory,
 ): DepartmentCategory[] => {
-  const rawValues = value === undefined ? [fallbackPrimaryCategory] : Array.isArray(value) ? value : [value];
+  const rawValues =
+    value === undefined ? [fallbackPrimaryCategory] : Array.isArray(value) ? value : [value];
   if (rawValues.length === 0 || rawValues.length > MAX_ADMIN_DEPARTMENT_CATEGORIES) {
     throw new Error('Invalid department categories');
   }
@@ -540,11 +529,7 @@ export const normalizeAdminDepartmentCategories = (
   return categories;
 };
 
-const sendAdminGrantError = (
-  res: Response,
-  error: unknown,
-  fallbackMessage: string,
-) => {
+const sendAdminGrantError = (res: Response, error: unknown, fallbackMessage: string) => {
   const isValidationFailure = error instanceof AdminGrantValidationError;
   res.status(isValidationFailure ? 400 : 500).json({
     error: isValidationFailure ? 'Invalid admin grant request' : fallbackMessage,
@@ -638,20 +623,16 @@ router.get('/access-review', async (req: Request, res: Response) => {
   }
 });
 
-router.get(
-  '/access-review/:id',
-  validateObjectId('id'),
-  async (req: Request, res: Response) => {
-    try {
-      const result = await getAccessReviewEntity(req.params.id);
-      if (!result) return res.status(404).json({ error: 'Research entity not found' });
-      res.json(result);
-    } catch (error) {
-      console.error('Admin: Error fetching access review entity:', sanitizeLogValue(error));
-      res.status(500).json({ error: 'Failed to fetch access review entity' });
-    }
-  },
-);
+router.get('/access-review/:id', validateObjectId('id'), async (req: Request, res: Response) => {
+  try {
+    const result = await getAccessReviewEntity(req.params.id);
+    if (!result) return res.status(404).json({ error: 'Research entity not found' });
+    res.json(result);
+  } catch (error) {
+    console.error('Admin: Error fetching access review entity:', sanitizeLogValue(error));
+    res.status(500).json({ error: 'Failed to fetch access review entity' });
+  }
+});
 
 router.put(
   '/access-review/:id/manual-locks',
@@ -938,7 +919,11 @@ router.put('/research-areas/:id', validateObjectId('id'), async (req: Request, r
     const update: any = {};
 
     if (name !== undefined) {
-      update.name = normalizeAdminTaxonomyLabel(name, 'research area name', MAX_RESEARCH_AREA_NAME_LENGTH);
+      update.name = normalizeAdminTaxonomyLabel(
+        name,
+        'research area name',
+        MAX_RESEARCH_AREA_NAME_LENGTH,
+      );
     }
     if (field !== undefined) {
       if (!Object.values(ResearchField).includes(field)) {
@@ -1059,7 +1044,8 @@ router.put('/departments/:id', validateObjectId('id'), async (req: Request, res:
     if (displayName !== undefined) {
       update.displayName = normalizeAdminTaxonomyLabel(displayName, 'department display name');
     }
-    if (categories !== undefined) update.categories = normalizeAdminDepartmentCategories(categories);
+    if (categories !== undefined)
+      update.categories = normalizeAdminDepartmentCategories(categories);
     if (primaryCategory !== undefined) {
       const normalizedPrimaryCategory = normalizeAdminDepartmentCategory(primaryCategory);
       update.primaryCategory = normalizedPrimaryCategory;
@@ -1101,7 +1087,6 @@ router.delete('/departments/:id', validateObjectId('id'), async (req: Request, r
   }
 });
 
-
 const requestHead = (parsed: URL): Promise<{ status: number; reachable: boolean }> =>
   new Promise((resolve, reject) => {
     const client = parsed.protocol === 'https:' ? https : http;
@@ -1124,7 +1109,9 @@ const requestHead = (parsed: URL): Promise<{ status: number; reachable: boolean 
         response.resume();
         resolve({
           status: response.statusCode || 0,
-          reachable: Boolean(response.statusCode && response.statusCode >= 200 && response.statusCode < 300),
+          reachable: Boolean(
+            response.statusCode && response.statusCode >= 200 && response.statusCode < 300,
+          ),
         });
       },
     );
@@ -1142,7 +1129,7 @@ export const checkAdminUrlReachability = async (url: string): Promise<AdminUrlCh
   if (trimmedUrl.length === 0 || url.length > MAX_ADMIN_URL_CHECK_URL_LENGTH) {
     return { url: displayUrl, status: 0, reachable: false, error: 'URL too long' };
   }
-  if (ADMIN_URL_CHECK_UNSAFE_INPUT_RE.test(trimmedUrl)) {
+  if (hasUnsafeAdminUrlInput(trimmedUrl)) {
     return { url: displayUrl, status: 0, reachable: false, error: 'Invalid URL' };
   }
 
@@ -1211,7 +1198,7 @@ router.post('/check-urls', async (req: Request, res: Response) => {
       if (trimmed.length === 0 || trimmed.length > MAX_ADMIN_URL_CHECK_URL_LENGTH) {
         return res.status(400).json({ error: 'Each URL must be between 1 and 2048 characters' });
       }
-      if (ADMIN_URL_CHECK_UNSAFE_INPUT_RE.test(trimmed)) {
+      if (hasUnsafeAdminUrlInput(trimmed)) {
         return res.status(400).json({ error: 'Each URL must be a canonical HTTP(S) URL' });
       }
       normalizedInputs.push(trimmed);

--- a/server/src/routes/researchAreas.ts
+++ b/server/src/routes/researchAreas.ts
@@ -8,13 +8,14 @@ import { invalidateConfigCache } from '../services/configService';
 import { escapeRegex, buildSafeSearchRegex } from '../utils/regex';
 import { sanitizeLogValue } from '../utils/logSanitizer';
 import { redactDirectContactInfo } from '../utils/contactRedaction';
+import { replaceAsciiControls } from '../utils/asciiControl';
 
 const router = Router();
 const MAX_RESEARCH_AREA_NAME_LENGTH = 120;
 const MAX_RESEARCH_AREA_SEARCH_QUERY_LENGTH = 120;
 
 const normalizeResearchAreaLabel = (value: string): string =>
-  value.replace(/[\u0000-\u001f\u007f]/g, ' ').replace(/\s+/g, ' ').trim();
+  replaceAsciiControls(value, ' ').replace(/\s+/g, ' ').trim();
 
 const hasDirectContactInfo = (value: string): boolean => redactDirectContactInfo(value) !== value;
 
@@ -69,7 +70,9 @@ router.post('/', isAuthenticated, isProfessor, async (req: Request, res: Respons
     }
 
     if (hasDirectContactInfo(trimmedName)) {
-      return res.status(400).json({ message: 'Research area name cannot include contact information' });
+      return res
+        .status(400)
+        .json({ message: 'Research area name cannot include contact information' });
     }
 
     const existing = await ResearchArea.findOne({

--- a/server/src/scripts/scriptWriteGuards.ts
+++ b/server/src/scripts/scriptWriteGuards.ts
@@ -48,7 +48,7 @@ export function resolveSafeJsonReportOutputPath(
   if (!output || output.startsWith('--')) {
     throw new Error(`${flag} requires a path`);
   }
-  if (/[\u0000-\u001f\u007f]/.test(output)) {
+  if (containsAsciiControl(output)) {
     throw new Error(`${flag} path contains invalid characters`);
   }
 
@@ -65,3 +65,4 @@ export function resolveSafeJsonReportOutputPath(
 
   return resolved;
 }
+import { containsAsciiControl } from '../utils/asciiControl';

--- a/server/src/services/configService.ts
+++ b/server/src/services/configService.ts
@@ -4,6 +4,7 @@
 import { ResearchArea, ResearchField, fieldColorKeys } from '../models/researchArea';
 import { Department, DepartmentCategory } from '../models/department';
 import { redactDirectContactInfo } from '../utils/contactRedaction';
+import { replaceAsciiControls } from '../utils/asciiControl';
 
 let configCache: ConfigData | null = null;
 let cacheTimestamp: number = 0;
@@ -63,15 +64,15 @@ const publicConfigText = (
   value: unknown,
   maxLength: number = MAX_PUBLIC_CONFIG_TEXT_LENGTH,
 ): string => {
-  const text = typeof value === 'string' ? value : value === undefined || value === null ? '' : String(value);
-  return redactDirectContactInfo(text).replace(/[\u0000-\u001f\u007f]/g, ' ').replace(/\s+/g, ' ').trim().slice(0, maxLength);
+  const text =
+    typeof value === 'string' ? value : value === undefined || value === null ? '' : String(value);
+  return replaceAsciiControls(redactDirectContactInfo(text), ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, maxLength);
 };
 
-const publicConfigTextArray = (
-  values: unknown,
-  maxItems: number,
-  maxLength: number,
-): string[] => {
+const publicConfigTextArray = (values: unknown, maxItems: number, maxLength: number): string[] => {
   if (!Array.isArray(values)) return [];
   return Array.from(
     new Set(
@@ -86,11 +87,20 @@ const publicConfigTextArray = (
 const publicDepartmentCategories = (values: unknown): string[] => {
   if (!Array.isArray(values)) return [];
   const allowed = new Set<string>(Object.values(DepartmentCategory));
-  return Array.from(new Set(values.filter((value): value is string => typeof value === 'string' && allowed.has(value))));
+  return Array.from(
+    new Set(
+      values.filter((value): value is string => typeof value === 'string' && allowed.has(value)),
+    ),
+  );
 };
 
 const publicDepartmentColorKey = (value: unknown): number => {
-  return typeof value === 'number' && Number.isInteger(value) && value >= 0 && value <= MAX_PUBLIC_CONFIG_COLOR_KEY ? value : 0;
+  return typeof value === 'number' &&
+    Number.isInteger(value) &&
+    value >= 0 &&
+    value <= MAX_PUBLIC_CONFIG_COLOR_KEY
+    ? value
+    : 0;
 };
 
 const publicResearchAreaColorKey = (value: unknown, fallback: unknown): string => {
@@ -129,7 +139,10 @@ export const getConfig = async (
       areas: researchAreas.map((area: any) => ({
         name: publicConfigText(area.name),
         field: publicConfigText(area.field),
-        colorKey: publicResearchAreaColorKey(area.colorKey, fieldColorKeys[area.field as ResearchField]),
+        colorKey: publicResearchAreaColorKey(
+          area.colorKey,
+          fieldColorKeys[area.field as ResearchField],
+        ),
         isDefault: area.isDefault || false,
       })),
       fields,
@@ -146,7 +159,8 @@ export const getConfig = async (
           MAX_PUBLIC_CONFIG_ALIAS_LENGTH,
         ),
         categories: publicDepartmentCategories(dept.categories),
-        primaryCategory: publicDepartmentCategories([dept.primaryCategory])[0] || DepartmentCategory.COMPUTING_AI,
+        primaryCategory:
+          publicDepartmentCategories([dept.primaryCategory])[0] || DepartmentCategory.COMPUTING_AI,
         colorKey: publicDepartmentColorKey(dept.colorKey),
       })),
       categories: Object.values(DepartmentCategory),

--- a/server/src/utils/asciiControl.ts
+++ b/server/src/utils/asciiControl.ts
@@ -1,0 +1,9 @@
+export const isAsciiControlCode = (code: number): boolean => code <= 0x1f || code === 0x7f;
+
+export const containsAsciiControl = (value: string): boolean =>
+  Array.from(value).some((character) => isAsciiControlCode(character.charCodeAt(0)));
+
+export const replaceAsciiControls = (value: string, replacement: string): string =>
+  Array.from(value, (character) =>
+    isAsciiControlCode(character.charCodeAt(0)) ? replacement : character,
+  ).join('');

--- a/server/src/utils/spreadsheetSafety.ts
+++ b/server/src/utils/spreadsheetSafety.ts
@@ -1,6 +1,20 @@
-const SPREADSHEET_FORMULA_PREFIX = /^[\s\u0000-\u001f]*[=+\-@]/;
+import { isAsciiControlCode } from './asciiControl';
+
+const startsWithSpreadsheetFormula = (value: string): boolean => {
+  const characters = Array.from(value);
+  const firstContentCharacter = characters.find((character) => {
+    const code = character.charCodeAt(0);
+    return !isAsciiControlCode(code) && !/\s/.test(character);
+  });
+  return (
+    firstContentCharacter === '=' ||
+    firstContentCharacter === '+' ||
+    firstContentCharacter === '-' ||
+    firstContentCharacter === '@'
+  );
+};
 
 export function safeSpreadsheetCell(value: unknown): string {
   const text = String(value ?? '');
-  return SPREADSHEET_FORMULA_PREFIX.test(text) ? `'${text}` : text;
+  return startsWithSpreadsheetFormula(text) ? `'${text}` : text;
 }

--- a/server/src/utils/ssrfGuard.ts
+++ b/server/src/utils/ssrfGuard.ts
@@ -9,9 +9,11 @@ import dns from 'dns/promises';
 import http from 'http';
 import https from 'https';
 import type { LookupFunction } from 'net';
+import { containsAsciiControl } from './asciiControl';
 
 const MAX_SSRF_PUBLIC_HTTP_URL_LENGTH = 2048;
-const UNSAFE_SSRF_PUBLIC_HTTP_URL_RE = /[\u0000-\u001f\u007f\s\\]/;
+const hasUnsafePublicHttpUrlCharacter = (value: string): boolean =>
+  containsAsciiControl(value) || /[\s\\]/.test(value);
 
 export const stripIpv6Brackets = (addr: string): string =>
   addr.replace(/^\[/, '').replace(/\]$/, '');
@@ -19,7 +21,10 @@ export const stripIpv6Brackets = (addr: string): string =>
 const ipv4ToNumber = (addr: string): number | null => {
   if (net.isIP(addr) !== 4) return null;
   const parts = addr.split('.').map(Number);
-  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
+  if (
+    parts.length !== 4 ||
+    parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)
+  ) {
     return null;
   }
   return parts.reduce((acc, part) => (acc << 8) + part, 0) >>> 0;
@@ -182,7 +187,7 @@ export const assertPublicHttpUrl = async (rawUrl: string): Promise<URL> => {
   if (!trimmed || trimmed.length > MAX_SSRF_PUBLIC_HTTP_URL_LENGTH) {
     throw new SsrfBlockedError('Invalid URL');
   }
-  if (UNSAFE_SSRF_PUBLIC_HTTP_URL_RE.test(trimmed)) {
+  if (hasUnsafePublicHttpUrlCharacter(trimmed)) {
     throw new SsrfBlockedError('Invalid URL');
   }
 

--- a/server/src/utils/urlSafety.ts
+++ b/server/src/utils/urlSafety.ts
@@ -1,5 +1,11 @@
+import { isAsciiControlCode } from './asciiControl';
+
 export const MAX_PUBLIC_HTTP_URL_LENGTH = 2048;
-const UNSAFE_RAW_PUBLIC_URL_CHAR_RE = /[\u0000-\u0020\u007f\\]/;
+const hasUnsafeRawPublicUrlCharacter = (value: string): boolean =>
+  Array.from(value).some((character) => {
+    const code = character.charCodeAt(0);
+    return isAsciiControlCode(code) || code === 0x20 || character === '\\';
+  });
 const PRIVATE_IPV4_CIDRS: Array<[string, number]> = [
   ['0.0.0.0', 8],
   ['10.0.0.0', 8],
@@ -58,7 +64,7 @@ export function isPublicHttpUrl(value: unknown): value is string {
   const trimmed = value.trim();
   if (!trimmed) return false;
   if (trimmed.length > MAX_PUBLIC_HTTP_URL_LENGTH) return false;
-  if (UNSAFE_RAW_PUBLIC_URL_CHAR_RE.test(trimmed)) return false;
+  if (hasUnsafeRawPublicUrlCharacter(trimmed)) return false;
 
   try {
     const url = new URL(trimmed);


### PR DESCRIPTION
## Summary
- replace lint-invalid ASCII control regexes with shared character-code helpers while preserving validation behavior
- fix Google Sheets TypeScript/lint issues and adapt the Passport logout handler to Express's void callback contract
- update security source-shape checks for the new sanitization helpers

## Validation
- yarn lint (0 errors; 47 existing warnings)
- yarn --cwd client test:ci (763 passed)
- yarn --cwd server test (2533 passed)
- yarn tsc --noEmit -p server/tsconfig.json
- yarn build:server && yarn build:client
- yarn security:policy
- yarn security:secrets

Graphify outputs intentionally unchanged per repository policy.