### PR TITLE
Fix Programs keyboard and screen-reader access

### DIFF
--- a/client/src/components/fellowship/FellowshipModal.tsx
+++ b/client/src/components/fellowship/FellowshipModal.tsx
@@ -1,7 +1,7 @@
 /**
  * Detail modal for viewing full fellowship information.
  */
-import React, { useContext } from 'react';
+import React, { useContext, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Fellowship } from '../../types/types';
 import FellowshipSearchContext from '../../contexts/FellowshipSearchContext';
@@ -112,6 +112,75 @@ const FellowshipModal = ({
     setQueryString,
   } = useContext(FellowshipSearchContext);
 
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const titleRef = useRef<HTMLHeadingElement>(null);
+  const returnFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+
+    returnFocusRef.current = document.activeElement as HTMLElement | null;
+    const inerted: Array<{ element: HTMLElement; inert: boolean; ariaHidden: string | null }> = [];
+    let branch: HTMLElement | null = overlayRef.current;
+
+    while (branch?.parentElement) {
+      Array.from(branch.parentElement.children).forEach((sibling) => {
+        if (sibling === branch || !(sibling instanceof HTMLElement)) return;
+        inerted.push({
+          element: sibling,
+          inert: sibling.inert,
+          ariaHidden: sibling.getAttribute('aria-hidden'),
+        });
+        sibling.inert = true;
+        sibling.setAttribute('aria-hidden', 'true');
+      });
+      branch = branch.parentElement;
+      if (branch === document.body) break;
+    }
+
+    titleRef.current?.focus();
+
+    return () => {
+      inerted.forEach(({ element, inert, ariaHidden }) => {
+        element.inert = inert;
+        if (ariaHidden === null) element.removeAttribute('aria-hidden');
+        else element.setAttribute('aria-hidden', ariaHidden);
+      });
+      returnFocusRef.current?.focus();
+    };
+  }, [isOpen]);
+
+  const handleDialogKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      onClose();
+      return;
+    }
+    if (event.key !== 'Tab' || !dialogRef.current) return;
+
+    const focusable = Array.from(
+      dialogRef.current.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ),
+    ).filter((element) => !element.hidden && element.getAttribute('aria-hidden') !== 'true');
+    if (focusable.length === 0) {
+      event.preventDefault();
+      titleRef.current?.focus();
+      return;
+    }
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (event.shiftKey && (document.activeElement === first || document.activeElement === titleRef.current)) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
   if (!isOpen || !fellowship) return null;
   const cycleStatus = getFellowshipCycleStatus(fellowship);
   const applicationStatus = getFellowshipApplicationStatus(fellowship);
