### PR TITLE
Add guarded recurring fellowship refresh

### DIFF
--- a/docs/scraper-deployment-runbook.md
+++ b/docs/scraper-deployment-runbook.md
@@ -470,15 +470,44 @@ Use separate Render Cron jobs per source or per source group and stagger start t
 
 Do not enable recurring cron for a source until its row is accepted. A source may be accepted for manual guarded runs while remaining unaccepted for unattended cron.
 
-| Source                            | Cron acceptance prerequisites                                                                                                                                                           | First cron posture                                                                           | Hold if                                                                                                                                 |
-| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `ysm-atoz-index`                  | Manual production or accepted Beta evidence shows entity discovery is stable, `materialization.errors = 0`, and source health has no unexplained errors.                                | Weekly, one source-specific cron, report saved with run ID.                                  | Selector/fetch failures, duplicate entity churn, or unexpected access artifacts.                                                        |
-| `department-undergrad-research`   | Source metadata exists, output is verified as undergraduate-access evidence rather than generic department discovery, and public contact policy is reviewed.                            | Manual or low-frequency cron after one accepted guarded run.                                 | It emits unsupported access claims, non-public contact data, or department pages require Yale-network-only access.                      |
-| `yale-college-fellowships-office` | Fellowship program mapping and public application/contact routes are reviewed; no private recipient or applicant data is required.                                                      | Monthly or term-bound cron, aligned to public deadline cycles.                               | The run depends on manual/private files, creates person-level scraped data, or deadline state cannot be verified.                       |
-| `lab-microsite-undergrad-llm`     | WorkPlanner target list is accepted, paid/LLM cost cap is set, stale-only or bounded scope is enforced, and contact redaction is smoke-tested.                                          | Weekly after WorkPlanner, with saved report and sampled public UI smoke.                     | Cost cap is missing, source emits raw non-public emails, or materialization conflicts are unexplained.                                  |
-| `student-decision-llm`            | Source-backed access evidence exists, target list excludes entities with existing explanations, paid/LLM cost cap is set, and rejected-output samples are reviewed for invented claims. | Manual bounded enrichment only; use `--use-cache` for cache-only replay when possible.       | Cost cap is missing, outputs mention unsupported application routes/direct contacts, or validator rejection rate is unexplained.        |
-| `openalex`                        | Production storage posture is accepted, compact-retention/report-save policy is recorded, and identifier-backed candidate rules are confirmed.                                          | Weekly or monthly, bounded by identifiers/offsets; save reports before pruning observations. | Name-only discovery is enabled unintentionally, Atlas storage is insufficient, or materialization creates unsupported authorship links. |
-| `arxiv`                           | Accepted ORCID/input target list is current, backoff window has cleared, and metadata-only behavior does not create name-only Yale author links.                                        | Weekly with `--since` or bounded accepted targets.                                           | Rate limits/timeouts recur, ORCID input is stale, or the source attempts unsupported faculty links.                                     |
+| Source                            | Cron acceptance prerequisites                                                                                                                                | First cron posture                                             | Hold if                                                                                                            |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `ysm-atoz-index`                  | Manual production or accepted Beta evidence shows entity discovery is stable, `materialization.errors = 0`, and source health has no unexplained errors.     | Weekly, one source-specific cron, report saved with run ID.    | Selector/fetch failures, duplicate entity churn, or unexpected access artifacts.                                   |
+| `department-undergrad-research`   | Source metadata exists, output is verified as undergraduate-access evidence rather than generic department discovery, and public contact policy is reviewed. | Manual or low-frequency cron after one accepted guarded run.   | It emits unsupported access claims, non-public contact data, or department pages require Yale-network-only access. |
+| `yale-college-fellowships-office` | Fellowship program mapping and public application/contact routes are reviewed; no private recipient or applicant data is required.                           | Monthly or term-bound cron, aligned to public deadline cycles. | The run depends on manual/private files, creates person-level scraped data, or deadline state cannot be verified.  |
+
+### Recurring fellowship refresh
+
+`yarn --cwd server fellowships:refresh` is the deployable scheduler entrypoint for the official Yale fellowship catalog.
+No recurring job is configured in the repository, so it is disabled by default.
+Configure it as a separate monthly scheduled job, with additional runs six weeks before the usual fall and spring application cycles, only after the target-specific database name and restore workflow have been verified.
+
+The command is dry-run by default and prints only aggregate, redacted counts.
+It requires an explicit `--target=beta|prod`, a matching `SCRAPER_ENV`, and a connected database whose name exactly matches `FELLOWSHIP_REFRESH_BETA_DB` or `FELLOWSHIP_REFRESH_PROD_DB`.
+Use an uncached bounded Beta dry-run first:
+
+```bash
+SCRAPER_ENV=beta \
+FELLOWSHIP_REFRESH_BETA_DB=<beta-db-name> \
+MONGODBURL=<beta-url> \
+yarn --cwd server fellowships:refresh --target=beta --limit=50
+```
+
+Review the aggregate created, updated, unchanged, review-required, and reopened counts plus the private review queue before execute mode.
+Execute mode additionally requires `--execute --confirm=execute-fellowship-refresh-beta --restore-token=<restore-id>`.
+Production requires the corresponding `prod` target and confirmation, plus `--confirm-prod=confirm-production-fellowship-refresh`.
+Never put a restore token in scheduler configuration committed to this repository.
+Use the secret manager provided by the deployment platform and rotate the token after the verified rollback window closes.
+
+Each run is bounded to at most 100 records, uses the existing distributed scraper lease, retries official page fetches with exponential backoff, and upserts by the authoritative source key.
+Missing or invalid deadlines, duplicate source identities, junk titles, and non-authoritative URLs go to `fellowship_refresh_review_queue` instead of changing a fellowship.
+Validated past-to-future transitions emit one idempotent `program_reopened` row in `program_watch_events` for downstream watchlist delivery.
+No future deadline is synthesized.
+Successful execute runs write aggregate freshness state to `fellowship_refresh_runs`; alert when no successful run exists within 45 days or when every discovered row requires review.
+| `lab-microsite-undergrad-llm` | WorkPlanner target list is accepted, paid/LLM cost cap is set, stale-only or bounded scope is enforced, and contact redaction is smoke-tested. | Weekly after WorkPlanner, with saved report and sampled public UI smoke. | Cost cap is missing, source emits raw non-public emails, or materialization conflicts are unexplained. |
+| `student-decision-llm` | Source-backed access evidence exists, target list excludes entities with existing explanations, paid/LLM cost cap is set, and rejected-output samples are reviewed for invented claims. | Manual bounded enrichment only; use `--use-cache` for cache-only replay when possible. | Cost cap is missing, outputs mention unsupported application routes/direct contacts, or validator rejection rate is unexplained. |
+| `openalex` | Production storage posture is accepted, compact-retention/report-save policy is recorded, and identifier-backed candidate rules are confirmed. | Weekly or monthly, bounded by identifiers/offsets; save reports before pruning observations. | Name-only discovery is enabled unintentionally, Atlas storage is insufficient, or materialization creates unsupported authorship links. |
+| `arxiv` | Accepted ORCID/input target list is current, backoff window has cleared, and metadata-only behavior does not create name-only Yale author links. | Weekly with `--since` or bounded accepted targets. | Rate limits/timeouts recur, ORCID input is stale, or the source attempts unsupported faculty links. |
 
 ### Compact Observation Retention
 

