### PR TITLE
FR-26: guard lead-faculty identity consistency

### DIFF
--- a/client/src/pages/labDetail.tsx
+++ b/client/src/pages/labDetail.tsx
@@ -327,6 +327,7 @@ const resolveDecisionProfileUrl = (
   contactRoutes: LabContactRoute[],
   group?: any,
 ): string | undefined => {
+  if (group?.leadIdentityStatus === 'under_review') return undefined;
   const labWebsiteDestinations = new Set(
     [group?.websiteUrl, group?.website]
       .filter((url) => url && !isProfileLikeWebsiteUrl(url))
@@ -1148,6 +1149,7 @@ const LabDetail = () => {
     group,
   );
   const principalInvestigators = dedupeLeadMembers(members);
+  const leadIdentityUnderReview = group.leadIdentityStatus === 'under_review';
   const membersById = new Map(members.map((member) => [memberId(member), member]));
   const primaryRecentWorkMember =
     memberRecentWorkLinks
@@ -1211,7 +1213,14 @@ const LabDetail = () => {
 
           <section>
             <SectionHeading>Principal Investigator</SectionHeading>
-            <LabMembersList members={principalInvestigators} />
+            {leadIdentityUnderReview ? (
+              <div className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950" role="status">
+                <p className="font-semibold">Lead identity under review</p>
+                <p className="mt-1">The research information remains available, but this lead and profile link are not shown until their sources agree.</p>
+              </div>
+            ) : (
+              <LabMembersList members={principalInvestigators} />
+            )}
           </section>
 
           {hasDirectRelatedResearch && (

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,7 @@
     "research-entity:disambiguate-surname-labs": "tsx src/scripts/disambiguateSurnameLabNames.ts",
     "research-entity:repair-archived-artifacts": "tsx src/scripts/repairArchivedEntityArtifacts.ts",
     "research-entity-members:audit-user-refs": "tsx src/scripts/researchEntityMemberReferenceAudit.ts",
+    "research-entity:audit-lead-identity": "tsx src/scripts/leadIdentityConsistencyAudit.ts",
     "users:dedupe-by-identity": "tsx src/scripts/dedupeUsersByIdentity.ts",
     "users:email-hygiene": "tsx src/scripts/userEmailHygiene.ts",
     "users:repair-mismatched-emails": "tsx src/scripts/repairMismatchedPersonEmails.ts",

--- a/server/src/scripts/leadIdentityConsistencyAudit.ts
+++ b/server/src/scripts/leadIdentityConsistencyAudit.ts
@@ -1,0 +1,39 @@
+import 'dotenv/config';
+import mongoose from 'mongoose';
+import { initializeConnections } from '../db/connections';
+import { ResearchEntity } from '../models/researchEntity';
+
+const includeHandles = process.argv.includes('--include-handles');
+const limitArg = process.argv.find((arg) => arg.startsWith('--limit='));
+const sampleLimit = Math.min(25, Math.max(0, Number(limitArg?.split('=')[1] || 10)));
+
+async function main() {
+  await initializeConnections();
+  const [total, conflicts] = await Promise.all([
+    ResearchEntity.countDocuments({ archived: { $ne: true } }),
+    ResearchEntity.find({
+      archived: { $ne: true },
+      'qualitySummary.repairFlags': 'pi_identity_conflict',
+    })
+      .select(includeHandles ? '_id slug' : '_id')
+      .limit(sampleLimit)
+      .lean(),
+  ]);
+  const conflictCount = await ResearchEntity.countDocuments({
+    archived: { $ne: true },
+    'qualitySummary.repairFlags': 'pi_identity_conflict',
+  });
+  console.log(JSON.stringify({
+    mode: 'read-only',
+    totalResearchEntities: total,
+    piIdentityConflicts: conflictCount,
+    samples: includeHandles ? conflicts.map((row: any) => ({ id: String(row._id), slug: row.slug })) : [],
+  }, null, 2));
+}
+
+void main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(() => mongoose.disconnect());

--- a/server/src/services/__tests__/leadIdentityConsistency.test.ts
+++ b/server/src/services/__tests__/leadIdentityConsistency.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { validateLeadIdentityConsistency } from '../leadIdentityConsistency';
+
+describe('validateLeadIdentityConsistency', () => {
+  it('matches stable faculty identity', () => {
+    expect(validateLeadIdentityConsistency({ facultyMemberId: 'f1' }, { facultyMemberId: 'F1' }).status).toBe('matched');
+  });
+
+  it('does not guess from a matching name alone', () => {
+    expect(validateLeadIdentityConsistency({ name: 'Tore Eid' }, { name: 'Tore Eid' }).status).toBe('under_review');
+  });
+
+  it('guards the known YNN wrong-person pairing', () => {
+    expect(validateLeadIdentityConsistency(
+      { facultyMemberId: 'tore-eid', name: 'Tore Eid' },
+      { facultyMemberId: 'hitten-zaveri', name: 'Hitten Zaveri' },
+    )).toMatchObject({ status: 'under_review', selected: null });
+  });
+
+  it('reconciles only decisively stronger evidence', () => {
+    expect(validateLeadIdentityConsistency(
+      { facultyMemberId: 'f1', netid: 'te1', profileUrl: 'https://medicine.yale.edu/profile/tore-eid/' },
+      { name: 'Hitten Zaveri', profileUrl: 'https://medicine.yale.edu/profile/hitten-zaveri/' },
+    )).toMatchObject({ status: 'reconciled', selected: 'member' });
+  });
+
+  it('reports missing evidence without inventing an identity', () => {
+    expect(validateLeadIdentityConsistency()).toEqual({ status: 'missing', selected: null, reason: 'no_lead_evidence' });
+  });
+});

--- a/server/src/services/leadIdentityConsistency.ts
+++ b/server/src/services/leadIdentityConsistency.ts
@@ -1,0 +1,76 @@
+export type LeadIdentityEvidence = {
+  userId?: unknown;
+  facultyMemberId?: unknown;
+  netid?: unknown;
+  name?: unknown;
+  profileUrl?: unknown;
+  sourceUrl?: unknown;
+  confidence?: unknown;
+};
+
+export type LeadIdentityDecision = {
+  status: 'matched' | 'reconciled' | 'under_review' | 'missing';
+  selected: 'member' | 'route' | null;
+  reason: string;
+};
+
+const text = (value: unknown): string => String(value || '').trim();
+const stable = (value: unknown): string => text(value).toLowerCase();
+
+export const normalizeLeadProfileUrl = (value: unknown): string => {
+  const raw = text(value);
+  if (!raw) return '';
+  try {
+    const url = new URL(raw);
+    url.hash = '';
+    url.search = '';
+    return `${url.hostname.toLowerCase()}${url.pathname.replace(/\/+$/, '').toLowerCase()}`;
+  } catch {
+    return '';
+  }
+};
+
+const stableKeys = (value: LeadIdentityEvidence): Set<string> =>
+  new Set(
+    [
+      value.facultyMemberId ? `faculty:${stable(value.facultyMemberId)}` : '',
+      value.userId ? `user:${stable(value.userId)}` : '',
+      value.netid ? `netid:${stable(value.netid)}` : '',
+      normalizeLeadProfileUrl(value.profileUrl || value.sourceUrl)
+        ? `profile:${normalizeLeadProfileUrl(value.profileUrl || value.sourceUrl)}`
+        : '',
+    ].filter(Boolean),
+  );
+
+const evidenceScore = (value: LeadIdentityEvidence): number => {
+  const keys = stableKeys(value);
+  const confidence = Number(value.confidence);
+  return keys.size * 2 + (Number.isFinite(confidence) ? Math.max(0, Math.min(1, confidence)) : 0);
+};
+
+/** Names are supporting evidence only; they never establish or reconcile identity. */
+export function validateLeadIdentityConsistency(
+  member?: LeadIdentityEvidence | null,
+  route?: LeadIdentityEvidence | null,
+): LeadIdentityDecision {
+  if (!member && !route) return { status: 'missing', selected: null, reason: 'no_lead_evidence' };
+  if (!member || !route) {
+    return { status: 'under_review', selected: null, reason: 'one_sided_lead_evidence' };
+  }
+
+  const memberKeys = stableKeys(member);
+  const routeKeys = stableKeys(route);
+  if ([...memberKeys].some((key) => routeKeys.has(key))) {
+    return { status: 'matched', selected: 'member', reason: 'stable_identity_match' };
+  }
+
+  const memberScore = evidenceScore(member);
+  const routeScore = evidenceScore(route);
+  if (memberScore >= routeScore + 2) {
+    return { status: 'reconciled', selected: 'member', reason: 'member_evidence_decisively_stronger' };
+  }
+  if (routeScore >= memberScore + 2) {
+    return { status: 'reconciled', selected: 'route', reason: 'route_evidence_decisively_stronger' };
+  }
+  return { status: 'under_review', selected: null, reason: 'conflicting_lead_identity' };
+}

--- a/server/src/services/researchGroupService.ts
+++ b/server/src/services/researchGroupService.ts
@@ -1965,6 +1965,10 @@ export async function getResearchGroupDetail(slug: string): Promise<{
   return addResearchEntityDetailAlias({
     group: {
       ...publicGroupForResponse,
+      leadIdentityStatus: Array.isArray((publicGroupForResponse as any).qualitySummary?.repairFlags) &&
+        (publicGroupForResponse as any).qualitySummary.repairFlags.includes('pi_identity_conflict')
+        ? 'under_review'
+        : 'verified',
       accessSummary,
       studentDecisionExplanation: studentDecisionExplanation || undefined,
     },


### PR DESCRIPTION
## Summary

- add deterministic lead-faculty identity validation based on stable identifiers and canonical profile URLs
- expose and render an honest `Lead identity under review` state while suppressing an untrusted PI/profile pairing
- add a read-only corpus audit with aggregate counts and opt-in bounded private handles

## Identity rules

- names are supporting evidence only and never establish or reconcile identity
- a shared stable faculty/user/NetID/profile key is a match
- reconciliation occurs only when one side has decisively stronger stable evidence
- ambiguous and one-sided evidence remains under review and uses the existing `pi_identity_conflict` Access Review lane

## Validation

- 47 targeted server tests passed
- server production build passed
- client production build passed
- changed-file lint passed (one pre-existing warning in `researchGroupService.ts`)
- repository-wide lint remains blocked by 24 unrelated baseline errors
