### PR TITLE
Guard research activity attribution

### DIFF
--- a/client/src/pages/labDetail.tsx
+++ b/client/src/pages/labDetail.tsx
@@ -1050,6 +1050,7 @@ const LabDetail = () => {
     researchEntity,
     members,
     researchActivityLinks: payloadResearchActivityLinks = [],
+    earlierResearchActivityLinks = [],
     scholarlyLinks = [],
     memberScholarlyLinks = [],
     recentPapers = [],
@@ -1237,6 +1238,16 @@ const LabDetail = () => {
                   emptyText="No professor research activity is attached yet."
                 />
               </div>
+            </section>
+          )}
+
+          {earlierResearchActivityLinks.length > 0 && (
+            <section>
+              <SectionHeading>Earlier work by listed professors</SectionHeading>
+              <LabPapersList
+                papers={earlierResearchActivityLinks.slice(0, 3)}
+                emptyText="No earlier work is attached."
+              />
             </section>
           )}
 

--- a/client/src/types/labDetail.ts
+++ b/client/src/types/labDetail.ts
@@ -174,6 +174,7 @@ export interface LabDetailPayload {
   researchEntity?: ResearchEntity;
   members: LabMember[];
   researchActivityLinks?: LabResearchActivityLink[];
+  earlierResearchActivityLinks?: LabResearchActivityLink[];
   scholarlyLinks?: LabScholarlyLink[];
   memberScholarlyLinks?: LabScholarlyLink[];
   recentPapers: LabPaper[];

--- a/client/src/types/researchEntity.ts
+++ b/client/src/types/researchEntity.ts
@@ -177,6 +177,7 @@ export function normalizeResearchEntityDetailPayload(
     group: normalizedGroup,
     members: payload.members ?? [],
     researchActivityLinks: payload.researchActivityLinks ?? [],
+    earlierResearchActivityLinks: payload.earlierResearchActivityLinks ?? [],
     scholarlyLinks: payload.scholarlyLinks ?? [],
     memberScholarlyLinks: payload.memberScholarlyLinks ?? [],
     recentPapers: payload.recentPapers ?? [],

--- a/server/package.json
+++ b/server/package.json
@@ -68,6 +68,7 @@
     "scholarly-links:quality-audit": "tsx src/scripts/paperQualityAudit.ts",
     "scholarly-links:suppression-audit": "tsx src/scripts/scholarlyLinkSuppressionAudit.ts",
     "scholarly-links:provenance-audit": "tsx src/scripts/scholarlyLinkProvenanceAudit.ts",
+    "scholarly-links:integrity-audit": "tsx src/scripts/researchActivityIntegrityAudit.ts",
     "scholarly-links:repair-official-profile-pointers": "tsx src/scripts/repairOfficialProfilePublicationPointers.ts",
     "scraper:integrity-gate": "tsx src/scripts/scraperIntegrityGate.ts",
     "scraper:integrity-duplicates-review": "tsx src/scripts/scraperIntegrityDuplicateReview.ts",

--- a/server/src/scripts/researchActivityIntegrityAudit.ts
+++ b/server/src/scripts/researchActivityIntegrityAudit.ts
@@ -1,0 +1,142 @@
+import dotenv from 'dotenv';
+import mongoose from 'mongoose';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { initializeConnections } from '../db/connections';
+import { ResearchEntity } from '../models/researchEntity';
+import { ResearchGroupMember } from '../models/researchGroupMember';
+import { ResearchScholarlyAttribution } from '../models/researchScholarlyAttribution';
+import { ResearchScholarlyLink } from '../models/researchScholarlyLink';
+import {
+  evaluateResearchActivityIntegrity,
+  researchActivityIntegrityCounts,
+  type ResearchActivityCandidate,
+} from '../services/researchActivityIntegrity';
+import { serializedDocumentId } from '../utils/idSerialization';
+import { sanitizeLogValue } from '../utils/logSanitizer';
+import { assertScriptApplyAllowed } from './scriptWriteGuards';
+
+dotenv.config();
+
+const __filename = fileURLToPath(import.meta.url);
+const id = (value: unknown) => serializedDocumentId(value) || '';
+
+export interface ResearchActivityIntegrityAuditReport {
+  generatedAt: string;
+  mode: 'read-only';
+  counts: ReturnType<typeof researchActivityIntegrityCounts>;
+  entitiesEvaluated: number;
+  entitiesWithExcludedConflicts: number;
+  entitiesWithDuplicates: number;
+  entitiesWithEarlierWork: number;
+}
+
+export const buildResearchActivityIntegrityAuditReport = (
+  decisionsByEntity: Map<string, ReturnType<typeof evaluateResearchActivityIntegrity>>,
+  generatedAt = new Date(),
+): ResearchActivityIntegrityAuditReport => {
+  const decisions = [...decisionsByEntity.values()].flat();
+  return {
+    generatedAt: generatedAt.toISOString(),
+    mode: 'read-only',
+    counts: researchActivityIntegrityCounts(decisions),
+    entitiesEvaluated: decisionsByEntity.size,
+    entitiesWithExcludedConflicts: [...decisionsByEntity.values()].filter((rows) =>
+      rows.some((row) => row.disposition === 'identity_conflict'),
+    ).length,
+    entitiesWithDuplicates: [...decisionsByEntity.values()].filter((rows) =>
+      rows.some((row) => row.disposition === 'duplicate'),
+    ).length,
+    entitiesWithEarlierWork: [...decisionsByEntity.values()].filter((rows) =>
+      rows.some((row) => row.disposition === 'earlier'),
+    ).length,
+  };
+};
+
+async function main() {
+  assertScriptApplyAllowed({
+    apply: false,
+    scriptName: 'researchActivityIntegrityAudit',
+    mongoUrl: process.env.MONGODBURL,
+  });
+  await initializeConnections();
+
+  const [attributions, links, members, entities] = await Promise.all([
+    ResearchScholarlyAttribution.find({ archived: { $ne: true } })
+      .select(
+        'scholarlyLinkId targetUserId relationshipBasis evidenceLabel confidence observedAt sourceName sourceUrl',
+      )
+      .lean(),
+    ResearchScholarlyLink.find({ archived: { $ne: true } })
+      .select('_id title url year venue externalIds discoveredVia destinationKind')
+      .lean(),
+    ResearchGroupMember.find({ archived: { $ne: true }, endedAt: { $exists: false } })
+      .select('researchEntityId researchGroupId userId startedAt endedAt')
+      .lean(),
+    ResearchEntity.find({ archived: { $ne: true } })
+      .select('_id name researchAreas methods shortDescription fullDescription')
+      .lean(),
+  ]);
+
+  const linksById = new Map(links.map((link: any) => [id(link._id), link]));
+  const entitiesById = new Map(entities.map((entity: any) => [id(entity._id), entity]));
+  const membershipsByUser = new Map<string, any[]>();
+  for (const member of members as any[]) {
+    const userId = id(member.userId);
+    if (!userId) continue;
+    membershipsByUser.set(userId, [...(membershipsByUser.get(userId) || []), member]);
+  }
+
+  const candidatesByEntity = new Map<string, ResearchActivityCandidate[]>();
+  for (const attribution of attributions as any[]) {
+    const link = linksById.get(id(attribution.scholarlyLinkId));
+    if (!link) continue;
+    for (const member of membershipsByUser.get(id(attribution.targetUserId)) || []) {
+      const entityId = id(member.researchEntityId || member.researchGroupId);
+      if (!entityId || !entitiesById.has(entityId)) continue;
+      const candidate: ResearchActivityCandidate = {
+        link,
+        relationshipBasis: attribution.relationshipBasis,
+        evidenceLabel: attribution.evidenceLabel,
+        confidence: attribution.confidence,
+        observedAt: attribution.observedAt,
+        sourceName: attribution.sourceName,
+        sourceUrl: attribution.sourceUrl,
+        appointmentStartedAt: member.startedAt,
+        appointmentEndedAt: member.endedAt,
+      };
+      candidatesByEntity.set(entityId, [...(candidatesByEntity.get(entityId) || []), candidate]);
+    }
+  }
+
+  const decisionsByEntity = new Map(
+    [...candidatesByEntity.entries()].map(([entityId, candidates]) => {
+      const entity: any = entitiesById.get(entityId);
+      return [
+        entityId,
+        evaluateResearchActivityIntegrity(candidates, [
+          entity?.name,
+          entity?.researchAreas,
+          entity?.methods,
+          entity?.shortDescription,
+          entity?.fullDescription,
+        ]),
+      ];
+    }),
+  );
+
+  console.log(
+    JSON.stringify(buildResearchActivityIntegrityAuditReport(decisionsByEntity), null, 2),
+  );
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  main()
+    .catch((error) => {
+      console.error('Failed to run research activity integrity audit:', sanitizeLogValue(error));
+      process.exitCode = 1;
+    })
+    .finally(async () => {
+      await mongoose.disconnect();
+    });
+}

--- a/server/src/services/__tests__/researchActivityIntegrity.test.ts
+++ b/server/src/services/__tests__/researchActivityIntegrity.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canonicalScholarlyWorkKey,
+  evaluateResearchActivityIntegrity,
+  researchActivityIntegrityCounts,
+} from '../researchActivityIntegrity';
+import { buildResearchActivityIntegrityAuditReport } from '../../scripts/researchActivityIntegrityAudit';
+
+describe('research activity integrity', () => {
+  it('excludes the known wrong-person military and veteran collision from an immunology lab', () => {
+    const [decision] = evaluateResearchActivityIntegrity(
+      [
+        {
+          memberDisplayId: 'faculty-public-key',
+          relationshipBasis: 'identity_authorship',
+          link: {
+            title: 'LGBT military personnel and veteran homelessness',
+            url: 'https://example.org/collision',
+            year: 2025,
+          },
+        },
+      ],
+      ['Immunology', 'T cell signaling and immune disease'],
+    );
+
+    expect(decision.disposition).toBe('identity_conflict');
+    expect(decision.reason).toBe('Topic conflict without persistent-author evidence');
+  });
+
+  it('retains cross-disciplinary work when persistent author identity evidence is present', () => {
+    const [decision] = evaluateResearchActivityIntegrity(
+      [
+        {
+          memberDisplayId: 'faculty-public-key',
+          relationshipBasis: 'orcid-record',
+          link: {
+            title: 'Machine learning models of immune cell signaling',
+            externalIds: {
+              doi: '10.1000/cross-disciplinary',
+              authorOrcids: ['0000-0001-0000-0000'],
+            },
+            year: 2025,
+          },
+        },
+      ],
+      ['Immunology', 'T cell signaling'],
+    );
+
+    expect(decision.disposition).toBe('current');
+  });
+
+  it('collapses DOI and versioned arXiv duplicates by canonical identity', () => {
+    const decisions = evaluateResearchActivityIntegrity(
+      [
+        { link: { title: 'DOI one', externalIds: { doi: 'https://doi.org/10.1000/SAME' } } },
+        { link: { title: 'DOI two', externalIds: { doi: '10.1000/same' } } },
+        { link: { title: 'Preprint one', externalIds: { arxivId: '2604.01023v2' } } },
+        { link: { title: 'Preprint two', url: 'https://arxiv.org/abs/2604.01023v3' } },
+      ],
+      [],
+    );
+
+    expect(decisions.map((decision) => decision.disposition)).toEqual([
+      'current',
+      'duplicate',
+      'current',
+      'duplicate',
+    ]);
+    expect(canonicalScholarlyWorkKey(decisions[0].candidate.link)).toBe('doi:10.1000/same');
+  });
+
+  it('separates work before a documented appointment without calling missing coverage inactive', () => {
+    const decisions = evaluateResearchActivityIntegrity(
+      [
+        { link: { title: 'Earlier paper', year: 2018 }, appointmentStartedAt: '2020-07-01' },
+        { link: { title: 'Unknown timing' } },
+      ],
+      [],
+    );
+
+    expect(decisions.map((decision) => decision.disposition)).toEqual(['earlier', 'current']);
+    expect(researchActivityIntegrityCounts(decisions)).toEqual({
+      current: 1,
+      earlier: 1,
+      identity_conflict: 0,
+      duplicate: 0,
+    });
+    expect(JSON.stringify(decisions)).not.toMatch(/inactive/i);
+  });
+
+  it('reports affected counts without titles, people, or entity identifiers', () => {
+    const decisions = evaluateResearchActivityIntegrity(
+      [
+        { link: { title: 'Veteran homelessness', url: 'https://example.org/wrong' } },
+        { link: { title: 'Earlier immunology', year: 2018 }, appointmentStartedAt: '2020-01-01' },
+      ],
+      ['Immunology'],
+    );
+    const report = buildResearchActivityIntegrityAuditReport(
+      new Map([['private-entity-id', decisions]]),
+      new Date('2026-07-11T12:00:00Z'),
+    );
+
+    expect(report).toEqual({
+      generatedAt: '2026-07-11T12:00:00.000Z',
+      mode: 'read-only',
+      counts: { current: 0, earlier: 1, identity_conflict: 1, duplicate: 0 },
+      entitiesEvaluated: 1,
+      entitiesWithExcludedConflicts: 1,
+      entitiesWithDuplicates: 0,
+      entitiesWithEarlierWork: 1,
+    });
+    expect(JSON.stringify(report)).not.toMatch(
+      /private-entity-id|Veteran homelessness|Earlier immunology/,
+    );
+  });
+});

--- a/server/src/services/__tests__/researchGroupService.test.ts
+++ b/server/src/services/__tests__/researchGroupService.test.ts
@@ -1399,6 +1399,75 @@ describe('listResearchEntityRelationshipPayload', () => {
 });
 
 describe('buildResearchActivityLinkPayload', () => {
+  it('keeps one canonical work when entity and member sources repeat the same DOI', () => {
+    const result = buildResearchActivityLinkPayload({
+      researchEntityId: 'entity-1',
+      entityScholarlyLinks: [
+        {
+          _id: 'entity-link',
+          title: 'Canonical paper',
+          url: 'https://doi.org/10.1000/SAME',
+          externalIds: { DOI: '10.1000/SAME' },
+        },
+      ],
+      memberScholarlyLinkPairs: [
+        {
+          memberDisplayId: 'member-1',
+          link: {
+            _id: 'member-link',
+            title: 'Canonical paper duplicate',
+            url: 'https://doi.org/10.1000/same',
+            externalIds: { doi: '10.1000/same' },
+          },
+        },
+      ],
+    });
+
+    expect(result.researchActivityLinks).toHaveLength(1);
+    expect(result.researchActivityLinks[0]).toEqual(
+      expect.objectContaining({ relationshipBasis: 'explicit_entity_link' }),
+    );
+  });
+
+  it('keeps earlier work separate and excludes an unsupported identity collision', () => {
+    const result = buildResearchActivityLinkPayload({
+      researchEntityId: 'entity-1',
+      entityTopicEvidence: ['Immunology and T cell signaling'],
+      memberScholarlyLinkPairs: [
+        {
+          memberDisplayId: 'member-1',
+          appointmentStartedAt: '2020-01-01',
+          link: {
+            _id: 'earlier',
+            title: 'Immune cell signaling',
+            url: 'https://doi.org/10.1000/earlier',
+            externalIds: { doi: '10.1000/earlier' },
+            year: 2018,
+          },
+        },
+        {
+          memberDisplayId: 'member-1',
+          link: {
+            _id: 'collision',
+            title: 'LGBT military personnel and veteran homelessness',
+            url: 'https://doi.org/10.1000/collision',
+            externalIds: { doi: '10.1000/collision' },
+            year: 2025,
+          },
+        },
+      ],
+    });
+
+    expect(result.researchActivityLinks).toEqual([]);
+    expect(result.earlierResearchActivityLinks).toEqual([
+      expect.objectContaining({
+        title: 'Immune cell signaling',
+        evidenceLabel:
+          'Earlier work by a listed professor, before the documented current appointment',
+      }),
+    ]);
+  });
+
   it('uses research scholarly links for entity and member research activity', () => {
     const result = buildResearchActivityLinkPayload({
       researchEntityId: 'entity-1',

--- a/server/src/services/researchActivityIntegrity.ts
+++ b/server/src/services/researchActivityIntegrity.ts
@@ -1,0 +1,173 @@
+const DOI_PREFIX_RE = /^https?:\/\/(?:dx\.)?doi\.org\//i;
+const ARXIV_PREFIX_RE = /^(?:https?:\/\/arxiv\.org\/(?:abs|pdf)\/|arxiv:\s*)/i;
+
+const normalizeIdentifier = (value: unknown): string =>
+  typeof value === 'string'
+    ? value
+        .trim()
+        .toLowerCase()
+        .replace(/[?#].*$/, '')
+        .replace(/\/+$/, '')
+    : '';
+
+export const canonicalScholarlyWorkKey = (link: Record<string, any>): string => {
+  const doiValue =
+    link.externalIds?.doi ||
+    link.externalIds?.DOI ||
+    link.doi ||
+    (DOI_PREFIX_RE.test(String(link.url || '')) ? link.url : undefined);
+  const doi = normalizeIdentifier(doiValue).replace(DOI_PREFIX_RE, '');
+  if (doi) return `doi:${doi}`;
+
+  const arxiv = normalizeIdentifier(
+    link.externalIds?.arxivId ||
+      link.externalIds?.arxiv ||
+      link.externalIds?.ARXIV ||
+      link.arxivId ||
+      link.url,
+  )
+    .replace(ARXIV_PREFIX_RE, '')
+    .replace(/v\d+$/, '')
+    .replace(/\.pdf$/, '');
+  if (/^(?:\d{4}\.\d{4,5}|[a-z-]+\/\d{7})$/i.test(arxiv)) return `arxiv:${arxiv}`;
+
+  for (const [prefix, value] of [
+    ['openalex', link.externalIds?.openAlexId],
+    ['pmid', link.externalIds?.pmid],
+    ['pmcid', link.externalIds?.pmcid],
+  ] as const) {
+    const normalized = normalizeIdentifier(value);
+    if (normalized) return `${prefix}:${normalized}`;
+  }
+
+  const url = normalizeIdentifier(link.url);
+  if (url) return `url:${url}`;
+  return `title:${normalizeIdentifier(link.title)}|year:${Number(link.year) || ''}`;
+};
+
+const TOPIC_FAMILIES: Record<string, readonly RegExp[]> = {
+  biomedical: [
+    /\b(?:immun(?:e|ity|ology)|cell|molecular|genom|protein|cancer|disease|pathogen|microbi|antibod|cytokine|t\s*cell)\w*\b/i,
+  ],
+  militarySocialPolicy: [
+    /\b(?:military|veteran|armed forces|homelessness|lgbtq?|sexual minorit|housing insecurity)\w*\b/i,
+  ],
+};
+
+const topicFamilies = (value: unknown): Set<string> => {
+  const text = Array.isArray(value) ? value.join(' ') : String(value || '');
+  return new Set(
+    Object.entries(TOPIC_FAMILIES)
+      .filter(([, patterns]) => patterns.some((pattern) => pattern.test(text)))
+      .map(([family]) => family),
+  );
+};
+
+const hasPersistentAuthorEvidence = (pair: ResearchActivityCandidate): boolean => {
+  const ids = pair.link.externalIds || {};
+  return Boolean(
+    ids.authorOrcids?.length ||
+    ids.authorOrcid ||
+    ids.orcid ||
+    pair.relationshipBasis?.toLowerCase().includes('orcid') ||
+    pair.relationshipBasis?.toLowerCase().includes('manual'),
+  );
+};
+
+export interface ResearchActivityCandidate {
+  link: Record<string, any>;
+  memberDisplayId?: unknown;
+  relationshipBasis?: string;
+  evidenceLabel?: string;
+  confidence?: number;
+  observedAt?: unknown;
+  sourceName?: string;
+  sourceUrl?: string;
+  appointmentStartedAt?: unknown;
+  appointmentEndedAt?: unknown;
+}
+
+export type ResearchActivityIntegrityDisposition =
+  | 'current'
+  | 'earlier'
+  | 'identity_conflict'
+  | 'duplicate';
+
+export interface ResearchActivityIntegrityDecision {
+  candidate: ResearchActivityCandidate;
+  disposition: ResearchActivityIntegrityDisposition;
+  reason?: string;
+  canonicalKey: string;
+}
+
+const validYear = (value: unknown): number | undefined => {
+  const year = Number(value);
+  return Number.isInteger(year) && year >= 1800 && year <= 2200 ? year : undefined;
+};
+
+const dateYear = (value: unknown): number | undefined => {
+  if (!value) return undefined;
+  const date = new Date(String(value));
+  return Number.isNaN(date.getTime()) ? undefined : date.getUTCFullYear();
+};
+
+export function evaluateResearchActivityIntegrity(
+  candidates: ResearchActivityCandidate[],
+  entityTopicEvidence: unknown,
+): ResearchActivityIntegrityDecision[] {
+  const entityFamilies = topicFamilies(entityTopicEvidence);
+  const seen = new Set<string>();
+
+  return candidates.map((candidate) => {
+    const canonicalKey = canonicalScholarlyWorkKey(candidate.link);
+    if (seen.has(canonicalKey)) {
+      return {
+        candidate,
+        disposition: 'duplicate',
+        reason: 'Same canonical work already shown',
+        canonicalKey,
+      };
+    }
+    seen.add(canonicalKey);
+
+    const paperFamilies = topicFamilies(
+      [candidate.link.title, candidate.link.venue, candidate.link.abstract].filter(Boolean),
+    );
+    // This is intentionally a conflict flag, not a relevance classifier. The
+    // audited collision is unusually specific; broader cross-field mismatch
+    // rules would hide legitimate interdisciplinary scholarship.
+    const topicConflict =
+      (entityFamilies.has('biomedical') && paperFamilies.has('militarySocialPolicy')) ||
+      (entityFamilies.has('militarySocialPolicy') && paperFamilies.has('biomedical'));
+    if (topicConflict && !hasPersistentAuthorEvidence(candidate)) {
+      return {
+        candidate,
+        disposition: 'identity_conflict',
+        reason: 'Topic conflict without persistent-author evidence',
+        canonicalKey,
+      };
+    }
+
+    const workYear = validYear(candidate.link.year);
+    const appointmentStartYear = dateYear(candidate.appointmentStartedAt);
+    if (workYear && appointmentStartYear && workYear < appointmentStartYear) {
+      return {
+        candidate,
+        disposition: 'earlier',
+        reason: 'Published before the documented current appointment',
+        canonicalKey,
+      };
+    }
+
+    return { candidate, disposition: 'current', canonicalKey };
+  });
+}
+
+export const researchActivityIntegrityCounts = (decisions: ResearchActivityIntegrityDecision[]) =>
+  decisions.reduce(
+    (counts, decision) => {
+      counts[decision.disposition] += 1;
+      return counts;
+    },
+    { current: 0, earlier: 0, identity_conflict: 0, duplicate: 0 },
+  );

--- a/server/src/services/researchGroupService.ts
+++ b/server/src/services/researchGroupService.ts
@@ -67,6 +67,11 @@ import { redactDirectContactInfo } from '../utils/contactRedaction';
 import { serializedDocumentId } from '../utils/idSerialization';
 import { studentPathwayMongoMatch } from './studentAccessPublicationPolicy';
 import { isApprovedPublicContactRoute } from './studentAccessPublicationPolicy';
+import {
+  canonicalScholarlyWorkKey,
+  evaluateResearchActivityIntegrity,
+  type ResearchActivityCandidate,
+} from './researchActivityIntegrity';
 
 const NON_LAB_CATEGORIES = new Set<string>([
   DepartmentCategory.SOCIAL_SCIENCES,
@@ -1678,12 +1683,14 @@ export function dedupeSameNameLeadMembers<T extends { user: any; role: string; r
 
 export function buildResearchActivityLinkPayload({
   researchEntityId,
+  entityTopicEvidence = [],
   entityLinkedPapers = [],
   memberPaperPairs = [],
   entityScholarlyLinks = [],
   memberScholarlyLinkPairs = [],
 }: {
   researchEntityId: unknown;
+  entityTopicEvidence?: unknown;
   entityLinkedPapers?: Array<Record<string, any>>;
   memberPaperPairs?: Array<{ paper: Record<string, any>; memberDisplayId?: unknown }>;
   entityScholarlyLinks?: Array<Record<string, any>>;
@@ -1696,9 +1703,12 @@ export function buildResearchActivityLinkPayload({
     observedAt?: unknown;
     sourceName?: string;
     sourceUrl?: string;
+    appointmentStartedAt?: unknown;
+    appointmentEndedAt?: unknown;
   }>;
 }) {
   const seen = new Set<string>();
+  const seenCanonicalWorks = new Set<string>();
   const uniqueKey = (basis: string, id: unknown, owner?: unknown) =>
     [basis, researchGroupDocumentId(id), researchGroupDocumentId(owner)].join(':');
 
@@ -1724,27 +1734,38 @@ export function buildResearchActivityLinkPayload({
     })),
   ].filter((link) => {
     const key = uniqueKey(link.relationshipBasis || '', link._id);
-    if (seen.has(key) || !isPublicResearchPaperLink(link)) return false;
+    const canonicalKey = canonicalScholarlyWorkKey(link);
+    if (seen.has(key) || seenCanonicalWorks.has(canonicalKey) || !isPublicResearchPaperLink(link))
+      return false;
     seen.add(key);
+    seenCanonicalWorks.add(canonicalKey);
     return true;
   });
 
+  const integrityDecisions = evaluateResearchActivityIntegrity(
+    memberScholarlyLinkPairs.filter((pair) => pair.memberDisplayId) as ResearchActivityCandidate[],
+    entityTopicEvidence,
+  );
+  const publicMemberLink = (pair: ResearchActivityCandidate, earlier = false) => ({
+    ...withoutInternalResearchActivityIds(
+      scholarlyLinkToPublicLink(pair.link, {
+        relationshipBasis: pair.relationshipBasis || 'identity_authorship',
+        evidenceLabel: earlier
+          ? 'Earlier work by a listed professor, before the documented current appointment'
+          : pair.evidenceLabel || 'Authored by a verified Yale faculty identity',
+        confidence: pair.confidence,
+        observedAt: pair.observedAt,
+        sourceName: pair.sourceName,
+        sourceUrl: pair.sourceUrl,
+      }),
+    ),
+    memberKey: pair.memberDisplayId,
+  });
+
   const memberScholarlyLinks = [
-    ...memberScholarlyLinkPairs
-      .filter((pair) => pair.memberDisplayId)
-      .map((pair) => ({
-        ...withoutInternalResearchActivityIds(
-          scholarlyLinkToPublicLink(pair.link, {
-            relationshipBasis: pair.relationshipBasis || 'identity_authorship',
-            evidenceLabel: pair.evidenceLabel || 'Authored by a verified Yale faculty identity',
-            confidence: pair.confidence,
-            observedAt: pair.observedAt,
-            sourceName: pair.sourceName,
-            sourceUrl: pair.sourceUrl,
-          }),
-        ),
-        memberKey: pair.memberDisplayId,
-      })),
+    ...integrityDecisions
+      .filter((decision) => decision.disposition === 'current')
+      .map((pair) => publicMemberLink(pair.candidate)),
     ...memberPaperPairs
       .filter((pair) => pair.memberDisplayId)
       .map((pair) => ({
@@ -1755,15 +1776,29 @@ export function buildResearchActivityLinkPayload({
       })),
   ].filter((link: any) => {
     const key = uniqueKey(link.relationshipBasis || '', link._id, link.memberKey);
-    if (seen.has(key) || !isPublicResearchPaperLink(link)) return false;
+    const canonicalKey = canonicalScholarlyWorkKey(link);
+    if (seen.has(key) || seenCanonicalWorks.has(canonicalKey) || !isPublicResearchPaperLink(link))
+      return false;
     seen.add(key);
+    seenCanonicalWorks.add(canonicalKey);
     return true;
   });
+
+  const earlierMemberScholarlyLinks = integrityDecisions
+    .filter((decision) => decision.disposition === 'earlier')
+    .map((decision) => publicMemberLink(decision.candidate, true))
+    .filter((link) => {
+      const canonicalKey = canonicalScholarlyWorkKey(link);
+      if (seenCanonicalWorks.has(canonicalKey) || !isPublicResearchPaperLink(link)) return false;
+      seenCanonicalWorks.add(canonicalKey);
+      return true;
+    });
 
   return {
     scholarlyLinks,
     memberScholarlyLinks,
     researchActivityLinks: [...scholarlyLinks, ...memberScholarlyLinks],
+    earlierResearchActivityLinks: earlierMemberScholarlyLinks,
   };
 }
 
@@ -2016,6 +2051,7 @@ export async function getResearchGroupDetail(slug: string): Promise<{
   recentPapers: any[];
   recentArxivPreprints: any[];
   researchActivityLinks: any[];
+  earlierResearchActivityLinks: any[];
   scholarlyLinks: any[];
   memberScholarlyLinks: any[];
   activeListings: any[];
@@ -2146,6 +2182,14 @@ export async function getResearchGroupDetail(slug: string): Promise<{
         return id ? [id, publicMemberKeyForResearchDetail(member.user, member.role)] : undefined;
       })
       .filter((entry): entry is [string, string] => Boolean(entry)),
+  );
+  const memberAppointmentsByInternalId = new Map(
+    dedupedMembersWithRows.flatMap((member) => {
+      const id = normalizeResearchGroupObjectId(member.user?._id);
+      return id
+        ? [[id, { startedAt: member.row?.startedAt, endedAt: member.row?.endedAt }] as const]
+        : [];
+    }),
   );
   const members = dedupedMembersWithRows.map(({ row: _row, ...member }) => {
     return {
@@ -2278,6 +2322,9 @@ export async function getResearchGroupDetail(slug: string): Promise<{
   const memberScholarlyLinkPairs = (attributionRows as any[]).flatMap((row) => {
     const link = scholarlyLinksById.get(researchGroupDocumentId(row.scholarlyLinkId));
     if (!link) return [];
+    const appointment = memberAppointmentsByInternalId.get(
+      researchGroupDocumentId(row.targetUserId),
+    );
     return [
       {
         link,
@@ -2290,11 +2337,20 @@ export async function getResearchGroupDetail(slug: string): Promise<{
         observedAt: row.observedAt,
         sourceName: row.sourceName,
         sourceUrl: row.sourceUrl,
+        appointmentStartedAt: appointment?.startedAt,
+        appointmentEndedAt: appointment?.endedAt,
       },
     ];
   });
   const researchActivity = buildResearchActivityLinkPayload({
     researchEntityId: (group as any)._id,
+    entityTopicEvidence: [
+      (group as any).researchAreas,
+      (group as any).methods,
+      (group as any).shortDescription,
+      (group as any).fullDescription,
+      (group as any).name,
+    ],
     entityScholarlyLinks: entityScholarlyLinks as any[],
     memberScholarlyLinkPairs,
   });


### PR DESCRIPTION
## Summary
- classify member publications as current, earlier, identity-conflicting, or duplicate before public profile publication
- deduplicate canonical scholarly works across entity and member attribution paths
- expose earlier work separately and add a read-only aggregate integrity audit with privacy-safe counts

## Validation
- focused server: 53 tests passed
- focused client: 47 tests passed
- full server: 2,560 tests passed
- full client: 773 tests passed
- server and client TypeScript passed
- lint passed
- server and client builds passed
- security policy and secrets scan passed
- aggregate audit report smoke passed

No database mutation, ranking cache, Redis, Meilisearch, or production write behavior is included.