--- a/server/package.json
+++ b/server/package.json
@@ -48,6 +48,7 @@
     "programs:backfill-official-sources": "tsx src/scripts/backfillProgramOfficialSources.ts",
     "programs:accept-formalization-exceptions": "tsx src/scripts/acceptFormalizationReviewExceptions.ts",
     "programs:audit-research-relevance": "tsx src/scripts/auditProgramResearchRelevance.ts",
+    "fellowships:refresh": "tsx src/scripts/fellowshipRefresh.ts",
     "student-visibility:backfill": "tsx src/scripts/backfillStudentVisibilityTiers.ts",
     "student-visibility:gate": "tsx src/scripts/studentVisibilityGate.ts",
     "launch:trust-contract": "tsx src/scripts/launchTrustContract.ts",

--- a/server/src/scrapers/sources/yaleCollegeFellowshipsOfficeScraper.ts
+++ b/server/src/scrapers/sources/yaleCollegeFellowshipsOfficeScraper.ts
@@ -86,6 +86,7 @@ type FetchPage = (url: string, useCache: boolean) => Promise<string>;
 interface YaleCollegeFellowshipsOfficeScraperDeps {
   pageUrls?: string[];
   fetchPage?: FetchPage;
+  retryDelay?: (attempt: number) => Promise<void>;
 }
 
 function normalizeWhitespace(value: string): string {
@@ -122,9 +123,7 @@ function normalizeLinkUrl(url: string): string {
     if (parsed.hostname.endsWith('communityforce.com')) parsed.protocol = 'https:';
     if (parsed.hostname === 'yalecollege.yale.edu') {
       const movedUrl =
-        MOVED_YALE_COLLEGE_FINANCIAL_AWARD_URLS[
-          parsed.pathname.toLowerCase().replace(/\/$/, '')
-        ];
+        MOVED_YALE_COLLEGE_FINANCIAL_AWARD_URLS[parsed.pathname.toLowerCase().replace(/\/$/, '')];
       if (movedUrl) return movedUrl;
     }
     return parsed.toString();
@@ -174,15 +173,11 @@ function isHtmlLikeUrl(url: string): boolean {
 function isGenericCatalogTitle(title: string): boolean {
   const normalized = normalizeWhitespace(title);
   return (
-    /^(?:about|advising|administering|contact|connect|find|prepare|search)\b/i.test(
-      normalized,
-    ) ||
+    /^(?:about|advising|administering|contact|connect|find|prepare|search)\b/i.test(normalized) ||
     /\b(?:alternative funding|funding options|funding sources|student grants database)\b/i.test(
       normalized,
     ) ||
-    /\b(?:faculty|staff|advisers?|advisors?|resources|directory|subjects?)\b/i.test(
-      normalized,
-    ) ||
+    /\b(?:faculty|staff|advisers?|advisors?|resources|directory|subjects?)\b/i.test(normalized) ||
     /^(?:fellowships?(?: and funding)?|fellowships and funding directory)$/i.test(normalized) ||
     /offered through|opportunities at yale|fellowships and funding$/i.test(normalized)
   );
@@ -225,9 +220,7 @@ function isEligibleCandidateHref(url: string): boolean {
   return isCommunityForceUrl(url) || isLikelyPublicFellowshipDetailUrl(url);
 }
 
-function isInExcludedPageRegion(
-  $link: cheerio.Cheerio<any>,
-): boolean {
+function isInExcludedPageRegion($link: cheerio.Cheerio<any>): boolean {
   return (
     $link.closest(
       'header, nav, footer, aside, [role="navigation"], [role="banner"], [role="contentinfo"], .breadcrumb, .menu, .sidebar',
@@ -235,10 +228,7 @@ function isInExcludedPageRegion(
   );
 }
 
-function isInPrimaryContent(
-  $: cheerio.CheerioAPI,
-  $link: cheerio.Cheerio<any>,
-): boolean {
+function isInPrimaryContent($: cheerio.CheerioAPI, $link: cheerio.Cheerio<any>): boolean {
   const primaryScopes = $('main, [role="main"], article');
   if (primaryScopes.length === 0) return true;
   return $link.closest('main, [role="main"], article').length > 0;
@@ -267,7 +257,9 @@ function extractEmail(text: string): string | undefined {
 }
 
 function hasExplicitActiveApplicationLanguage(text: string): boolean {
-  return /\bapplications?\s+(are\s+)?(now\s+)?open\b|\bcurrently accepting applications\b/i.test(text);
+  return /\bapplications?\s+(are\s+)?(now\s+)?open\b|\bcurrently accepting applications\b/i.test(
+    text,
+  );
 }
 
 function bestDeadlineText(text: string): string {
@@ -297,17 +289,15 @@ export function parseDeadlineToUtcEndOfDay(
     year += 1;
     date = new Date(Date.UTC(year, month, day, 23, 59, 59, 999));
   }
-  if (
-    date.getUTCFullYear() !== year ||
-    date.getUTCMonth() !== month ||
-    date.getUTCDate() !== day
-  ) {
+  if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month || date.getUTCDate() !== day) {
     return undefined;
   }
   return date;
 }
 
-function fingerprintCandidate(candidate: Omit<FellowshipCatalogCandidate, 'sourceFingerprint'>): string {
+function fingerprintCandidate(
+  candidate: Omit<FellowshipCatalogCandidate, 'sourceFingerprint'>,
+): string {
   const stable = {
     title: candidate.title,
     summary: candidate.summary || '',
@@ -356,10 +346,7 @@ function existingKeyForCandidate(
     : undefined;
   if (applicationLink) {
     for (const [key, existing] of byKey) {
-      const existingUrls = [
-        existing.applicationLink,
-        ...existing.links.map((link) => link.url),
-      ]
+      const existingUrls = [existing.applicationLink, ...existing.links.map((link) => link.url)]
         .filter((url): url is string => !!url)
         .map(normalizeLinkUrl);
       if (existingUrls.includes(applicationLink)) return key;
@@ -569,7 +556,11 @@ export function parseFellowshipCatalogPage(
   return Array.from(byKey.values()).sort((a, b) => a.title.localeCompare(b.title));
 }
 
-function observation(field: string, value: unknown, candidate: FellowshipCatalogCandidate): ObservationInput | null {
+function observation(
+  field: string,
+  value: unknown,
+  candidate: FellowshipCatalogCandidate,
+): ObservationInput | null {
   if (value === undefined || value === null || value === '') return null;
   if (Array.isArray(value) && value.length === 0) return null;
   return {
@@ -658,10 +649,14 @@ export class YaleCollegeFellowshipsOfficeScraper implements IScraper {
 
   private readonly pageUrls: string[];
   private readonly fetchPage: FetchPage;
+  private readonly retryDelay: (attempt: number) => Promise<void>;
 
   constructor(deps: YaleCollegeFellowshipsOfficeScraperDeps = {}) {
     this.pageUrls = deps.pageUrls || DEFAULT_PAGE_URLS;
     this.fetchPage = deps.fetchPage || fetchHtml;
+    this.retryDelay =
+      deps.retryDelay ||
+      ((attempt) => new Promise((resolve) => setTimeout(resolve, 250 * 2 ** attempt)));
   }
 
   async run(ctx: ScraperContext): Promise<ScraperResult> {
@@ -685,17 +680,24 @@ export class YaleCollegeFellowshipsOfficeScraper implements IScraper {
       }
     };
     const tryParseAndMerge = async (url: string): Promise<boolean> => {
-      try {
-        await parseAndMerge(url);
-        return true;
-      } catch (error) {
-        failedUrls.push(url);
-        ctx.log('Skipping fellowship catalog page after fetch/parse failure', {
-          url,
-          error: sanitizeLogValue(error),
-        });
-        return false;
+      let lastError: unknown;
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        try {
+          // A failed fetch must be retryable rather than treated as already fetched.
+          fetched.delete(url);
+          await parseAndMerge(url);
+          return true;
+        } catch (error) {
+          lastError = error;
+          if (attempt < 2) await this.retryDelay(attempt);
+        }
       }
+      failedUrls.push(url);
+      ctx.log('Skipping fellowship catalog page after fetch/parse failure', {
+        url,
+        error: sanitizeLogValue(lastError),
+      });
+      return false;
     };
 
     let seedPageSuccesses = 0;
@@ -729,9 +731,7 @@ export class YaleCollegeFellowshipsOfficeScraper implements IScraper {
       a.title.localeCompare(b.title),
     );
     const selected =
-      limitOption !== undefined
-        ? allCandidates.slice(0, limitOption)
-        : allCandidates;
+      limitOption !== undefined ? allCandidates.slice(0, limitOption) : allCandidates;
     const observations = selected.flatMap(candidateToObservations);
     if (observations.length > 0) await ctx.emit(observations);
 

--- a/server/src/scripts/__tests__/fellowshipRefreshCore.test.ts
+++ b/server/src/scripts/__tests__/fellowshipRefreshCore.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import type { FellowshipCatalogCandidate } from '../../scrapers/sources/yaleCollegeFellowshipsOfficeScraper';
+import {
+  aggregateFellowshipRefreshPlan,
+  assertFellowshipRefreshGuards,
+  buildFellowshipRefreshPlan,
+  fellowshipRefreshAuditToken,
+  validateFellowshipRefreshCandidate,
+} from '../fellowshipRefreshCore';
+
+const now = new Date('2026-07-11T12:00:00.000Z');
+function candidate(
+  overrides: Partial<FellowshipCatalogCandidate> = {},
+): FellowshipCatalogCandidate {
+  return {
+    sourceKey: 'yale-college-fellowships-office:summer-research-fellowship',
+    sourceFingerprint: 'new-fingerprint',
+    title: 'Summer Research Fellowship',
+    sourceUrl: 'https://funding.yale.edu/fellowships/summer-research',
+    applicationLink: 'https://funding.yale.edu/apply',
+    links: [],
+    deadline: new Date('2027-02-01T23:59:59.999Z'),
+    yearOfStudy: [],
+    termOfAward: ['Summer'],
+    purpose: ['Research'],
+    globalRegions: [],
+    citizenshipStatus: [],
+    isAcceptingApplications: true,
+    reviewRequired: false,
+    ...overrides,
+  };
+}
+
+describe('fellowship refresh planning', () => {
+  it('emits a reopen only for a validated past-to-future transition', () => {
+    const plan = buildFellowshipRefreshPlan({
+      candidates: [candidate()],
+      existing: [
+        {
+          sourceKey: candidate().sourceKey,
+          sourceFingerprint: 'old',
+          deadline: new Date('2026-02-01T23:59:59.999Z'),
+          isAcceptingApplications: false,
+        },
+      ],
+      now,
+    });
+    expect(plan[0]).toMatchObject({ action: 'update', transition: 'reopened' });
+    expect(aggregateFellowshipRefreshPlan(plan).reopened).toBe(1);
+  });
+
+  it('is idempotent when the authoritative fingerprint is unchanged', () => {
+    const item = candidate();
+    expect(
+      buildFellowshipRefreshPlan({
+        candidates: [item],
+        existing: [{ sourceKey: item.sourceKey, sourceFingerprint: item.sourceFingerprint }],
+      })[0],
+    ).toMatchObject({ action: 'unchanged', changedFields: [] });
+  });
+
+  it('routes missing and invalid deadlines to review without inventing dates', () => {
+    const missing = candidate({ deadline: undefined });
+    const invalid = candidate({
+      sourceKey: 'yale-college-fellowships-office:invalid-date-fellowship',
+      deadline: new Date('invalid'),
+    });
+    const plan = buildFellowshipRefreshPlan({ candidates: [missing, invalid], existing: [] });
+    expect(plan.map((item) => item.reviewReason)).toEqual(['missing-deadline', 'invalid-deadline']);
+    expect(plan.every((item) => item.action === 'review')).toBe(true);
+  });
+
+  it('rejects junk titles and non-authoritative sources', () => {
+    expect(validateFellowshipRefreshCandidate(candidate({ title: 'Apply' }))).toBe('junk-title');
+    expect(
+      validateFellowshipRefreshCandidate(candidate({ sourceUrl: 'https://example.com/program' })),
+    ).toBe('non-authoritative-source');
+  });
+
+  it('routes a duplicate source identity to review', () => {
+    const plan = buildFellowshipRefreshPlan({
+      candidates: [candidate(), candidate()],
+      existing: [],
+    });
+    expect(plan[1]).toMatchObject({ action: 'review', reviewReason: 'duplicate-source-key' });
+  });
+
+  it('enforces the bounded batch', () => {
+    expect(() =>
+      buildFellowshipRefreshPlan({ candidates: [], existing: [], maxBatch: 101 }),
+    ).toThrow(/1 through 100/);
+  });
+});
+
+describe('fellowship refresh execution guards', () => {
+  it('rejects target mismatch', () => {
+    expect(() =>
+      assertFellowshipRefreshGuards({ target: 'beta', runtimeTarget: 'prod', execute: false }),
+    ).toThrow(/does not match/);
+  });
+
+  it('requires execute confirmation and a rollback token', () => {
+    expect(() =>
+      assertFellowshipRefreshGuards({ target: 'beta', runtimeTarget: 'beta', execute: true }),
+    ).toThrow(/confirmation/);
+    expect(() =>
+      assertFellowshipRefreshGuards({
+        target: 'beta',
+        runtimeTarget: 'beta',
+        execute: true,
+        confirmation: 'execute-fellowship-refresh-beta',
+      }),
+    ).toThrow(/restore token/);
+  });
+
+  it('requires a separate production confirmation', () => {
+    expect(() =>
+      assertFellowshipRefreshGuards({
+        target: 'prod',
+        runtimeTarget: 'prod',
+        execute: true,
+        confirmation: 'execute-fellowship-refresh-prod',
+        restoreToken: 'restore-123',
+      }),
+    ).toThrow(/production confirmation/);
+  });
+
+  it('stores only a one-way restore token digest', () => {
+    const digest = fellowshipRefreshAuditToken('private-restore-token');
+    expect(digest).toMatch(/^[a-f0-9]{64}$/);
+    expect(digest).not.toContain('private-restore-token');
+  });
+
+  it('keeps aggregate reports free of source URLs and titles', () => {
+    const report = JSON.stringify(
+      aggregateFellowshipRefreshPlan(
+        buildFellowshipRefreshPlan({ candidates: [candidate()], existing: [] }),
+      ),
+    );
+    expect(report).not.toContain('funding.yale.edu');
+    expect(report).not.toContain('Summer Research Fellowship');
+  });
+});

--- a/server/src/scripts/fellowshipRefresh.ts
+++ b/server/src/scripts/fellowshipRefresh.ts
@@ -1,0 +1,222 @@
+import dotenv from 'dotenv';
+dotenv.config();
+import mongoose from 'mongoose';
+import { randomUUID } from 'crypto';
+import { Fellowship } from '../models/fellowship';
+import { acquireScrapeJobLock, releaseScrapeJobLock } from '../scrapers/scrapeJobLock';
+import type { ObservationInput, ScraperContext } from '../scrapers/types';
+import {
+  YALE_COLLEGE_FELLOWSHIPS_OFFICE_SOURCE,
+  YaleCollegeFellowshipsOfficeScraper,
+  type FellowshipCatalogCandidate,
+} from '../scrapers/sources/yaleCollegeFellowshipsOfficeScraper';
+import { sanitizeLogValue } from '../utils/logSanitizer';
+import {
+  aggregateFellowshipRefreshPlan,
+  assertFellowshipRefreshGuards,
+  buildFellowshipRefreshPlan,
+  fellowshipRefreshAuditToken,
+} from './fellowshipRefreshCore';
+
+type Flags = Record<string, string | true>;
+function parseFlags(argv: string[]): Flags {
+  const flags: Flags = {};
+  for (const arg of argv) {
+    if (!arg.startsWith('--')) throw new Error('all arguments must be named flags');
+    const [name, ...parts] = arg.slice(2).split('=');
+    if (!name || name in flags) throw new Error('duplicate or invalid flag');
+    flags[name] = parts.length ? parts.join('=') : true;
+  }
+  return flags;
+}
+
+function value(flags: Flags, name: string, required = false): string | undefined {
+  const result = flags[name];
+  if (result === true || (required && typeof result !== 'string'))
+    throw new Error(`--${name} requires a value`);
+  return typeof result === 'string' ? result : undefined;
+}
+
+function observationsToCandidates(observations: ObservationInput[]): FellowshipCatalogCandidate[] {
+  const rows = new Map<string, Record<string, unknown>>();
+  for (const observation of observations) {
+    if (observation.entityType !== 'fellowship' || !observation.entityKey) continue;
+    const row = rows.get(observation.entityKey) || {};
+    row[observation.field] = observation.value;
+    rows.set(observation.entityKey, row);
+  }
+  return Array.from(rows.values()).map((row) => row as unknown as FellowshipCatalogCandidate);
+}
+
+async function collectCandidates(limit: number): Promise<FellowshipCatalogCandidate[]> {
+  const observations: ObservationInput[] = [];
+  const scraper = new YaleCollegeFellowshipsOfficeScraper();
+  const context = {
+    options: { dryRun: true, useCache: false, limit },
+    emit: async (items: ObservationInput[]) => {
+      observations.push(...items);
+    },
+    log: () => undefined,
+  } as unknown as ScraperContext;
+  await scraper.run(context);
+  return observationsToCandidates(observations);
+}
+
+function writableCandidate(candidate: FellowshipCatalogCandidate, now: Date) {
+  return {
+    ...candidate,
+    sourceName: YALE_COLLEGE_FELLOWSHIPS_OFFICE_SOURCE,
+    sourceLastVerifiedAt: now,
+    sourceLastChangedAt: now,
+    archived: false,
+  };
+}
+
+async function main(): Promise<void> {
+  const flags = parseFlags(process.argv.slice(2));
+  const target = value(flags, 'target', true)!;
+  const execute = flags.execute === true;
+  const runtimeTarget = process.env.SCRAPER_ENV === 'production' ? 'prod' : process.env.SCRAPER_ENV;
+  assertFellowshipRefreshGuards({
+    target,
+    runtimeTarget,
+    execute,
+    confirmation: value(flags, 'confirm'),
+    restoreToken: value(flags, 'restore-token'),
+    prodConfirmation: value(flags, 'confirm-prod'),
+  });
+  const limit = Number(value(flags, 'limit') || '50');
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100)
+    throw new Error('--limit must be an integer from 1 through 100');
+  const mongoUrl = process.env.MONGODBURL;
+  if (!mongoUrl) throw new Error('MONGODBURL is required');
+  await mongoose.connect(mongoUrl);
+  const actualDb = mongoose.connection.db?.databaseName || '';
+  const expectedDb =
+    target === 'prod'
+      ? process.env.FELLOWSHIP_REFRESH_PROD_DB
+      : process.env.FELLOWSHIP_REFRESH_BETA_DB;
+  if (!expectedDb || actualDb !== expectedDb)
+    throw new Error('connected Mongo destination does not match the configured target database');
+
+  const ownerId = randomUUID();
+  if (execute) {
+    const lock = await acquireScrapeJobLock({
+      environment: target === 'prod' ? 'production' : 'beta',
+      sourceName: `${YALE_COLLEGE_FELLOWSHIPS_OFFICE_SOURCE}-refresh`,
+      ownerId,
+    });
+    if (!lock.acquired) {
+      console.log(JSON.stringify({ target, mode: 'execute', skipped: true, reason: 'lock-held' }));
+      return;
+    }
+  }
+  let succeeded = false;
+  try {
+    const now = new Date();
+    const candidates = await collectCandidates(limit);
+    const existing = await Fellowship.find({
+      sourceKey: { $in: candidates.map((item) => item.sourceKey) },
+    })
+      .select('sourceKey sourceFingerprint deadline isAcceptingApplications')
+      .lean();
+    const plan = buildFellowshipRefreshPlan({
+      candidates,
+      existing: existing as any[],
+      now,
+      maxBatch: limit,
+    });
+    if (execute) {
+      const review = mongoose.connection.db!.collection('fellowship_refresh_review_queue');
+      const events = mongoose.connection.db!.collection('program_watch_events');
+      for (const item of plan) {
+        if (item.action === 'review') {
+          await review.updateOne(
+            {
+              sourceKey: item.candidate.sourceKey,
+              sourceFingerprint: item.candidate.sourceFingerprint,
+            },
+            {
+              $setOnInsert: {
+                sourceKey: item.candidate.sourceKey,
+                sourceFingerprint: item.candidate.sourceFingerprint,
+                reason: item.reviewReason,
+                sourceName: YALE_COLLEGE_FELLOWSHIPS_OFFICE_SOURCE,
+                createdAt: now,
+              },
+            },
+            { upsert: true },
+          );
+          continue;
+        }
+        if (item.action === 'unchanged') {
+          await Fellowship.updateOne(
+            { sourceKey: item.candidate.sourceKey },
+            { $set: { sourceLastVerifiedAt: now } },
+          );
+          continue;
+        }
+        await Fellowship.updateOne(
+          { sourceKey: item.candidate.sourceKey },
+          {
+            $set: writableCandidate(item.candidate, now),
+            $setOnInsert: { title: item.candidate.title },
+          },
+          { upsert: true, runValidators: true },
+        );
+        if (item.transition === 'reopened') {
+          await events.updateOne(
+            {
+              sourceKey: item.candidate.sourceKey,
+              sourceFingerprint: item.candidate.sourceFingerprint,
+              eventType: 'program_reopened',
+            },
+            {
+              $setOnInsert: {
+                sourceKey: item.candidate.sourceKey,
+                sourceFingerprint: item.candidate.sourceFingerprint,
+                eventType: 'program_reopened',
+                occurredAt: now,
+              },
+            },
+            { upsert: true },
+          );
+        }
+      }
+      await mongoose.connection.db!.collection('fellowship_refresh_runs').insertOne({
+        target,
+        sourceName: YALE_COLLEGE_FELLOWSHIPS_OFFICE_SOURCE,
+        status: 'success',
+        finishedAt: now,
+        summary: aggregateFellowshipRefreshPlan(plan),
+        restoreTokenHash: fellowshipRefreshAuditToken(value(flags, 'restore-token')!),
+      });
+    }
+    succeeded = true;
+    console.log(
+      JSON.stringify({
+        target,
+        db: actualDb,
+        mode: execute ? 'execute' : 'dry-run',
+        ...aggregateFellowshipRefreshPlan(plan),
+        redacted: true,
+      }),
+    );
+  } finally {
+    if (execute) {
+      await releaseScrapeJobLock({
+        environment: target === 'prod' ? 'production' : 'beta',
+        sourceName: `${YALE_COLLEGE_FELLOWSHIPS_OFFICE_SOURCE}-refresh`,
+        ownerId,
+        releaseReason: succeeded ? 'success' : 'failure',
+      });
+    }
+  }
+}
+
+main()
+  .catch((error) => {
+    console.error('Fellowship refresh failed:', sanitizeLogValue(error));
+    process.exitCode = 1;
+  })
+  .finally(() => mongoose.disconnect());

--- a/server/src/scripts/fellowshipRefreshCore.ts
+++ b/server/src/scripts/fellowshipRefreshCore.ts
@@ -1,0 +1,145 @@
+import { createHash } from 'crypto';
+import type { FellowshipCatalogCandidate } from '../scrapers/sources/yaleCollegeFellowshipsOfficeScraper';
+
+export const FELLOWSHIP_REFRESH_MAX_BATCH = 100;
+export type FellowshipRefreshTarget = 'beta' | 'prod';
+
+export interface ExistingFellowshipRefreshRecord {
+  sourceKey: string;
+  sourceFingerprint?: string;
+  deadline?: Date | string | null;
+  isAcceptingApplications?: boolean;
+}
+
+export interface FellowshipRefreshPlanItem {
+  candidate: FellowshipCatalogCandidate;
+  action: 'create' | 'update' | 'unchanged' | 'review';
+  changedFields: string[];
+  transition?: 'reopened';
+  reviewReason?: string;
+}
+
+const JUNK_TITLE =
+  /^(?:about|apply|application|contact|find funding|fellowships?|funding|home|learn more|more|read more|resources?)$/i;
+
+export function validateFellowshipRefreshCandidate(
+  candidate: FellowshipCatalogCandidate,
+): string | undefined {
+  const title = candidate.title.trim();
+  if (title.length < 5 || title.length > 180 || JUNK_TITLE.test(title)) return 'junk-title';
+  if (!candidate.sourceKey.startsWith('yale-college-fellowships-office:'))
+    return 'invalid-source-key';
+  try {
+    const url = new URL(candidate.sourceUrl);
+    if (
+      url.protocol !== 'https:' ||
+      !(url.hostname === 'yale.edu' || url.hostname.endsWith('.yale.edu'))
+    ) {
+      return 'non-authoritative-source';
+    }
+  } catch {
+    return 'invalid-source-url';
+  }
+  if (candidate.deadline && Number.isNaN(candidate.deadline.getTime())) return 'invalid-deadline';
+  if (!candidate.deadline) return 'missing-deadline';
+  return undefined;
+}
+
+function oldDate(value: Date | string | null | undefined): number | undefined {
+  if (!value) return undefined;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date.getTime();
+}
+
+export function buildFellowshipRefreshPlan(input: {
+  candidates: FellowshipCatalogCandidate[];
+  existing: ExistingFellowshipRefreshRecord[];
+  now?: Date;
+  maxBatch?: number;
+}): FellowshipRefreshPlanItem[] {
+  const maxBatch = input.maxBatch ?? FELLOWSHIP_REFRESH_MAX_BATCH;
+  if (!Number.isSafeInteger(maxBatch) || maxBatch < 1 || maxBatch > FELLOWSHIP_REFRESH_MAX_BATCH) {
+    throw new Error(`max batch must be an integer from 1 through ${FELLOWSHIP_REFRESH_MAX_BATCH}`);
+  }
+  const now = input.now ?? new Date();
+  const existing = new Map(input.existing.map((row) => [row.sourceKey, row]));
+  const seen = new Set<string>();
+  return input.candidates.slice(0, maxBatch).map((candidate) => {
+    if (seen.has(candidate.sourceKey)) {
+      return {
+        candidate,
+        action: 'review',
+        changedFields: [],
+        reviewReason: 'duplicate-source-key',
+      };
+    }
+    seen.add(candidate.sourceKey);
+    const reviewReason = validateFellowshipRefreshCandidate(candidate);
+    if (reviewReason) return { candidate, action: 'review', changedFields: [], reviewReason };
+    const previous = existing.get(candidate.sourceKey);
+    if (!previous) return { candidate, action: 'create', changedFields: ['new-record'] };
+    if (previous.sourceFingerprint === candidate.sourceFingerprint) {
+      return { candidate, action: 'unchanged', changedFields: [] };
+    }
+    const changedFields: string[] = ['sourceFingerprint'];
+    const previousDeadline = oldDate(previous.deadline);
+    const nextDeadline = candidate.deadline?.getTime();
+    if (previousDeadline !== nextDeadline) changedFields.push('deadline');
+    if (previous.isAcceptingApplications !== candidate.isAcceptingApplications) {
+      changedFields.push('isAcceptingApplications');
+    }
+    const reopened =
+      candidate.isAcceptingApplications &&
+      Boolean(nextDeadline && nextDeadline >= now.getTime()) &&
+      (previous.isAcceptingApplications !== true ||
+        Boolean(previousDeadline && previousDeadline < now.getTime()));
+    return {
+      candidate,
+      action: 'update',
+      changedFields,
+      transition: reopened ? 'reopened' : undefined,
+    };
+  });
+}
+
+export function assertFellowshipRefreshGuards(options: {
+  target: string;
+  runtimeTarget?: string;
+  execute: boolean;
+  confirmation?: string;
+  restoreToken?: string;
+  prodConfirmation?: string;
+}): asserts options is typeof options & { target: FellowshipRefreshTarget } {
+  if (options.target !== 'beta' && options.target !== 'prod')
+    throw new Error('target must be beta or prod');
+  if (options.runtimeTarget && options.runtimeTarget !== options.target)
+    throw new Error('target does not match runtime environment');
+  if (!options.execute) return;
+  if (options.confirmation !== `execute-fellowship-refresh-${options.target}`) {
+    throw new Error('execute confirmation does not match target');
+  }
+  if (!options.restoreToken?.trim()) throw new Error('execute requires a backup/restore token');
+  if (
+    options.target === 'prod' &&
+    options.prodConfirmation !== 'confirm-production-fellowship-refresh'
+  ) {
+    throw new Error('production execute requires the production confirmation');
+  }
+}
+
+export function fellowshipRefreshAuditToken(restoreToken: string): string {
+  return createHash('sha256').update(`fellowship-refresh:${restoreToken}`).digest('hex');
+}
+
+export function aggregateFellowshipRefreshPlan(plan: FellowshipRefreshPlanItem[]) {
+  const count = (action: FellowshipRefreshPlanItem['action']) =>
+    plan.filter((item) => item.action === action).length;
+  return {
+    discovered: plan.length,
+    created: count('create'),
+    updated: count('update'),
+    unchanged: count('unchanged'),
+    reviewRequired: count('review'),
+    reopened: plan.filter((item) => item.transition === 'reopened').length,
+  };
+}


### PR DESCRIPTION
## Summary
- add a bounded recurring fellowship refresh planner and CLI
- require explicit target, environment, database, restore-token, and production confirmations before writes
- queue ambiguous changes for review and emit idempotent reopen events
- document the manual rollout posture with recurring scheduling disabled

## Validation
- focused fellowship tests: 37 passed
- full server suite: 2564 passed
- server TypeScript: passed
- lint: passed
- server build: passed
- security policy and secrets scan: passed
- dry-run CLI guard smoke with MONGODBURL unset: passed (stopped at required database guard)

## Deployment posture
- scheduler remains disabled
- no Beta or production database writes were performed