### PR TITLE
Add safe pathway evidence review gate

### DIFF
--- a/docs/scraper-deployment-runbook.md
+++ b/docs/scraper-deployment-runbook.md
@@ -60,6 +60,12 @@ Source metadata
 
 The current system avoids most duplicate materialized entities through stable slugs, identifiers, derivation keys, and upserts. Observation rows are append-only during a run; identical observations can be superseded, and old superseded rows can be pruned by the compact-retention command after reports are captured. Use the WorkPlanner task before unattended recurring runs for expensive sources.
 
+### PFR-3 pathway evidence review
+
+Resolve no more than 25 salted queue handles at a time with `pfr3:pathway-evidence-review`. The command defaults to dry-run, requires an explicit `--target=beta|prod`, and writes the minimum necessary record and lineage fields only to a mode-0600 JSON path under the system or project `tmp` directory. Never attach that PRIVATE artifact to a PR, ticket, chat, or log.
+
+Decision files require a safe public HTTP source, quoted or summarized evidence, and operator rationale for each recency, source-repair, or new-source decision. The current command validates these decisions as `manual_only`: evidence must first be ingested by an approved scraper or observation workflow and then passed through normal access materialization. It never changes pathway status, evidence strength, confidence, or source fields directly. Execute mode additionally requires a matching target confirmation, backup/restore token, and a separate production confirmation; these guards do not make a manual-only decision writable.
+
 ## Environment Progression
 
 ### 1. Development Testing

--- a/scripts/security-preflight.test.mjs
+++ b/scripts/security-preflight.test.mjs
@@ -170,6 +170,17 @@ test('PFR-3 pathway source queue is read-only and redacted', () => {
   assert.doesNotMatch(core, /destination|email|phone|excerpt/);
 });
 
