### PR TITLE
Add guarded PFR-3 operational rollout tooling

### DIFF
--- a/docs/pfr3-rollout-runbook.md
+++ b/docs/pfr3-rollout-runbook.md
@@ -1,0 +1,54 @@
+# PFR-3 Operational Rollout
+
+This rollout is fail-closed and staged.
+The review and monitoring commands are read-only.
+The pathway rebuild remains the only write operation and requires a verified restore point.
+
+## 1. Admin contact-route review
+
+Run `yarn --cwd server pfr3:contact-route-review` against Beta.
+The queue contains only structurally eligible public HTTP(S) destinations and sources, policy, evidence strength, confidence, priority, and current review state.
+It excludes approved, archived, direct-email, unknown-policy, and no-direct-contact routes.
+It never changes review status and contains no database identifiers, names, email addresses, or evidence excerpts.
+
+An admin must inspect the source and destination, verify the policy, and approve through the existing access-review workflow.
+Re-run the queue until the remaining candidates are understood.
+Do not bulk-approve.
+
+## 2. Beta preflight and rebuild
+
+Confirm the deployed Beta service has all of the following values from the deployment control plane:
+
+- `SCRAPER_ENV=beta`
+- `MONGODBURL` targeting the Beta database
+- `MEILISEARCH_HOST` targeting the remote Beta search service, never localhost
+- `MEILISEARCH_INDEX_PREFIX` beginning with `beta_`
+- `PFR3_MEILI_RESTORE_POINT` naming a verified pre-rebuild snapshot or export
+
+Record the current Pathways index document count and the restore procedure.
+Then run:
+
+```bash
+yarn --cwd server meili:rebuild-pathways --clear --confirm-meili-rebuild --output=/tmp/ylabs-pfr3-beta-pathways.json
+```
+
+The JSON report's `fetchedHitCount` is the qualifying pathway count under the student publication policy, including the `>= 0.70` confidence threshold.
+Compare it with the preflight expectation and sample student-visible results before proceeding.
+Stop if the count is unexpectedly low or the index prefix in the output is wrong.
+
+## 3. Production rollout
+
+Create and verify a production Pathways index snapshot or export first.
+Set `SCRAPER_ENV=production`, an explicit production database, a remote production Meilisearch host, a prefix beginning with `production_`, `CONFIRM_PROD_SCRAPE=true`, and the verified `PFR3_MEILI_RESTORE_POINT` value.
+Run the same rebuild command during the approved change window.
+
+Verify index count, settings, representative searches, and application health before closing the change.
+If verification fails, stop traffic to the new index, restore the recorded snapshot/export under the production prefix, and repeat the representative searches before restoring normal traffic.
+
+## 4. Outreach monitoring
+
+Run `yarn --cwd server pfr3:outreach-report` after each staged rollout interval.
+The report includes consented aggregate counts only.
+`officialRouteAttempts` means a student opened an official route, not that an application was submitted.
+`confirmedOutcomes` includes only rows with `outcomeReportedAt`; `selfReportedOutcomes` is its external-self-reported subset.
+The report never emits student, entity, tracking, or event identifiers and never lists recent events.

--- a/scripts/security-preflight.test.mjs
+++ b/scripts/security-preflight.test.mjs
@@ -131,6 +131,8 @@ test('operator scripts sanitize raw caught error messages before logging', () =>
     '../server/src/scripts/duplicateEntityNameReview.ts',
     '../server/src/scripts/importFaculty.ts',
     '../server/src/scripts/backfillProfileBiosFromOfficialUrls.ts',
+    '../server/src/scripts/pfr3ContactRouteReview.ts',
+    '../server/src/scripts/pfr3StudentOutreachReport.ts',
   ];
 
   for (const file of files) {
@@ -141,6 +143,21 @@ test('operator scripts sanitize raw caught error messages before logging', () =>
     assert.doesNotMatch(source, /console\.error\([^;\n]*\(error as Error\)\.message\)/);
     assert.doesNotMatch(source, /candidate\.netid[^;\n]*error/);
   }
+});
+
+test('PFR-3 rollout tooling stays aggregate-only and fail-closed', () => {
+  const core = fs.readFileSync(new URL('../server/src/scripts/pfr3RolloutCore.ts', import.meta.url), 'utf8');
+  const review = fs.readFileSync(new URL('../server/src/scripts/pfr3ContactRouteReview.ts', import.meta.url), 'utf8');
+  const outreach = fs.readFileSync(new URL('../server/src/scripts/pfr3StudentOutreachReport.ts', import.meta.url), 'utf8');
+  const rebuild = fs.readFileSync(new URL('../server/src/scripts/rebuildPathwaySearchIndex.ts', import.meta.url), 'utf8');
+  assert.match(core, /refuses a localhost Meilisearch target/);
+  assert.match(core, /PFR3_MEILI_RESTORE_POINT is required/);
+  assert.match(review, /review\.status.*\$ne: 'approved'/s);
+  assert.doesNotMatch(review, /\.update|\.save|findOneAnd/);
+  assert.match(outreach, /studentConsentedToAggregateUse: true/);
+  assert.match(outreach, /outcomeReportedAt/);
+  assert.doesNotMatch(outreach, /studentProfileId|researchEntityId|trackingId|reachedOutAt/);
+  assert.match(rebuild, /assertPathwayIndexRolloutTarget/);
 });
 
 

