### PR TITLE
Add safe PFR-3 pathway source queue

### DIFF
--- a/docs/pfr3-rollout-runbook.md
+++ b/docs/pfr3-rollout-runbook.md
@@ -16,7 +16,7 @@ PFR3_QUEUE_HANDLE_SALT='<environment-specific secret, at least 16 characters>' \
 The default report is aggregate-only. Its mutually exclusive buckets are worked in order:
 
 1. `status_recency_review`: evidence, confidence, and a safe public source already qualify; a human must verify whether the pathway is currently active or recurring.
-2. `source_repair`: the pathway lacks a safe public HTTP(S) source or an evidence reference; an operator must locate and validate an authoritative public source.
+2. `source_repair`: the pathway lacks a safe public HTTP(S) source; an operator must locate and validate an authoritative public source.
 3. `new_source_acquisition`: weak evidence is also below the `0.70` confidence threshold; acquire new authoritative evidence through the normal scraper/observation workflow.
 
 For bounded assignment samples, add `--sample-limit=N` where `N` is at most 100. Samples contain only salted, non-reversible handles and coarse quality labels. Keep the environment-specific salt stable for one review cycle, store it outside reports, and rotate it between cycles. The command never prints URLs, evidence IDs, database IDs, excerpts, names, or contact details.

--- a/docs/pfr3-rollout-runbook.md
+++ b/docs/pfr3-rollout-runbook.md
@@ -4,6 +4,25 @@ This rollout is fail-closed and staged.
 The review and monitoring commands are read-only.
 The pathway rebuild remains the only write operation and requires a verified restore point.
 
+## Source acquisition queue
+
+Generate the read-only remediation queue before assigning source work:
+
+```bash
+PFR3_QUEUE_HANDLE_SALT='<environment-specific secret, at least 16 characters>' \
+  yarn --cwd server pfr3:pathway-source-queue
+```
+
+The default report is aggregate-only. Its mutually exclusive buckets are worked in order:
+
+1. `status_recency_review`: evidence, confidence, and a safe public source already qualify; a human must verify whether the pathway is currently active or recurring.
+2. `source_repair`: the pathway lacks a safe public HTTP(S) source or an evidence reference; an operator must locate and validate an authoritative public source.
+3. `new_source_acquisition`: weak evidence is also below the `0.70` confidence threshold; acquire new authoritative evidence through the normal scraper/observation workflow.
+
+For bounded assignment samples, add `--sample-limit=N` where `N` is at most 100. Samples contain only salted, non-reversible handles and coarse quality labels. Keep the environment-specific salt stable for one review cycle, store it outside reports, and rotate it between cycles. The command never prints URLs, evidence IDs, database IDs, excerpts, names, or contact details.
+
+The queue is triage only. Operators must not directly upgrade pathway status, evidence strength, or confidence. Re-scrape or add source-backed observations, run the normal materializer and review flow, then regenerate this report to confirm the pathway moved buckets.
+
 ## 1. Admin contact-route review
 
 Run `yarn --cwd server pfr3:contact-route-review` against Beta.

--- a/scripts/security-preflight.test.mjs
+++ b/scripts/security-preflight.test.mjs
@@ -160,6 +160,16 @@ test('PFR-3 rollout tooling stays aggregate-only and fail-closed', () => {
   assert.match(rebuild, /assertPathwayIndexRolloutTarget/);
 });
 