@@ -176,14 +245,18 @@ const FellowshipModal = ({
 
   return (
     <div
+      ref={overlayRef}
       className="fixed inset-0 bg-black/60 z-[1200] flex items-center justify-center overflow-y-auto p-4 pt-20"
       onClick={onClose}
     >
       <div
+        ref={dialogRef}
         className="bg-[var(--yr-panel)] rounded-xl shadow-2xl w-full max-w-4xl h-[85vh] flex flex-col overflow-hidden"
         role="dialog"
         aria-modal="true"
         aria-labelledby="program-detail-title"
+        aria-describedby="program-detail-description"
+        onKeyDown={handleDialogKeyDown}
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex-shrink-0 border-b border-[var(--yr-line)]">
@@ -207,9 +280,17 @@ const FellowshipModal = ({
                   </span>
                 </div>
 
-                <h2 id="program-detail-title" className="text-xl font-bold text-gray-900 leading-tight">
+                <h2
+                  ref={titleRef}
+                  id="program-detail-title"
+                  tabIndex={-1}
+                  className="text-xl font-bold text-gray-900 leading-tight focus:outline-none"
+                >
                   {fellowship.title}
                 </h2>
+                <p id="program-detail-description" className="sr-only">
+                  Program details, eligibility, deadlines, and application actions.
+                </p>
               </div>
 
               <div className="flex flex-shrink-0 flex-wrap items-center gap-1">

--- a/client/src/components/fellowship/__tests__/FellowshipModal.test.tsx
+++ b/client/src/components/fellowship/__tests__/FellowshipModal.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -86,6 +86,61 @@ const renderModal = (override: Partial<Fellowship> = {}) =>
   );
 
 describe('FellowshipModal', () => {
+  it('contains keyboard focus, closes on Escape, and returns focus to the exact trigger', () => {
+    const trigger = document.createElement('button');
+    trigger.textContent = 'Open program';
+    document.body.appendChild(trigger);
+    trigger.focus();
+    const onClose = vi.fn();
+
+    const { rerender } = render(
+      <MemoryRouter>
+        <FellowshipSearchContext.Provider value={defaultFellowshipSearchContext}>
+          <FellowshipModal
+            fellowship={fellowship}
+            isOpen
+            isFavorite={false}
+            onClose={onClose}
+            toggleFavorite={vi.fn()}
+          />
+        </FellowshipSearchContext.Provider>
+      </MemoryRouter>,
+    );
+
+    const dialog = screen.getByRole('dialog', { name: fellowship.title });
+    expect(document.activeElement).toBe(screen.getByRole('heading', { name: fellowship.title }));
+    expect(trigger.inert).toBe(true);
+    expect(trigger).toHaveAttribute('aria-hidden', 'true');
+
+    const lastAction = screen.getByRole('link', { name: /Apply Now/i });
+    lastAction.focus();
+    fireEvent.keyDown(dialog, { key: 'Tab' });
+    expect(document.activeElement).toBe(screen.getByRole('link', { name: 'Apply' }));
+
+    fireEvent.keyDown(dialog, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(lastAction);
+
+    fireEvent.keyDown(dialog, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+    rerender(
+      <MemoryRouter>
+        <FellowshipSearchContext.Provider value={defaultFellowshipSearchContext}>
+          <FellowshipModal
+            fellowship={fellowship}
+            isOpen={false}
+            isFavorite={false}
+            onClose={onClose}
+            toggleFavorite={vi.fn()}
+          />
+        </FellowshipSearchContext.Provider>
+      </MemoryRouter>,
+    );
+    expect(document.activeElement).toBe(trigger);
+    expect(trigger.inert).not.toBe(true);
+    expect(trigger).not.toHaveAttribute('aria-hidden');
+    trigger.remove();
+  });
+
   it('keeps detail actions and filter chips large enough for touch input', () => {
     renderModal();
 

--- a/client/src/components/shared/ActiveFilters.tsx
+++ b/client/src/components/shared/ActiveFilters.tsx
@@ -72,6 +72,8 @@ const ActiveFilters = ({
                 return (
                   <button
                     key={option.value}
+                    type="button"
+                    aria-pressed={isActive}
                     onClick={() => onQuickFilterChange(isActive ? null : option.value)}
                     className={`
                     inline-flex min-h-[44px] items-center gap-1.5 rounded-md px-3 py-2 text-xs font-medium
@@ -111,7 +113,12 @@ const ActiveFilters = ({
               {isLoading && (
                 <div className="w-3 h-3 border-2 border-blue-200 border-t-blue-500 rounded-full animate-spin" />
               )}
-              <span className="text-xs text-gray-400 whitespace-nowrap">
+              <span
+                className="text-xs text-gray-400 whitespace-nowrap"
+                role="status"
+                aria-live="polite"
+                aria-atomic="true"
+              >
                 {totalCount} {totalCount === 1 ? 'result' : 'results'}
               </span>
             </div>

--- a/client/src/components/shared/BrowseCard.tsx
+++ b/client/src/components/shared/BrowseCard.tsx
@@ -101,7 +101,7 @@ const BrowseCard = React.memo(({ item, isFavorite, onToggleFavorite, onOpenModal
   return (
     <div
       className={`yr-card-interactive group relative rounded-md ${isAudited ? 'border-green-400 ring-1 ring-green-200' : ''} cursor-pointer overflow-hidden h-full flex flex-col ${isArchived ? 'opacity-75' : ''}`}
-      onClick={handleClick}
+      onClick={item.type === 'fellowship' ? undefined : handleClick}
     >
       {showUrgentBanner && daysUntil !== null && (
         <UrgentBadge daysUntil={daysUntil} variant="banner" />
@@ -265,8 +265,15 @@ const BrowseCard = React.memo(({ item, isFavorite, onToggleFavorite, onOpenModal
               </div>
             )}
 
-            <h3 className="text-base font-bold text-gray-900 mb-1 line-clamp-2 leading-tight">
-              {item.data.title}
+            <h3 className="mb-1 text-base font-bold leading-tight text-gray-900">
+              <button
+                type="button"
+                onClick={handleClick}
+                className="line-clamp-2 text-left hover:text-blue-700 focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                aria-label={`View details for ${item.data.title}`}
+              >
+                {item.data.title}
+              </button>
             </h3>
 
             <p className={`text-sm mb-1 ${subtitleColor}`}>

--- a/client/src/components/shared/BrowseListItem.tsx
+++ b/client/src/components/shared/BrowseListItem.tsx
@@ -106,7 +106,7 @@ const BrowseListItem = React.memo(({ item, isFavorite, onToggleFavorite, onOpenM
   return (
     <div
       className={`group bg-[var(--yr-panel)] rounded-md border ${isAudited ? 'border-green-400 ring-1 ring-green-200' : 'border-[var(--yr-line)]'} hover:border-blue-400 hover:shadow-sm transition-all duration-200 cursor-pointer ${isArchived ? 'opacity-75' : ''}`}
-      onClick={handleClick}
+      onClick={item.type === 'fellowship' ? undefined : handleClick}
     >
       <div className="p-4 grid grid-cols-12 gap-4 items-start">
         <div className={`col-span-12 ${isCompact ? 'md:col-span-10' : 'md:col-span-4'}`}>
@@ -151,8 +151,15 @@ const BrowseListItem = React.memo(({ item, isFavorite, onToggleFavorite, onOpenM
             </>
           ) : (
             <>
-              <h3 className="text-sm font-semibold text-gray-900 truncate">
-                {item.data.title}
+              <h3 className="text-sm font-semibold text-gray-900">
+                <button
+                  type="button"
+                  onClick={handleClick}
+                  className="block max-w-full truncate text-left hover:text-blue-700 focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                  aria-label={`View details for ${item.data.title}`}
+                >
+                  {item.data.title}
+                </button>
               </h3>
               <p className={`text-xs ${subtitleColor} truncate`}>
                 {subtitle}

--- a/client/src/components/shared/CombinedFilterDropdown.tsx
+++ b/client/src/components/shared/CombinedFilterDropdown.tsx
@@ -76,6 +76,9 @@ const CombinedFilterDropdown = ({ tabs }: CombinedFilterDropdownProps) => {
   return (
     <div className="relative" ref={dropdownRef}>
       <button
+        type="button"
+        aria-expanded={isOpen}
+        aria-haspopup="dialog"
         onClick={() => setIsOpen(!isOpen)}
         className="flex min-h-[44px] items-center rounded-md border border-[var(--yr-line-strong)] bg-[var(--yr-panel)] px-3 text-sm transition-colors hover:bg-[var(--yr-panel-muted)] focus:outline-none focus:ring-2 focus:ring-blue-500 whitespace-nowrap"
         style={{ color: '#374151' }}
@@ -115,6 +118,8 @@ const CombinedFilterDropdown = ({ tabs }: CombinedFilterDropdownProps) => {
             {tabs.map((tab) => (
               <button
                 key={tab.key}
+                type="button"
+                aria-pressed={activeTabKey === tab.key}
                 onClick={() => setActiveTabKey(tab.key)}
                 className={`relative flex min-h-[44px] flex-1 items-center justify-center px-2 py-2.5 text-xs font-medium transition-colors whitespace-nowrap ${
                   activeTabKey === tab.key
@@ -165,43 +170,34 @@ const CombinedFilterDropdown = ({ tabs }: CombinedFilterDropdownProps) => {
               </button>
             )}
 
-            <ul className="space-y-1 max-h-[220px] overflow-y-auto">
+            <fieldset className="space-y-1 max-h-[220px] overflow-y-auto">
+              <legend className="sr-only">{activeTab.label} filters</legend>
               {getFilteredOptions(activeTab).map((option) => {
                 const isSelected = activeTab.selected.includes(option);
                 const colors = activeTab.colorFn?.(option);
 
                 return (
-                  <li
+                  <label
                     key={option}
-                    tabIndex={0}
-                    role="option"
-                    aria-selected={isSelected}
-                    onClick={() => {
-                      if (isSelected) {
-                        activeTab.setSelected((prev) => prev.filter((v) => v !== option));
-                      } else {
-                        activeTab.setSelected((prev) => [...prev, option]);
-                      }
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault();
-                        if (isSelected) {
-                          activeTab.setSelected((prev) => prev.filter((v) => v !== option));
-                        } else {
-                          activeTab.setSelected((prev) => [...prev, option]);
-                        }
-                      }
-                    }}
                     className={`flex min-h-[44px] cursor-pointer items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-inset ${
                       isSelected ? 'bg-[var(--yr-blue-soft)] text-blue-900' : 'hover:bg-[var(--yr-panel-muted)] text-gray-700'
                     }`}
-                    onMouseDown={(e) => e.preventDefault()}
                   >
-                    <div
+                    <input
+                      type="checkbox"
+                      checked={isSelected}
+                      onChange={() => {
+                        activeTab.setSelected((prev) =>
+                          isSelected ? prev.filter((v) => v !== option) : [...prev, option],
+                        );
+                      }}
+                      className="peer sr-only"
+                    />
+                    <span
                       className={`w-4 h-4 rounded border flex-shrink-0 flex items-center justify-center transition-colors ${
                         isSelected ? 'bg-blue-500 border-blue-500' : 'border-[var(--yr-line-strong)]'
-                      }`}
+                      } peer-focus-visible:ring-2 peer-focus-visible:ring-blue-500 peer-focus-visible:ring-offset-2`}
+                      aria-hidden="true"
                     >
                       {isSelected && (
                         <svg
@@ -218,7 +214,7 @@ const CombinedFilterDropdown = ({ tabs }: CombinedFilterDropdownProps) => {
                           />
                         </svg>
                       )}
-                    </div>
+                    </span>
                     {colors ? (
                       <span
                         className={`${colors.bg} ${colors.text} text-xs rounded px-2 py-1 truncate`}
@@ -228,18 +224,18 @@ const CombinedFilterDropdown = ({ tabs }: CombinedFilterDropdownProps) => {
                     ) : (
                       <span className="truncate">{option}</span>
                     )}
-                  </li>
+                  </label>
                 );
               })}
               {getFilteredOptions(activeTab).length === 0 && (
-                <li className="px-3 py-2 text-sm text-gray-500">No options found</li>
+                <p className="px-3 py-2 text-sm text-gray-500">No options found</p>
               )}
               {activeTab.maxDisplay && activeTab.options.length > activeTab.maxDisplay && (
-                <li className="px-3 py-2 text-xs text-gray-400 text-center">
+                <p className="px-3 py-2 text-xs text-gray-400 text-center">
                   Showing first {activeTab.maxDisplay}. Type to search more...
-                </li>
+                </p>
               )}
-            </ul>
+            </fieldset>
           </div>
 
           {totalFilters > 0 && (

--- a/client/src/components/shared/__tests__/BrowseCard.test.tsx
+++ b/client/src/components/shared/__tests__/BrowseCard.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -91,6 +91,23 @@ const renderAdmin = (children: ReactNode) =>
   );
 
 describe('Browse admin controls', () => {
+  it('opens program card details from a semantic keyboard action', () => {
+    const onOpenModal = vi.fn();
+    renderAdmin(
+      <BrowseCard item={item} isFavorite={false} onOpenModal={onOpenModal} onAdminEdit={vi.fn()} />,
+    );
+
+    const titleAction = screen.getByRole('button', {
+      name: 'View details for Summer Research Fellowship',
+    });
+    titleAction.focus();
+    fireEvent.keyDown(titleAction, { key: 'Enter' });
+    fireEvent.click(titleAction);
+
+    expect(onOpenModal).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('button', { name: 'Admin edit' })).not.toBe(titleAction);
+  });
+
   it('keeps card admin edit controls large enough for touch input', () => {
     renderAdmin(
       <BrowseCard item={item} isFavorite={false} onOpenModal={vi.fn()} onAdminEdit={vi.fn()} />,

--- a/client/src/pages/__tests__/fellowships.test.tsx
+++ b/client/src/pages/__tests__/fellowships.test.tsx
@@ -385,12 +385,18 @@ describe('Programs page', () => {
 
     await userEvent.click(screen.getByRole('button', { name: /filters/i }));
     await userEvent.click(screen.getByRole('button', { name: 'Year' }));
-    await userEvent.click(screen.getByRole('option', { name: 'Senior' }));
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Senior' }));
 
     expect(setSelectedYearOfStudy).toHaveBeenCalled();
     const update = setSelectedYearOfStudy.mock.calls[0][0];
     expect(typeof update).toBe('function');
     expect(update([])).toEqual(['Senior']);
+    expect(screen.queryByRole('option')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Open Only' })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+    expect(screen.getByRole('status')).toHaveTextContent('1 result');
   });
 
   it('sorts visible program cards inside their cycle section from local sort controls', async () => {


### PR DESCRIPTION
## Summary

- add semantic, keyboard-operable program title actions without nesting favorite or admin controls
- contain program detail dialog focus, support Escape, restore the exact trigger, and inert background content
- expose quick-filter state and polite result-count updates
- replace invalid ARIA options with native labelled multi-select checkboxes

## Validation

- `cd client && yarn tsc --noEmit`
- `cd client && yarn vitest run src/components/shared/__tests__/BrowseCard.test.tsx src/components/fellowship/__tests__/FellowshipModal.test.tsx src/pages/__tests__/fellowships.test.tsx` (19 passed)
- `cd client && yarn test:ci` (773 passed)
- `cd client && yarn build`
- `yarn lint`
- `yarn security:policy`
- `yarn security:secrets`