--- a/server/package.json
+++ b/server/package.json
@@ -28,6 +28,8 @@
     "observations:repair-profile-description-conflicts": "tsx src/scripts/repairProfileDescriptionBackfillConflicts.ts",
     "observations:stale-conflict-review": "tsx src/scripts/staleObservationConflictReview.ts",
     "meili:rebuild-pathways": "tsx src/scripts/rebuildPathwaySearchIndex.ts",
+    "pfr3:contact-route-review": "tsx src/scripts/pfr3ContactRouteReview.ts",
+    "pfr3:outreach-report": "tsx src/scripts/pfr3StudentOutreachReport.ts",
     "meili:rebuild-research-entities": "tsx src/scripts/rebuildResearchEntitySearchIndex.ts",
     "meili:seed": "yarn meili:rebuild-research-entities --clear --confirm-meili-rebuild && yarn meili:rebuild-pathways --clear --confirm-meili-rebuild",
     "research-entity:audit-rename": "tsx src/scripts/auditResearchEntityRename.ts",

--- a/server/src/scripts/__tests__/pfr3RolloutCore.test.ts
+++ b/server/src/scripts/__tests__/pfr3RolloutCore.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertPathwayIndexRolloutTarget,
+  buildContactRouteReviewQueue,
+  buildStudentOutreachCountReport,
+} from '../pfr3RolloutCore';
+
+describe('PFR-3 rollout core', () => {
+  it('builds a deterministic safe review queue without auto-approval or identifiers', () => {
+    const queue = buildContactRouteReviewQueue([
+      {
+        routeType: 'OFFICIAL_APPLICATION',
+        url: 'https://example.edu/apply',
+        sourceUrl: 'https://example.edu/source',
+        contactPolicy: 'OFFICIAL_ROUTE',
+        confidence: 0.8,
+        priority: 20,
+        review: { status: 'pending' },
+      },
+      {
+        routeType: 'FACULTY_EMAIL',
+        url: 'mailto:person@example.edu',
+        sourceUrl: 'https://example.edu/source',
+        contactPolicy: 'FACULTY_CONTACT',
+        confidence: 0.99,
+      },
+      {
+        routeType: 'OFFICIAL_APPLICATION',
+        url: 'https://example.edu/approved',
+        sourceUrl: 'https://example.edu/source',
+        contactPolicy: 'OFFICIAL_ROUTE',
+        confidence: 1,
+        review: { status: 'approved' },
+      },
+      {
+        routeType: 'OFFICIAL_APPLICATION',
+        url: 'https://example.edu/apply-2',
+        sourceUrl: 'https://example.edu/source-2',
+        contactPolicy: 'OFFICIAL_ROUTE',
+        confidence: 0.9,
+        priority: 50,
+      },
+    ]);
+    expect(queue).toHaveLength(2);
+    expect(queue.map((item) => item.destination)).toEqual([
+      'https://example.edu/apply-2',
+      'https://example.edu/apply',
+    ]);
+    expect(JSON.stringify(queue)).not.toMatch(/email|personName|researchEntityId|approved/i);
+  });
+
+  it('counts official-route attempts separately from reported outcomes', () => {
+    expect(
+      buildStudentOutreachCountReport([
+        {
+          deliveryMethod: 'official-route',
+          outcome: 'unknown',
+          outcomeReportedAt: false,
+          count: 4,
+        },
+        {
+          deliveryMethod: 'official-route',
+          outcome: 'responded-interested',
+          outcomeReportedAt: true,
+          count: 2,
+        },
+        {
+          deliveryMethod: 'external-self-reported',
+          outcome: 'joined-lab',
+          outcomeReportedAt: true,
+          count: 1,
+        },
+      ]),
+    ).toEqual({
+      totalAttempts: 7,
+      officialRouteAttempts: 6,
+      confirmedOutcomes: 3,
+      selfReportedOutcomes: 1,
+      outcomes: { 'responded-interested': 2, 'joined-lab': 1 },
+    });
+  });
+
+  it('requires an unambiguous remote target and restore point', () => {
+    expect(() =>
+      assertPathwayIndexRolloutTarget({
+        environment: 'beta',
+        meiliHost: 'http://localhost:7700',
+        indexPrefix: 'beta_',
+        restorePoint: 'snapshot-123',
+      }),
+    ).toThrow(/localhost/);
+    expect(() =>
+      assertPathwayIndexRolloutTarget({
+        environment: 'beta',
+        meiliHost: 'https://search.example.test',
+        indexPrefix: 'production_',
+        restorePoint: 'snapshot-123',
+      }),
+    ).toThrow(/match/);
+    expect(() =>
+      assertPathwayIndexRolloutTarget({
+        environment: 'production',
+        meiliHost: 'https://search.example.test',
+        indexPrefix: 'production_',
+      }),
+    ).toThrow(/RESTORE_POINT/);
+    expect(
+      assertPathwayIndexRolloutTarget({
+        environment: 'beta',
+        meiliHost: 'https://search.example.test',
+        indexPrefix: 'beta_',
+        restorePoint: 'snapshot-2026-07-10',
+      }),
+    ).toEqual({ environment: 'beta', indexPrefix: 'beta_', restorePoint: 'snapshot-2026-07-10' });
+  });
+});