+test('PFR-3 pathway source queue is read-only and redacted', () => {
+  const queue = fs.readFileSync(new URL('../server/src/scripts/pfr3PathwaySourceQueue.ts', import.meta.url), 'utf8');
+  const core = fs.readFileSync(new URL('../server/src/scripts/pfr3PathwaySourceQueueCore.ts', import.meta.url), 'utf8');
+  assert.match(queue, /assertScriptApplyAllowed/);
+  assert.match(queue, /\.select\('_id status evidenceStrength confidence sourceUrls sourceEvidenceIds archived'\)/);
+  assert.doesNotMatch(queue, /\.update|\.save|findOneAnd|bulkWrite|insertMany|deleteMany/);
+  assert.match(core, /createHash\('sha256'\)/);
+  assert.doesNotMatch(core, /destination|email|phone|excerpt/);
+});
+
 
 test('admin access-review validation responses use fixed public copy', () => {
   const source = fs.readFileSync(new URL('../server/src/routes/admin.ts', import.meta.url), 'utf8');

--- a/server/package.json
+++ b/server/package.json
@@ -30,6 +30,7 @@
     "meili:rebuild-pathways": "tsx src/scripts/rebuildPathwaySearchIndex.ts",
     "pfr3:contact-route-review": "tsx src/scripts/pfr3ContactRouteReview.ts",
     "pfr3:outreach-report": "tsx src/scripts/pfr3StudentOutreachReport.ts",
+    "pfr3:pathway-source-queue": "tsx src/scripts/pfr3PathwaySourceQueue.ts",
     "meili:rebuild-research-entities": "tsx src/scripts/rebuildResearchEntitySearchIndex.ts",
     "meili:seed": "yarn meili:rebuild-research-entities --clear --confirm-meili-rebuild && yarn meili:rebuild-pathways --clear --confirm-meili-rebuild",
     "research-entity:audit-rename": "tsx src/scripts/auditResearchEntityRename.ts",

--- a/server/src/scripts/__tests__/pfr3PathwaySourceQueueCore.test.ts
+++ b/server/src/scripts/__tests__/pfr3PathwaySourceQueueCore.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { buildPathwaySourceQueue } from '../pfr3PathwaySourceQueueCore';
+
+const salt = 'test-only-queue-handle-salt';
+
+describe('buildPathwaySourceQueue', () => {
+  it('builds mutually exclusive deterministic remediation buckets', () => {
+    const candidates = [
+      {
+        id: 'status',
+        status: 'UNKNOWN',
+        evidenceStrength: 'STRONG',
+        confidence: 0.8,
+        sourceUrls: ['https://yale.edu/a'],
+        sourceEvidenceIds: ['e1'],
+      },
+      {
+        id: 'url',
+        status: 'ACTIVE',
+        evidenceStrength: 'STRONG',
+        confidence: 0.8,
+        sourceUrls: ['mailto:person@yale.edu'],
+        sourceEvidenceIds: ['e2'],
+      },
+      {
+        id: 'weak',
+        status: 'ACTIVE',
+        evidenceStrength: 'WEAK',
+        confidence: 0.5,
+        sourceUrls: ['https://yale.edu/c'],
+        sourceEvidenceIds: ['e3'],
+      },
+      {
+        id: 'ready',
+        status: 'ACTIVE',
+        evidenceStrength: 'STRONG',
+        confidence: 0.8,
+        sourceUrls: ['https://yale.edu/d'],
+        sourceEvidenceIds: ['e4'],
+      },
+    ];
+    const first = buildPathwaySourceQueue(candidates, { sampleLimit: 10, handleSalt: salt });
+    const second = buildPathwaySourceQueue([...candidates].reverse(), {
+      sampleLimit: 10,
+      handleSalt: salt,
+    });
+    expect(first).toEqual(second);
+    expect(first.buckets.status_recency_review.count).toBe(1);
+    expect(first.buckets.source_repair.count).toBe(1);
+    expect(first.buckets.new_source_acquisition.count).toBe(1);
+  });
+
+  it('emits no raw ids, URLs, evidence references, or contact data', () => {
+    const report = buildPathwaySourceQueue(
+      [
+        {
+          id: 'raw-db-id',
+          status: 'ACTIVE',
+          evidenceStrength: 'WEAK',
+          confidence: 0.5,
+          sourceUrls: ['https://example.edu/private?q=person@yale.edu'],
+          sourceEvidenceIds: ['raw-evidence-id'],
+        },
+      ],
+      { sampleLimit: 1, handleSalt: salt },
+    );
+    const output = JSON.stringify(report);
+    expect(output).not.toContain('raw-db-id');
+    expect(output).not.toContain('example.edu');
+    expect(output).not.toContain('person@yale.edu');
+    expect(output).not.toContain('raw-evidence-id');
+    expect(output).toMatch(/pathway-[a-f0-9]{12}/);
+  });
+
+  it('defaults to aggregate-only and rejects excessive sample limits', () => {
+    const report = buildPathwaySourceQueue(
+      [
+        {
+          id: 'one',
+          status: 'UNKNOWN',
+          evidenceStrength: 'STRONG',
+          confidence: 0.8,
+          sourceUrls: ['https://yale.edu'],
+          sourceEvidenceIds: ['e'],
+        },
+      ],
+      { handleSalt: salt },
+    );
+    expect(report.buckets.status_recency_review.samples).toEqual([]);
+    expect(() => buildPathwaySourceQueue([], { sampleLimit: 101, handleSalt: salt })).toThrow();
+  });
+});

--- a/server/src/scripts/pfr3PathwaySourceQueue.ts
+++ b/server/src/scripts/pfr3PathwaySourceQueue.ts
@@ -1,0 +1,55 @@
+import dotenv from 'dotenv';
+dotenv.config();
+import mongoose from 'mongoose';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { initializeConnections } from '../db/connections';
+import { EntryPathway } from '../models/entryPathway';
+import { sanitizeLogValue } from '../utils/logSanitizer';
+import { buildPathwaySourceQueue } from './pfr3PathwaySourceQueueCore';
+import { assertScriptApplyAllowed } from './scriptWriteGuards';
+
+function parseSampleLimit(argv: string[]): number {
+  if (argv.length === 0) return 0;
+  if (argv.length !== 1 || !argv[0].startsWith('--sample-limit=')) {
+    throw new Error('Usage: pfr3:pathway-source-queue [--sample-limit=0..100]');
+  }
+  const value = argv[0].slice('--sample-limit='.length);
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isSafeInteger(parsed) || parsed < 0 || parsed > 100 || String(parsed) !== value) {
+    throw new Error('--sample-limit requires an integer from 0 through 100');
+  }
+  return parsed;
+}
+
+async function main(): Promise<void> {
+  const sampleLimit = parseSampleLimit(process.argv.slice(2));
+  assertScriptApplyAllowed({
+    apply: false,
+    scriptName: 'pfr3:pathway-source-queue',
+    mongoUrl: process.env.MONGODBURL,
+  });
+  const handleSalt = process.env.PFR3_QUEUE_HANDLE_SALT?.trim();
+  if (!handleSalt || handleSalt.length < 16) {
+    throw new Error('PFR3_QUEUE_HANDLE_SALT must contain at least 16 characters');
+  }
+  await initializeConnections();
+  const candidates = await EntryPathway.find({ archived: { $ne: true } })
+    .select('_id status evidenceStrength confidence sourceUrls sourceEvidenceIds archived')
+    .lean();
+  const report = buildPathwaySourceQueue(
+    candidates.map((candidate: any) => ({ ...candidate, id: candidate._id })),
+    { sampleLimit, handleSalt },
+  );
+  console.log(JSON.stringify({ generatedAt: new Date().toISOString(), ...report }, null, 2));
+}
+
+const __filename = fileURLToPath(import.meta.url);
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  main()
+    .catch((error) => {
+      console.error('Failed to build PFR-3 pathway source queue:', sanitizeLogValue(error));
+      process.exitCode = 1;
+    })
+    .finally(() => mongoose.disconnect());
+}

