### PR TITLE
Add pathway publication readiness audit

### DIFF
--- a/docs/pfr3-rollout-runbook.md
+++ b/docs/pfr3-rollout-runbook.md
@@ -17,6 +17,18 @@ Do not bulk-approve.
 
 ## 2. Beta preflight and rebuild
 
+Before rebuilding, generate an aggregate-only readiness artifact:
+
+```bash
+yarn --cwd server pathway:quality-audit --sample-limit=0 --output=/tmp/ylabs-pfr3-pathway-quality.json
+```
+
+Review `studentPublishablePathways`, `publicationBlockers`, and
+`publicationBlockerCombinations`. These counts apply the same status, evidence,
+confidence, and source URL gates as publication. A status or evidence blocker is
+not permission to promote records: resolve it only from authoritative source
+evidence through the normal materialization and review workflows.
+
 Confirm the deployed Beta service has all of the following values from the deployment control plane:
 
 - `SCRAPER_ENV=beta`

--- a/server/src/scripts/__tests__/pathwayQualityAuditCore.test.ts
+++ b/server/src/scripts/__tests__/pathwayQualityAuditCore.test.ts
@@ -22,6 +22,7 @@ describe('buildPathwayQualityAudit', () => {
           derivationKey: 'visibility-repair:official-profile-outreach:entity-1',
           sourceUrls: ['https://medicine.yale.edu/profile/example/'],
           sourceEvidenceIds: [],
+          confidence: 0.5,
         },
         {
           id: 'pathway-2',
@@ -32,6 +33,7 @@ describe('buildPathwayQualityAudit', () => {
           derivationKey: 'listing:listing-1:POSTED_ROLE',
           sourceUrls: ['https://example.test/listing'],
           sourceEvidenceIds: ['obs-1'],
+          confidence: 0.9,
         },
       ],
       routes: [
@@ -62,6 +64,7 @@ describe('buildPathwayQualityAudit', () => {
       activeListingsWithoutPostedOpportunity: 1,
       weakPathwaysNeedingEvidence: 1,
       missingSourceEvidenceIds: 1,
+      studentPublishablePathways: 1,
     });
     expect(report.byType).toMatchObject({
       EXPLORATORY_CONTACT: 1,
@@ -70,6 +73,15 @@ describe('buildPathwayQualityAudit', () => {
     expect(report.byDerivationPrefix).toMatchObject({
       'visibility-repair': 1,
       listing: 1,
+    });
+    expect(report.publicationBlockers).toEqual({
+      status: 1,
+      evidence_strength: 1,
+      confidence: 1,
+    });
+    expect(report.publicationBlockerCombinations).toEqual({
+      'status+evidence_strength+confidence': 1,
+      publishable: 1,
     });
     expect(report.samples.weakPathwaysNeedingEvidence[0].missingContext).toEqual([
       'source_evidence',
@@ -111,6 +123,19 @@ describe('buildPathwayQualityAudit', () => {
     expect(() =>
       parsePathwayQualityAuditArgs(['--output', '/tmp/pathway-quality.txt']),
     ).toThrow(/--output must point to a \.json report file/);
+  });
+
+  it('rejects unsafe evidence URLs from the publication funnel', () => {
+    const report = buildPathwayQualityAudit({
+      pathways: [{
+        id: 'pathway-1', researchEntityId: 'entity-1', status: 'ACTIVE',
+        evidenceStrength: 'DIRECT', confidence: 0.9,
+        sourceUrls: ['http://127.0.0.1/private'], sourceEvidenceIds: ['obs-1'],
+      }],
+      routes: [], listings: [], entityContexts: [], sampleLimit: 0,
+    });
+    expect(report.summary.studentPublishablePathways).toBe(0);
+    expect(report.publicationBlockers).toEqual({ source_url: 1 });
   });
 
   it('writes the pathway quality artifact when output is provided', () => {

--- a/server/src/scripts/pathwayQualityAudit.ts
+++ b/server/src/scripts/pathwayQualityAudit.ts
@@ -185,7 +185,7 @@ async function main(): Promise<void> {
       archived: { $ne: true },
       status: { $nin: ['NOT_CURRENTLY_AVAILABLE', 'NO_EVIDENCE'] },
     })
-      .select('_id researchEntityId pathwayType status evidenceStrength derivationKey sourceUrls sourceEvidenceIds')
+      .select('_id researchEntityId pathwayType status evidenceStrength confidence derivationKey sourceUrls sourceEvidenceIds')
       .lean(),
     ContactRoute.find({ archived: { $ne: true }, routeType: 'OFFICIAL_APPLICATION' })
       .select('_id researchEntityId entryPathwayId routeType sourceUrl sourceEvidenceIds')
@@ -224,6 +224,7 @@ async function main(): Promise<void> {
     derivationKey: pathway.derivationKey,
     sourceUrls: strings(pathway.sourceUrls),
     sourceEvidenceIds: strings(pathway.sourceEvidenceIds),
+    confidence: typeof pathway.confidence === 'number' ? pathway.confidence : undefined,
   }));
   const routes: PathwayQualityRouteFact[] = (routeDocs as any[]).map((route) => ({
     id: stringId(route._id),

--- a/server/src/scripts/pathwayQualityAuditCore.ts
+++ b/server/src/scripts/pathwayQualityAuditCore.ts
@@ -7,6 +7,7 @@ export interface PathwayQualityPathwayFact {
   derivationKey?: string;
   sourceUrls?: string[];
   sourceEvidenceIds?: string[];
+  confidence?: number;
 }
 
 export interface PathwayQualityRouteFact {
@@ -51,11 +52,14 @@ export interface PathwayQualityAuditResult {
     weakPathwaysNeedingEvidence: number;
     missingSourceUrls: number;
     missingSourceEvidenceIds: number;
+    studentPublishablePathways: number;
   };
   byType: Record<string, number>;
   byStatus: Record<string, number>;
   byEvidenceStrength: Record<string, number>;
   byDerivationPrefix: Record<string, number>;
+  publicationBlockers: Record<string, number>;
+  publicationBlockerCombinations: Record<string, number>;
   samples: {
     activeListingsWithoutPostedOpportunity: PathwayQualityListingFact[];
     routesWithoutLinkedPathway: PathwayQualityRouteFact[];
@@ -106,6 +110,26 @@ function take<T>(items: T[], limit: number): T[] {
   return items.slice(0, Math.max(0, limit));
 }
 
+function publicationBlockers(pathway: PathwayQualityPathwayFact): string[] {
+  const blockers: string[] = [];
+  if (!['ACTIVE', 'RECURRING'].includes(pathway.status || '')) blockers.push('status');
+  if (!['DIRECT', 'STRONG', 'MODERATE'].includes(pathway.evidenceStrength || '')) {
+    blockers.push('evidence_strength');
+  }
+  if (typeof pathway.confidence !== 'number' || pathway.confidence < 0.7) {
+    blockers.push('confidence');
+  }
+  const hasSafeSourceUrl = nonEmpty(pathway.sourceUrls).some((value) => {
+    try {
+      return isPublicHttpUrl(value);
+    } catch {
+      return false;
+    }
+  });
+  if (!hasSafeSourceUrl) blockers.push('source_url');
+  return blockers;
+}
+
 export function buildPathwayQualityAudit(
   input: PathwayQualityAuditInput,
 ): PathwayQualityAuditResult {
@@ -114,6 +138,8 @@ export function buildPathwayQualityAudit(
   const byStatus: Record<string, number> = {};
   const byEvidenceStrength: Record<string, number> = {};
   const byDerivationPrefix: Record<string, number> = {};
+  const publicationBlockerCounts: Record<string, number> = {};
+  const publicationBlockerCombinations: Record<string, number> = {};
   const contexts = contextMap(input.entityContexts);
 
   for (const pathway of input.pathways) {
@@ -121,6 +147,9 @@ export function buildPathwayQualityAudit(
     increment(byStatus, pathway.status);
     increment(byEvidenceStrength, pathway.evidenceStrength);
     increment(byDerivationPrefix, derivationPrefix(pathway.derivationKey));
+    const blockers = publicationBlockers(pathway);
+    for (const blocker of blockers) increment(publicationBlockerCounts, blocker);
+    increment(publicationBlockerCombinations, blockers.length ? blockers.join('+') : 'publishable');
   }
 
   const missingSourceUrls = input.pathways.filter(
@@ -161,11 +190,14 @@ export function buildPathwayQualityAudit(
       weakPathwaysNeedingEvidence: weakPathwaysNeedingEvidence.length,
       missingSourceUrls: missingSourceUrls.length,
       missingSourceEvidenceIds: missingSourceEvidenceIds.length,
+      studentPublishablePathways: publicationBlockerCombinations.publishable || 0,
     },
     byType,
     byStatus,
     byEvidenceStrength,
     byDerivationPrefix,
+    publicationBlockers: publicationBlockerCounts,
+    publicationBlockerCombinations,
     samples: {
       activeListingsWithoutPostedOpportunity: take(activeListingsWithoutPostedOpportunity, sampleLimit),
       routesWithoutLinkedPathway: take(routesWithoutLinkedPathway, sampleLimit),
@@ -175,3 +207,4 @@ export function buildPathwayQualityAudit(
     },
   };
 }
+import { isPublicHttpUrl } from '../utils/urlSafety';


### PR DESCRIPTION
## Summary
- add aggregate publication blocker counts and blocker combinations to the pathway quality audit
- apply the same status, evidence, confidence, and public URL safety gates used for student publication
- document the pre-rebuild readiness check and prohibit evidence-free promotion

## Beta findings
- 6 of 2,365 eligible non-archived pathways are publishable
- 2,359 are blocked by status, 1,973 by confidence, 1,590 by evidence strength, and 26 by missing or unsafe source URLs
- no records were changed

## Validation
- targeted Vitest: 8 passed
- security preflight: 271 passed
- server TypeScript no-emit check passed
- live Beta audit ran read-only with sample-limit=0