### PR TITLE
feat: add public research front door

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -48,7 +48,7 @@ const App = () => {
                     <Routes>
                       <Route
                         path="/"
-                        element={<PrivateRoute Component={RootRedirect} unknownBlocked={true} />}
+                        element={<RootRedirect />}
                       />
                       <Route
                         path="/listings"

--- a/client/src/__tests__/AppRouting.test.tsx
+++ b/client/src/__tests__/AppRouting.test.tsx
@@ -101,6 +101,17 @@ describe('App routing', () => {
     expect(getByTestId('research-page').textContent).toBe('Yale Research');
   });
 
+  it('makes the root URL a public entry to Yale Research', async () => {
+    window.history.pushState({}, '', '/');
+
+    const { getByTestId } = render(<App />);
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/research');
+    });
+    expect(getByTestId('research-page').textContent).toBe('Yale Research');
+  });
+
   it('renders Programs & Fellowships at /programs', async () => {
     window.history.pushState({}, '', '/programs');
 

--- a/client/src/components/__tests__/PrivateRoute.test.tsx
+++ b/client/src/components/__tests__/PrivateRoute.test.tsx
@@ -1,0 +1,55 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import UserContext from '../../contexts/UserContext';
+import PrivateRoute from '../PrivateRoute';
+
+const Account = () => <div>Private account</div>;
+
+const Location = () => {
+  const location = useLocation();
+  return <div>{`${location.pathname}:${String(location.state?.from)}`}</div>;
+};
+
+const renderRoute = (isAuthenticated: boolean) =>
+  render(
+    <UserContext.Provider
+      value={{
+        isLoading: false,
+        isAuthenticated,
+        user: isAuthenticated
+          ? { userType: 'student', netId: 'student', userConfirmed: true }
+          : undefined,
+        authError: undefined,
+        checkContext: async () => undefined,
+      }}
+    >
+      <MemoryRouter
+        initialEntries={['/account']}
+        future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+      >
+        <Routes>
+          <Route path="/account" element={<PrivateRoute Component={Account} />} />
+          <Route path="/login" element={<Location />} />
+        </Routes>
+      </MemoryRouter>
+    </UserContext.Provider>,
+  );
+
+afterEach(cleanup);
+
+describe('PrivateRoute', () => {
+  it('keeps account routes protected and preserves the return path', () => {
+    renderRoute(false);
+
+    expect(screen.getByText('/login:/account')).toBeTruthy();
+    expect(screen.queryByText('Private account')).toBeNull();
+  });
+
+  it('preserves authenticated access to account routes', () => {
+    renderRoute(true);
+
+    expect(screen.getByText('Private account')).toBeTruthy();
+  });
+});

--- a/client/src/pages/__tests__/login.test.tsx
+++ b/client/src/pages/__tests__/login.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ContextType } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import UserContext from '../../contexts/UserContext';
@@ -27,7 +27,10 @@ const renderLogin = (from?: string, context: Partial<UserContextValue> = {}) => 
         future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
         initialEntries={[{ pathname: '/login', state: from ? { from } : null }]}
       >
-        <Login />
+        <Routes>
+          <Route path="/login" element={<Login />} />
+          <Route path="/research" element={<div>Public research directory</div>} />
+        </Routes>
       </MemoryRouter>
     </UserContext.Provider>,
   );
@@ -41,6 +44,16 @@ afterEach(() => {
 });
 
 describe('Login', () => {
+  it('offers visitors a public research path from the CAS gate', async () => {
+    const user = userEvent.setup();
+    renderLogin('/account');
+
+    await user.click(
+      screen.getByRole('link', { name: 'Explore Yale research without signing in' }),
+    );
+
+    expect(screen.getByText('Public research directory')).toBeTruthy();
+  });
   it('uses the default Yale Research context for unknown retired surfaces', () => {
     renderLogin('/old-research-entry');
 

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -6,7 +6,7 @@ import { useContext } from 'react';
 
 import SignInButton from '../components/SignInButton';
 import UserContext from '../contexts/UserContext';
-import { Navigate, useLocation } from 'react-router-dom';
+import { Link, Navigate, useLocation } from 'react-router-dom';
 import useDocumentTitle from '../hooks/useDocumentTitle';
 
 const Login = () => {
@@ -138,6 +138,14 @@ const Login = () => {
               !authError && <SignInButton />
             )}
           </div>
+          {!isLoading && !isAuthenticated && (
+            <Link
+              to="/research"
+              className="mt-3 inline-flex min-h-[44px] w-full items-center justify-center rounded-md border border-[var(--yr-blue)] px-4 py-2 text-center text-sm font-semibold text-[var(--yr-blue)] transition-colors hover:bg-blue-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700"
+            >
+              Explore Yale research without signing in
+            </Link>
+          )}
         </section>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- make the root URL a public redirect to the research directory
- add a prominent visitor link to the Yale CAS panel
- preserve protected account routes and authenticated access with routing regressions

## Validation
- focused routing/login tests: 20 passed
- full client tests: 769 passed
- standalone client TypeScript: passed
- lint: passed
- client build: passed
- security policy: passed
- secrets scan: passed

## UX verification
Browser screenshots were not captured because no Chrome browser transport is available in this task environment. Routing and link navigation are covered through integration tests.