--- a/server/src/scripts/pfr3PathwaySourceQueueCore.ts
+++ b/server/src/scripts/pfr3PathwaySourceQueueCore.ts
@@ -1,0 +1,116 @@
+import { createHash } from 'crypto';
+import { isPublicHttpUrl } from '../utils/urlSafety';
+
+export type PathwaySourceQueueBucket =
+  | 'status_recency_review'
+  | 'source_repair'
+  | 'new_source_acquisition';
+
+export interface PathwaySourceQueueCandidate {
+  id: unknown;
+  status?: unknown;
+  evidenceStrength?: unknown;
+  confidence?: unknown;
+  sourceUrls?: unknown;
+  sourceEvidenceIds?: unknown;
+  archived?: unknown;
+}
+
+export interface PathwaySourceQueueSample {
+  handle: string;
+  status: string;
+  evidenceStrength: string;
+  confidenceBand: 'missing' | 'below_0.70' | 'at_least_0.70';
+}
+
+export interface PathwaySourceQueueReport {
+  candidateCount: number;
+  buckets: Record<PathwaySourceQueueBucket, { count: number; samples: PathwaySourceQueueSample[] }>;
+}
+
+const ACTIVE_STATUSES = new Set(['ACTIVE', 'RECURRING']);
+const QUALIFYING_EVIDENCE = new Set(['DIRECT', 'STRONG', 'MODERATE']);
+
+function strings(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+    : [];
+}
+
+function hasSafePublicSource(candidate: PathwaySourceQueueCandidate): boolean {
+  return strings(candidate.sourceUrls).some((url) => {
+    try {
+      return isPublicHttpUrl(url);
+    } catch {
+      return false;
+    }
+  });
+}
+
+function confidenceBand(value: unknown): PathwaySourceQueueSample['confidenceBand'] {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 'missing';
+  return value < 0.7 ? 'below_0.70' : 'at_least_0.70';
+}
+
+function handleFor(id: unknown, salt: string): string {
+  return `pathway-${createHash('sha256')
+    .update(`${salt}:${String(id)}`)
+    .digest('hex')
+    .slice(0, 12)}`;
+}
+
+function bucketFor(candidate: PathwaySourceQueueCandidate): PathwaySourceQueueBucket | null {
+  if (candidate.archived === true) return null;
+  const status = typeof candidate.status === 'string' ? candidate.status : '';
+  const evidence = typeof candidate.evidenceStrength === 'string' ? candidate.evidenceStrength : '';
+  const confidence = typeof candidate.confidence === 'number' ? candidate.confidence : undefined;
+  const safeSource = hasSafePublicSource(candidate);
+  const hasEvidenceReference = strings(candidate.sourceEvidenceIds).length > 0;
+
+  const statusIsOnlyBlocker =
+    !ACTIVE_STATUSES.has(status) &&
+    QUALIFYING_EVIDENCE.has(evidence) &&
+    typeof confidence === 'number' &&
+    confidence >= 0.7 &&
+    safeSource;
+  if (statusIsOnlyBlocker) return 'status_recency_review';
+  if (!safeSource || !hasEvidenceReference) return 'source_repair';
+  if (evidence === 'WEAK' && (confidence === undefined || confidence < 0.7)) {
+    return 'new_source_acquisition';
+  }
+  return null;
+}
+
+export function buildPathwaySourceQueue(
+  candidates: PathwaySourceQueueCandidate[],
+  options: { sampleLimit?: number; handleSalt: string },
+): PathwaySourceQueueReport {
+  if (!options.handleSalt.trim()) throw new Error('A non-empty handle salt is required');
+  const sampleLimit = options.sampleLimit ?? 0;
+  if (!Number.isSafeInteger(sampleLimit) || sampleLimit < 0 || sampleLimit > 100) {
+    throw new Error('sampleLimit must be an integer from 0 through 100');
+  }
+  const buckets: PathwaySourceQueueReport['buckets'] = {
+    status_recency_review: { count: 0, samples: [] },
+    source_repair: { count: 0, samples: [] },
+    new_source_acquisition: { count: 0, samples: [] },
+  };
+  const sorted = [...candidates].sort((left, right) =>
+    handleFor(left.id, options.handleSalt).localeCompare(handleFor(right.id, options.handleSalt)),
+  );
+  for (const candidate of sorted) {
+    const bucket = bucketFor(candidate);
+    if (!bucket) continue;
+    buckets[bucket].count += 1;
+    if (buckets[bucket].samples.length < sampleLimit) {
+      buckets[bucket].samples.push({
+        handle: handleFor(candidate.id, options.handleSalt),
+        status: typeof candidate.status === 'string' ? candidate.status : 'UNKNOWN',
+        evidenceStrength:
+          typeof candidate.evidenceStrength === 'string' ? candidate.evidenceStrength : 'UNKNOWN',
+        confidenceBand: confidenceBand(candidate.confidence),
+      });
+    }
+  }
+  return { candidateCount: candidates.length, buckets };
+}

