### PR TITLE
Eliminate remaining ESLint warnings

### DIFF
--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -196,7 +196,6 @@ export default function Navbar() {
   const isAdmin = user?.userType === 'admin';
   const isProfessorUser = user?.userType === 'professor' || user?.userType === 'faculty';
   const isListingsPage = false;
-  const isHomePage = isListingsPage;
 
   const {
     selectedDepartments,

--- a/client/src/components/accounts/FavoritesManager.tsx
+++ b/client/src/components/accounts/FavoritesManager.tsx
@@ -193,7 +193,7 @@ const FavoritesManager = ({ variant = 'student', onSummaryChange }: FavoritesMan
 
   useEffect(() => {
     reloadFavorites();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+
   }, []);
 
   const nextProgramDeadline = useMemo(

--- a/client/src/components/accounts/ListingEditor.tsx
+++ b/client/src/components/accounts/ListingEditor.tsx
@@ -50,7 +50,7 @@ const ListingEditor = ({ user }: ListingEditorProps) => {
 
   useEffect(() => {
     reloadListings();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+
   }, []);
 
   useEffect(() => {

--- a/client/src/components/admin/AdminListingsTable.tsx
+++ b/client/src/components/admin/AdminListingsTable.tsx
@@ -122,7 +122,7 @@ const AdminListingsTable = () => {
       search ? 400 : 0,
     );
     return () => clearTimeout(debounce);
-  }, [fetchListings]);
+  }, [fetchListings, search]);
 
   const handleDelete = async (listing: AdminListing) => {
     const confirmed = await swal({

--- a/client/src/components/admin/AdminOperatorBoard.tsx
+++ b/client/src/components/admin/AdminOperatorBoard.tsx
@@ -777,12 +777,6 @@ const sourceDecisionValidationStatusText = (
 
 const total = (rows: TierCount[]) => rows.reduce((sum, row) => sum + row.count, 0);
 
-const queueKindLabel: Record<QueueKind, string> = {
-  blocking: 'Repair queue',
-  evidence: 'Evidence signal',
-  review: 'Review signal',
-};
-
 const queueKindStyles: Record<QueueKind, string> = {
   blocking: 'border-red-200 bg-red-50 text-red-700',
   evidence: 'border-emerald-200 bg-emerald-50 text-emerald-700',

--- a/client/src/components/profile/CourseTableSection.tsx
+++ b/client/src/components/profile/CourseTableSection.tsx
@@ -43,7 +43,7 @@ const CourseTableSection = ({ netid, onAvailabilityChange }: CourseTableSectionP
         onAvailabilityChange?.(false);
       })
       .finally(() => setLoading(false));
-  }, [netid]);
+  }, [netid, onAvailabilityChange]);
 
   if (loading) {
     return (

--- a/client/src/hooks/useSearchLifecycle.ts
+++ b/client/src/hooks/useSearchLifecycle.ts
@@ -68,7 +68,7 @@ export function useSearchLifecycle({
     }, debounceMs);
 
     return () => clearTimeout(t);
-  }, [queryString, enabled, ready, debounceMs, setPage]);
+  }, [queryString, queryStringLoaded, enabled, ready, debounceMs, setPage, setQueryStringLoaded]);
 
   useEffect(() => {
     if (!enabled || !ready) return;

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -59,7 +59,7 @@ const Home = () => {
 
   useEffect(() => {
     setQueryString('');
-  }, []);
+  }, [setQueryString]);
 
   const reloadFavorites = async () => {
     axios
@@ -77,7 +77,7 @@ const Home = () => {
   useEffect(() => {
     refreshListings();
     reloadFavorites();
-  }, []);
+  }, [refreshListings]);
 
   useEffect(() => {
     const listingId = searchParams.get('listing');

--- a/client/src/pages/profile.tsx
+++ b/client/src/pages/profile.tsx
@@ -7,7 +7,7 @@
  * stays as plain local state — each is single-concern and unrelated to the
  * fetch lifecycle, so the reducer indirection would obscure rather than clarify.
  */
-import { useState, useEffect, useContext, useReducer, type ReactNode } from 'react';
+import { useState, useEffect, useContext, useReducer, useCallback, type ReactNode } from 'react';
 import { Link, useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { FacultyProfile } from '../types/types';
 import UserContext from '../contexts/UserContext';
@@ -71,7 +71,7 @@ const Profile = () => {
   const bioText = profile?.bio || '';
   useDocumentTitle(profile ? `${profile.fname} ${profile.lname}` : 'Faculty profile');
 
-  const fetchProfile = () => {
+  const fetchProfile = useCallback(() => {
     if (!netid) return;
     dispatch({ type: 'FETCH_START' });
     axios
@@ -86,11 +86,11 @@ const Profile = () => {
           dispatch({ type: 'FETCH_FAILURE', payload: 'Failed to load profile.' });
         }
       });
-  };
+  }, [netid]);
 
   useEffect(() => {
     fetchProfile();
-  }, [netid]);
+  }, [netid, fetchProfile]);
 
   useEffect(() => {
     const nextTab = tabParam && VALID_TABS.includes(tabParam) ? tabParam : 'bio';

--- a/client/src/pages/research.tsx
+++ b/client/src/pages/research.tsx
@@ -698,6 +698,13 @@ const Research = () => {
     }
   };
 
+  const runSearchRef = useRef(runSearch);
+  const runDefaultResearchHomeSearchRef = useRef(runDefaultResearchHomeSearch);
+  const runSearchResultsPageRef = useRef(runSearchResultsPage);
+  runSearchRef.current = runSearch;
+  runDefaultResearchHomeSearchRef.current = runDefaultResearchHomeSearch;
+  runSearchResultsPageRef.current = runSearchResultsPage;
+
   const studentSearchFilters = (
     school = selectedSchool,
     department = selectedDepartment,
@@ -820,7 +827,7 @@ const Research = () => {
       if (departmentSearch?.label === urlDepartmentSearch.label && hasSubmittedSearch) {
         return;
       }
-      runSearch(urlDepartmentSearch.label, {
+      void runSearchRef.current(urlDepartmentSearch.label, {
         searchQuery: '',
         filters: { departments: urlDepartmentSearch.filters.departments },
         hasFilterSelections: true,
@@ -838,7 +845,7 @@ const Research = () => {
       ) {
         return;
       }
-      runSearch(urlQuery, { filters: studentFilters, syncUrl: false });
+      void runSearchRef.current(urlQuery, { filters: studentFilters, syncUrl: false });
       return;
     }
 
@@ -849,7 +856,7 @@ const Research = () => {
       ) {
         return;
       }
-      runSearch('', {
+      void runSearchRef.current('', {
         filters: studentFilters,
         hasFilterSelections: true,
         syncUrl: false,
@@ -872,7 +879,7 @@ const Research = () => {
     setDefaultSearchTotal(0);
     setDefaultSearchExhausted(false);
     setDefaultSearchPage(1);
-    runDefaultResearchHomeSearch(1);
+    void runDefaultResearchHomeSearchRef.current(1);
   }, [
     searchParams,
     pageSnapshotKey,
@@ -919,6 +926,7 @@ const Research = () => {
     };
   }, [
     pageSnapshotKey,
+    isAdmin,
     query,
     submittedQuery,
     departmentSearch,
@@ -945,12 +953,12 @@ const Research = () => {
 
   useEffect(() => {
     if (hasSubmittedSearch || defaultSearchPage <= 1) return;
-    runDefaultResearchHomeSearch(defaultSearchPage);
+    void runDefaultResearchHomeSearchRef.current(defaultSearchPage);
   }, [defaultSearchPage, hasSubmittedSearch]);
 
   useEffect(() => {
     if (!hasSubmittedSearch || searchPage <= 1 || !activeSearchRequest) return;
-    runSearchResultsPage(searchPage);
+    void runSearchResultsPageRef.current(searchPage);
   }, [activeSearchRequest, hasSubmittedSearch, searchPage]);
 
   const activeResults = useMemo(() => groupedResults, [groupedResults]);

--- a/client/src/providers/FellowshipSearchContextProvider.tsx
+++ b/client/src/providers/FellowshipSearchContextProvider.tsx
@@ -129,7 +129,7 @@ const FellowshipSearchContextProvider: FC<FellowshipSearchContextProviderProps> 
       type: 'SET_SORT_BY',
       payload: sortableKeys.includes(value) ? value : sortableKeys[0],
     });
-  }, []);
+  }, [sortableKeys]);
 
   const setSortOrder = useCallback((value: number) => {
     dispatch({ type: 'SET_SORT_ORDER', payload: value });
@@ -334,7 +334,7 @@ const FellowshipSearchContextProvider: FC<FellowshipSearchContextProviderProps> 
     return () => {
       clearTimeout(debounceTimeout);
     };
-  }, [queryString, filterOptionsLoaded, isActive]);
+  }, [queryString, queryStringLoaded, filterOptionsLoaded, isActive, handleSearch]);
 
   useEffect(() => {
     if (!isActive) return;
@@ -361,6 +361,8 @@ const FellowshipSearchContextProvider: FC<FellowshipSearchContextProviderProps> 
     sortOrder,
     filterOptionsLoaded,
     isActive,
+    filtersLoaded,
+    handleSearch,
   ]);
 
   useEffect(() => {
@@ -368,7 +370,7 @@ const FellowshipSearchContextProvider: FC<FellowshipSearchContextProviderProps> 
     if (page > 1 && filterOptionsLoaded) {
       handleSearch(page);
     }
-  }, [page, filterOptionsLoaded, isActive]);
+  }, [page, filterOptionsLoaded, isActive, handleSearch]);
 
   return (
     <FellowshipSearchContext.Provider

--- a/client/src/providers/SearchContextProvider.tsx
+++ b/client/src/providers/SearchContextProvider.tsx
@@ -29,9 +29,11 @@ interface SearchContextProviderProps {
   children: ReactNode;
 }
 
+const LISTING_SORTABLE_KEYS = ['default', 'title'];
+
 const SearchContextProvider: FC<SearchContextProviderProps> = ({ children }) => {
   const pageSize = 20;
-  const sortableKeys = ['default', 'title'];
+  const sortableKeys = LISTING_SORTABLE_KEYS;
 
   const { isAuthenticated, isLoading: authLoading } = useContext(UserContext);
   const isListingsRoute = false;
@@ -122,7 +124,7 @@ const SearchContextProvider: FC<SearchContextProviderProps> = ({ children }) => 
 
   const setSortBy = useCallback((value: string) => {
     dispatch({ type: 'SET_SORT_BY', payload: sortableKeys.includes(value) ? value : sortableKeys[0] });
-  }, []);
+  }, [sortableKeys]);
 
   const setSortOrder = useCallback((value: number) => {
     dispatch({ type: 'SET_SORT_ORDER', payload: value });
@@ -266,7 +268,7 @@ const SearchContextProvider: FC<SearchContextProviderProps> = ({ children }) => 
     return () => {
       clearTimeout(debounceTimeout);
     };
-  }, [queryString, configLoaded, isListingsRoute]);
+  }, [queryString, queryStringLoaded, configLoaded, isListingsRoute, handleSearch]);
 
   useEffect(() => {
     if (!isListingsRoute || !configLoaded) return;
@@ -287,13 +289,15 @@ const SearchContextProvider: FC<SearchContextProviderProps> = ({ children }) => 
     sortOrder,
     configLoaded,
     isListingsRoute,
+    departmentsLoaded,
+    handleSearch,
   ]);
 
   useEffect(() => {
     if (isListingsRoute && page > 1 && configLoaded) {
       handleSearch(page);
     }
-  }, [page, configLoaded, isListingsRoute]);
+  }, [page, configLoaded, isListingsRoute, handleSearch]);
 
   return (
     <SearchContext.Provider

--- a/server/src/controllers/fellowshipController.ts
+++ b/server/src/controllers/fellowshipController.ts
@@ -151,7 +151,7 @@ export const getFellowshipFilterOptions = async (request: Request, response: Res
   try {
     const options = await getFilterOptions();
     response.status(200).json(options);
-  } catch (error: any) {
+  } catch {
     response.status(500).json({ error: 'Failed to fetch fellowship filters' });
   }
 };

--- a/server/src/controllers/programController.ts
+++ b/server/src/controllers/programController.ts
@@ -190,7 +190,7 @@ export const getProgramFilterOptions = async (_request: Request, response: Respo
   try {
     const options = await readProgramFilterOptions();
     response.status(200).json(options);
-  } catch (error: any) {
+  } catch {
     response.status(500).json({ error: 'Failed to fetch program filters' });
   }
 };

--- a/server/src/controllers/userController.ts
+++ b/server/src/controllers/userController.ts
@@ -890,7 +890,7 @@ const UNKNOWN_BOOTSTRAP_FIELDS = ['fname', 'lname', 'email'] as const;
 export const updateCurrentUser = async (
   request: Request,
   response: Response,
-  next: NextFunction,
+  _next: NextFunction,
 ) => {
   try {
     const currentUser = request.user as {

--- a/server/src/middleware/errorHandler.ts
+++ b/server/src/middleware/errorHandler.ts
@@ -116,6 +116,6 @@ type AsyncRequestHandler = (req: Request, res: Response, next: NextFunction) => 
 
 export const asyncHandler = (fn: AsyncRequestHandler) => {
   return (req: Request, res: Response, next: NextFunction) => {
-    Promise.resolve(fn(req, res, next)).catch(next);
+    void Promise.resolve(fn(req, res, next)).catch(next);
   };
 };

--- a/server/src/passport.ts
+++ b/server/src/passport.ts
@@ -546,7 +546,7 @@ const casLogin = function (
     function (
       err: Error | null,
       user: AuthenticatedSessionUser | false | null | undefined,
-      info: PassportAuthInfo = {},
+      _info: PassportAuthInfo = {},
     ) {
       if (err) {
         console.log('Error in authenticate function');

--- a/server/src/scrapers/__tests__/openAlexPaperScraper.test.ts
+++ b/server/src/scrapers/__tests__/openAlexPaperScraper.test.ts
@@ -385,7 +385,7 @@ describe('OpenAlexPaperScraper.run', () => {
   });
 
   it('keeps successful name lookup review-only and does not create authorship', async () => {
-    const fetcher: HttpFetcher = vi.fn(async (url, params) => {
+    const fetcher: HttpFetcher = vi.fn(async (url, _params) => {
       if (url === 'https://api.openalex.org/authors') {
         // Name search returns one exact match.
         return {

--- a/server/src/scrapers/sources/nihReporterScraper.ts
+++ b/server/src/scrapers/sources/nihReporterScraper.ts
@@ -32,7 +32,7 @@ import { User } from '../../models/user';
 import { serializedDocumentId } from '../../utils/idSerialization';
 import { sanitizeLogValue } from '../../utils/logSanitizer';
 import { getCached, setCached } from '../snapshotCache';
-import { normalizeName, slugify, splitName } from '../utils/scraperHelpers';
+import { slugify, splitName } from '../utils/scraperHelpers';
 import type { IScraper, ScraperContext, ScraperResult, ObservationInput } from '../types';
 
 const REPORTER_ENDPOINT = 'https://api.reporter.nih.gov/v2/projects/search';

--- a/server/src/scrapers/sources/yaleDirectoryScraper.ts
+++ b/server/src/scrapers/sources/yaleDirectoryScraper.ts
@@ -291,7 +291,6 @@ export class YaleDirectoryScraper implements IScraper {
       try {
         records = await fetchYaliesPage(pageNum, undefined, ctx.options.useCache);
       } catch (err: unknown) {
-        const errAny = err as { message?: string; response?: { status?: number } };
         if (axios.isAxiosError(err) && err.response?.status === 401) {
           ctx.log(`Yalies API returned 401 (auth failed); aborting after page ${pageNum}.`);
           break;

--- a/server/src/scrapers/utils/scraperHelpers.ts
+++ b/server/src/scrapers/utils/scraperHelpers.ts
@@ -50,14 +50,6 @@ function asciiTokens(input: string): string[] {
     .filter((token) => token && !/^\d+$/.test(token));
 }
 
-function givenNameCompatible(a: string, b: string): boolean {
-  if (!a || !b) return false;
-  if (a === b) return true;
-  if (a.length === 1 && b.startsWith(a)) return true;
-  if (b.length === 1 && a.startsWith(b)) return true;
-  return a.length >= 4 && b.length >= 4 && (a.startsWith(b) || b.startsWith(a));
-}
-
 /**
  * Return true only when a Yale email is plausibly owned by the supplied person.
  *

--- a/server/src/scripts/betaSeedEnvironment.ts
+++ b/server/src/scripts/betaSeedEnvironment.ts
@@ -415,7 +415,7 @@ async function runPlan(plan: BetaSeedPlan): Promise<BetaSeedRunResult> {
   const results: BetaSeedRunResult['results'] = [];
   for (const step of plan.steps) {
     // Sequential execution avoids DB and Meili contention during launch operations.
-    // eslint-disable-next-line no-await-in-loop
+
     const result = await runStep(step);
     results.push(result);
     if (!result.ok) break;

--- a/server/src/scripts/dedupeUsersByIdentityCore.ts
+++ b/server/src/scripts/dedupeUsersByIdentityCore.ts
@@ -294,7 +294,6 @@ function emailLooksPersonSpecific(identityValue: string, normalizedName: string)
   const givenNames = nameTokens.slice(0, -1);
   if (!tokens.length || !lastName || givenNames.length === 0) return false;
 
-  const tokenText = tokens.join(' ');
   const compactTokenText = tokens.join('');
   const reversedCompact = [lastName, ...givenNames].join('');
   const normalCompact = [...givenNames, lastName].join('');

--- a/server/src/scripts/duplicateEntityNameReview.ts
+++ b/server/src/scripts/duplicateEntityNameReview.ts
@@ -32,8 +32,6 @@ const DEFAULT_MAX_APPLY = 10;
 const MAX_ENTITIES_PER_CLUSTER = 10;
 const REVIEW_DECISION_APPLY_STATUS =
   'Accepted duplicate-name decisions can drive apply mode for shared-website, zero-reference cross-department, or specific-website cross-department merge_into_canonical plans; ambiguous manual disambiguation decisions remain review-only.';
-const APPLY_BLOCKED_REASON =
-  'Apply requires reviewed duplicate-name decisions and is limited to shared-website, zero-reference cross-department, or specific-website cross-department merge_into_canonical plans.';
 const DUPLICATE_ENTITY_NAME_REVIEW_OBJECT_ID_RE = /^[a-f0-9]{24}$/i;
 
 const EMPTY_REFERENCE_IMPACT_COUNTS: DuplicateEntityReferenceImpactCounts = {

--- a/server/src/scripts/launchAcquisitionReport.ts
+++ b/server/src/scripts/launchAcquisitionReport.ts
@@ -6,7 +6,6 @@ import mongoose from 'mongoose';
 import { initializeConnections } from '../db/connections';
 import {
   buildLaunchAcquisitionReport,
-  type LaunchAcquisitionReport,
   type LaunchAcquisitionReportOptions,
 } from '../services/launchAcquisitionReportService';
 import { assertScriptApplyAllowed, resolveSafeJsonReportOutputPath } from './scriptWriteGuards';
@@ -27,14 +26,6 @@ function parsePositiveInteger(value: string, flag: string): number {
     throw new Error(`${flag} must be a positive integer`);
   }
   return parsed;
-}
-
-function parseRequiredValue(value: string | undefined, flag: string, requirement: string): string {
-  const trimmed = value?.trim();
-  if (!trimmed || trimmed.startsWith('--')) {
-    throw new Error(`${flag} requires ${requirement}`);
-  }
-  return trimmed;
 }
 
 export function parseLaunchAcquisitionReportArgs(argv: string[]): LaunchAcquisitionReportCliOptions {

--- a/server/src/scripts/refreshGateScorecards.ts
+++ b/server/src/scripts/refreshGateScorecards.ts
@@ -154,7 +154,7 @@ export async function runGateRefresh(): Promise<FeederResult[]> {
     const startedAt = Date.now();
     process.stdout.write(`\n=== gates:refresh → ${feeder.gate} (${feeder.script}) → ${feeder.output} ===\n`);
     // Sequential by design: several feeders hit the same DB and Meili; avoid contention.
-    // eslint-disable-next-line no-await-in-loop
+
     const result = await runFeeder(feeder, startedAt);
     results.push(result);
     process.stdout.write(

--- a/server/src/scripts/researchEntityCoverageAudit.ts
+++ b/server/src/scripts/researchEntityCoverageAudit.ts
@@ -17,7 +17,6 @@ import {
   buildCoverageAuditRow,
   extractSuspiciousConstraintQuotes,
   summarizeIssueCounts,
-  type CoverageAuditCounts,
   type CoverageAuditFacts,
   type CoverageObservationFlags,
 } from './researchEntityCoverageAuditCore';
@@ -158,20 +157,6 @@ export function buildResearchEntityCoverageAuditOutput<T extends object>(
 
 function stringId(value: unknown): string {
   return value === undefined || value === null ? '' : String(value);
-}
-
-function makeEmptyCounts(): CoverageAuditCounts {
-  return {
-    researchAreas: 0,
-    sourceUrls: 0,
-    members: 0,
-    pathways: 0,
-    publicContactRoutes: 0,
-    totalContactRoutes: 0,
-    accessSignals: 0,
-    postedOpportunities: 0,
-    activeListings: 0,
-  };
 }
 
 function buildObservationFlags(observations: ObservationHint[]): CoverageObservationFlags {

--- a/server/src/scripts/sourceHealth.ts
+++ b/server/src/scripts/sourceHealth.ts
@@ -806,7 +806,7 @@ function summarizeReviewArtifactCommands(
 ): SourceHealthReviewArtifactStatus {
   const missingCommands = commands
     .filter((command) => !command.artifactAvailable)
-    .map(({ artifactAvailable, ...command }) => command);
+    .map(({ artifactAvailable: _artifactAvailable, ...command }) => command);
   return {
     total: commands.length,
     available: commands.length - missingCommands.length,

--- a/server/src/services/adminOperatorBoardService.ts
+++ b/server/src/services/adminOperatorBoardService.ts
@@ -759,7 +759,7 @@ export function readPromotionCopyDryRunArtifact(
         ? parsed.collectionCategories.length
         : 0,
     };
-  } catch (error) {
+  } catch {
     return {
       artifactStatus: 'invalid',
       artifactPath: safeArtifactPath,
@@ -824,7 +824,7 @@ export function readBetaRepairQueueGateArtifact(
       ...summarizePatchSummaries(parsed.attempts),
       ...summarizeRepairSourceHosts(parsed.attempts),
     };
-  } catch (error) {
+  } catch {
     return {
       artifactStatus: 'invalid',
       artifactPath: safeArtifactPath,
@@ -1031,7 +1031,7 @@ export function readDataQualityGateArtifact(
         parsed?.hygiene?.emails?.suspiciousUserEmails,
       ),
     };
-  } catch (error) {
+  } catch {
     return {
       artifactStatus: 'invalid',
       artifactPath: safeArtifactPath,
@@ -1397,7 +1397,7 @@ export function readScraperIntegrityGateArtifact(
           ).map(betaTargetCommand)
         : [],
     };
-  } catch (error) {
+  } catch {
     return {
       artifactStatus: 'invalid',
       artifactPath: safeArtifactPath,
@@ -1572,7 +1572,7 @@ export function readLaunchTrustGateArtifact(
             .map(betaTargetCommand)
         : [],
     };
-  } catch (error) {
+  } catch {
     return {
       artifactStatus: 'invalid',
       artifactPath: safeArtifactPath,
@@ -1638,7 +1638,7 @@ export function readLaunchReviewExceptionsArtifact(
       invalidDecisionCount: Number(parsed.reviewDecisionValidation.invalidDecisionCount || 0),
       unreviewedPlanCount: Number(parsed.reviewDecisionValidation.unreviewedPlanCount || 0),
     };
-  } catch (error) {
+  } catch {
     return {
       artifactStatus: 'invalid',
       artifactPath: safeArtifactPath,
@@ -1774,7 +1774,7 @@ export function readLaunchAcquisitionGateArtifact(
       ),
       untrustedExternalRouteEvidence: groupCount(actionGroups, 'untrustedExternalRouteEvidence'),
     };
-  } catch (error) {
+  } catch {
     return {
       artifactStatus: 'invalid',
       artifactPath: safeArtifactPath,

--- a/server/src/services/fellowshipService.ts
+++ b/server/src/services/fellowshipService.ts
@@ -2,7 +2,6 @@
  * Service layer for fellowship CRUD, search, and filter operations.
  */
 import { NotFoundError, ObjectIdError } from '../utils/errors';
-import mongoose from 'mongoose';
 import {
   Fellowship,
   programCategories,

--- a/server/src/services/profileService.ts
+++ b/server/src/services/profileService.ts
@@ -1426,25 +1426,6 @@ const expandedResearchAreasPublicBio = (user: Record<string, any>, rawBio: strin
   )}, based on Yale's official profile data.`;
 };
 
-const officialProfileResearchInterestTermsBio = (user: Record<string, any>): string => {
-  if (!hasOfficialYaleProfileUrl(user)) return '';
-  if (isLikelySameNameContaminatedProfile(user)) return '';
-
-  const terms = sanitizeProfileResearchTerms(user.researchInterests || user.research_interests || [])
-    .filter((term) => {
-      const normalized = normalizeNameToken(term);
-      if (normalized.length < 4) return false;
-      return !/^(?:u s|usa|uk|eu)$/.test(normalized);
-    })
-    .slice(0, 5);
-  const displayName = publicProfileDisplayName(user);
-  if (!displayName || terms.length < 2) return '';
-
-  return `${displayName}'s official Yale profile lists research interests in ${formatPublicBioList(
-    terms,
-  )}, based on Yale's official profile data.`;
-};
-
 export const cleanPublicProfileBio = (user: Record<string, any>): string => {
   const rawBioText = String(user.bio || '').trim();
   if (!rawBioText) return '';


### PR DESCRIPTION
## Summary

- remove dead imports, bindings, helpers, and stale ESLint directives
- stabilize search and profile hook dependencies without changing search triggers
- explicitly mark fire-and-forget async error forwarding
- bring repository lint to zero errors and zero warnings

## Validation

- `yarn lint` (0 errors, 0 warnings)
- client tests: 94 files, 763 tests passed
- server tests: 221 files, 2,537 tests passed
- focused OpenAlex scraper tests: 31 passed
- client production build
- server production build
- server TypeScript check
- security policy test
- committed-secret scan
- production dependency audit (no suggestions)

Client standalone `tsc --noEmit` continues to report the existing beta baseline of unrelated type errors; the Vite production build and full client test suite pass.
