### PR TITLE
Harden Yalies credential scanning and rotation verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test:ci": "yarn --cwd client test:ci",
     "security:policy": "node --test scripts/security-preflight.test.mjs",
     "security:secrets": "node scripts/check-no-secrets.mjs",
+    "security:verify-yalies-rotation": "node scripts/verify-yalies-rotation.mjs",
     "security:audit:production": "yarn npm audit --severity moderate --environment production && yarn --cwd server npm audit --severity moderate --environment production && yarn --cwd client npm audit --severity moderate --environment production",
     "security:preflight": "yarn security:policy && yarn security:secrets && yarn security:audit:production",
     "security:smoke:production": "node client/scripts/productionPromotionSmoke.mjs --api-base ${SMOKE_API_BASE:-https://yalelabs.io/api} --app-base ${SMOKE_APP_BASE:-https://yalelabs.io} --ui=false",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,6 +8,9 @@ Check this inventory before deleting or moving anything in this directory.
 | `check-no-secrets.mjs` | Root `security:secrets` script. |
 | `check-no-secrets-core.mjs` | Shared implementation for `check-no-secrets.mjs` and `check-no-secrets.test.mjs`. |
 | `check-no-secrets.test.mjs` | Node test coverage for the secret scanner. |
+| `verify-yalies-rotation.mjs` | Operator-only check that an old Yalies credential is rejected and its replacement succeeds; reads credentials from process environment and logs statuses only. |
+| `verify-yalies-rotation-core.mjs` | Testable fixed-endpoint implementation for Yalies credential verification. |
+| `verify-yalies-rotation.test.mjs` | Node test coverage for rotation verification and credential-safe request construction. |
 | `ensure-server-build-fresh.mjs` | Server `start` preflight in `server/package.json`. |
 | `research-detail-professor-audit.mjs` | Root `audit:research-detail-professors` script. |
 | `research-detail-professor-audit-core.mjs` | Shared helpers for the audit script and server-side tests. |

--- a/scripts/check-no-secrets-core.mjs
+++ b/scripts/check-no-secrets-core.mjs
@@ -25,6 +25,11 @@ const SECRET_RULES = [
   },
 ];
 