--- a/server/src/scripts/pfr3PathwaySourceQueueCore.ts
+++ b/server/src/scripts/pfr3PathwaySourceQueueCore.ts
@@ -65,7 +65,6 @@ function bucketFor(candidate: PathwaySourceQueueCandidate): PathwaySourceQueueBu
   const evidence = typeof candidate.evidenceStrength === 'string' ? candidate.evidenceStrength : '';
   const confidence = typeof candidate.confidence === 'number' ? candidate.confidence : undefined;
   const safeSource = hasSafePublicSource(candidate);
-  const hasEvidenceReference = strings(candidate.sourceEvidenceIds).length > 0;
 
   const statusIsOnlyBlocker =
     !ACTIVE_STATUSES.has(status) &&
@@ -74,7 +73,7 @@ function bucketFor(candidate: PathwaySourceQueueCandidate): PathwaySourceQueueBu
     confidence >= 0.7 &&
     safeSource;
   if (statusIsOnlyBlocker) return 'status_recency_review';
-  if (!safeSource || !hasEvidenceReference) return 'source_repair';
+  if (!safeSource) return 'source_repair';
   if (evidence === 'WEAK' && (confidence === undefined || confidence < 0.7)) {
     return 'new_source_acquisition';
   }


### PR DESCRIPTION
## Summary

- add a read-only, aggregate-first pathway source remediation queue
- separate status recency review, source repair, and new source acquisition into deterministic mutually exclusive buckets
- allow only bounded samples with salted one-way handles and coarse non-sensitive labels
- document the operator workflow and prohibit direct quality promotion

## Safety

- no database writes or mutation APIs
- no database IDs, URLs, evidence IDs, excerpts, names, or contact details in reports
- unsafe/non-public URLs are treated as missing and routed to source repair
- no automatic status, evidence-strength, or confidence upgrades

## Validation

- `yarn --cwd server test src/scripts/__tests__/pfr3PathwaySourceQueueCore.test.ts`
- `node --test scripts/security-preflight.test.mjs`
- `yarn --cwd server test`
- `yarn --cwd server build`
- focused ESLint on changed TypeScript files