--- a/server/src/scripts/pfr3ContactRouteReview.ts
+++ b/server/src/scripts/pfr3ContactRouteReview.ts
@@ -1,0 +1,38 @@
+import dotenv from 'dotenv';
+dotenv.config();
+import mongoose from 'mongoose';
+import { fileURLToPath } from 'url';
+import path from 'path';
+import { initializeConnections } from '../db/connections';
+import { ContactRoute } from '../models/contactRoute';
+import { sanitizeLogValue } from '../utils/logSanitizer';
+import { buildContactRouteReviewQueue } from './pfr3RolloutCore';
+
+async function main() {
+  await initializeConnections();
+  const candidates = await ContactRoute.find({
+    archived: { $ne: true },
+    'review.status': { $ne: 'approved' },
+  })
+    .select(
+      'routeType url sourceUrl contactPolicy evidenceStrength confidence priority review.status archived',
+    )
+    .lean();
+  const queue = buildContactRouteReviewQueue(candidates);
+  console.log(
+    JSON.stringify(
+      { generatedAt: new Date().toISOString(), candidateCount: queue.length, candidates: queue },
+      null,
+      2,
+    ),
+  );
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main()
+    .catch((error) => {
+      console.error('Failed to build PFR-3 contact-route review queue:', sanitizeLogValue(error));
+      process.exitCode = 1;
+    })
+    .finally(() => mongoose.disconnect());
+}