+const YALIES_API_HOST_RE = /\bapi\.yalies\.io\b/i;
+const YALIES_API_KEY_ASSIGNMENT_RE =
+  /\bYALIES_API_KEY\b\s*[=:]\s*["']?([A-Za-z0-9._~+/=-]{20,})/gi;
+const BEARER_TOKEN_RE = /\bBearer\s+([A-Za-z0-9._~+/=-]{20,})\b/gi;
+
 const PLACEHOLDER_PATTERNS = [
   /<redacted>/i,
   /<user>:<password>@<cluster>/i,
@@ -42,6 +47,31 @@ const lineNumberForIndex = (content, index) => content.slice(0, index).split('\n
 const isAllowedPlaceholder = (matchText) =>
   PLACEHOLDER_PATTERNS.some((pattern) => pattern.test(matchText));
 
+const yaliesCredentialFindings = (file) => {
+  const findings = [];
+  const patterns = [
+    { rule: 'yalies-api-key-assignment', pattern: YALIES_API_KEY_ASSIGNMENT_RE },
+    ...(YALIES_API_HOST_RE.test(file.content)
+      ? [{ rule: 'yalies-bearer-token', pattern: BEARER_TOKEN_RE }]
+      : []),
+  ];
+
+  for (const { rule, pattern } of patterns) {
+    pattern.lastIndex = 0;
+    for (const match of file.content.matchAll(pattern)) {
+      const credential = match[1] || '';
+      if (isAllowedPlaceholder(credential)) continue;
+      findings.push({
+        path: file.path,
+        line: lineNumberForIndex(file.content, match.index || 0),
+        rule,
+      });
+    }
+  }
+
+  return findings;
+};
+
 export function candidateSecretScanPaths(paths) {
   return Array.from(
     new Set(
@@ -57,6 +87,7 @@ export function findSecretFindings(files) {
   const findings = [];
 
   for (const file of files) {
+    findings.push(...yaliesCredentialFindings(file));
     for (const rule of SECRET_RULES) {
       rule.pattern.lastIndex = 0;
       for (const match of file.content.matchAll(rule.pattern)) {

--- a/scripts/check-no-secrets.mjs
+++ b/scripts/check-no-secrets.mjs
@@ -38,11 +38,11 @@ const readFiles = (files) =>
 const findings = findSecretFindings(readFiles(listFiles()));
 
 if (findings.length > 0) {
-  console.error('Potential committed secrets found:');
+  console.error('Potential secrets found:');
   for (const finding of findings) {
     console.error(`- ${finding.path}:${finding.line} ${finding.rule}`);
   }
   process.exit(1);
 }
 
-console.log('No high-confidence committed secrets found.');
+console.log('No high-confidence secrets found in tracked or untracked non-ignored files.');

--- a/scripts/check-no-secrets.test.mjs
+++ b/scripts/check-no-secrets.test.mjs
@@ -91,3 +91,47 @@ test('selects tracked and untracked non-ignored files for scanning', () => {
     'graphify-out/graph.json',
   ]);
 });
+
+test('flags synthetic Yalies credentials without returning their values', () => {
+  const assignedCredential = ['synthetic', 'Yalies', 'Credential', '1234567890'].join('');
+  const bearerCredential = ['another', 'Synthetic', 'Bearer', '0987654321'].join('');
+  const findings = findSecretFindings([
+    {
+      path: 'operator.env',
+      content: `YALIES_API_KEY=${assignedCredential}`,
+    },
+    {
+      path: 'scratch/request.ts',
+      content: [
+        "const endpoint = 'https://api.yalies.io/v2/people';",
+        `const header = 'Bearer ${bearerCredential}';`,
+      ].join('\n'),
+    },
+  ]);
+
+  assert.deepEqual(
+    findings.map(({ path, line, rule }) => ({ path, line, rule })),
+    [
+      { path: 'operator.env', line: 1, rule: 'yalies-api-key-assignment' },
+      { path: 'scratch/request.ts', line: 2, rule: 'yalies-bearer-token' },
+    ],
+  );
+  assert.ok(!JSON.stringify(findings).includes(assignedCredential));
+  assert.ok(!JSON.stringify(findings).includes(bearerCredential));
+});
+
+test('allows Yalies environment references and bearer examples outside Yalies context', () => {
+  const genericBearer = ['generic', 'Bearer', 'Fixture', '1234567890'].join('');
+  const files = [
+    {
+      path: 'server/src/service.ts',
+      content: "const key = process.env.YALIES_API_KEY;\nAuthorization: `Bearer ${key}`;",
+    },
+    {
+      path: 'docs/oauth.md',
+      content: `Authorization: Bearer ${genericBearer}`,
+    },
+  ];
+
+  assert.deepEqual(findSecretFindings(files), []);
+});

--- a/scripts/verify-yalies-rotation-core.mjs
+++ b/scripts/verify-yalies-rotation-core.mjs
@@ -1,0 +1,26 @@
+export const YALIES_VERIFICATION_URL = 'https://api.yalies.io/v2/people';
+
+const statusResult = (status) => ({ status, ok: status >= 200 && status < 300 });
+
+export async function verifyYaliesCredential(credential, request = fetch) {
+  if (!credential || typeof credential !== 'string') {
+    throw new Error('credential is required');
+  }
+
+  const response = await request(YALIES_VERIFICATION_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${credential}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ page: 1, page_size: 1, filters: {} }),
+    redirect: 'error',
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  return statusResult(response.status);
+}
+
+export function rotationIsVerified(oldResult, newResult) {
+  return [401, 403].includes(oldResult.status) && newResult.ok;
+}

--- a/scripts/verify-yalies-rotation.mjs
+++ b/scripts/verify-yalies-rotation.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+import {
+  rotationIsVerified,
+  verifyYaliesCredential,
+} from './verify-yalies-rotation-core.mjs';
+
+const oldCredential = process.env.YALIES_OLD_API_KEY;
+const newCredential = process.env.YALIES_NEW_API_KEY;
+
+if (!oldCredential || !newCredential) {
+  console.error('Set YALIES_OLD_API_KEY and YALIES_NEW_API_KEY in the process environment.');
+  process.exit(2);
+}
+
+try {
+  const oldResult = await verifyYaliesCredential(oldCredential);
+  const newResult = await verifyYaliesCredential(newCredential);
+
+  console.log(`Old credential HTTP status: ${oldResult.status}`);
+  console.log(`New credential HTTP status: ${newResult.status}`);
+
+  if (!rotationIsVerified(oldResult, newResult)) {
+    console.error('Rotation is not verified: old must be rejected and new must succeed.');
+    process.exit(1);
+  }
+
+  console.log('Rotation verified: old credential rejected and new credential accepted.');
+} catch {
+  console.error('Rotation verification request failed; no credential values were logged.');
+  process.exit(1);
+}

--- a/scripts/verify-yalies-rotation.test.mjs
+++ b/scripts/verify-yalies-rotation.test.mjs
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  rotationIsVerified,
+  verifyYaliesCredential,
+  YALIES_VERIFICATION_URL,
+} from './verify-yalies-rotation-core.mjs';
+
+test('probes only the fixed Yalies endpoint and does not place credentials in the body', async () => {
+  const credential = ['synthetic', 'Rotation', 'Credential', '123456'].join('');
+  let captured;
+  const request = async (url, options) => {
+    captured = { url, options };
+    return { status: 200 };
+  };
+
+  assert.deepEqual(await verifyYaliesCredential(credential, request), { status: 200, ok: true });
+  assert.equal(captured.url, YALIES_VERIFICATION_URL);
+  assert.equal(captured.options.redirect, 'error');
+  assert.ok(!captured.options.body.includes(credential));
+  assert.equal(captured.options.headers.Authorization, `Bearer ${credential}`);
+});
+
+test('requires rejection of the old credential and success of the new credential', () => {
+  assert.equal(rotationIsVerified({ status: 401 }, { status: 200, ok: true }), true);
+  assert.equal(rotationIsVerified({ status: 403 }, { status: 204, ok: true }), true);
+  assert.equal(rotationIsVerified({ status: 200 }, { status: 200, ok: true }), false);
+  assert.equal(rotationIsVerified({ status: 401 }, { status: 500, ok: false }), false);
+});


### PR DESCRIPTION
## Summary
- detect literal Yalies API key assignments and bearer credentials in Yalies API context
- keep scanner output credential-free and cover tracked/untracked nonignored paths with synthetic regressions
- add a fixed-endpoint operator check for old-key rejection and replacement-key health

## Validation
- node --test scripts/check-no-secrets.test.mjs scripts/verify-yalies-rotation.test.mjs
- yarn security:secrets
- yarn security:policy (271 passed)
- yarn lint (0 errors; existing warnings)
- yarn build:server
- yarn build:client
- staged synthetic credential acceptance test exits nonzero and prints path/line/rule only

## Operations
This does not rotate any external credential. An operator must rotate it through Yalies, then run security:verify-yalies-rotation with both credentials supplied only through the process environment.