### PR TITLE
Fix faculty profile persistence and verification requests

### DIFF
--- a/client/src/components/accounts/ProfileEditor.tsx
+++ b/client/src/components/accounts/ProfileEditor.tsx
@@ -22,6 +22,27 @@ interface ProfileEditorProps {
   netid: string;
 }
 
+type EditableProfileFields = {
+  bio: string;
+  primaryDepartment: string;
+  secondaryDepartments: string[];
+  researchInterests: string[];
+  imageUrl: string;
+};
+
+const normalizedEditableFields = (profile: Record<string, any>): EditableProfileFields => ({
+  bio: String(profile.bio || '').trim(),
+  primaryDepartment: String(profile.primaryDepartment ?? profile.primary_department ?? '').trim(),
+  secondaryDepartments: profile.secondaryDepartments ?? profile.secondary_departments ?? [],
+  researchInterests: profile.researchInterests ?? profile.research_interests ?? [],
+  imageUrl: String(profile.imageUrl ?? profile.image_url ?? '').trim(),
+});
+
+export const profileSaveMatches = (
+  submitted: EditableProfileFields,
+  returned: Record<string, any>,
+): boolean => JSON.stringify(submitted) === JSON.stringify(normalizedEditableFields(returned));
+
 const ProfileEditor = ({ netid }: ProfileEditorProps) => {
   const [state, dispatch] = useReducer(profileEditorReducer, undefined, () =>
     createInitialProfileEditorState(),
@@ -104,6 +125,9 @@ const ProfileEditor = ({ netid }: ProfileEditorProps) => {
     const errors: string[] = [];
     if (!primaryDept.trim()) errors.push('Primary Department is required.');
     if (researchInterests.length === 0) errors.push('At least one Research Interest is required.');
+    if (imageUrl.trim() && !/^https:\/\//i.test(imageUrl.trim())) {
+      errors.push('Profile Image URL must use HTTPS.');
+    }
     if (errors.length > 0) {
       dispatch({ type: 'SAVE_VALIDATION_FAILED', errors });
       window.setTimeout(() => validationSummaryRef.current?.focus(), 0);
@@ -111,37 +135,40 @@ const ProfileEditor = ({ netid }: ProfileEditorProps) => {
     }
 
     try {
-      const data: any = {
-        bio,
-        primary_department: primaryDept.trim(),
-        secondary_departments: secondaryDepts,
-        research_interests: researchInterests,
-        image_url: imageUrl.trim(),
+      const data: EditableProfileFields = {
+        bio: bio.trim(),
+        primaryDepartment: primaryDept.trim(),
+        secondaryDepartments: secondaryDepts,
+        researchInterests,
+        imageUrl: imageUrl.trim(),
       };
 
       const saveRes = await axios.put('/profiles/me', data);
+      if (!saveRes.data?.profile || !profileSaveMatches(data, saveRes.data.profile)) {
+        dispatch({
+          type: 'SAVE_FAILURE',
+          message: {
+            type: 'error',
+            text: 'The server did not persist all profile fields. Please try again.',
+          },
+        });
+        return;
+      }
       const savedProfile: FacultyProfile = {
         ...(profile as FacultyProfile),
         ...saveRes.data.profile,
       };
 
-      if (isUnverified) {
-        await axios.put('/profiles/me/verify');
-        dispatch({
-          type: 'SAVE_SUCCESS',
-          profile: { ...savedProfile, profileVerified: true },
-          message: { type: 'success', text: 'Profile verified. Students can now trust this profile.' },
-        });
-      } else {
-        dispatch({
-          type: 'SAVE_SUCCESS',
-          profile: savedProfile,
-          message: {
-            type: 'success',
-            text: 'Profile updated. Department changes have been applied to your research profile.',
-          },
-        });
-      }
+      dispatch({
+        type: 'SAVE_SUCCESS',
+        profile: savedProfile,
+        message: {
+          type: 'success',
+          text: savedProfile.profileVerificationRequestedAt
+            ? 'Profile updated and submitted for administrator verification.'
+            : 'Profile updated. Department changes have been applied to your research profile.',
+        },
+      });
     } catch (err: any) {
       dispatch({
         type: 'SAVE_FAILURE',
@@ -236,8 +263,9 @@ const ProfileEditor = ({ netid }: ProfileEditorProps) => {
             databases.
           </p>
           <p className="text-xs text-amber-600 mt-0.5">
-            Please review your information below. A primary department and at least one research
-            interest are required to save and verify your profile.
+            {profile.profileVerificationRequestedAt
+              ? `Submitted for administrator verification on ${new Date(profile.profileVerificationRequestedAt).toLocaleString()}.`
+              : 'Complete all readiness fields to submit your profile for administrator verification.'}
           </p>
         </div>
       )}

--- a/client/src/components/accounts/__tests__/ProfileEditor.test.ts
+++ b/client/src/components/accounts/__tests__/ProfileEditor.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { profileSaveMatches } from '../ProfileEditor';
+
+const submitted = {
+  bio: 'A bio',
+  primaryDepartment: 'Computer Science',
+  secondaryDepartments: ['Statistics and Data Science'],
+  researchInterests: ['Security'],
+  imageUrl: 'https://faculty.yale.edu/profile.jpg',
+};
+
+describe('ProfileEditor save contract', () => {
+  it('accepts a round trip containing all five editable fields', () => {
+    expect(
+      profileSaveMatches(submitted, {
+        bio: 'A bio',
+        primary_department: 'Computer Science',
+        secondary_departments: ['Statistics and Data Science'],
+        research_interests: ['Security'],
+        image_url: 'https://faculty.yale.edu/profile.jpg',
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects a response that silently drops or changes any submitted field', () => {
+    expect(profileSaveMatches(submitted, { ...submitted, researchInterests: [] })).toBe(false);
+  });
+});

--- a/client/src/types/types.tsx
+++ b/client/src/types/types.tsx
@@ -186,6 +186,7 @@ export type FacultyProfile = {
   research_interest_summary?: string;
   topics: string[];
   profileVerified: boolean;
+  profileVerificationRequestedAt?: string;
   ownListings: string[];
 };
 

--- a/server/src/controllers/__tests__/profileController.test.ts
+++ b/server/src/controllers/__tests__/profileController.test.ts
@@ -453,6 +453,8 @@ describe('profileController', () => {
         userType: 'professor',
         primaryDepartment: 'Computer Science',
         researchInterests: ['systems'],
+        bio: 'Systems research.',
+        imageUrl: 'https://faculty.yale.edu/profile.jpg',
       }),
     });
     mocks.userFindOneAndUpdate.mockReturnValue({

--- a/server/src/controllers/profileController.ts
+++ b/server/src/controllers/profileController.ts
@@ -289,8 +289,8 @@ export const updateProfile = async (req: Request, res: Response) => {
 };
 
 /**
- * PUT /profiles/me/verify — set profileVerified=true
- * Requires primaryDepartment and at least one research_interest.
+ * PUT /profiles/me/verify — request admin verification for a complete profile.
+ * Kept as a compatibility endpoint; profile saves request automatically.
  */
 export const verifyProfile = async (req: Request, res: Response) => {
   try {
@@ -305,7 +305,7 @@ export const verifyProfile = async (req: Request, res: Response) => {
     if (profile.userType !== 'professor' && profile.userType !== 'faculty') {
       return res
         .status(403)
-        .json({ error: 'Only faculty accounts can self-verify their profile.' });
+        .json({ error: 'Only faculty accounts can request profile verification.' });
     }
     if (!profile.primaryDepartment?.trim()) {
       return res.status(400).json({ error: 'Primary department is required for verification.' });
@@ -315,14 +315,21 @@ export const verifyProfile = async (req: Request, res: Response) => {
         .status(400)
         .json({ error: 'At least one research interest is required for verification.' });
     }
+    if (!profile.bio?.trim() || !profile.imageUrl?.trim()) {
+      return res.status(400).json({ error: 'Bio and profile image are required for verification.' });
+    }
 
     const user = await User.findOneAndUpdate(
-      { netid: currentUser.netId },
-      { profileVerified: true },
+      {
+        netid: currentUser.netId,
+        profileVerified: { $ne: true },
+        profileVerificationRequestedAt: { $exists: false },
+      },
+      { $set: { profileVerificationRequestedAt: new Date() } },
       { new: true },
     ).lean();
 
-    res.json({ profile: normalizePublicProfile(user as any) });
+    res.json({ profile: normalizePublicProfile((user || existing) as any) });
   } catch (error: any) {
     console.error('Profile: Error verifying profile:', sanitizeLogValue(error));
     sendProfileMutationError(res, error, 'Failed to verify profile');

--- a/server/src/models/user.ts
+++ b/server/src/models/user.ts
@@ -219,6 +219,10 @@ const userSchema = new mongoose.Schema(
       type: Boolean,
       default: false,
     },
+    profileVerificationRequestedAt: {
+      type: Date,
+      required: false,
+    },
     dataSources: {
       type: [String],
       default: [],

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -141,6 +141,7 @@ export const adminProfileDto = (user: any, includePublications = false) => {
     profile_urls: profileUrls,
     topics,
     profileVerified: user?.profileVerified === true,
+    profileVerificationRequestedAt: user?.profileVerificationRequestedAt,
     userType: user?.userType || 'professor',
     userConfirmed: user?.userConfirmed === true,
     ownListingCount: ownListings.length,

--- a/server/src/services/__tests__/profileService.test.ts
+++ b/server/src/services/__tests__/profileService.test.ts
@@ -2070,16 +2070,9 @@ describe('profileService admin profile update persistence', () => {
 });
 
 describe('updateOwnProfile', () => {
-  it('sanitizes self-edit URL fields before persisting a faculty profile', async () => {
-    userModelMock.findOneAndUpdate.mockReturnValue({
-      lean: vi.fn().mockResolvedValue({
-        netid: 'prof123',
-        website: 'https://faculty.example.test/',
-        profileUrls: { yale: 'https://faculty.example.test/profile' },
-      }),
-    });
-
-    await updateOwnProfile('prof123', {
+  it('rejects an unsafe self-edit image URL instead of silently dropping it', async () => {
+    const callsBefore = userModelMock.findOneAndUpdate.mock.calls.length;
+    await expect(updateOwnProfile('prof123', {
       bio: 'I study secure systems.',
       website: 'javascript:alert(document.cookie)',
       imageUrl: 'data:text/html,<script>alert(1)</script>',
@@ -2088,21 +2081,8 @@ describe('updateOwnProfile', () => {
         mail: 'mailto:prof123@yale.edu',
         script: 'javascript:alert(document.cookie)',
       },
-    });
-
-    expect(userModelMock.findOneAndUpdate).toHaveBeenCalledWith(
-      { netid: 'prof123' },
-      {
-        bio: 'I study secure systems.',
-        profileUrls: {
-          yale: 'https://faculty.example.test/profile',
-        },
-      },
-      {
-        new: true,
-        runValidators: true,
-      },
-    );
+    })).rejects.toThrow('Profile image URL must be a public HTTPS URL');
+    expect(userModelMock.findOneAndUpdate.mock.calls).toHaveLength(callsBefore);
   });
 
   it('sanitizes admin profile URL fields before persisting a faculty profile', async () => {
@@ -2259,5 +2239,66 @@ describe('updateOwnProfile', () => {
     expect(Object.keys(persisted.profileUrls)).toHaveLength(20);
     expect(Object.keys(persisted.profileUrls).every((key) => key.length <= 80)).toBe(true);
     expect(persisted.departments).toHaveLength(51);
+  });
+
+  it('persists all editable fields and requests verification once when completion transitions', async () => {
+    userModelMock.findOne.mockReturnValue({
+      lean: vi.fn().mockResolvedValue({ netid: 'prof123', profileVerified: false }),
+    });
+    userModelMock.findOneAndUpdate
+      .mockReturnValueOnce({ lean: vi.fn().mockResolvedValue({ netid: 'prof123' }) })
+      .mockReturnValueOnce({
+        lean: vi.fn().mockResolvedValue({
+          netid: 'prof123',
+          profileVerificationRequestedAt: new Date(),
+        }),
+      });
+
+    await updateOwnProfile('prof123', {
+      bio: 'Secure systems research.',
+      primaryDepartment: 'Computer Science',
+      secondaryDepartments: ['Statistics and Data Science'],
+      researchInterests: ['Security'],
+      imageUrl: 'https://faculty.yale.edu/profile.jpg',
+    });
+
+    const update = userModelMock.findOneAndUpdate.mock.calls.at(-2)![1];
+    expect(update).toMatchObject({
+      bio: 'Secure systems research.',
+      primaryDepartment: 'Computer Science',
+      secondaryDepartments: ['Statistics and Data Science'],
+      researchInterests: ['Security'],
+      imageUrl: 'https://faculty.yale.edu/profile.jpg',
+    });
+    expect(update).not.toHaveProperty('profileVerificationRequestedAt');
+    expect(userModelMock.findOneAndUpdate.mock.lastCall![0]).toMatchObject({
+      netid: 'prof123',
+      profileVerified: { $ne: true },
+      profileVerificationRequestedAt: { $exists: false },
+    });
+  });
+
+  it('does not replace an existing verification request timestamp on repeated saves', async () => {
+    const requestedAt = new Date('2026-07-01T12:00:00.000Z');
+    userModelMock.findOne.mockReturnValue({
+      lean: vi.fn().mockResolvedValue({
+        netid: 'prof123',
+        profileVerified: false,
+        profileVerificationRequestedAt: requestedAt,
+        primaryDepartment: 'Computer Science',
+        researchInterests: ['Security'],
+        bio: 'Existing bio',
+        imageUrl: 'https://faculty.yale.edu/profile.jpg',
+      }),
+    });
+    userModelMock.findOneAndUpdate.mockReturnValue({
+      lean: vi.fn().mockResolvedValue({ netid: 'prof123' }),
+    });
+
+    await updateOwnProfile('prof123', { bio: 'Updated bio' });
+
+    expect(userModelMock.findOneAndUpdate.mock.lastCall![1]).not.toHaveProperty(
+      'profileVerificationRequestedAt',
+    );
   });
 });

--- a/server/src/services/profileService.ts
+++ b/server/src/services/profileService.ts
@@ -536,6 +536,7 @@ const PUBLIC_PROFILE_BASE_FIELDS = [
   'lname',
   'userType',
   'profileVerified',
+  'profileVerificationRequestedAt',
   'title',
   'bio',
   // Direct contact/location fields are intentionally excluded from public
@@ -625,6 +626,9 @@ const publicProfileBase = (user: Record<string, any>): Record<string, any> => {
       profile[field] = publicProfileTextArray(value);
     } else if (field === 'profileVerified') {
       profile[field] = value === true;
+    } else if (field === 'profileVerificationRequestedAt') {
+      const requestedAt = new Date(value);
+      if (!Number.isNaN(requestedAt.getTime())) profile[field] = requestedAt.toISOString();
     } else if (field === 'hIndex') {
       const hIndex = typeof value === 'number' ? value : Number(value);
       if (Number.isFinite(hIndex) && hIndex >= 0) profile[field] = Math.trunc(hIndex);
@@ -2058,6 +2062,16 @@ const boundedPublicProfileUrl = (value: unknown): string | undefined => {
   return url && url.length <= MAX_SELF_PROFILE_URL_LENGTH ? url : undefined;
 };
 
+const boundedHttpsProfileImageUrl = (value: unknown): string | undefined => {
+  const url = boundedPublicProfileUrl(value);
+  if (!url) return undefined;
+  try {
+    return new URL(url).protocol === 'https:' ? url : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
 const boundedPublicationText = (value: unknown): string | undefined => {
   if (typeof value !== 'string') return undefined;
   const text = redactDirectContactInfo(value).trim().slice(0, MAX_ADMIN_PROFILE_PUBLICATION_TEXT_LENGTH);
@@ -2132,9 +2146,16 @@ const sanitizeSelfEditableProfileUrlFields = (update: Record<string, any>) => {
   }
 
   if ('imageUrl' in update) {
-    const imageUrl = boundedPublicProfileUrl(update.imageUrl);
-    if (imageUrl) update.imageUrl = imageUrl;
-    else delete update.imageUrl;
+    if (update.imageUrl === '') {
+      update.imageUrl = '';
+    } else {
+      const imageUrl = boundedPublicProfileUrl(update.imageUrl);
+      if (!imageUrl) {
+        delete update.imageUrl;
+      } else {
+        update.imageUrl = imageUrl;
+      }
+    }
   }
 
   if ('profileUrls' in update) {
@@ -2174,20 +2195,53 @@ export const updateOwnProfile = async (netid: string, data: any) => {
       update[field] = value;
     }
   }
+  if (
+    update.imageUrl !== undefined &&
+    update.imageUrl !== '' &&
+    !boundedHttpsProfileImageUrl(update.imageUrl)
+  ) {
+    throw selfProfileValidationError('Profile image URL must be a public HTTPS URL');
+  }
   sanitizeSelfEditableProfileTextFields(update);
   sanitizeSelfEditableProfileUrlFields(update);
 
+  const current = await User.findOne({ netid }).lean();
   if (update.primaryDepartment !== undefined || update.secondaryDepartments !== undefined) {
-    const current = await User.findOne({ netid }).lean();
     const primary = update.primaryDepartment ?? (current as any)?.primaryDepartment ?? '';
     const secondary = update.secondaryDepartments ?? (current as any)?.secondaryDepartments ?? [];
     update.departments = [primary, ...secondary].filter(Boolean);
   }
 
+  const completedProfile = {
+    ...(current as any),
+    ...update,
+  };
+  const shouldRequestVerification =
+    !completedProfile.profileVerified &&
+    !completedProfile.profileVerificationRequestedAt &&
+    String(completedProfile.primaryDepartment || '').trim() &&
+    Array.isArray(completedProfile.researchInterests) &&
+    completedProfile.researchInterests.length > 0 &&
+    String(completedProfile.bio || '').trim() &&
+    String(completedProfile.imageUrl || '').trim();
+
   const user = await User.findOneAndUpdate({ netid }, update, {
     new: true,
     runValidators: true,
   }).lean();
+
+  if (shouldRequestVerification) {
+    const requested = await User.findOneAndUpdate(
+      {
+        netid,
+        profileVerified: { $ne: true },
+        profileVerificationRequestedAt: { $exists: false },
+      },
+      { $set: { profileVerificationRequestedAt: new Date() } },
+      { new: true, runValidators: true },
+    ).lean();
+    return requested || user;
+  }
 
   return user;
 };


### PR DESCRIPTION
## Summary
- send the canonical camelCase faculty profile contract and verify every returned editable field before showing success
- require public HTTPS profile-image URLs while preserving immediate bio/photo persistence
- replace faculty self-verification with an idempotent, admin-owned verification request timestamp
- expose request state to faculty and the existing admin profile review surface

## Validation
- focused server tests: 102 passed
- focused client tests: 2 passed
- full client tests: 767 passed
- full server suite: passed
- standalone client/server TypeScript: passed
- ESLint: passed
- client/server production builds: passed
- security policy and secrets scan: passed