### PR TITLE
Persist saved program tracking

### DIFF
--- a/client/src/components/accounts/FavoritesManager.tsx
+++ b/client/src/components/accounts/FavoritesManager.tsx
@@ -14,10 +14,7 @@ import {
   normalizeAccountTrackingStorageOwner,
   persistAccountTrackingToStorage,
 } from '../../reducers/accountTrackingReducer';
-import {
-  createInitialFavoritesState,
-  favoritesReducer,
-} from '../../reducers/favoritesReducer';
+import { createInitialFavoritesState, favoritesReducer } from '../../reducers/favoritesReducer';
 import { BrowsableItem } from '../../types/browsable';
 import { createFellowship } from '../../utils/createFellowship';
 import BrowseListItem from '../shared/BrowseListItem';
@@ -65,6 +62,15 @@ const csvCell = (cell: unknown): string => {
   return `"${neutralizedValue.replace(/"/g, '""')}"`;
 };
 
+type ProgramTrackingRecord = {
+  note: string;
+  stage: FellowshipStage;
+  revision: number;
+  updatedAt: string;
+};
+
+type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+
 export const savedProgramDeadlineSummary = (
   fellowships: Fellowship[],
   now = new Date(),
@@ -101,58 +107,23 @@ const FavoritesManager = ({ variant = 'student', onSummaryChange }: FavoritesMan
   const [favState, favDispatch] = useReducer(favoritesReducer, undefined, () =>
     createInitialFavoritesState(),
   );
-  const {
-    favFellowships,
-    favFellowshipIds,
-  } = favState;
+  const { favFellowships, favFellowshipIds } = favState;
 
   const [tracking, trackingDispatch] = useReducer(accountTrackingReducer, undefined, () =>
     createInitialAccountTrackingState(),
   );
-  const {
-    fellowshipStage,
-    fellowshipNotes,
-    editingFellowshipNoteId,
-  } = tracking;
+  const { fellowshipStage, fellowshipNotes, editingFellowshipNoteId } = tracking;
 
   const [isLoading, setIsLoading] = useState(true);
   const [isFellowshipModalOpen, setIsFellowshipModalOpen] = useState(false);
   const [selectedFellowship, setSelectedFellowship] = useState<Fellowship | null>(null);
   const [showFellowshipExportMenu, setShowFellowshipExportMenu] = useState(false);
-  const [hydratedTrackingOwner, setHydratedTrackingOwner] = useState<string | undefined>(undefined);
+  const [saveStatuses, setSaveStatuses] = useState<Record<string, SaveStatus>>({});
   const fellowshipExportMenuRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!trackingStorageOwner) {
-      setHydratedTrackingOwner(undefined);
-      return;
-    }
-    trackingDispatch({
-      type: 'HYDRATE',
-      payload: loadAccountTrackingFromStorage(localStorage, trackingStorageOwner),
-    });
-    setHydratedTrackingOwner(trackingStorageOwner);
-  }, [trackingStorageOwner]);
-
-  useEffect(() => {
-    if (!trackingStorageOwner || hydratedTrackingOwner !== trackingStorageOwner) return;
-    persistAccountTrackingToStorage(
-      localStorage,
-      'fellowship-stages',
-      fellowshipStage,
-      trackingStorageOwner,
-    );
-  }, [fellowshipStage, hydratedTrackingOwner, trackingStorageOwner]);
-
-  useEffect(() => {
-    if (!trackingStorageOwner || hydratedTrackingOwner !== trackingStorageOwner) return;
-    persistAccountTrackingToStorage(
-      localStorage,
-      'fellowship-notes',
-      fellowshipNotes,
-      trackingStorageOwner,
-    );
-  }, [fellowshipNotes, hydratedTrackingOwner, trackingStorageOwner]);
+  const trackingRecordsRef = useRef<Record<string, ProgramTrackingRecord>>({});
+  const noteTimersRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+  const saveSequenceRef = useRef<Record<string, number>>({});
+  const saveQueueRef = useRef<Record<string, Promise<void>>>({});
 
   useEffect(() => {
     if (!showFellowshipExportMenu) return;
@@ -171,9 +142,43 @@ const FavoritesManager = ({ variant = 'student', onSummaryChange }: FavoritesMan
   const reloadFavorites = async () => {
     setIsLoading(true);
     try {
-      const response = await axios.get('/users/savedPrograms');
-      const rawFellowships = response.data.savedPrograms || [];
+      const [programResponse, trackingResponse] = await Promise.all([
+        axios.get('/users/savedPrograms'),
+        axios.get('/users/savedProgramTracking'),
+      ]);
+      const rawFellowships = programResponse.data.savedPrograms || [];
       const fellowships: Fellowship[] = rawFellowships.map((f: any) => createFellowship(f));
+      const serverTracking = (trackingResponse.data.savedProgramTracking || {}) as Record<
+        string,
+        ProgramTrackingRecord
+      >;
+      const cached = trackingStorageOwner
+        ? loadAccountTrackingFromStorage(localStorage, trackingStorageOwner)
+        : createInitialAccountTrackingState();
+      const mergedStage = { ...cached.fellowshipStage };
+      const notes: Record<string, string> = {};
+      for (const [programId, record] of Object.entries(serverTracking)) {
+        mergedStage[programId] = record.stage;
+        notes[programId] = record.note;
+      }
+      trackingRecordsRef.current = serverTracking;
+      trackingDispatch({
+        type: 'HYDRATE',
+        payload: { fellowshipStage: mergedStage, fellowshipNotes: notes },
+      });
+      for (const fellowship of fellowships) {
+        if (!serverTracking[fellowship.id] && cached.fellowshipStage[fellowship.id] === 'applied') {
+          void saveProgramTracking(fellowship.id, '', 'applied');
+        }
+      }
+      if (trackingStorageOwner) {
+        persistAccountTrackingToStorage(
+          localStorage,
+          'fellowship-stages',
+          mergedStage,
+          trackingStorageOwner,
+        );
+      }
       favDispatch({
         type: 'SET_FAV_FELLOWSHIPS',
         favFellowships: fellowships,
@@ -193,8 +198,8 @@ const FavoritesManager = ({ variant = 'student', onSummaryChange }: FavoritesMan
 
   useEffect(() => {
     reloadFavorites();
-
-  }, []);
+    return () => Object.values(noteTimersRef.current).forEach(clearTimeout);
+  }, [trackingStorageOwner]);
 
   const nextProgramDeadline = useMemo(
     () => savedProgramDeadlineSummary(favFellowships),
@@ -263,8 +268,70 @@ const FavoritesManager = ({ variant = 'student', onSummaryChange }: FavoritesMan
     }
   };
 
+  const saveProgramTracking = (fellowshipId: string, note: string, stage: FellowshipStage) => {
+    const sequence = (saveSequenceRef.current[fellowshipId] || 0) + 1;
+    saveSequenceRef.current[fellowshipId] = sequence;
+    setSaveStatuses((statuses) => ({ ...statuses, [fellowshipId]: 'saving' }));
+    const queued = (saveQueueRef.current[fellowshipId] || Promise.resolve())
+      .catch(() => undefined)
+      .then(async () => {
+        const current = trackingRecordsRef.current[fellowshipId];
+        try {
+          const response = await axios.put(`/users/savedProgramTracking/${fellowshipId}`, {
+            data: { tracking: { note, stage, revision: current?.revision || 0 } },
+          });
+          trackingRecordsRef.current[fellowshipId] = response.data.tracking;
+          if (saveSequenceRef.current[fellowshipId] !== sequence) return;
+          setSaveStatuses((statuses) => ({ ...statuses, [fellowshipId]: 'saved' }));
+          if (trackingStorageOwner) {
+            persistAccountTrackingToStorage(
+              localStorage,
+              'fellowship-stages',
+              { ...fellowshipStage, [fellowshipId]: stage },
+              trackingStorageOwner,
+            );
+          }
+        } catch (error: any) {
+          if (error?.response?.status === 409 && error.response.data?.current) {
+            const latest = error.response.data.current as ProgramTrackingRecord;
+            trackingRecordsRef.current[fellowshipId] = latest;
+            trackingDispatch({
+              type: 'HYDRATE',
+              payload: {
+                fellowshipStage: { ...fellowshipStage, [fellowshipId]: latest.stage },
+                fellowshipNotes: { ...fellowshipNotes, [fellowshipId]: latest.note },
+              },
+            });
+          }
+          if (saveSequenceRef.current[fellowshipId] === sequence) {
+            setSaveStatuses((statuses) => ({ ...statuses, [fellowshipId]: 'error' }));
+          }
+        }
+      });
+    saveQueueRef.current[fellowshipId] = queued;
+    return queued;
+  };
+
   const handleFellowshipStageChange = (fellowshipId: string, stage: FellowshipStage) => {
     trackingDispatch({ type: 'SET_FELLOWSHIP_STAGE', fellowshipId, stage });
+    void saveProgramTracking(fellowshipId, fellowshipNotes[fellowshipId] || '', stage);
+  };
+
+  const scheduleNoteSave = (fellowshipId: string, note: string) => {
+    clearTimeout(noteTimersRef.current[fellowshipId]);
+    setSaveStatuses((statuses) => ({ ...statuses, [fellowshipId]: 'idle' }));
+    noteTimersRef.current[fellowshipId] = setTimeout(() => {
+      void saveProgramTracking(fellowshipId, note, fellowshipStage[fellowshipId] || 'not_applied');
+    }, 700);
+  };
+
+  const flushNoteSave = (fellowshipId: string) => {
+    clearTimeout(noteTimersRef.current[fellowshipId]);
+    void saveProgramTracking(
+      fellowshipId,
+      fellowshipNotes[fellowshipId] || '',
+      fellowshipStage[fellowshipId] || 'not_applied',
+    );
   };
 
   const exportFellowshipsToCSV = () => {
@@ -290,16 +357,14 @@ const FavoritesManager = ({ variant = 'student', onSummaryChange }: FavoritesMan
       fellowship.deadline ? new Date(fellowship.deadline).toLocaleDateString() : 'No deadline',
       fellowship.awardAmount || '',
       fellowship.isAcceptingApplications ? 'Accepting' : 'Closed',
-      ...(
-        isProfessorVariant
-          ? []
-          : [
-              (fellowshipStage[fellowship.id] || 'not_applied') === 'applied'
-                ? 'Applied'
-                : 'Not Applied',
-              fellowshipNotes[fellowship.id] || '',
-            ]
-      ),
+      ...(isProfessorVariant
+        ? []
+        : [
+            (fellowshipStage[fellowship.id] || 'not_applied') === 'applied'
+              ? 'Applied'
+              : 'Not Applied',
+            fellowshipNotes[fellowship.id] || '',
+          ]),
       fellowship.applicationLink || '',
       fellowship.contactEmail || fellowship.contactName || '',
     ]);
@@ -340,16 +405,14 @@ const FavoritesManager = ({ variant = 'student', onSummaryChange }: FavoritesMan
       fellowship.deadline ? new Date(fellowship.deadline).toLocaleDateString() : 'No deadline',
       fellowship.awardAmount || '',
       fellowship.isAcceptingApplications ? 'Accepting' : 'Closed',
-      ...(
-        isProfessorVariant
-          ? []
-          : [
-              (fellowshipStage[fellowship.id] || 'not_applied') === 'applied'
-                ? 'Applied'
-                : 'Not Applied',
-              fellowshipNotes[fellowship.id] || '',
-            ]
-      ),
+      ...(isProfessorVariant
+        ? []
+        : [
+            (fellowshipStage[fellowship.id] || 'not_applied') === 'applied'
+              ? 'Applied'
+              : 'Not Applied',
+            fellowshipNotes[fellowship.id] || '',
+          ]),
       fellowship.applicationLink || '',
       fellowship.contactEmail || fellowship.contactName || '',
     ]);
@@ -402,12 +465,12 @@ const FavoritesManager = ({ variant = 'student', onSummaryChange }: FavoritesMan
         {favFellowships.length > 0 && (
           <div className="flex flex-wrap items-center gap-2 sm:justify-end">
             <div className="relative" ref={fellowshipExportMenuRef}>
-	              <button
-	                onClick={() => setShowFellowshipExportMenu(!showFellowshipExportMenu)}
-	                className="inline-flex min-h-[44px] items-center gap-1 rounded-md border border-green-200 bg-green-50 px-3 py-2 text-xs font-semibold text-green-700 transition-colors hover:bg-green-100"
-	              >
-	                Export
-	              </button>
+              <button
+                onClick={() => setShowFellowshipExportMenu(!showFellowshipExportMenu)}
+                className="inline-flex min-h-[44px] items-center gap-1 rounded-md border border-green-200 bg-green-50 px-3 py-2 text-xs font-semibold text-green-700 transition-colors hover:bg-green-100"
+              >
+                Export
+              </button>
               {showFellowshipExportMenu && (
                 <div className="absolute right-0 top-full mt-1 bg-[var(--yr-panel)] border border-[var(--yr-line)] rounded-md shadow-lg z-20 min-w-[180px]">
                   <button
@@ -415,7 +478,7 @@ const FavoritesManager = ({ variant = 'student', onSummaryChange }: FavoritesMan
                       exportFellowshipsToCSV();
                       setShowFellowshipExportMenu(false);
                     }}
-	                    className="min-h-[44px] w-full px-3 py-2 text-left text-sm hover:bg-[var(--yr-panel-muted)]"
+                    className="min-h-[44px] w-full px-3 py-2 text-left text-sm hover:bg-[var(--yr-panel-muted)]"
                   >
                     Export as CSV
                   </button>
@@ -424,7 +487,7 @@ const FavoritesManager = ({ variant = 'student', onSummaryChange }: FavoritesMan
                       exportFellowshipsToGoogleSheets();
                       setShowFellowshipExportMenu(false);
                     }}
-	                    className="min-h-[44px] w-full border-t border-[var(--yr-line)] px-3 py-2 text-left text-sm hover:bg-[var(--yr-panel-muted)]"
+                    className="min-h-[44px] w-full border-t border-[var(--yr-line)] px-3 py-2 text-left text-sm hover:bg-[var(--yr-panel-muted)]"
                   >
                     Open in Google Sheets
                   </button>
@@ -437,128 +500,146 @@ const FavoritesManager = ({ variant = 'student', onSummaryChange }: FavoritesMan
 
       {favFellowships.length > 0 ? (
         <ul>
-            {favFellowships.map((fellowship) => (
-              <li key={fellowship.id} className="mb-2">
-                <div className="flex flex-col gap-2 sm:flex-row sm:items-stretch">
-                  <div className="flex-1">
-                    <BrowseListItem
-                      item={fellowshipToBrowsable(fellowship)}
-                      isFavorite={favFellowshipIds.includes(fellowship.id)}
-                      onToggleFavorite={(event) => {
-                        event.stopPropagation();
-                        updateFellowshipFavorite(
-                          fellowship.id,
-                          !favFellowshipIds.includes(fellowship.id),
-                        );
-                      }}
-                      onOpenModal={() => openFellowshipModal(fellowship)}
-                    />
-                  </div>
-                  {!isProfessorVariant && (
-                    <div className="flex flex-row gap-1 sm:flex-col sm:justify-center">
-	                      <button
-	                        onClick={() =>
-	                          handleFellowshipStageChange(
-                            fellowship.id,
-                            (fellowshipStage[fellowship.id] || 'not_applied') === 'applied'
-                              ? 'not_applied'
-                              : 'applied',
-	                            )
-	                        }
-	                        aria-label={
-	                          (fellowshipStage[fellowship.id] || 'not_applied') === 'applied'
-	                            ? 'Mark as not applied'
-	                            : 'Mark as applied'
-	                        }
-	                        className={`inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded border p-2 transition-colors ${
-	                          (fellowshipStage[fellowship.id] || 'not_applied') === 'applied'
-	                            ? 'bg-green-50 border-green-300 text-green-600'
-	                            : 'border-[var(--yr-line)] text-gray-400 hover:text-gray-600 hover:border-[var(--yr-line-strong)]'
-                        }`}
-                        title={
-                          (fellowshipStage[fellowship.id] || 'not_applied') === 'applied'
-                            ? 'Mark as not applied'
-                            : 'Mark as applied'
-                        }
-                      >
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          width="16"
-                          height="16"
-                          viewBox="0 0 24 24"
-                          fill={
-                            (fellowshipStage[fellowship.id] || 'not_applied') === 'applied'
-                              ? 'currentColor'
-                              : 'none'
-                          }
-                          stroke="currentColor"
-                          strokeWidth="2"
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                        >
-                          <polyline points="20 6 9 17 4 12" />
-                        </svg>
-                      </button>
-	                      <button
-	                        onClick={() =>
-	                          trackingDispatch({
-                            type: 'TOGGLE_EDITING_FELLOWSHIP_NOTE',
-	                            fellowshipId: fellowship.id,
-	                          })
-	                        }
-	                        aria-label="Add note"
-	                        className={`inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded border p-2 transition-colors ${
-	                          fellowshipNotes[fellowship.id]
-	                            ? 'bg-yellow-50 border-yellow-300 text-yellow-600'
-	                            : 'border-[var(--yr-line)] text-gray-400 hover:text-gray-600 hover:border-[var(--yr-line-strong)]'
-                        }`}
-                        title="Add note"
-                      >
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          width="16"
-                          height="16"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                        >
-                          <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
-                          <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
-                        </svg>
-                      </button>
-                    </div>
-                  )}
+          {favFellowships.map((fellowship) => (
+            <li key={fellowship.id} className="mb-2">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-stretch">
+                <div className="flex-1">
+                  <BrowseListItem
+                    item={fellowshipToBrowsable(fellowship)}
+                    isFavorite={favFellowshipIds.includes(fellowship.id)}
+                    onToggleFavorite={(event) => {
+                      event.stopPropagation();
+                      updateFellowshipFavorite(
+                        fellowship.id,
+                        !favFellowshipIds.includes(fellowship.id),
+                      );
+                    }}
+                    onOpenModal={() => openFellowshipModal(fellowship)}
+                  />
                 </div>
-                {!isProfessorVariant && editingFellowshipNoteId === fellowship.id && (
-                  <div className="mt-1">
-                      <textarea
-                      aria-label={`Note for ${fellowship.title}`}
-                      value={fellowshipNotes[fellowship.id] || ''}
-                      onChange={(event) =>
+                {!isProfessorVariant && (
+                  <div className="flex flex-row gap-1 sm:flex-col sm:justify-center">
+                    <button
+                      onClick={() =>
+                        handleFellowshipStageChange(
+                          fellowship.id,
+                          (fellowshipStage[fellowship.id] || 'not_applied') === 'applied'
+                            ? 'not_applied'
+                            : 'applied',
+                        )
+                      }
+                      aria-label={
+                        (fellowshipStage[fellowship.id] || 'not_applied') === 'applied'
+                          ? 'Mark as not applied'
+                          : 'Mark as applied'
+                      }
+                      className={`inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded border p-2 transition-colors ${
+                        (fellowshipStage[fellowship.id] || 'not_applied') === 'applied'
+                          ? 'bg-green-50 border-green-300 text-green-600'
+                          : 'border-[var(--yr-line)] text-gray-400 hover:text-gray-600 hover:border-[var(--yr-line-strong)]'
+                      }`}
+                      title={
+                        (fellowshipStage[fellowship.id] || 'not_applied') === 'applied'
+                          ? 'Mark as not applied'
+                          : 'Mark as applied'
+                      }
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill={
+                          (fellowshipStage[fellowship.id] || 'not_applied') === 'applied'
+                            ? 'currentColor'
+                            : 'none'
+                        }
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      >
+                        <polyline points="20 6 9 17 4 12" />
+                      </svg>
+                    </button>
+                    <button
+                      onClick={() =>
                         trackingDispatch({
-                          type: 'SET_FELLOWSHIP_NOTE',
+                          type: 'TOGGLE_EDITING_FELLOWSHIP_NOTE',
                           fellowshipId: fellowship.id,
-                          value: event.target.value,
                         })
                       }
-                      placeholder="Add a note about this program..."
-                      rows={2}
-                      className="w-full text-sm border border-[var(--yr-line)] rounded-md px-3 py-2 focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
-                    />
+                      aria-label="Add note"
+                      className={`inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded border p-2 transition-colors ${
+                        fellowshipNotes[fellowship.id]
+                          ? 'bg-yellow-50 border-yellow-300 text-yellow-600'
+                          : 'border-[var(--yr-line)] text-gray-400 hover:text-gray-600 hover:border-[var(--yr-line-strong)]'
+                      }`}
+                      title="Add note"
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      >
+                        <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+                        <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+                      </svg>
+                    </button>
                   </div>
                 )}
-                {!isProfessorVariant &&
-                  fellowshipNotes[fellowship.id] &&
-                  editingFellowshipNoteId !== fellowship.id && (
-                    <p className="text-xs text-gray-500 mt-0.5 ml-1 italic truncate">
-                      Note: {fellowshipNotes[fellowship.id]}
-                    </p>
-                  )}
-              </li>
-            ))}
+              </div>
+              {!isProfessorVariant && editingFellowshipNoteId === fellowship.id && (
+                <div className="mt-1">
+                  <textarea
+                    aria-label={`Note for ${fellowship.title}`}
+                    value={fellowshipNotes[fellowship.id] || ''}
+                    onChange={(event) => {
+                      trackingDispatch({
+                        type: 'SET_FELLOWSHIP_NOTE',
+                        fellowshipId: fellowship.id,
+                        value: event.target.value,
+                      });
+                      scheduleNoteSave(fellowship.id, event.target.value);
+                    }}
+                    onBlur={() => flushNoteSave(fellowship.id)}
+                    maxLength={2000}
+                    placeholder="Add a note about this program..."
+                    rows={2}
+                    className="w-full text-sm border border-[var(--yr-line)] rounded-md px-3 py-2 focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+                  />
+                  <p
+                    className={`mt-1 text-xs ${
+                      saveStatuses[fellowship.id] === 'error' ? 'text-red-700' : 'text-gray-500'
+                    }`}
+                    role={saveStatuses[fellowship.id] === 'error' ? 'alert' : 'status'}
+                    aria-live="polite"
+                  >
+                    {saveStatuses[fellowship.id] === 'saving'
+                      ? 'Saving...'
+                      : saveStatuses[fellowship.id] === 'saved'
+                        ? 'Saved'
+                        : saveStatuses[fellowship.id] === 'error'
+                          ? 'Not saved. Check your connection or sign in again, then retry.'
+                          : ''}
+                  </p>
+                </div>
+              )}
+              {!isProfessorVariant &&
+                fellowshipNotes[fellowship.id] &&
+                editingFellowshipNoteId !== fellowship.id && (
+                  <p className="text-xs text-gray-500 mt-0.5 ml-1 italic truncate">
+                    Note: {fellowshipNotes[fellowship.id]}
+                  </p>
+                )}
+            </li>
+          ))}
         </ul>
       ) : (
         <div className="rounded-md border border-dashed border-[var(--yr-line-strong)] bg-[var(--yr-panel-muted)] p-5 text-center">

--- a/client/src/components/accounts/FavoritesManager.tsx
+++ b/client/src/components/accounts/FavoritesManager.tsx
@@ -118,12 +118,33 @@ const FavoritesManager = ({ variant = 'student', onSummaryChange }: FavoritesMan
   const [isFellowshipModalOpen, setIsFellowshipModalOpen] = useState(false);
   const [selectedFellowship, setSelectedFellowship] = useState<Fellowship | null>(null);
   const [showFellowshipExportMenu, setShowFellowshipExportMenu] = useState(false);
+  const [hydratedTrackingOwner, setHydratedTrackingOwner] = useState<string | undefined>(undefined);
   const [saveStatuses, setSaveStatuses] = useState<Record<string, SaveStatus>>({});
   const fellowshipExportMenuRef = useRef<HTMLDivElement>(null);
   const trackingRecordsRef = useRef<Record<string, ProgramTrackingRecord>>({});
   const noteTimersRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
   const saveSequenceRef = useRef<Record<string, number>>({});
   const saveQueueRef = useRef<Record<string, Promise<void>>>({});
+
+  useEffect(() => {
+    if (!trackingStorageOwner || hydratedTrackingOwner !== trackingStorageOwner) return;
+    persistAccountTrackingToStorage(
+      localStorage,
+      'fellowship-stages',
+      fellowshipStage,
+      trackingStorageOwner,
+    );
+  }, [fellowshipStage, hydratedTrackingOwner, trackingStorageOwner]);
+
+  useEffect(() => {
+    if (!trackingStorageOwner || hydratedTrackingOwner !== trackingStorageOwner) return;
+    persistAccountTrackingToStorage(
+      localStorage,
+      'fellowship-notes',
+      fellowshipNotes,
+      trackingStorageOwner,
+    );
+  }, [fellowshipNotes, hydratedTrackingOwner, trackingStorageOwner]);
 
   useEffect(() => {
     if (!showFellowshipExportMenu) return;
@@ -166,6 +187,7 @@ const FavoritesManager = ({ variant = 'student', onSummaryChange }: FavoritesMan
         type: 'HYDRATE',
         payload: { fellowshipStage: mergedStage, fellowshipNotes: notes },
       });
+      setHydratedTrackingOwner(trackingStorageOwner);
       for (const fellowship of fellowships) {
         if (!serverTracking[fellowship.id] && cached.fellowshipStage[fellowship.id] === 'applied') {
           void saveProgramTracking(fellowship.id, '', 'applied');
@@ -197,8 +219,12 @@ const FavoritesManager = ({ variant = 'student', onSummaryChange }: FavoritesMan
   };
 
   useEffect(() => {
+    if (!trackingStorageOwner) setHydratedTrackingOwner(undefined);
+    const noteTimers = noteTimersRef.current;
     reloadFavorites();
-    return () => Object.values(noteTimersRef.current).forEach(clearTimeout);
+    return () => Object.values(noteTimers).forEach(clearTimeout);
+    // reloadFavorites intentionally reruns only when the authenticated storage owner changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [trackingStorageOwner]);
 
   const nextProgramDeadline = useMemo(
@@ -631,6 +657,26 @@ const FavoritesManager = ({ variant = 'student', onSummaryChange }: FavoritesMan
                   </p>
                 </div>
               )}
+              {!isProfessorVariant &&
+                editingFellowshipNoteId !== fellowship.id &&
+                saveStatuses[fellowship.id] &&
+                saveStatuses[fellowship.id] !== 'idle' && (
+                  <p
+                    className={`mt-1 text-xs ${
+                      saveStatuses[fellowship.id] === 'error'
+                        ? 'text-red-700'
+                        : 'text-gray-500'
+                    }`}
+                    role={saveStatuses[fellowship.id] === 'error' ? 'alert' : 'status'}
+                    aria-live="polite"
+                  >
+                    {saveStatuses[fellowship.id] === 'saving'
+                      ? 'Saving...'
+                      : saveStatuses[fellowship.id] === 'saved'
+                        ? 'Saved'
+                        : 'Not saved. Check your connection or sign in again, then retry.'}
+                  </p>
+                )}
               {!isProfessorVariant &&
                 fellowshipNotes[fellowship.id] &&
                 editingFellowshipNoteId !== fellowship.id && (

--- a/client/src/components/accounts/__tests__/FavoritesManager.test.tsx
+++ b/client/src/components/accounts/__tests__/FavoritesManager.test.tsx
@@ -39,6 +39,7 @@ vi.mock('../../shared/FellowshipKanbanBoard', () => ({
 
 const mockedAxios = axios as unknown as {
   get: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
 };
 
 afterEach(() => {
@@ -48,6 +49,108 @@ afterEach(() => {
 });
 
 describe('FavoritesManager', () => {
+  const programId = '665f0b0c0b0c0b0c0b0c0b0c';
+
+  it('hydrates server-backed stage and note after reload', async () => {
+    mockedAxios.get.mockImplementation((url: string) => {
+      if (url === '/users/savedPrograms') {
+        return Promise.resolve({
+          data: { savedPrograms: [{ _id: programId, id: programId, title: 'Tracked Program' }] },
+        });
+      }
+      return Promise.resolve({
+        data: {
+          savedProgramTracking: {
+            [programId]: {
+              note: 'Ask about the faculty mentor.',
+              stage: 'applied',
+              revision: 3,
+              updatedAt: '2026-07-11T12:00:00.000Z',
+            },
+          },
+        },
+      });
+    });
+
+    render(
+      <MemoryRouter>
+        <FavoritesManager />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText('Tracked Program');
+    expect(screen.getByTitle('Mark as not applied')).toBeTruthy();
+    expect(screen.getByText('Note: Ask about the faculty mentor.')).toBeTruthy();
+  });
+
+  it('flushes a note on blur and announces success only after the server responds', async () => {
+    let resolveSave: (value: unknown) => void = () => {};
+    mockedAxios.get.mockImplementation((url: string) =>
+      Promise.resolve(
+        url === '/users/savedPrograms'
+          ? { data: { savedPrograms: [{ _id: programId, id: programId, title: 'Blur Program' }] } }
+          : { data: { savedProgramTracking: {} } },
+      ),
+    );
+    mockedAxios.put.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSave = resolve;
+      }),
+    );
+
+    render(
+      <MemoryRouter>
+        <FavoritesManager />
+      </MemoryRouter>,
+    );
+    await screen.findByText('Blur Program');
+    fireEvent.click(screen.getByTitle('Add note'));
+    const note = screen.getByRole('textbox', { name: 'Note for Blur Program' });
+    fireEvent.change(note, { target: { value: 'Draft application question' } });
+    fireEvent.blur(note);
+
+    expect(await screen.findByText('Saving...')).toBeTruthy();
+    expect(screen.queryByText('Saved')).toBeNull();
+    resolveSave({
+      data: {
+        tracking: {
+          note: 'Draft application question',
+          stage: 'not_applied',
+          revision: 1,
+          updatedAt: '2026-07-11T12:00:00.000Z',
+        },
+      },
+    });
+    expect(await screen.findByText('Saved')).toBeTruthy();
+    expect(mockedAxios.put).toHaveBeenCalledWith(`/users/savedProgramTracking/${programId}`, {
+      data: {
+        tracking: { note: 'Draft application question', stage: 'not_applied', revision: 0 },
+      },
+    });
+  });
+
+  it('announces an honest error when a tracking save fails', async () => {
+    mockedAxios.get.mockImplementation((url: string) =>
+      Promise.resolve(
+        url === '/users/savedPrograms'
+          ? { data: { savedPrograms: [{ _id: programId, id: programId, title: 'Error Program' }] } }
+          : { data: { savedProgramTracking: {} } },
+      ),
+    );
+    mockedAxios.put.mockRejectedValue({ response: { status: 401 } });
+
+    render(
+      <MemoryRouter>
+        <FavoritesManager />
+      </MemoryRouter>,
+    );
+    await screen.findByText('Error Program');
+    fireEvent.click(screen.getByTitle('Mark as applied'));
+    expect(
+      await screen.findByText('Not saved. Check your connection or sign in again, then retry.'),
+    ).toBeTruthy();
+  });
+
   it('keeps date-only saved program deadlines visible through the due date', () => {
     expect(
       savedProgramDeadlineSummary(

--- a/server/src/controllers/userController.ts
+++ b/server/src/controllers/userController.ts
@@ -23,6 +23,8 @@ import {
   pruneSavedPathwayPlansForExistingPathways,
   updateSavedPathwayPlan as updateSavedPathwayPlanService,
   deleteSavedPathwayPlan as deleteSavedPathwayPlanService,
+  getSavedProgramTracking as getSavedProgramTrackingService,
+  updateSavedProgramTracking as updateSavedProgramTrackingService,
 } from '../services/userService';
 import { publicProgramForReader } from './programPayload';
 import { isPublicHttpUrl } from '../utils/urlSafety';
@@ -518,6 +520,39 @@ export const removeSavedPrograms = async (request: Request, response: Response) 
   } catch (error: any) {
     console.error('Saved program removal failed:', sanitizeLogValue(error));
     sendAccountMutationError(response, error, 'Failed to remove saved programs');
+  }
+};
+
+export const getSavedProgramTracking = async (request: Request, response: Response) => {
+  try {
+    const currentUser = request.user as { netId?: string };
+    const savedProgramTracking = await getSavedProgramTrackingService(currentUser.netId);
+    setPrivateAccountResponseHeaders(response);
+    response.status(200).json({ savedProgramTracking });
+  } catch (error: any) {
+    console.error('Saved program tracking fetch failed:', sanitizeLogValue(error));
+    sendPrivateAccountError(response, error, 'Failed to fetch saved program tracking');
+  }
+};
+
+export const updateSavedProgramTracking = async (request: Request, response: Response) => {
+  try {
+    const currentUser = request.user as { netId?: string };
+    const tracking = await updateSavedProgramTrackingService(
+      currentUser.netId,
+      request.params.programId,
+      request.body?.data?.tracking || request.body?.tracking || {},
+    );
+    setPrivateAccountResponseHeaders(response);
+    response.status(200).json({ tracking });
+  } catch (error: any) {
+    console.error('Saved program tracking update failed:', sanitizeLogValue(error));
+    if (error?.status === 409 && error.current) {
+      setPrivateAccountResponseHeaders(response);
+      response.status(409).json({ error: error.message, current: error.current });
+      return;
+    }
+    sendPrivateAccountError(response, error, 'Failed to update saved program tracking');
   }
 };
 

--- a/server/src/models/user.ts
+++ b/server/src/models/user.ts
@@ -142,6 +142,10 @@ const userSchema = new mongoose.Schema(
       type: mongoose.Schema.Types.Mixed,
       default: {},
     },
+    savedProgramTracking: {
+      type: mongoose.Schema.Types.Mixed,
+      default: {},
+    },
     publications: {
       type: [publicationSchema],
       default: [],

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -213,6 +213,13 @@ router.delete(
 
 router.get('/savedProgramIds', isAuthenticated, userController.getSavedProgramIds);
 router.get('/savedPrograms', isAuthenticated, userController.getSavedPrograms);
+router.get('/savedProgramTracking', isAuthenticated, userController.getSavedProgramTracking);
+router.put(
+  '/savedProgramTracking/:programId',
+  isAuthenticated,
+  validateObjectId('programId'),
+  userController.updateSavedProgramTracking,
+);
 router.put(
   '/savedPrograms',
   isAuthenticated,

--- a/server/src/services/__tests__/userService.test.ts
+++ b/server/src/services/__tests__/userService.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import mongoose from 'mongoose';
 import {
   MAX_SAVED_PATHWAY_NOTE_LENGTH,
+  MAX_SAVED_PROGRAM_NOTE_LENGTH,
   buildCaseInsensitiveNetidFilter,
   buildSavedPathwayPlanUnsetForIds,
   buildSavedPathwayPlansExport,
@@ -10,6 +11,7 @@ import {
   normalizeUserLookupObjectId,
   pruneSavedPathwayPlansForExistingPathways,
   sanitizeSavedPathwayPlanForStorage,
+  sanitizeSavedProgramTrackingForResponse,
   type SavedPathwayPlanInput,
 } from '../userService';
 import type { PathwaySearchHit } from '../pathwaySearchService';
@@ -88,6 +90,44 @@ describe('normalizeUserLookupObjectId', () => {
         toString: () => '665f0b0c0b0c0b0c0b0c0b0c',
       }),
     ).toBeNull();
+  });
+});
+
+describe('sanitizeSavedProgramTrackingForResponse', () => {
+  it('returns only bounded records keyed by canonical program ids', () => {
+    const id = '665f0b0c0b0c0b0c0b0c0b0c';
+    expect(
+      sanitizeSavedProgramTrackingForResponse({
+        [id]: {
+          note: 'x'.repeat(MAX_SAVED_PROGRAM_NOTE_LENGTH + 20),
+          stage: 'applied',
+          revision: 4,
+          updatedAt: '2026-07-11T12:00:00.000Z',
+        },
+        '__proto__.bad': { note: 'private', stage: 'applied' },
+      }),
+    ).toEqual({
+      [id]: {
+        note: 'x'.repeat(MAX_SAVED_PROGRAM_NOTE_LENGTH),
+        stage: 'applied',
+        revision: 4,
+        updatedAt: '2026-07-11T12:00:00.000Z',
+      },
+    });
+  });
+
+  it('normalizes malformed stored metadata without exposing extra fields', () => {
+    const id = '665f0b0c0b0c0b0c0b0c0b0c';
+    expect(
+      sanitizeSavedProgramTrackingForResponse({
+        [id]: { note: 12, stage: 'admin', revision: -1, updatedAt: 'bad', secret: 'no' },
+      })[id],
+    ).toEqual({
+      note: '',
+      stage: 'not_applied',
+      revision: 0,
+      updatedAt: new Date(0).toISOString(),
+    });
   });
 });
 

--- a/server/src/services/userService.ts
+++ b/server/src/services/userService.ts
@@ -36,10 +36,59 @@ const MAX_USER_UPDATE_VALUE_DEPTH = 20;
 const MAX_USER_UPDATE_VALUE_ARRAY_ITEMS = 200;
 const MAX_USER_UPDATE_VALUE_OBJECT_KEYS = 200;
 export const MAX_SAVED_PATHWAY_NOTE_LENGTH = 5000;
+export const MAX_SAVED_PROGRAM_NOTE_LENGTH = 2000;
 const NETID_LOOKUP_RE = /^[A-Za-z0-9]{2,12}$/;
 const USER_UPDATE_OPERATORS = new Set(['$set', '$unset', '$addToSet']);
 const USER_UPDATE_PATH_SEGMENT_RE = /^[A-Za-z0-9_-]+$/;
 type FavoriteObjectIdArrayField = 'favListings' | 'favFellowships' | 'favPathways';
+
+export interface SavedProgramTrackingInput {
+  note?: unknown;
+  stage?: unknown;
+  revision?: unknown;
+}
+
+export interface SavedProgramTrackingItem {
+  note: string;
+  stage: 'not_applied' | 'applied';
+  revision: number;
+  updatedAt: string;
+}
+
+const sanitizeSavedProgramTrackingItem = (value: unknown): SavedProgramTrackingItem | undefined => {
+  if (!isPlainRecord(value)) return undefined;
+  const revision =
+    Number.isSafeInteger(value.revision) && Number(value.revision) >= 0
+      ? Number(value.revision)
+      : 0;
+  const updatedAt =
+    typeof value.updatedAt === 'string' && !Number.isNaN(Date.parse(value.updatedAt))
+      ? new Date(value.updatedAt).toISOString()
+      : new Date(0).toISOString();
+  return {
+    note: typeof value.note === 'string' ? value.note.slice(0, MAX_SAVED_PROGRAM_NOTE_LENGTH) : '',
+    stage: value.stage === 'applied' ? 'applied' : 'not_applied',
+    revision,
+    updatedAt,
+  };
+};
+
+export const sanitizeSavedProgramTrackingForResponse = (
+  value: unknown,
+): Record<string, SavedProgramTrackingItem> => {
+  if (!isPlainRecord(value)) return {};
+  const result: Record<string, SavedProgramTrackingItem> = {};
+  for (const [programId, item] of Object.entries(value).slice(0, MAX_ACCOUNT_MUTATION_IDS)) {
+    try {
+      const key = normalizeObjectIdStringForUserMutation(programId, 'program');
+      const sanitized = sanitizeSavedProgramTrackingItem(item);
+      if (sanitized) result[key] = sanitized;
+    } catch {
+      continue;
+    }
+  }
+  return result;
+};
 
 const recordFavoriteCounterSideEffect = async (
   label: string,
@@ -114,14 +163,13 @@ const sanitizeSavedPathwayChecklistKey = (key: unknown): string | undefined => {
   return trimmed.replace(/^\$+/, '_').replace(/\./g, '_');
 };
 
-export function sanitizeSavedPathwayPlanForStorage(
-  plan: unknown,
-): Required<SavedPathwayPlanInput> {
-  const candidate =
-    plan && typeof plan === 'object' ? (plan as SavedPathwayPlanInput) : {};
+export function sanitizeSavedPathwayPlanForStorage(plan: unknown): Required<SavedPathwayPlanInput> {
+  const candidate = plan && typeof plan === 'object' ? (plan as SavedPathwayPlanInput) : {};
   const checklist: Record<string, boolean> = {};
   const rawChecklist =
-    candidate.checklist && typeof candidate.checklist === 'object' && !Array.isArray(candidate.checklist)
+    candidate.checklist &&
+    typeof candidate.checklist === 'object' &&
+    !Array.isArray(candidate.checklist)
       ? candidate.checklist
       : {};
   let checklistCount = 0;
@@ -158,8 +206,7 @@ export function sanitizeSavedPathwayPlanForStorage(
   }
 
   return {
-    intent:
-      candidate.intent && PLANNING_INTENTS.has(candidate.intent) ? candidate.intent : 'later',
+    intent: candidate.intent && PLANNING_INTENTS.has(candidate.intent) ? candidate.intent : 'later',
     stage: candidate.stage && PLANNING_STAGES.has(candidate.stage) ? candidate.stage : 'saved',
     note:
       typeof candidate.note === 'string'
@@ -173,7 +220,11 @@ export function sanitizeSavedPathwayPlanForStorage(
 export function sanitizeSavedPathwayPlansForResponse(
   savedPathwayPlans: unknown,
 ): Record<string, Required<SavedPathwayPlanInput>> {
-  if (!savedPathwayPlans || typeof savedPathwayPlans !== 'object' || Array.isArray(savedPathwayPlans)) {
+  if (
+    !savedPathwayPlans ||
+    typeof savedPathwayPlans !== 'object' ||
+    Array.isArray(savedPathwayPlans)
+  ) {
     return {};
   }
 
@@ -228,12 +279,11 @@ const exportTextWithoutDirectContact = (value: unknown): string =>
 const exportUserTextForSpreadsheet = (value: unknown): string =>
   safeSpreadsheetCell(String(value || ''));
 
-const exportChecklistForSpreadsheet = (checklist: Record<string, boolean>): Record<string, boolean> =>
+const exportChecklistForSpreadsheet = (
+  checklist: Record<string, boolean>,
+): Record<string, boolean> =>
   Object.fromEntries(
-    Object.entries(checklist).map(([key, value]) => [
-      exportUserTextForSpreadsheet(key),
-      value,
-    ]),
+    Object.entries(checklist).map(([key, value]) => [exportUserTextForSpreadsheet(key), value]),
   );
 
 export const buildSavedPathwayPlansExport = (
@@ -291,9 +341,7 @@ export function pruneSavedPathwayPlansForExistingPathways(
   pathwayIds: Array<string | mongoose.Types.ObjectId>,
 ): Record<string, SavedPathwayPlanInput | undefined> {
   const validIds = new Set(
-    pathwayIds
-      .map((id) => normalizeObjectIdStringForUserMutation(id, 'pathway'))
-      .filter(Boolean),
+    pathwayIds.map((id) => normalizeObjectIdStringForUserMutation(id, 'pathway')).filter(Boolean),
   );
   return Object.fromEntries(
     Object.entries(savedPathwayPlans).filter(([pathwayId]) => validIds.has(pathwayId)),
@@ -396,10 +444,7 @@ const assertSafeUserUpdateDocument = (data: unknown): Record<string, unknown> =>
   return data;
 };
 
-export function normalizeObjectIdStringForUserMutation(
-  value: unknown,
-  fieldName: string,
-): string {
+export function normalizeObjectIdStringForUserMutation(value: unknown, fieldName: string): string {
   const id =
     typeof value === 'string'
       ? value.trim()
@@ -660,14 +705,20 @@ export const updateUser = async (id: any, data: any) => {
   const safeData = assertSafeUserUpdateDocument(data);
   const objectId = normalizeUserLookupObjectId(id);
   if (objectId) {
-    const user = await User.findByIdAndUpdate(objectId, safeData, { new: true, runValidators: true });
+    const user = await User.findByIdAndUpdate(objectId, safeData, {
+      new: true,
+      runValidators: true,
+    });
     if (!user) {
       throw new NotFoundError('User not found');
     }
     return user.toObject();
   } else {
     const netidFilter = buildCaseInsensitiveNetidFilter(id);
-    const user = await User.findOneAndUpdate(netidFilter, safeData, { new: true, runValidators: true });
+    const user = await User.findOneAndUpdate(netidFilter, safeData, {
+      new: true,
+      runValidators: true,
+    });
     if (!user) {
       throw new NotFoundError('User not found');
     }
@@ -796,9 +847,8 @@ export const addFavListings = async (id: any, Listings: [mongoose.Types.ObjectId
     const result = await addFavoriteObjectIdIfMissing(id, 'favListings', listingId);
     newUser = result.user;
     if (!result.added) continue;
-    await recordFavoriteCounterSideEffect(
-      'Listing favorite counter increment',
-      () => addFavorite(listingId.toHexString(), id),
+    await recordFavoriteCounterSideEffect('Listing favorite counter increment', () =>
+      addFavorite(listingId.toHexString(), id),
     );
   }
 
@@ -818,9 +868,8 @@ export const deleteFavListings = async (id: any, removedListings: [mongoose.Type
     const result = await removeFavoriteObjectIdIfPresent(id, 'favListings', listingId);
     newUser = result.user;
     if (!result.removed) continue;
-    await recordFavoriteCounterSideEffect(
-      'Listing favorite counter decrement',
-      () => removeFavorite(listingId.toHexString(), id),
+    await recordFavoriteCounterSideEffect('Listing favorite counter decrement', () =>
+      removeFavorite(listingId.toHexString(), id),
     );
   }
 
@@ -848,9 +897,8 @@ export const addFavFellowships = async (id: any, fellowships: mongoose.Types.Obj
     const result = await addFavoriteObjectIdIfMissing(id, 'favFellowships', fellowshipId);
     newUser = result.user;
     if (!result.added) continue;
-    await recordFavoriteCounterSideEffect(
-      'Fellowship favorite counter increment',
-      () => addFellowshipFavorite(fellowshipId.toHexString()),
+    await recordFavoriteCounterSideEffect('Fellowship favorite counter increment', () =>
+      addFellowshipFavorite(fellowshipId.toHexString()),
     );
   }
 
@@ -873,26 +921,101 @@ export const deleteFavFellowships = async (
     const result = await removeFavoriteObjectIdIfPresent(id, 'favFellowships', fellowshipId);
     newUser = result.user;
     if (!result.removed) continue;
-    await recordFavoriteCounterSideEffect(
-      'Fellowship favorite counter decrement',
-      () => removeFellowshipFavorite(fellowshipId.toHexString()),
+    await recordFavoriteCounterSideEffect('Fellowship favorite counter decrement', () =>
+      removeFellowshipFavorite(fellowshipId.toHexString()),
     );
   }
 
   newUser = await removeFavoriteObjectIdsWithoutCounters(id, 'favFellowships', fellowshipIds);
+  if (fellowshipIds.length > 0) {
+    await updateUser(id, {
+      $unset: Object.fromEntries(
+        fellowshipIds.map((programId) => [`savedProgramTracking.${programId.toHexString()}`, '']),
+      ),
+    });
+  }
 
   return newUser;
 };
 
 export const clearFavFellowships = async (id: any) => {
-  const newUser = await updateUser(id, { favFellowships: [] });
+  const newUser = await updateUser(id, { favFellowships: [], savedProgramTracking: {} });
 
   return newUser;
 };
 
+export const getSavedProgramTracking = async (id: any) => {
+  const user = await readUser(id);
+  const savedIds = new Set(
+    storedObjectIdStringsForUserMutation(user.favFellowships, 'favFellowships'),
+  );
+  return Object.fromEntries(
+    Object.entries(sanitizeSavedProgramTrackingForResponse(user.savedProgramTracking)).filter(
+      ([programId]) => savedIds.has(programId),
+    ),
+  );
+};
+
+export const updateSavedProgramTracking = async (
+  id: any,
+  programId: string,
+  input: SavedProgramTrackingInput,
+): Promise<SavedProgramTrackingItem> => {
+  const programKey = normalizeObjectIdStringForUserMutation(programId, 'program');
+  if (!isPlainRecord(input)) throw badRequestError('Invalid program tracking payload');
+  if (typeof input.note !== 'string' || input.note.length > MAX_SAVED_PROGRAM_NOTE_LENGTH) {
+    throw badRequestError(
+      `Program note must be at most ${MAX_SAVED_PROGRAM_NOTE_LENGTH} characters`,
+    );
+  }
+  if (input.stage !== 'not_applied' && input.stage !== 'applied') {
+    throw badRequestError('Invalid program tracking stage');
+  }
+  if (!Number.isSafeInteger(input.revision) || Number(input.revision) < 0) {
+    throw badRequestError('Invalid program tracking revision');
+  }
+
+  const expectedRevision = Number(input.revision);
+  const next: SavedProgramTrackingItem = {
+    note: input.note,
+    stage: input.stage,
+    revision: expectedRevision + 1,
+    updatedAt: new Date().toISOString(),
+  };
+  const revisionPath = `savedProgramTracking.${programKey}.revision`;
+  const filter: Record<string, unknown> = {
+    ...userLookupFilterForMutation(id),
+    favFellowships: new mongoose.Types.ObjectId(programKey),
+    ...(expectedRevision === 0
+      ? { $or: [{ [revisionPath]: 0 }, { [revisionPath]: { $exists: false } }] }
+      : { [revisionPath]: expectedRevision }),
+  };
+  const user = await User.findOneAndUpdate(
+    filter,
+    { $set: { [`savedProgramTracking.${programKey}`]: next } },
+    { new: true, runValidators: true },
+  );
+  if (user) return next;
+
+  const existing = await User.findOne(userLookupFilterForMutation(id)).lean();
+  if (!existing) throw new NotFoundError('User not found');
+  const savedIds = new Set(
+    storedObjectIdStringsForUserMutation(existing.favFellowships, 'favFellowships'),
+  );
+  if (!savedIds.has(programKey)) throw new NotFoundError('Saved program not found');
+  const error: any = new Error('Program tracking changed in another session');
+  error.status = 409;
+  error.current = sanitizeSavedProgramTrackingForResponse(existing.savedProgramTracking)[
+    programKey
+  ];
+  throw error;
+};
+
 export const addFavPathways = async (id: any, pathways: [mongoose.Types.ObjectId]) => {
   const pathwayIds = normalizeObjectIdsForUserMutation(pathways, 'favPathways');
-  const visiblePathways = await getPathwaysByIds(pathwayIds.map((pathwayId) => pathwayId.toHexString()));
+  const visiblePathways = await getPathwaysByIds(
+    pathwayIds.map((pathwayId) => pathwayId.toHexString()),
+  );
   const visiblePathwayIds = normalizeObjectIdsForUserMutation(
     visiblePathways.map((pathway) => pathway._id),
     'favPathways',
@@ -907,10 +1030,7 @@ export const addFavPathways = async (id: any, pathways: [mongoose.Types.ObjectId
   return newUser;
 };
 
-export const deleteFavPathways = async (
-  id: any,
-  removedPathways: [mongoose.Types.ObjectId],
-) => {
+export const deleteFavPathways = async (id: any, removedPathways: [mongoose.Types.ObjectId]) => {
   const pathwayIds = normalizeObjectIdsForUserMutation(removedPathways, 'favPathways');
   const newUser = await removeSavedPathwayIdsAndPlans(id, pathwayIds);
 

--- a/server/src/services/userService.ts
+++ b/server/src/services/userService.ts
@@ -279,9 +279,7 @@ const exportTextWithoutDirectContact = (value: unknown): string =>
 const exportUserTextForSpreadsheet = (value: unknown): string =>
   safeSpreadsheetCell(String(value || ''));
 
-const exportChecklistForSpreadsheet = (
-  checklist: Record<string, boolean>,
-): Record<string, boolean> =>
+const exportChecklistForSpreadsheet = (checklist: Record<string, boolean>): Record<string, boolean> =>
   Object.fromEntries(
     Object.entries(checklist).map(([key, value]) => [exportUserTextForSpreadsheet(key), value]),
   );
@@ -1013,9 +1011,7 @@ export const updateSavedProgramTracking = async (
 
 export const addFavPathways = async (id: any, pathways: [mongoose.Types.ObjectId]) => {
   const pathwayIds = normalizeObjectIdsForUserMutation(pathways, 'favPathways');
-  const visiblePathways = await getPathwaysByIds(
-    pathwayIds.map((pathwayId) => pathwayId.toHexString()),
-  );
+  const visiblePathways = await getPathwaysByIds(pathwayIds.map((pathwayId) => pathwayId.toHexString()));
   const visiblePathwayIds = normalizeObjectIdsForUserMutation(
     visiblePathways.map((pathway) => pathway._id),
     'favPathways',


### PR DESCRIPTION
## Summary

- persist saved-program notes and application stage on the user record
- expose authenticated read/update routes with optimistic revision conflict handling
- hydrate the account dashboard from server state and retain bounded owner-scoped local migration
- surface saving, saved, and failed states for both notes and stage changes
- remove tracking records when their saved program is removed

## Schema

Adds `User.savedProgramTracking` as a mixed object keyed by program ObjectId string. Each value is normalized to:

```ts
{
  note: string; // max 2,000 characters
  stage: 'not_applied' | 'applied';
  revision: number;
  updatedAt: string; // ISO timestamp
}
```

No migration or external data mutation is required. Existing saved programs begin without a tracking entry; bounded owner-scoped local application-stage state is migrated on account load.

## Validation

- focused FavoritesManager: 9 tests passed
- focused user service/controller/routes: 74 tests passed
- full client: 95 files, 776 tests passed
- full server: 224 files, 2,555 tests passed
- standalone client and server TypeScript checks passed
- lint passed with zero warnings
- client and server production builds passed
- security policy and secrets scan passed
- `git diff --check` passed