+test('PFR-3 pathway evidence review keeps private data off stdout and forbids direct promotion', () => {
+  const workflow = fs.readFileSync(new URL('../server/src/scripts/pfr3PathwayEvidenceReview.ts', import.meta.url), 'utf8');
+  const core = fs.readFileSync(new URL('../server/src/scripts/pfr3PathwayEvidenceReviewCore.ts', import.meta.url), 'utf8');
+  assert.match(workflow, /mode: 0o600/);
+  assert.match(workflow, /appliedCount: 0/);
+  assert.doesNotMatch(workflow, /EntryPathway\.(update|findOneAndUpdate|bulkWrite)/);
+  assert.doesNotMatch(workflow, /console\.log\([^)]*(artifact|decisions|privateOutput)/s);
+  assert.match(core, /disposition: 'manual_only'/);
+  assert.doesNotMatch(core, /evidenceStrength:\s*['"](DIRECT|STRONG|MODERATE)['"]/);
+});
+
 
 test('admin access-review validation responses use fixed public copy', () => {
   const source = fs.readFileSync(new URL('../server/src/routes/admin.ts', import.meta.url), 'utf8');

--- a/scripts/security-preflight.test.mjs
+++ b/scripts/security-preflight.test.mjs
@@ -176,7 +176,12 @@ test('PFR-3 pathway evidence review keeps private data off stdout and forbids di
   assert.match(workflow, /mode: 0o600/);
   assert.match(workflow, /appliedCount: 0/);
   assert.doesNotMatch(workflow, /EntryPathway\.(update|findOneAndUpdate|bulkWrite)/);
-  assert.doesNotMatch(workflow, /console\.log\([^)]*(artifact|decisions|privateOutput)/s);
+  const stdoutPayload = workflow.match(/console\.log\(JSON\.stringify\(\{([\s\S]*?)\}\)\);/);
+  assert.ok(stdoutPayload, 'aggregate stdout serializer should exist');
+  assert.doesNotMatch(
+    stdoutPayload[1],
+    /handle:|recordId:|researchEntityId:|sourceUrls:|sourceEvidenceIds:|sourceUrl:|evidence:|rationale:|privateOutput/,
+  );
   assert.match(core, /disposition: 'manual_only'/);
   assert.doesNotMatch(core, /evidenceStrength:\s*['"](DIRECT|STRONG|MODERATE)['"]/);
 });

--- a/server/package.json
+++ b/server/package.json
@@ -31,6 +31,7 @@
     "pfr3:contact-route-review": "tsx src/scripts/pfr3ContactRouteReview.ts",
     "pfr3:outreach-report": "tsx src/scripts/pfr3StudentOutreachReport.ts",
     "pfr3:pathway-source-queue": "tsx src/scripts/pfr3PathwaySourceQueue.ts",
+    "pfr3:pathway-evidence-review": "tsx src/scripts/pfr3PathwayEvidenceReview.ts",
     "meili:rebuild-research-entities": "tsx src/scripts/rebuildResearchEntitySearchIndex.ts",
     "meili:seed": "yarn meili:rebuild-research-entities --clear --confirm-meili-rebuild && yarn meili:rebuild-pathways --clear --confirm-meili-rebuild",
     "research-entity:audit-rename": "tsx src/scripts/auditResearchEntityRename.ts",

--- a/server/src/scripts/__tests__/pfr3PathwayEvidenceReviewCore.test.ts
+++ b/server/src/scripts/__tests__/pfr3PathwayEvidenceReviewCore.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertExecutionGuards,
+  pathwayReviewHandle,
+  resolveReviewCandidates,
+  validateReviewDecisions,
+} from '../pfr3PathwayEvidenceReviewCore';
+
+const salt = 'a-sufficiently-long-private-salt';
+const candidate = { id: '507f1f77bcf86cd799439011', status: 'PLAUSIBLE' };
+const handle = pathwayReviewHandle(candidate.id, salt);
+const valid = { handle, kind: 'source_repair', sourceUrl: 'https://www.yale.edu/research', evidence: 'Official page states the current route.', rationale: 'Repairs missing authoritative lineage.' };
+
+describe('PFR-3 pathway evidence review', () => {
+  it('rejects handle mismatch', () => expect(() => resolveReviewCandidates([candidate], ['pathway-wrong'], salt, 1)).toThrow(/do not match/));
+  it('bounds max batch at 25', () => expect(() => resolveReviewCandidates([candidate], [handle], salt, 26)).toThrow(/1 through 25/));
+  it('rejects unsafe URLs', () => expect(() => validateReviewDecisions([{ ...valid, sourceUrl: 'http://127.0.0.1/private' }], new Set([handle]))).toThrow(/safe public/));
+  it('requires evidence and rationale', () => {
+    expect(() => validateReviewDecisions([{ ...valid, evidence: '' }], new Set([handle]))).toThrow(/evidence is required/);
+    expect(() => validateReviewDecisions([{ ...valid, rationale: '' }], new Set([handle]))).toThrow(/rationale is required/);
+  });
+  it('defaults safely when execute is false', () => expect(() => assertExecutionGuards({ target: 'beta', execute: false })).not.toThrow());
+  it('rejects target mismatch', () => expect(() => assertExecutionGuards({ target: 'beta', runtimeTarget: 'prod', execute: false })).toThrow(/does not match/));
+  it('never directly promotes pathways', () => expect(validateReviewDecisions([valid], new Set([handle]))[0]).toMatchObject({ disposition: 'manual_only' }));
+});

--- a/server/src/scripts/pfr3PathwayEvidenceReview.ts
+++ b/server/src/scripts/pfr3PathwayEvidenceReview.ts
@@ -1,0 +1,105 @@
+import dotenv from 'dotenv';
+dotenv.config();
+import fs from 'fs';
+import mongoose from 'mongoose';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { initializeConnections } from '../db/connections';
+import { EntryPathway } from '../models/entryPathway';
+import { sanitizeLogValue } from '../utils/logSanitizer';
+import { resolveSafeJsonReportOutputPath } from './scriptWriteGuards';
+import {
+  assertExecutionGuards,
+  pathwayReviewHandle,
+  resolveReviewCandidates,
+  type ValidatedDecision,
+  validateReviewDecisions,
+} from './pfr3PathwayEvidenceReviewCore';
+
+type Flags = Record<string, string | boolean>;
+function flags(argv: string[]): Flags {
+  const parsed: Flags = {};
+  for (const arg of argv) {
+    if (!arg.startsWith('--')) throw new Error('all arguments must be named flags');
+    const [name, ...value] = arg.slice(2).split('=');
+    if (!name || name in parsed) throw new Error('duplicate or invalid flag');
+    parsed[name] = value.length ? value.join('=') : true;
+  }
+  return parsed;
+}
+
+function value(input: Flags, name: string, required = false): string | undefined {
+  const result = input[name];
+  if (result === true || (required && typeof result !== 'string')) throw new Error(`--${name} requires a value`);
+  return typeof result === 'string' ? result : undefined;
+}
+
+function readJson(file: string): unknown {
+  const resolved = path.resolve(file);
+  const stat = fs.statSync(resolved);
+  if (!stat.isFile() || stat.size > 256 * 1024) throw new Error('input JSON must be a file no larger than 256 KiB');
+  return JSON.parse(fs.readFileSync(resolved, 'utf8'));
+}
+
+async function main(): Promise<void> {
+  const args = flags(process.argv.slice(2));
+  const target = value(args, 'target', true)!;
+  const execute = args.execute === true;
+  assertExecutionGuards({
+    target,
+    execute,
+    confirmation: value(args, 'confirm'),
+    restoreToken: value(args, 'restore-token'),
+    prodConfirmation: value(args, 'confirm-prod'),
+    runtimeTarget: process.env.SCRAPER_ENV === 'production' ? 'prod' : process.env.SCRAPER_ENV,
+  });
+  const salt = process.env.PFR3_QUEUE_HANDLE_SALT?.trim() || '';
+  const maxBatch = Number(value(args, 'max-batch', true));
+  const handlesInput = readJson(value(args, 'handles', true)!);
+  if (!Array.isArray(handlesInput) || !handlesInput.every((item) => typeof item === 'string')) {
+    throw new Error('--handles must contain a JSON string array');
+  }
+  const privateOutput = resolveSafeJsonReportOutputPath(value(args, 'private-output'), '--private-output');
+  await initializeConnections();
+  const candidates = await EntryPathway.find({ archived: { $ne: true } })
+    .select('_id researchEntityId status evidenceStrength confidence sourceUrls sourceEvidenceIds lastObservedAt')
+    .lean();
+  const selected = resolveReviewCandidates(candidates.map((item: any) => ({ ...item, id: item._id })), handlesInput, salt, maxBatch);
+  const artifact = selected.map((item) => ({
+    handle: pathwayReviewHandle(item.id, salt),
+    recordId: String(item.id),
+    researchEntityId: item.researchEntityId ? String(item.researchEntityId) : undefined,
+    status: item.status,
+    evidenceStrength: item.evidenceStrength,
+    confidence: item.confidence,
+    sourceUrls: item.sourceUrls,
+    sourceEvidenceIds: Array.isArray(item.sourceEvidenceIds) ? item.sourceEvidenceIds.map(String) : [],
+    lastObservedAt: item.lastObservedAt,
+  }));
+  fs.writeFileSync(privateOutput, JSON.stringify({ classification: 'PRIVATE', target, records: artifact }, null, 2), { mode: 0o600, flag: 'w' });
+  fs.chmodSync(privateOutput, 0o600);
+
+  let decisions: ValidatedDecision[] = [];
+  if (value(args, 'decisions')) {
+    decisions = validateReviewDecisions(readJson(value(args, 'decisions')!), new Set(artifact.map((item) => item.handle)));
+  }
+  // Deliberately aggregate-only: handles, record ids, URLs, evidence, and paths never reach stdout.
+  console.log(JSON.stringify({
+    target,
+    mode: execute ? 'execute' : 'dry-run',
+    selectedCount: artifact.length,
+    decisionCount: decisions.length,
+    manualOnlyCount: decisions.filter((item) => item.disposition === 'manual_only').length,
+    appliedCount: 0,
+    idempotent: true,
+    privateArtifactWritten: true,
+  }));
+}
+
+const filename = fileURLToPath(import.meta.url);
+if (process.argv[1] && path.resolve(process.argv[1]) === filename) {
+  main().catch((error) => {
+    console.error('PFR-3 pathway evidence review failed:', sanitizeLogValue(error));
+    process.exitCode = 1;
+  }).finally(() => mongoose.disconnect());
+}

--- a/server/src/scripts/pfr3PathwayEvidenceReviewCore.ts
+++ b/server/src/scripts/pfr3PathwayEvidenceReviewCore.ts
@@ -1,0 +1,122 @@
+import { createHash } from 'crypto';
+import { isPublicHttpUrl } from '../utils/urlSafety';
+
+export const PFR3_REVIEW_MAX_BATCH = 25;
+export type ReviewKind = 'recency' | 'source_repair' | 'new_source';
+
+export interface ReviewCandidate {
+  id: unknown;
+  researchEntityId?: unknown;
+  status?: unknown;
+  evidenceStrength?: unknown;
+  confidence?: unknown;
+  sourceUrls?: unknown;
+  sourceEvidenceIds?: unknown;
+  lastObservedAt?: unknown;
+}
+
+export interface ReviewDecision {
+  handle?: unknown;
+  kind?: unknown;
+  sourceUrl?: unknown;
+  evidence?: unknown;
+  rationale?: unknown;
+  scraperSource?: unknown;
+}
+
+export interface ValidatedDecision {
+  handle: string;
+  kind: ReviewKind;
+  sourceUrl: string;
+  evidence: string;
+  rationale: string;
+  disposition: 'manual_only';
+  reason: string;
+  scraperSource?: string;
+}
+
+export function pathwayReviewHandle(id: unknown, salt: string): string {
+  if (salt.trim().length < 16) throw new Error('handle salt must contain at least 16 characters');
+  return `pathway-${createHash('sha256').update(`${salt}:${String(id)}`).digest('hex').slice(0, 12)}`;
+}
+
+export function resolveReviewCandidates(
+  candidates: ReviewCandidate[],
+  handles: string[],
+  salt: string,
+  maxBatch: number,
+): ReviewCandidate[] {
+  if (!Number.isSafeInteger(maxBatch) || maxBatch < 1 || maxBatch > PFR3_REVIEW_MAX_BATCH) {
+    throw new Error(`max batch must be an integer from 1 through ${PFR3_REVIEW_MAX_BATCH}`);
+  }
+  if (handles.length === 0 || handles.length > maxBatch || new Set(handles).size !== handles.length) {
+    throw new Error('handles must be unique, non-empty, and no larger than max batch');
+  }
+  const byHandle = new Map(candidates.map((candidate) => [pathwayReviewHandle(candidate.id, salt), candidate]));
+  const resolved = handles.map((handle) => byHandle.get(handle));
+  if (resolved.some((candidate) => !candidate)) throw new Error('one or more handles do not match this salt or queue');
+  return resolved as ReviewCandidate[];
+}
+
+function requiredText(value: unknown, field: string, max: number): string {
+  if (typeof value !== 'string' || !value.trim() || value.trim().length > max) {
+    throw new Error(`${field} is required and must be at most ${max} characters`);
+  }
+  return value.trim();
+}
+
+export function validateReviewDecisions(
+  input: unknown,
+  allowedHandles: Set<string>,
+): ValidatedDecision[] {
+  if (!Array.isArray(input) || input.length === 0 || input.length > PFR3_REVIEW_MAX_BATCH) {
+    throw new Error(`decision file must contain 1 through ${PFR3_REVIEW_MAX_BATCH} decisions`);
+  }
+  const seen = new Set<string>();
+  return input.map((raw) => {
+    const decision = (raw || {}) as ReviewDecision;
+    const handle = requiredText(decision.handle, 'handle', 64);
+    if (!allowedHandles.has(handle) || seen.has(handle)) throw new Error('decision handle is unknown or duplicated');
+    seen.add(handle);
+    if (!['recency', 'source_repair', 'new_source'].includes(String(decision.kind))) {
+      throw new Error('kind must be recency, source_repair, or new_source');
+    }
+    const sourceUrl = requiredText(decision.sourceUrl, 'sourceUrl', 2048);
+    if (!isPublicHttpUrl(sourceUrl)) throw new Error('sourceUrl must be a safe public HTTP URL');
+    const evidence = requiredText(decision.evidence, 'evidence', 2000);
+    const rationale = requiredText(decision.rationale, 'rationale', 1000);
+    const scraperSource =
+      decision.scraperSource === undefined
+        ? undefined
+        : requiredText(decision.scraperSource, 'scraperSource', 120);
+    return {
+      handle,
+      kind: decision.kind as ReviewKind,
+      sourceUrl,
+      evidence,
+      rationale,
+      scraperSource,
+      disposition: 'manual_only',
+      reason:
+        'Validated evidence must enter through an existing source observation and access materialization; this workflow never edits pathways directly.',
+    };
+  });
+}
+
+export function assertExecutionGuards(options: {
+  target: string;
+  execute: boolean;
+  confirmation?: string;
+  restoreToken?: string;
+  prodConfirmation?: string;
+  runtimeTarget?: string;
+}): void {
+  if (!['beta', 'prod'].includes(options.target)) throw new Error('target must be beta or prod');
+  if (options.runtimeTarget && options.runtimeTarget !== options.target) throw new Error('target does not match runtime environment');
+  if (!options.execute) return;
+  if (options.confirmation !== `execute-${options.target}`) throw new Error('execute confirmation does not match target');
+  if (!options.restoreToken?.trim()) throw new Error('execute requires a backup/restore token');
+  if (options.target === 'prod' && options.prodConfirmation !== 'confirm-production-pathway-review') {
+    throw new Error('production execute requires the production confirmation');
+  }
+}


### PR DESCRIPTION
## Summary
- add a bounded salted-handle pathway evidence review gate
- keep resolved records in a mode-0600 PRIVATE operator artifact and stdout aggregate-only
- validate authoritative source, evidence, and rationale while leaving unsupported changes manual-only
- require explicit environment and restore confirmations without directly promoting pathway fields

## Validation
- `yarn --cwd server tsc --noEmit`
- `yarn --cwd server test src/scripts/__tests__/pfr3PathwayEvidenceReviewCore.test.ts`
- `yarn --cwd server build`
- `node scripts/security-preflight.test.mjs`
- `git diff --check`

No external data or index state was mutated.
