### PR TITLE
Add faculty listing claim and correction workflow

### DIFF
--- a/client/src/components/admin/AdminListingClaims.tsx
+++ b/client/src/components/admin/AdminListingClaims.tsx
@@ -1,0 +1,180 @@
+import { useCallback, useEffect, useState } from 'react';
+import axios from '../../utils/axios';
+
+type ReviewStatus = 'pending' | 'changes_requested' | 'approved' | 'rejected';
+type Claim = {
+  _id: string;
+  requestType: 'claim' | 'correction';
+  status: ReviewStatus;
+  message: string;
+  evidenceUrls: string[];
+  adminNotes?: string;
+  listingSnapshot: { title: string };
+  requester: { name: string; userType: string; userConfirmed: boolean; profileVerified: boolean };
+  createdAt: string;
+};
+
+export default function AdminListingClaims() {
+  const [status, setStatus] = useState<ReviewStatus>('pending');
+  const [claims, setClaims] = useState<Claim[]>([]);
+  const [total, setTotal] = useState(0);
+  const [selected, setSelected] = useState<Claim | null>(null);
+  const [rationale, setRationale] = useState('');
+  const [error, setError] = useState('');
+  const load = useCallback(
+    () =>
+      axios.get(`/admin/listing-claims?status=${status}&pageSize=100`).then(({ data }) => {
+        setClaims(data.requests || []);
+        setTotal(data.total || 0);
+      }),
+    [status],
+  );
+  useEffect(() => {
+    load().catch(() => setError('Could not load listing requests.'));
+  }, [load]);
+  const review = async (nextStatus: Exclude<ReviewStatus, 'pending'>) => {
+    if (!selected || !rationale.trim()) {
+      setError('Reviewer rationale is required.');
+      return;
+    }
+    try {
+      await axios.put(`/admin/listing-claims/${selected._id}`, {
+        status: nextStatus,
+        adminNotes: rationale.trim(),
+      });
+      setSelected(null);
+      setRationale('');
+      setError('');
+      await load();
+    } catch (reviewError: any) {
+      setError(reviewError?.response?.data?.error || 'Review could not be saved.');
+    }
+  };
+  return (
+    <div>
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h3 className="text-xl font-semibold text-gray-900">Listing claims and corrections</h3>
+          <p className="text-sm text-gray-600">
+            {total} {status.replace('_', ' ')} requests
+          </p>
+        </div>
+        <label className="text-sm font-medium text-gray-800">
+          Status
+          <select
+            value={status}
+            onChange={(event) => setStatus(event.target.value as ReviewStatus)}
+            className="ml-2 min-h-11 rounded-md border border-gray-400 px-3"
+          >
+            <option value="pending">Pending</option>
+            <option value="changes_requested">Changes requested</option>
+            <option value="approved">Approved</option>
+            <option value="rejected">Rejected</option>
+          </select>
+        </label>
+      </div>
+      {error && (
+        <p role="alert" className="mt-3 text-sm text-red-700">
+          {error}
+        </p>
+      )}
+      <ul className="mt-4 divide-y divide-gray-200 border-y border-gray-200">
+        {claims.map((claim) => (
+          <li key={claim._id}>
+            <button
+              type="button"
+              onClick={() => {
+                setSelected(claim);
+                setRationale(claim.adminNotes || '');
+              }}
+              className="min-h-14 w-full px-2 py-3 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+            >
+              <span className="font-semibold text-gray-900">{claim.listingSnapshot.title}</span>
+              <span className="ml-2 text-sm capitalize text-gray-600">{claim.requestType}</span>
+              <p className="mt-1 line-clamp-2 text-sm text-gray-700">{claim.message}</p>
+            </button>
+          </li>
+        ))}
+      </ul>
+      {selected && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="review-title"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+          onKeyDown={(event) => {
+            if (event.key === 'Escape') setSelected(null);
+          }}
+        >
+          <div className="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-md bg-white p-6">
+            <h2 id="review-title" className="text-lg font-semibold">
+              {selected.listingSnapshot.title}
+            </h2>
+            <p className="mt-2 text-sm text-gray-700">
+              Submitted by {selected.requester.name || 'faculty member'} (
+              {selected.requester.userType})
+            </p>
+            <p className="mt-4 whitespace-pre-wrap text-sm text-gray-800">{selected.message}</p>
+            {selected.evidenceUrls.length > 0 && (
+              <ul className="mt-3 list-disc pl-5 text-sm">
+                {selected.evidenceUrls.map((url) => (
+                  <li key={url}>
+                    <a
+                      href={url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-blue-700 underline"
+                    >
+                      Review evidence
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            )}
+            <p className="mt-4 rounded-md bg-amber-50 p-3 text-sm text-amber-900">
+              Approval records an administrative decision only. It does not change listing ownership
+              or content.
+            </p>
+            <label htmlFor="review-rationale" className="mt-4 block text-sm font-medium">
+              Reviewer rationale
+            </label>
+            <textarea
+              id="review-rationale"
+              rows={4}
+              maxLength={4000}
+              value={rationale}
+              onChange={(event) => setRationale(event.target.value)}
+              className="mt-1 w-full rounded-md border border-gray-400 p-3"
+            />
+            <div className="mt-5 flex flex-wrap justify-end gap-2">
+              <button type="button" onClick={() => setSelected(null)} className="min-h-11 px-4">
+                Close
+              </button>
+              <button
+                type="button"
+                onClick={() => review('changes_requested')}
+                className="min-h-11 rounded-md border border-amber-600 px-4 font-semibold text-amber-800"
+              >
+                Request changes
+              </button>
+              <button
+                type="button"
+                onClick={() => review('rejected')}
+                className="min-h-11 rounded-md border border-red-600 px-4 font-semibold text-red-700"
+              >
+                Reject
+              </button>
+              <button
+                type="button"
+                onClick={() => review('approved')}
+                className="min-h-11 rounded-md bg-green-700 px-4 font-semibold text-white"
+              >
+                Approve review
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/admin/AdminPanel.tsx
+++ b/client/src/components/admin/AdminPanel.tsx
@@ -8,10 +8,12 @@ import AdminDepartments from './AdminDepartments';
 import AdminFacultyProfilesTable from './AdminFacultyProfilesTable';
 import AdminAccessReview from './AdminAccessReview';
 import AdminOperatorBoard from './AdminOperatorBoard';
+import AdminListingClaims from './AdminListingClaims';
 
 const TABS = [
   'Operator Board',
   'Access Review',
+  'Listing Requests',
   'Fellowships',
   'Research Areas',
   'Departments',
@@ -61,6 +63,7 @@ const AdminPanel = () => {
 
       {activeTab === 'Operator Board' && <AdminOperatorBoard />}
       {activeTab === 'Access Review' && <AdminAccessReview />}
+      {activeTab === 'Listing Requests' && <AdminListingClaims />}
       {activeTab === 'Fellowships' && <AdminFellowshipsTable />}
       {activeTab === 'Research Areas' && <AdminResearchAreas />}
       {activeTab === 'Departments' && <AdminDepartments />}

--- a/client/src/components/faculty/ListingClaimRequestPanel.tsx
+++ b/client/src/components/faculty/ListingClaimRequestPanel.tsx
@@ -1,0 +1,178 @@
+import { FormEvent, useEffect, useState } from 'react';
+import axios from '../../utils/axios';
+import type { Listing } from '../../types/types';
+
+type ClaimStatus = 'pending' | 'changes_requested' | 'approved' | 'rejected';
+type ClaimRequest = {
+  _id: string;
+  requestType: 'claim' | 'correction';
+  status: ClaimStatus;
+  message: string;
+  adminNotes?: string;
+  createdAt: string;
+};
+
+export default function ListingClaimRequestPanel({ listing }: { listing: Listing }) {
+  const [open, setOpen] = useState(false);
+  const [requestType, setRequestType] = useState<'claim' | 'correction'>('correction');
+  const [message, setMessage] = useState('');
+  const [evidence, setEvidence] = useState('');
+  const [requests, setRequests] = useState<ClaimRequest[]>([]);
+  const [feedback, setFeedback] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const loadHistory = () => {
+    axios
+      .get('/listings/claims/mine?pageSize=100')
+      .then(({ data }) => setRequests(data.requests || []))
+      .catch(() => setRequests([]));
+  };
+  useEffect(loadHistory, []);
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!message.trim()) {
+      setFeedback('Describe what should be claimed or corrected.');
+      return;
+    }
+    setSubmitting(true);
+    setFeedback('');
+    try {
+      await axios.post(`/listings/${listing.id}/claim`, {
+        requestType,
+        message: message.trim(),
+        evidenceUrls: evidence
+          .split(/\n|,/)
+          .map((url) => url.trim())
+          .filter(Boolean),
+      });
+      setFeedback('Request submitted for administrator review. No listing changes were made.');
+      setMessage('');
+      setEvidence('');
+      loadHistory();
+    } catch (error: any) {
+      setFeedback(
+        error?.response?.status === 409
+          ? 'You already have a pending request of this type for this listing.'
+          : error?.response?.data?.error || 'Request could not be submitted.',
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const listingRequests = requests.filter(
+    (request: any) => String(request.listingId) === listing.id,
+  );
+
+  return (
+    <section className="rounded-md border border-[var(--yr-line)] bg-[var(--yr-panel)] p-4">
+      <h2 className="text-xs font-semibold uppercase tracking-wider text-gray-600">
+        Faculty listing support
+      </h2>
+      <p className="mt-2 text-sm text-gray-700">
+        Request an ownership review or flag inaccurate public information for {listing.title}.
+      </p>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="mt-3 min-h-11 rounded-md border border-blue-600 px-4 py-2 text-sm font-semibold text-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+      >
+        Claim this listing / Request a correction
+      </button>
+      {listingRequests.length > 0 && (
+        <div className="mt-4" aria-label="Your request history">
+          <h3 className="text-sm font-semibold text-gray-900">Your request history</h3>
+          <ul className="mt-2 space-y-2">
+            {listingRequests.map((request) => (
+              <li
+                key={request._id}
+                className="border-l-2 border-gray-300 pl-3 text-sm text-gray-700"
+              >
+                <span className="font-medium capitalize">{request.requestType}</span>:{' '}
+                {request.status.replace('_', ' ')}
+                {request.adminNotes && <p className="mt-1">Reviewer: {request.adminNotes}</p>}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {open && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="claim-title"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+          onKeyDown={(event) => {
+            if (event.key === 'Escape') setOpen(false);
+          }}
+        >
+          <form onSubmit={submit} className="w-full max-w-lg rounded-md bg-white p-6 shadow-xl">
+            <h2 id="claim-title" className="text-lg font-semibold text-gray-900">
+              Listing review request
+            </h2>
+            <p className="mt-1 text-sm text-gray-600">{listing.title}</p>
+            <label className="mt-4 block text-sm font-medium text-gray-800" htmlFor="claim-type">
+              Request type
+            </label>
+            <select
+              id="claim-type"
+              value={requestType}
+              onChange={(event) => setRequestType(event.target.value as 'claim' | 'correction')}
+              className="mt-1 min-h-11 w-full rounded-md border border-gray-400 px-3"
+            >
+              <option value="correction">Request a correction</option>
+              <option value="claim">Claim this listing</option>
+            </select>
+            <label className="mt-4 block text-sm font-medium text-gray-800" htmlFor="claim-details">
+              Details
+            </label>
+            <textarea
+              id="claim-details"
+              required
+              maxLength={4000}
+              rows={5}
+              value={message}
+              onChange={(event) => setMessage(event.target.value)}
+              className="mt-1 w-full rounded-md border border-gray-400 p-3"
+            />
+            <label
+              className="mt-4 block text-sm font-medium text-gray-800"
+              htmlFor="claim-evidence"
+            >
+              Evidence links (optional, one per line)
+            </label>
+            <textarea
+              id="claim-evidence"
+              rows={3}
+              value={evidence}
+              onChange={(event) => setEvidence(event.target.value)}
+              className="mt-1 w-full rounded-md border border-gray-400 p-3"
+            />
+            {feedback && (
+              <p role="status" className="mt-3 text-sm text-gray-800">
+                {feedback}
+              </p>
+            )}
+            <div className="mt-5 flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="min-h-11 px-4 text-sm font-semibold text-gray-700"
+              >
+                Close
+              </button>
+              <button
+                type="submit"
+                disabled={submitting}
+                className="min-h-11 rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white disabled:opacity-60"
+              >
+                {submitting ? 'Submitting...' : 'Submit request'}
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/client/src/components/faculty/__tests__/ListingClaimRequestPanel.test.tsx
+++ b/client/src/components/faculty/__tests__/ListingClaimRequestPanel.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ListingClaimRequestPanel from '../ListingClaimRequestPanel';
+import axios from '../../../utils/axios';
+
+vi.mock('../../../utils/axios', () => ({
+  default: { get: vi.fn(), post: vi.fn() },
+}));
+
+const listing = {
+  id: '507f1f77bcf86cd799439011',
+  title: 'Cell Systems Lab',
+} as any;
+
+describe('ListingClaimRequestPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(axios.get).mockResolvedValue({ data: { requests: [] } });
+  });
+
+  it('submits structured correction details and reports non-mutating review', async () => {
+    vi.mocked(axios.post).mockResolvedValue({ data: { request: { _id: 'request-1' } } });
+    render(<ListingClaimRequestPanel listing={listing} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /claim this listing/i }));
+    fireEvent.change(screen.getByLabelText('Details'), {
+      target: { value: 'The listed research area is outdated.' },
+    });
+    fireEvent.change(screen.getByLabelText(/Evidence links/), {
+      target: { value: 'https://example.yale.edu/current' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit request' }));
+
+    await waitFor(() =>
+      expect(axios.post).toHaveBeenCalledWith(`/listings/${listing.id}/claim`, {
+        requestType: 'correction',
+        message: 'The listed research area is outdated.',
+        evidenceUrls: ['https://example.yale.edu/current'],
+      }),
+    );
+    expect(await screen.findByRole('status')).toHaveTextContent('No listing changes were made');
+  });
+
+  it('announces duplicate pending requests', async () => {
+    vi.mocked(axios.post).mockRejectedValue({ response: { status: 409 } });
+    render(<ListingClaimRequestPanel listing={listing} />);
+    fireEvent.click(screen.getByRole('button', { name: /claim this listing/i }));
+    fireEvent.change(screen.getByLabelText('Details'), { target: { value: 'Please review.' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit request' }));
+    expect(await screen.findByRole('status')).toHaveTextContent('already have a pending request');
+  });
+});

--- a/client/src/pages/labDetail.tsx
+++ b/client/src/pages/labDetail.tsx
@@ -11,14 +11,11 @@
  * props and render. This keeps the page consistent with the
  * `pages/profile.tsx` pattern.
  */
-import { useEffect, useReducer, useRef, useState } from 'react';
+import { useContext, useEffect, useReducer, useRef, useState } from 'react';
 import { isCancel } from 'axios';
 import { Link, useParams } from 'react-router-dom';
 import axios from '../utils/axios';
-import {
-  createInitialLabDetailState,
-  labDetailReducer,
-} from '../reducers/labDetailReducer';
+import { createInitialLabDetailState, labDetailReducer } from '../reducers/labDetailReducer';
 import LabHeader from '../components/labs/LabHeader';
 import LabMembersList from '../components/labs/LabMembersList';
 import LabPapersList from '../components/labs/LabPapersList';
@@ -51,11 +48,7 @@ import {
   getEvidenceSignalLabel,
   getEvidenceStrengthLabel,
 } from '../utils/researchDiscoveryAdapters';
-import {
-  computeAcceptanceVerdict,
-  EvidenceItem,
-  verdictLabel,
-} from '../utils/undergradAcceptance';
+import { computeAcceptanceVerdict, EvidenceItem, verdictLabel } from '../utils/undergradAcceptance';
 import {
   approachHeadingLabel,
   decisionHeadingLabel,
@@ -66,13 +59,13 @@ import {
   sanitizeFacultyResearchCopy,
 } from '../utils/researchEntityCopy';
 import { getUniqueDepartmentLabels } from '../utils/departmentNames';
+import UserContext from '../contexts/UserContext';
+import ListingClaimRequestPanel from '../components/faculty/ListingClaimRequestPanel';
 
 const FIRST_RESEARCH_PLAN_SAVE_KEY = 'yale-research.firstResearchPlanSave.v1';
 
 const SectionHeading = ({ children }: { children: React.ReactNode }) => (
-  <h2 className="text-xs font-semibold text-gray-600 uppercase tracking-wider mb-3">
-    {children}
-  </h2>
+  <h2 className="text-xs font-semibold text-gray-600 uppercase tracking-wider mb-3">{children}</h2>
 );
 
 const formatEntityKindTag = (kind?: string | null): string | undefined =>
@@ -86,11 +79,11 @@ const RelatedResearchEntitiesSection = ({
   relatedResearchEntities: ResearchEntity[];
 }) => {
   const relationshipByEntityKey = new Map(
-    relationships
-      .flatMap((relationship) => [
-        relationship.relatedResearchEntitySlug,
-        relationship.relatedResearchEntityId,
-      ].filter(Boolean).map((key) => [key, relationship] as const)),
+    relationships.flatMap((relationship) =>
+      [relationship.relatedResearchEntitySlug, relationship.relatedResearchEntityId]
+        .filter(Boolean)
+        .map((key) => [key, relationship] as const),
+    ),
   );
 
   return (
@@ -150,19 +143,20 @@ const AffiliatedResearchEntitiesSection = ({
       {affiliatedResearchEntities.map((entity) => {
         const content = (
           <>
-          <div className="flex flex-wrap gap-2">
-            {uniqueCompact([formatEntityKindTag(entity.kind), ...compactDepartmentLabels(entity.departments)], 3).map(
-              (tag) => (
+            <div className="flex flex-wrap gap-2">
+              {uniqueCompact(
+                [formatEntityKindTag(entity.kind), ...compactDepartmentLabels(entity.departments)],
+                3,
+              ).map((tag) => (
                 <span
                   key={tag}
                   className="rounded-full bg-[var(--yr-panel-muted)] px-2 py-1 text-xs font-medium text-gray-700"
                 >
                   {tag}
                 </span>
-              ),
-            )}
-          </div>
-          <h3 className="mt-3 text-sm font-semibold text-gray-900">{entity.name}</h3>
+              ))}
+            </div>
+            <h3 className="mt-3 text-sm font-semibold text-gray-900">{entity.name}</h3>
           </>
         );
         const className =
@@ -247,22 +241,14 @@ const isGenericTopic = (value: string): boolean =>
   /^yale faculty\b/i.test(value);
 
 const detailTopics = (group: any, limit = 6): string[] =>
-  uniqueCompact(
-    [
-      ...(group.researchAreas || []),
-    ],
-    limit * 2,
-  )
+  uniqueCompact([...(group.researchAreas || [])], limit * 2)
     .filter((value) => !isGenericTopic(value))
     .slice(0, limit);
 
 const directoryFirstPlanningCopy = (value: string | undefined | null, group: any): string => {
   if (!value) return '';
   return sanitizeFacultyResearchCopy(value, group)
-    .replace(
-      'Plan careful exploratory outreach.',
-      'Plan from source-backed context.',
-    )
+    .replace('Plan careful exploratory outreach.', 'Plan from source-backed context.')
     .replace(
       'This profile has source-backed evidence that outreach may be plausible, but no active posted role is attached.',
       'This profile has source-backed context for planning, but no active posted role is attached.',
@@ -283,7 +269,10 @@ const directoryFirstPlanningCopy = (value: string | undefined | null, group: any
       'Plan a specific outreach note that references the group’s work.',
       'Plan notes that reference the group’s work before taking next steps.',
     )
-    .replace(/targeted exploratory outreach is appropriate/gi, 'source details you should verify next')
+    .replace(
+      /targeted exploratory outreach is appropriate/gi,
+      'source details you should verify next',
+    )
     .replace(/targeted outreach is appropriate/gi, 'source details you should verify next')
     .replace(/outreach may be plausible/gi, 'planning context is available')
     .replace(/before outreach/gi, 'before planning next steps')
@@ -448,8 +437,7 @@ const dedupeLeadMembers = (members: LabMember[]): LabMember[] => {
     const current = byPerson.get(key);
     if (
       !current ||
-      (LEAD_ROLE_PRIORITY.get(member.role) ?? 99) <
-        (LEAD_ROLE_PRIORITY.get(current.role) ?? 99)
+      (LEAD_ROLE_PRIORITY.get(member.role) ?? 99) < (LEAD_ROLE_PRIORITY.get(current.role) ?? 99)
     ) {
       byPerson.set(key, member);
     }
@@ -632,10 +620,7 @@ const DecisionSummary = ({
               ? 'What this faculty research area covers'
               : decisionHeadingLabel(group)}
           </h2>
-          <LongText
-            text={description}
-            className="mt-2 text-base leading-relaxed text-gray-800"
-          />
+          <LongText text={description} className="mt-2 text-base leading-relaxed text-gray-800" />
           {displayStudentDecisionExplanation && (
             <div className="mt-5 rounded-md border border-[var(--yr-line)] bg-[var(--yr-panel-muted)] p-4">
               <SectionHeading>Student decision</SectionHeading>
@@ -974,22 +959,19 @@ const hasSpecificWaysToApproach = (
   );
 
 const LabDetail = () => {
+  const { user } = useContext(UserContext);
   const { slug } = useParams<{ slug: string }>();
-  const [state, dispatch] = useReducer(
-    labDetailReducer,
-    undefined,
-    () => createInitialLabDetailState(),
+  const [state, dispatch] = useReducer(labDetailReducer, undefined, () =>
+    createInitialLabDetailState(),
   );
   const { payload, loading, error, isInquireModalOpen } = state;
   const requestIdRef = useRef(0);
   const fetchAbortRef = useRef<AbortController | null>(null);
   const [showResearchPlanSavedCallout, setShowResearchPlanSavedCallout] = useState(false);
   const [outreachRecordError, setOutreachRecordError] = useState('');
-  const {
-    favIds: savedResearchPlanIds,
-    setFavorite: setSavedResearchPlanFavorite,
-  } = useFavorites('researchPlans');
-  const documentTitleGroup = payload ? payload.group ?? payload.researchEntity : null;
+  const { favIds: savedResearchPlanIds, setFavorite: setSavedResearchPlanFavorite } =
+    useFavorites('researchPlans');
+  const documentTitleGroup = payload ? (payload.group ?? payload.researchEntity) : null;
   useDocumentTitle(
     documentTitleGroup?.displayName || documentTitleGroup?.name || 'Research profile',
   );
@@ -1058,6 +1040,7 @@ const LabDetail = () => {
     entryPathways = [],
     accessSignals = [],
     postedOpportunities = [],
+    activeListings = [],
     entityRelationships = [],
     relatedResearchEntities = [],
     affiliatedResearchEntities = [],
@@ -1089,7 +1072,9 @@ const LabDetail = () => {
   );
   const hasActivePostedOpportunity = postedOpportunities.length > 0;
   const hasDirectRelatedResearch =
-    directRelatedResearchLinks.length > 0 || recentPapers.length > 0 || recentArxivPreprints.length > 0;
+    directRelatedResearchLinks.length > 0 ||
+    recentPapers.length > 0 ||
+    recentArxivPreprints.length > 0;
   const hasMemberRecentWork = memberRecentWorkLinks.length > 0;
   const hasResearchActivity = hasDirectRelatedResearch || hasMemberRecentWork;
   const hasWaysIn = entryPathways.length > 0 || postedOpportunities.length > 0;
@@ -1131,6 +1116,10 @@ const LabDetail = () => {
   const isPrimaryPathwaySaved = primaryPathway
     ? savedResearchPlanIds.includes(primaryPathway._id)
     : false;
+  const canRequestListingReview =
+    Boolean(user?.userConfirmed) &&
+    ['professor', 'faculty', 'staff'].includes(user?.userType || '') &&
+    activeListings.length > 0;
 
   const handleToggleSavedResearchPlan = (pathwayId: string, shouldSave: boolean) => {
     setSavedResearchPlanFavorite(pathwayId, shouldSave);
@@ -1199,12 +1188,14 @@ const LabDetail = () => {
               </>
             ) : (
               <p className="text-sm leading-relaxed text-gray-700">
-                No verified contact route is available yet. Administrators must approve an
-                official source before outreach is enabled.
+                No verified contact route is available yet. Administrators must approve an official
+                source before outreach is enabled.
               </p>
             )}
             {outreachRecordError && (
-              <p role="alert" className="mt-2 text-sm text-amber-800">{outreachRecordError}</p>
+              <p role="alert" className="mt-2 text-sm text-amber-800">
+                {outreachRecordError}
+              </p>
             )}
           </section>
 
@@ -1223,7 +1214,9 @@ const LabDetail = () => {
                     : [...recentPapers, ...recentArxivPreprints]
                 }
                 emptyText="No scholarly links are attached to this research profile yet."
-                showPreprintMeta={directRelatedResearchLinks.length === 0 && recentPapers.length === 0}
+                showPreprintMeta={
+                  directRelatedResearchLinks.length === 0 && recentPapers.length === 0
+                }
               />
             </section>
           )}
@@ -1268,6 +1261,8 @@ const LabDetail = () => {
             fallbackSourceUrl={fallbackSourceUrl}
           />
 
+          {canRequestListingReview && <ListingClaimRequestPanel listing={activeListings[0]} />}
+
           {sources.length > 0 && (
             <section>
               <SectionHeading>Sources</SectionHeading>
@@ -1293,7 +1288,6 @@ const LabDetail = () => {
           });
         }}
       />
-
     </div>
   );
 };

--- a/server/src/controllers/listingClaimRequestController.ts
+++ b/server/src/controllers/listingClaimRequestController.ts
@@ -58,6 +58,26 @@ export const listAdminListingClaimRequests = async (
   }
 };
 
+export const listMyListingClaimRequests = async (
+  request: Request,
+  response: Response,
+  next: NextFunction,
+) => {
+  try {
+    const currentUser = request.user as { netId?: string };
+    if (!currentUser.netId) return response.status(401).json({ error: 'Unauthorized' });
+    const result = await listListingClaimRequests({
+      requesterNetId: currentUser.netId,
+      status: request.query.status as string | undefined,
+      page: request.query.page as string | undefined,
+      pageSize: request.query.pageSize as string | undefined,
+    });
+    response.json(result);
+  } catch (error) {
+    next(error);
+  }
+};
+
 export const getAdminListingClaimRequest = async (
   request: Request,
   response: Response,

--- a/server/src/models/listingClaimRequest.ts
+++ b/server/src/models/listingClaimRequest.ts
@@ -4,7 +4,12 @@
 import mongoose from 'mongoose';
 
 export const ListingClaimRequestType = ['claim', 'correction'] as const;
-export const ListingClaimRequestStatus = ['pending', 'approved', 'rejected'] as const;
+export const ListingClaimRequestStatus = [
+  'pending',
+  'changes_requested',
+  'approved',
+  'rejected',
+] as const;
 
 const requesterSnapshotSchema = new mongoose.Schema(
   {
@@ -80,6 +85,20 @@ const listingClaimRequestSchema = new mongoose.Schema(
       default: '',
       maxlength: 4000,
     },
+    reviewHistory: {
+      type: [
+        new mongoose.Schema(
+          {
+            status: { type: String, enum: ListingClaimRequestStatus, required: true },
+            rationale: { type: String, required: true, maxlength: 4000 },
+            reviewedBy: { type: String, required: true },
+            reviewedAt: { type: Date, required: true },
+          },
+          { _id: false },
+        ),
+      ],
+      default: [],
+    },
   },
   {
     timestamps: true,
@@ -88,6 +107,10 @@ const listingClaimRequestSchema = new mongoose.Schema(
 
 listingClaimRequestSchema.index({ listingId: 1, status: 1, createdAt: -1 });
 listingClaimRequestSchema.index({ 'requester.netId': 1, createdAt: -1 });
+listingClaimRequestSchema.index(
+  { listingId: 1, requestType: 1, 'requester.netId': 1 },
+  { unique: true, partialFilterExpression: { status: 'pending' } },
+);
 
 export const ListingClaimRequest = mongoose.model(
   'listingClaimRequests',

--- a/server/src/routes/listings.ts
+++ b/server/src/routes/listings.ts
@@ -110,7 +110,9 @@ const logListingEvent = (eventType: AnalyticsEventType) => {
             netid: currentUser.netId,
             userType: currentUser.userType,
             listingId: listingId,
-          }).catch((err) => console.error(`Error logging ${eventType} event:`, sanitizeLogValue(err)));
+          }).catch((err) =>
+            console.error(`Error logging ${eventType} event:`, sanitizeLogValue(err)),
+          );
         }
       }
 
@@ -134,7 +136,9 @@ const logListingCreateEvent = async (req: Request, res: Response, next: NextFunc
           netid: currentUser.netId,
           userType: currentUser.userType,
           listingId: data.listing._id,
-        }).catch((err) => console.error('Error logging listing create event:', sanitizeLogValue(err)));
+        }).catch((err) =>
+          console.error('Error logging listing create event:', sanitizeLogValue(err)),
+        );
       }
     }
 
@@ -158,6 +162,13 @@ router.post(
   canCreateListing,
   logListingCreateEvent,
   listingController.createListingForCurrentUser,
+);
+
+router.get(
+  '/claims/mine',
+  isAuthenticated,
+  canSubmitListingClaimRequest,
+  listingClaimRequestController.listMyListingClaimRequests,
 );
 
 router.get('/:id', isAuthenticated, validateObjectId('id'), listingController.getListingById);

--- a/server/src/services/__tests__/listingClaimRequestService.test.ts
+++ b/server/src/services/__tests__/listingClaimRequestService.test.ts
@@ -17,6 +17,7 @@ vi.mock('../../db/connections', () => ({
 vi.mock('../../models/listingClaimRequest', () => ({
   ListingClaimRequest: {
     create: vi.fn(),
+    findOne: vi.fn(),
     findByIdAndUpdate: vi.fn(),
   },
 }));
@@ -37,6 +38,9 @@ const mockListingFindById = (listing: Record<string, unknown> | null) => {
 describe('listingClaimRequestService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(ListingClaimRequest.findOne).mockReturnValue({
+      select: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue(null) }),
+    } as any);
   });
 
   it('sanitizes proposed changes to known listing fields only', () => {
@@ -202,11 +206,18 @@ describe('listingClaimRequestService', () => {
 
     expect(request).toMatchObject({ _id: requestId, status: 'approved', reviewedBy: 'admin1' });
     expect(ListingClaimRequest.findByIdAndUpdate).toHaveBeenCalledWith(
-      requestId,
+      { _id: requestId, status: { $in: ['pending', 'changes_requested'] } },
       expect.objectContaining({
         status: 'approved',
         adminNotes: 'Verified by email.',
         reviewedBy: 'admin1',
+        $push: {
+          reviewHistory: expect.objectContaining({
+            status: 'approved',
+            rationale: 'Verified by email.',
+            reviewedBy: 'admin1',
+          }),
+        },
       }),
       { new: true, runValidators: true },
     );
@@ -219,7 +230,7 @@ describe('listingClaimRequestService', () => {
         adminNotes: 'Cannot move back to pending.',
       }),
     ).rejects.toMatchObject({
-      message: 'Status must be approved or rejected',
+      message: 'Status must be approved, rejected, or changes_requested',
       status: 400,
     });
 
@@ -236,11 +247,34 @@ describe('listingClaimRequestService', () => {
     'rejects malformed review request bodies with a 400-level error',
     async (body) => {
       await expect(reviewListingClaimRequest(requestId, 'admin1', body)).rejects.toMatchObject({
-        message: 'Status must be approved or rejected',
+        message: 'Status must be approved, rejected, or changes_requested',
         status: 400,
       });
 
       expect(ListingClaimRequest.findByIdAndUpdate).not.toHaveBeenCalled();
     },
   );
+
+  it('rejects a duplicate pending request before creating another record', async () => {
+    mockListingFindById({ _id: listingId, title: 'Existing listing' });
+    vi.mocked(ListingClaimRequest.findOne).mockReturnValue({
+      select: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue({ _id: requestId }) }),
+    } as any);
+
+    await expect(
+      createListingClaimRequest(
+        listingId,
+        { requestType: 'claim', message: 'Please review ownership.' },
+        { netId: 'fac1' },
+      ),
+    ).rejects.toMatchObject({ status: 409 });
+    expect(ListingClaimRequest.create).not.toHaveBeenCalled();
+  });
+
+  it('requires a reviewer rationale', async () => {
+    await expect(
+      reviewListingClaimRequest(requestId, 'admin1', { status: 'changes_requested' }),
+    ).rejects.toMatchObject({ message: 'Reviewer rationale is required', status: 400 });
+    expect(ListingClaimRequest.findByIdAndUpdate).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/services/listingClaimRequestService.ts
+++ b/server/src/services/listingClaimRequestService.ts
@@ -7,7 +7,7 @@ import { getListingModel } from '../db/connections';
 import { BadRequestError, NotFoundError, ObjectIdError } from '../utils/errors';
 
 const REQUEST_TYPES = new Set(['claim', 'correction']);
-const REQUEST_STATUSES = new Set(['pending', 'approved', 'rejected']);
+const REQUEST_STATUSES = new Set(['pending', 'changes_requested', 'approved', 'rejected']);
 
 const PROPOSED_CHANGE_FIELDS = [
   'title',
@@ -167,6 +167,20 @@ export const createListingClaimRequest = async (
     throw new NotFoundError(`Listing not found with ObjectId: ${listingId}`);
   }
 
+  const existingPending = await ListingClaimRequest.findOne({
+    listingId,
+    requestType,
+    'requester.netId': requester.netId,
+    status: 'pending',
+  })
+    .select('_id')
+    .lean();
+  if (existingPending) {
+    const error: any = new Error('A pending request of this type already exists for this listing');
+    error.status = 409;
+    throw error;
+  }
+
   const request = await ListingClaimRequest.create({
     listingId,
     requestType,
@@ -202,6 +216,7 @@ export const listListingClaimRequests = async (params: {
   listingId?: string;
   page?: string;
   pageSize?: string;
+  requesterNetId?: string;
 }) => {
   const filter: Record<string, unknown> = {};
 
@@ -215,6 +230,7 @@ export const listListingClaimRequests = async (params: {
     }
     filter.listingId = params.listingId;
   }
+  if (params.requesterNetId) filter['requester.netId'] = params.requesterNetId;
 
   const page = Math.max(1, parseInt(params.page || '1', 10) || 1);
   const pageSize = Math.min(100, Math.max(1, parseInt(params.pageSize || '25', 10) || 25));
@@ -262,22 +278,27 @@ export const reviewListingClaimRequest = async (
   const body = normalizeRequestBody(input);
   const status = body.status;
   if (typeof status !== 'string' || !REQUEST_STATUSES.has(status) || status === 'pending') {
-    throw new BadRequestError('Status must be approved or rejected');
+    throw new BadRequestError('Status must be approved, rejected, or changes_requested');
   }
 
+  const rationale = trimString(body.adminNotes);
+  if (!rationale) throw new BadRequestError('Reviewer rationale is required');
+  const reviewedAt = new Date();
+
   const request = await ListingClaimRequest.findByIdAndUpdate(
-    id,
+    { _id: id, status: { $in: ['pending', 'changes_requested'] } },
     {
       status,
-      adminNotes: trimString(body.adminNotes) || '',
+      adminNotes: rationale,
       reviewedBy: reviewerNetId,
-      reviewedAt: new Date(),
+      reviewedAt,
+      $push: { reviewHistory: { status, rationale, reviewedBy: reviewerNetId, reviewedAt } },
     },
     { new: true, runValidators: true },
   ).lean();
 
   if (!request) {
-    throw new NotFoundError(`Listing claim request not found with ObjectId: ${id}`);
+    throw new NotFoundError(`Open listing claim request not found with ObjectId: ${id}`);
   }
 
   return request;


### PR DESCRIPTION
## Summary
- add a confirmed faculty/staff claim and correction flow on research profiles with linked listings
- add faculty self-status history and duplicate pending-request guards
- add an Admin Controls review queue with pending counts, structured detail, rationale, audit history, and non-mutating approve/reject/request-changes decisions

## Safety
- students, unknown users, and unconfirmed accounts remain server-blocked
- approval records a reviewed hand-off only and does not mutate listing ownership or content
- verified faculty profile editing and profile verification remain separate workflows
- public UI does not expose requester email or netid

## Validation
- server build
- client production build
- lint
- focused claim/auth server tests: 39 passed
- focused faculty/lab-detail client tests: 43 passed
- full client suite: 775 passed
- full server suite: 2551 passed; 4 unrelated socket runtime tests could not bind 127.0.0.1 in the sandbox (EPERM)