--- a/server/src/scripts/pfr3RolloutCore.ts
+++ b/server/src/scripts/pfr3RolloutCore.ts
@@ -1,0 +1,136 @@
+import { isPublicHttpUrl } from '../utils/urlSafety';
+
+export type RolloutEnvironment = 'beta' | 'production';
+
+export interface ContactRouteReviewCandidate {
+  routeType?: unknown;
+  url?: unknown;
+  sourceUrl?: unknown;
+  contactPolicy?: unknown;
+  evidenceStrength?: unknown;
+  confidence?: unknown;
+  priority?: unknown;
+  review?: { status?: unknown };
+  archived?: unknown;
+}
+
+export interface ContactRouteReviewQueueItem {
+  routeType: string;
+  destination: string;
+  source: string;
+  contactPolicy: string;
+  evidenceStrength: string;
+  confidence: number;
+  priority: number;
+  reviewStatus: string;
+}
+
+const safeUrl = (value: unknown): string | null => {
+  if (typeof value !== 'string') return null;
+  try {
+    return isPublicHttpUrl(value) ? value : null;
+  } catch {
+    return null;
+  }
+};
+
+export function buildContactRouteReviewQueue(
+  candidates: ContactRouteReviewCandidate[],
+): ContactRouteReviewQueueItem[] {
+  return candidates
+    .flatMap((candidate) => {
+      const destination = safeUrl(candidate.url);
+      const source = safeUrl(candidate.sourceUrl);
+      const contactPolicy =
+        typeof candidate.contactPolicy === 'string' ? candidate.contactPolicy : '';
+      if (
+        candidate.archived === true ||
+        !destination ||
+        !source ||
+        !contactPolicy ||
+        ['UNKNOWN', 'NO_DIRECT_CONTACT'].includes(contactPolicy) ||
+        candidate.review?.status === 'approved'
+      ) {
+        return [];
+      }
+      return [
+        {
+          routeType: typeof candidate.routeType === 'string' ? candidate.routeType : 'UNKNOWN',
+          destination,
+          source,
+          contactPolicy,
+          evidenceStrength:
+            typeof candidate.evidenceStrength === 'string' ? candidate.evidenceStrength : 'UNKNOWN',
+          confidence: typeof candidate.confidence === 'number' ? candidate.confidence : 0,
+          priority: typeof candidate.priority === 'number' ? candidate.priority : 100,
+          reviewStatus:
+            typeof candidate.review?.status === 'string' ? candidate.review.status : 'unreviewed',
+        },
+      ];
+    })
+    .sort(
+      (left, right) =>
+        right.confidence - left.confidence ||
+        left.priority - right.priority ||
+        left.source.localeCompare(right.source) ||
+        left.destination.localeCompare(right.destination),
+    );
+}
+
+export interface OutreachCountRow {
+  deliveryMethod?: unknown;
+  outcome?: unknown;
+  outcomeReportedAt?: unknown;
+  count?: unknown;
+}
+
+export function buildStudentOutreachCountReport(rows: OutreachCountRow[]) {
+  const report = {
+    totalAttempts: 0,
+    officialRouteAttempts: 0,
+    confirmedOutcomes: 0,
+    selfReportedOutcomes: 0,
+    outcomes: {} as Record<string, number>,
+  };
+  for (const row of rows) {
+    const count = typeof row.count === 'number' && row.count > 0 ? Math.floor(row.count) : 0;
+    report.totalAttempts += count;
+    if (row.deliveryMethod === 'official-route') report.officialRouteAttempts += count;
+    if (row.outcomeReportedAt) {
+      report.confirmedOutcomes += count;
+      if (row.deliveryMethod === 'external-self-reported') report.selfReportedOutcomes += count;
+      const outcome = typeof row.outcome === 'string' ? row.outcome : 'unknown';
+      report.outcomes[outcome] = (report.outcomes[outcome] || 0) + count;
+    }
+  }
+  return report;
+}
+
+export function assertPathwayIndexRolloutTarget(input: {
+  environment?: string;
+  meiliHost?: string;
+  indexPrefix?: string;
+  restorePoint?: string;
+}): { environment: RolloutEnvironment; indexPrefix: string; restorePoint: string } {
+  if (input.environment !== 'beta' && input.environment !== 'production') {
+    throw new Error('PFR-3 rebuild requires an explicit beta or production environment');
+  }
+  let host: URL;
+  try {
+    host = new URL(input.meiliHost || '');
+  } catch {
+    throw new Error('PFR-3 rebuild requires an explicit valid MEILISEARCH_HOST');
+  }
+  if (['localhost', '127.0.0.1', '::1'].includes(host.hostname)) {
+    throw new Error('PFR-3 beta/production rebuild refuses a localhost Meilisearch target');
+  }
+  const prefix = input.indexPrefix?.trim();
+  if (!prefix || !prefix.toLowerCase().startsWith(`${input.environment}_`)) {
+    throw new Error('MEILISEARCH_INDEX_PREFIX must unambiguously match the target environment');
+  }
+  const restorePoint = input.restorePoint?.trim();
+  if (!restorePoint || !/^[A-Za-z0-9][A-Za-z0-9._:/-]{7,200}$/.test(restorePoint)) {
+    throw new Error('PFR3_MEILI_RESTORE_POINT is required before rebuilding');
+  }
+  return { environment: input.environment, indexPrefix: prefix, restorePoint };
+}

