### PR TITLE
Fix PFR-3 contact-route evidence priority

### DIFF
--- a/docs/pfr3-rollout-runbook.md
+++ b/docs/pfr3-rollout-runbook.md
@@ -7,7 +7,7 @@ The pathway rebuild remains the only write operation and requires a verified res
 ## 1. Admin contact-route review
 
 Run `yarn --cwd server pfr3:contact-route-review` against Beta.
-The queue contains only structurally eligible public HTTP(S) destinations and sources, policy, evidence strength, confidence, priority, and current review state.
+The queue contains only structurally eligible public HTTP(S) destinations and sources, policy, evidence-reference count, priority, and current review state.
 It excludes approved, archived, direct-email, unknown-policy, and no-direct-contact routes.
 It never changes review status and contains no database identifiers, names, email addresses, or evidence excerpts.
 

--- a/server/src/scripts/__tests__/pfr3RolloutCore.test.ts
+++ b/server/src/scripts/__tests__/pfr3RolloutCore.test.ts
@@ -13,7 +13,7 @@ describe('PFR-3 rollout core', () => {
         url: 'https://example.edu/apply',
         sourceUrl: 'https://example.edu/source',
         contactPolicy: 'OFFICIAL_ROUTE',
-        confidence: 0.8,
+        sourceEvidenceIds: ['evidence-b'],
         priority: 20,
         review: { status: 'pending' },
       },
@@ -22,14 +22,14 @@ describe('PFR-3 rollout core', () => {
         url: 'mailto:person@example.edu',
         sourceUrl: 'https://example.edu/source',
         contactPolicy: 'FACULTY_CONTACT',
-        confidence: 0.99,
+        sourceEvidenceIds: ['evidence-c'],
       },
       {
         routeType: 'OFFICIAL_APPLICATION',
         url: 'https://example.edu/approved',
         sourceUrl: 'https://example.edu/source',
         contactPolicy: 'OFFICIAL_ROUTE',
-        confidence: 1,
+        sourceEvidenceIds: ['evidence-d'],
         review: { status: 'approved' },
       },
       {
@@ -37,7 +37,7 @@ describe('PFR-3 rollout core', () => {
         url: 'https://example.edu/apply-2',
         sourceUrl: 'https://example.edu/source-2',
         contactPolicy: 'OFFICIAL_ROUTE',
-        confidence: 0.9,
+        sourceEvidenceIds: ['evidence-a', 'evidence-b'],
         priority: 50,
       },
     ]);
@@ -46,6 +46,7 @@ describe('PFR-3 rollout core', () => {
       'https://example.edu/apply-2',
       'https://example.edu/apply',
     ]);
+    expect(queue.map((item) => item.evidenceReferenceCount)).toEqual([2, 1]);
     expect(JSON.stringify(queue)).not.toMatch(/email|personName|researchEntityId|approved/i);
   });
 

--- a/server/src/scripts/pfr3ContactRouteReview.ts
+++ b/server/src/scripts/pfr3ContactRouteReview.ts
@@ -15,7 +15,7 @@ async function main() {
     'review.status': { $ne: 'approved' },
   })
     .select(
-      'routeType url sourceUrl contactPolicy evidenceStrength confidence priority review.status archived',
+      'routeType url sourceUrl contactPolicy sourceEvidenceId sourceEvidenceIds priority review.status archived',
     )
     .lean();
   const queue = buildContactRouteReviewQueue(candidates);

--- a/server/src/scripts/pfr3RolloutCore.ts
+++ b/server/src/scripts/pfr3RolloutCore.ts
@@ -7,8 +7,8 @@ export interface ContactRouteReviewCandidate {
   url?: unknown;
   sourceUrl?: unknown;
   contactPolicy?: unknown;
-  evidenceStrength?: unknown;
-  confidence?: unknown;
+  sourceEvidenceId?: unknown;
+  sourceEvidenceIds?: unknown;
   priority?: unknown;
   review?: { status?: unknown };
   archived?: unknown;
@@ -19,8 +19,7 @@ export interface ContactRouteReviewQueueItem {
   destination: string;
   source: string;
   contactPolicy: string;
-  evidenceStrength: string;
-  confidence: number;
+  evidenceReferenceCount: number;
   priority: number;
   reviewStatus: string;
 }
@@ -53,15 +52,22 @@ export function buildContactRouteReviewQueue(
       ) {
         return [];
       }
+      const evidenceReferenceCount = new Set(
+        [
+          ...(Array.isArray(candidate.sourceEvidenceIds) ? candidate.sourceEvidenceIds : []),
+          ...(candidate.sourceEvidenceId ? [candidate.sourceEvidenceId] : []),
+        ]
+          .map(String)
+          .filter(Boolean),
+      ).size;
+      if (evidenceReferenceCount === 0) return [];
       return [
         {
           routeType: typeof candidate.routeType === 'string' ? candidate.routeType : 'UNKNOWN',
           destination,
           source,
           contactPolicy,
-          evidenceStrength:
-            typeof candidate.evidenceStrength === 'string' ? candidate.evidenceStrength : 'UNKNOWN',
-          confidence: typeof candidate.confidence === 'number' ? candidate.confidence : 0,
+          evidenceReferenceCount,
           priority: typeof candidate.priority === 'number' ? candidate.priority : 100,
           reviewStatus:
             typeof candidate.review?.status === 'string' ? candidate.review.status : 'unreviewed',
@@ -70,7 +76,9 @@ export function buildContactRouteReviewQueue(
     })
     .sort(
       (left, right) =>
-        right.confidence - left.confidence ||
+        (left.routeType === 'OFFICIAL_APPLICATION' ? 0 : 1) -
+          (right.routeType === 'OFFICIAL_APPLICATION' ? 0 : 1) ||
+        right.evidenceReferenceCount - left.evidenceReferenceCount ||
         left.priority - right.priority ||
         left.source.localeCompare(right.source) ||
         left.destination.localeCompare(right.destination),


### PR DESCRIPTION
## Summary

- replace nonexistent ContactRoute confidence fields with actual evidence-reference counts
- exclude contact-route candidates that have no evidence reference
- prioritize official application routes, then stronger evidence coverage, then stored priority
- update focused tests and the operator runbook

## Validation

- `yarn --cwd server test src/scripts/__tests__/pfr3RolloutCore.test.ts`
- `yarn security:policy`
- `yarn build:server`
- changed-file ESLint
- `git diff --check`
- read-only Beta report generation (no identifiers or URLs surfaced in PR)

No route approval, database write, or search-index mutation was performed.