--- a/server/src/scripts/pfr3StudentOutreachReport.ts
+++ b/server/src/scripts/pfr3StudentOutreachReport.ts
@@ -1,0 +1,51 @@
+import dotenv from 'dotenv';
+dotenv.config();
+import mongoose from 'mongoose';
+import { fileURLToPath } from 'url';
+import path from 'path';
+import { initializeConnections } from '../db/connections';
+import { StudentOutreach } from '../models/studentOutreach';
+import { sanitizeLogValue } from '../utils/logSanitizer';
+import { buildStudentOutreachCountReport } from './pfr3RolloutCore';
+
+async function main() {
+  await initializeConnections();
+  const rows = await StudentOutreach.aggregate([
+    { $match: { studentConsentedToAggregateUse: true } },
+    {
+      $group: {
+        _id: {
+          deliveryMethod: '$deliveryMethod',
+          outcome: '$outcome',
+          outcomeReportedAt: { $ne: ['$outcomeReportedAt', null] },
+        },
+        count: { $sum: 1 },
+      },
+    },
+    {
+      $project: {
+        _id: 0,
+        deliveryMethod: '$_id.deliveryMethod',
+        outcome: '$_id.outcome',
+        outcomeReportedAt: '$_id.outcomeReportedAt',
+        count: 1,
+      },
+    },
+  ]);
+  console.log(
+    JSON.stringify(
+      { generatedAt: new Date().toISOString(), ...buildStudentOutreachCountReport(rows) },
+      null,
+      2,
+    ),
+  );
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main()
+    .catch((error) => {
+      console.error('Failed to build PFR-3 outreach report:', sanitizeLogValue(error));
+      process.exitCode = 1;
+    })
+    .finally(() => mongoose.disconnect());
+}

--- a/server/src/scripts/rebuildPathwaySearchIndex.ts
+++ b/server/src/scripts/rebuildPathwaySearchIndex.ts
@@ -13,6 +13,7 @@ import {
   resolveSafeJsonReportOutputPath,
   type ScriptApplyGuardResult,
 } from './scriptWriteGuards';
+import { assertPathwayIndexRolloutTarget } from './pfr3RolloutCore';
 
 export interface RebuildPathwaySearchIndexCliOptions {
   pageSize: number;
@@ -83,11 +84,13 @@ export function writeRebuildPathwaySearchIndexOutput(result: unknown, output?: s
   fs.writeFileSync(safeOutput, `${JSON.stringify(result, null, 2)}\n`);
 }
 
-export function assertRebuildPathwaySearchIndexAllowed(args: {
-  env?: NodeJS.ProcessEnv;
-  mongoUrl?: string;
-  confirmMeiliRebuild?: boolean;
-} = {}): ScriptApplyGuardResult {
+export function assertRebuildPathwaySearchIndexAllowed(
+  args: {
+    env?: NodeJS.ProcessEnv;
+    mongoUrl?: string;
+    confirmMeiliRebuild?: boolean;
+  } = {},
+): ScriptApplyGuardResult {
   if (!args.confirmMeiliRebuild) {
     throw new Error('--confirm-meili-rebuild is required when rebuilding Meilisearch indexes');
   }
@@ -124,6 +127,12 @@ async function main() {
   const guard = assertRebuildPathwaySearchIndexAllowed({
     confirmMeiliRebuild: options.confirmMeiliRebuild,
   });
+  const rollout = assertPathwayIndexRolloutTarget({
+    environment: guard.environment,
+    meiliHost: process.env.MEILISEARCH_HOST,
+    indexPrefix: process.env.MEILISEARCH_INDEX_PREFIX,
+    restorePoint: process.env.PFR3_MEILI_RESTORE_POINT,
+  });
   await initializeConnections();
 
   const result = await rebuildPathwaySearchIndex(
@@ -140,6 +149,7 @@ async function main() {
     db: mongoose.connection.db?.databaseName || mongoose.connection.name || guard.dbLabel,
     options,
   });
+  Object.assign(output, { rollout });
 
   console.log(JSON.stringify(output, null, 2));
   writeRebuildPathwaySearchIndexOutput(output, options.output);


### PR DESCRIPTION
## Summary

- add a deterministic, read-only contact-route review queue that excludes PII and never auto-approves
- add count-only outreach monitoring that separates official-route attempts from outcomes reported via `outcomeReportedAt`
- guard pathway index rebuilds with explicit remote environment, index-prefix, and restore-point requirements
- document staged Beta/production verification and rollback

## Validation

- `yarn --cwd server test src/scripts/__tests__/pfr3RolloutCore.test.ts src/scripts/__tests__/searchIndexRebuildCli.test.ts`
- `yarn security:policy`
- `yarn security:secrets`
- `yarn build:server`
- changed-file ESLint
- `git diff --check`

No external service or database mutations were performed.
