### PR TITLE
Improve access review queue throughput

### DIFF
--- a/client/src/components/admin/AdminAccessReview.tsx
+++ b/client/src/components/admin/AdminAccessReview.tsx
@@ -1,7 +1,7 @@
 /**
  * Admin review surface for derived research-access records.
  */
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import axios from '../../utils/axios';
 import swal from 'sweetalert';
 import { EXTERNAL_LINK_REL, safeHttpUrl, safeHttpUrlList, safeRouteSegment } from '../../utils/url';
@@ -23,6 +23,9 @@ interface AccessReviewEntitySummary {
   researchAreas?: string[];
   manuallyLockedFields?: string[];
   counts: AccessReviewCounts;
+  unreviewedCounts: AccessReviewCounts;
+  totalUnreviewed: number;
+  hasOfficialApplication: boolean;
 }
 
 type ReviewStatus = 'unreviewed' | 'approved' | 'needs_source' | 'disputed' | 'archived_by_review';
@@ -342,6 +345,7 @@ const RecordReviewControls = ({
   const [lockedFields, setLockedFields] = useState((record.review?.lockedFields || []).join(', '));
   const [note, setNote] = useState(record.review?.note || '');
   const [isSaving, setIsSaving] = useState(false);
+  const saveButtonRef = useRef<HTMLButtonElement>(null);
 
   const save = async () => {
     if (status !== 'unreviewed' && !note.trim()) {
@@ -370,6 +374,10 @@ const RecordReviewControls = ({
         },
       );
       onSaved(response.data.record);
+      const currentCard = saveButtonRef.current?.closest<HTMLElement>('[data-review-record]');
+      const cards = Array.from(document.querySelectorAll<HTMLElement>('[data-review-record]'));
+      const nextCard = cards[cards.indexOf(currentCard as HTMLElement) + 1];
+      nextCard?.focus();
       swal({ text: 'Review saved', icon: 'success', timer: 1200 });
     } catch {
       console.error('Error saving record review.');
@@ -381,6 +389,12 @@ const RecordReviewControls = ({
 
   return (
     <div className="mt-3 rounded border border-[var(--yr-line)] bg-[var(--yr-panel-muted)] p-3">
+      <a
+        href={`#${recordType}-${record._id}`}
+        className="mb-2 inline-block text-xs font-medium text-blue-700 underline underline-offset-2"
+      >
+        Link to record
+      </a>
       <div className="grid gap-2 md:grid-cols-[180px_1fr_auto]">
         <select
           aria-label="Review status"
@@ -403,6 +417,7 @@ const RecordReviewControls = ({
           className="min-h-[44px] rounded border border-[var(--yr-line-strong)] px-2 py-1.5 text-xs"
         />
         <button
+          ref={saveButtonRef}
           onClick={save}
           disabled={isSaving}
           className="min-h-[44px] rounded bg-gray-900 px-3 py-1.5 text-xs font-semibold text-white disabled:opacity-50"
@@ -454,6 +469,9 @@ const AdminAccessReview = () => {
   const [manualLocksText, setManualLocksText] = useState('');
   const [isSavingLocks, setIsSavingLocks] = useState(false);
   const [recordFilter, setRecordFilter] = useState<RecordFilter>('all');
+  const [hasUnreviewed, setHasUnreviewed] = useState(true);
+  const [queueSort, setQueueSort] = useState('unreviewed');
+  const [queueProgress, setQueueProgress] = useState({ reviewedToday: 0, remaining: 0 });
 
   const fetchEntities = useCallback(async () => {
     setIsLoadingList(true);
@@ -463,11 +481,14 @@ const AdminAccessReview = () => {
           search: search.trim() || undefined,
           page,
           pageSize,
+          hasUnreviewed,
+          sort: queueSort,
         },
       });
       setEntities(response.data.entities || []);
       setTotal(response.data.total || 0);
       setTotalPages(response.data.totalPages || 1);
+      setQueueProgress(response.data.progress || { reviewedToday: 0, remaining: 0 });
       if (!selectedId && response.data.entities?.[0]?._id) {
         setSelectedId(response.data.entities[0]._id);
       }
@@ -477,7 +498,7 @@ const AdminAccessReview = () => {
     } finally {
       setIsLoadingList(false);
     }
-  }, [page, pageSize, search, selectedId]);
+  }, [hasUnreviewed, page, pageSize, queueSort, search, selectedId]);
 
   const fetchDetail = useCallback(async (id: string) => {
     setIsLoadingDetail(true);
@@ -658,6 +679,27 @@ const AdminAccessReview = () => {
               ))}
             </select>
           </div>
+          <label className="inline-flex min-h-[44px] items-center gap-2 text-sm font-medium text-gray-700">
+            <input
+              type="checkbox"
+              checked={hasUnreviewed}
+              onChange={(event) => { setHasUnreviewed(event.target.checked); setPage(1); }}
+            />
+            Has unreviewed
+          </label>
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">Order</label>
+            <select
+              aria-label="Queue order"
+              value={queueSort}
+              onChange={(event) => { setQueueSort(event.target.value); setPage(1); }}
+              className="min-h-[44px] border border-[var(--yr-line-strong)] rounded-md px-3 py-2 text-sm"
+            >
+              <option value="unreviewed">Most unreviewed</option>
+              <option value="official_application">Official application first</option>
+              <option value="updated">Recently updated</option>
+            </select>
+          </div>
           <button
             onClick={fetchEntities}
             className="min-h-[44px] px-4 py-2 rounded-md bg-blue-600 text-white text-sm font-semibold hover:bg-blue-700"
@@ -676,6 +718,9 @@ const AdminAccessReview = () => {
             <p className="text-xs text-gray-500">
               Page {page} of {totalPages}
             </p>
+          </div>
+          <div className="px-4 py-2 border-b border-[var(--yr-line)] text-xs text-gray-600" role="status">
+            <strong>{queueProgress.reviewedToday}</strong> reviewed today · <strong>{queueProgress.remaining}</strong> remaining
           </div>
 
           {isLoadingList && entities.length === 0 ? (
@@ -712,11 +757,14 @@ const AdminAccessReview = () => {
                     </span>
                   </div>
                   <div className="flex flex-wrap gap-1 mt-3">
-                    <CountPill label="pathways" value={entity.counts.entryPathways} />
-                    <CountPill label="signals" value={entity.counts.accessSignals} />
-                    <CountPill label="routes" value={entity.counts.contactRoutes} />
-                    <CountPill label="posts" value={entity.counts.postedOpportunities} />
+                    <CountPill label={`pathways (${entity.unreviewedCounts.entryPathways} new)`} value={entity.counts.entryPathways} />
+                    <CountPill label={`signals (${entity.unreviewedCounts.accessSignals} new)`} value={entity.counts.accessSignals} />
+                    <CountPill label={`routes (${entity.unreviewedCounts.contactRoutes} new)`} value={entity.counts.contactRoutes} />
+                    <CountPill label={`posts (${entity.unreviewedCounts.postedOpportunities} new)`} value={entity.counts.postedOpportunities} />
                   </div>
+                  <p className="mt-2 text-xs font-semibold text-gray-700">
+                    {entity.totalUnreviewed} unreviewed{entity.hasOfficialApplication ? ' · official application' : ''}
+                  </p>
                   {(entity.manuallyLockedFields || []).length > 0 && (
                     <p className="text-xs text-amber-700 mt-2">
                       {entity.manuallyLockedFields?.length} manual lock
@@ -910,6 +958,9 @@ const AdminAccessReview = () => {
                   {filteredRecords.entryPathways.map((pathway) => (
                     <div
                       key={pathway._id}
+                      id={`entryPathway-${pathway._id}`}
+                      data-review-record
+                      tabIndex={-1}
                       className="border border-[var(--yr-line)] rounded-lg p-4"
                     >
                       <div className="flex flex-wrap items-center gap-2 mb-2">
@@ -966,7 +1017,7 @@ const AdminAccessReview = () => {
                 <h4 className="text-lg font-bold text-gray-900 mb-3">Access Signals</h4>
                 <div className="space-y-3">
                   {filteredRecords.accessSignals.map((signal) => (
-                    <div key={signal._id} className="border border-[var(--yr-line)] rounded-lg p-4">
+                    <div key={signal._id} id={`accessSignal-${signal._id}`} data-review-record tabIndex={-1} className="border border-[var(--yr-line)] rounded-lg p-4">
                       <div className="flex flex-wrap items-center gap-2 mb-2">
                         <span className="font-semibold text-gray-900">
                           {formatToken(signal.signalType)}
@@ -1014,7 +1065,7 @@ const AdminAccessReview = () => {
                 <h4 className="text-lg font-bold text-gray-900 mb-3">Contact Routes</h4>
                 <div className="space-y-3">
                   {filteredRecords.contactRoutes.map((route) => (
-                    <div key={route._id} className="border border-[var(--yr-line)] rounded-lg p-4">
+                    <div key={route._id} id={`contactRoute-${route._id}`} data-review-record tabIndex={-1} className="border border-[var(--yr-line)] rounded-lg p-4">
                       <div className="flex flex-wrap items-center gap-2 mb-2">
                         <span className="font-semibold text-gray-900">
                           {route.label ||
@@ -1069,6 +1120,9 @@ const AdminAccessReview = () => {
                     return (
                       <div
                         key={opportunity._id}
+                        id={`postedOpportunity-${opportunity._id}`}
+                        data-review-record
+                        tabIndex={-1}
                         className="border border-[var(--yr-line)] rounded-lg p-4"
                       >
                         <div className="flex flex-wrap items-center gap-2 mb-2">

--- a/scripts/security-preflight.test.mjs
+++ b/scripts/security-preflight.test.mjs
@@ -1286,7 +1286,7 @@ test('admin access-review lock fields are bounded before persistence', () => {
   assert.match(source, /id instanceof mongoose\.Types\.ObjectId/);
   assert.match(source, /id\.toHexString\(\)/);
   assert.match(source, /if \(!\/\^\[a-f0-9\]\{24\}\$\/i\.test\(value\)\) return null/);
-  assert.match(source, /accessReviewDocumentId\(row\._id\)/);
+  assert.match(source, /accessReviewDocumentId\(group\._id\)/);
   assert.match(source, /records\.map\(\(record\) => accessReviewDocumentId\(record\._id\)\)/);
   assert.match(source, /accessReviewDocumentId\(obs\._id\)/);
   assert.match(source, /scrapeRunId: accessReviewDocumentId\(obs\.scrapeRunId\) \|\| undefined/);

--- a/server/src/models/accessSignal.ts
+++ b/server/src/models/accessSignal.ts
@@ -99,6 +99,7 @@ accessSignalSchema.index({ observedAt: -1 });
 accessSignalSchema.index({ sourceEvidenceId: 1 });
 accessSignalSchema.index({ archived: 1 });
 accessSignalSchema.index({ 'review.status': 1 });
+accessSignalSchema.index({ researchEntityId: 1, 'review.status': 1, 'review.reviewedAt': -1 });
 accessSignalSchema.index(
   { researchEntityId: 1, signalType: 1, derivationKey: 1 },
   {

--- a/server/src/models/contactRoute.ts
+++ b/server/src/models/contactRoute.ts
@@ -130,6 +130,7 @@ contactRouteSchema.index({ visibility: 1 });
 contactRouteSchema.index({ contactPolicy: 1 });
 contactRouteSchema.index({ archived: 1 });
 contactRouteSchema.index({ 'review.status': 1 });
+contactRouteSchema.index({ researchEntityId: 1, 'review.status': 1, 'review.reviewedAt': -1 });
 contactRouteSchema.index(
   { researchEntityId: 1, derivationKey: 1 },
   {

--- a/server/src/models/entryPathway.ts
+++ b/server/src/models/entryPathway.ts
@@ -98,6 +98,7 @@ entryPathwaySchema.index({ evidenceStrength: 1 });
 entryPathwaySchema.index({ compensation: 1 });
 entryPathwaySchema.index({ archived: 1 });
 entryPathwaySchema.index({ 'review.status': 1 });
+entryPathwaySchema.index({ researchEntityId: 1, 'review.status': 1, 'review.reviewedAt': -1 });
 entryPathwaySchema.index(
   { researchEntityId: 1, derivationKey: 1 },
   {

--- a/server/src/models/postedOpportunity.ts
+++ b/server/src/models/postedOpportunity.ts
@@ -103,6 +103,7 @@ postedOpportunitySchema.index({ term: 1 });
 postedOpportunitySchema.index({ applicationUrl: 1 });
 postedOpportunitySchema.index({ archived: 1 });
 postedOpportunitySchema.index({ 'review.status': 1 });
+postedOpportunitySchema.index({ researchEntityId: 1, 'review.status': 1, 'review.reviewedAt': -1 });
 postedOpportunitySchema.index(
   { entryPathwayId: 1, derivationKey: 1 },
   {

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -613,6 +613,8 @@ router.get('/access-review', async (req: Request, res: Response) => {
       search: typeof req.query.search === 'string' ? req.query.search : undefined,
       page: req.query.page,
       pageSize: req.query.pageSize,
+      hasUnreviewed: req.query.hasUnreviewed,
+      sort: req.query.sort,
     });
     res.json(result);
   } catch (error) {

--- a/server/src/services/__tests__/adminAccessReviewService.test.ts
+++ b/server/src/services/__tests__/adminAccessReviewService.test.ts
@@ -5,7 +5,9 @@ const mocks = vi.hoisted(() => ({
   researchEntityFind: vi.fn(),
   researchEntityCountDocuments: vi.fn(),
   researchEntityFindByIdAndUpdate: vi.fn(),
+  researchEntityAggregate: vi.fn(),
   entryPathwayFindByIdAndUpdate: vi.fn(),
+  countDocuments: vi.fn(),
 }));
 
 vi.mock('../../models/researchEntity', () => ({
@@ -13,6 +15,7 @@ vi.mock('../../models/researchEntity', () => ({
     find: mocks.researchEntityFind,
     countDocuments: mocks.researchEntityCountDocuments,
     findByIdAndUpdate: mocks.researchEntityFindByIdAndUpdate,
+    aggregate: mocks.researchEntityAggregate,
   },
 }));
 
@@ -20,24 +23,28 @@ vi.mock('../../models/entryPathway', () => ({
   EntryPathway: {
     aggregate: vi.fn(),
     findByIdAndUpdate: mocks.entryPathwayFindByIdAndUpdate,
+    countDocuments: mocks.countDocuments,
   },
 }));
 
 vi.mock('../../models/accessSignal', () => ({
   AccessSignal: {
     aggregate: vi.fn(),
+    countDocuments: mocks.countDocuments,
   },
 }));
 
 vi.mock('../../models/contactRoute', () => ({
   ContactRoute: {
     aggregate: vi.fn(),
+    countDocuments: mocks.countDocuments,
   },
 }));
 
 vi.mock('../../models/postedOpportunity', () => ({
   PostedOpportunity: {
     aggregate: vi.fn(),
+    countDocuments: mocks.countDocuments,
   },
 }));
 
@@ -53,19 +60,8 @@ import {
   updateAccessReviewManualLocks,
   updateAccessReviewRecordReview,
   listAccessReviewEntities,
+  redactAccessReviewContactRoute,
 } from '../adminAccessReviewService';
-
-const findChain = () => {
-  const chain = {
-    select: vi.fn().mockReturnThis(),
-    sort: vi.fn().mockReturnThis(),
-    skip: vi.fn().mockReturnThis(),
-    limit: vi.fn().mockReturnThis(),
-    lean: vi.fn().mockResolvedValue([]),
-  };
-  mocks.researchEntityFind.mockReturnValue(chain);
-  return chain;
-};
 
 describe('adminAccessReviewService', () => {
   beforeEach(() => {
@@ -73,16 +69,16 @@ describe('adminAccessReviewService', () => {
   });
 
   it('caps access review page before building Mongo skip and limit values', async () => {
-    const chain = findChain();
-    mocks.researchEntityCountDocuments.mockResolvedValue(0);
+    mocks.researchEntityAggregate.mockReturnValue({ exec: vi.fn().mockResolvedValue([{ rows: [], meta: [] }]) });
+    mocks.countDocuments.mockResolvedValue(0);
 
     const result = await listAccessReviewEntities({
       page: 999_999_999,
       pageSize: 500,
     });
 
-    expect(chain.skip).toHaveBeenCalledWith(99_900);
-    expect(chain.limit).toHaveBeenCalledWith(100);
+    const pipeline = mocks.researchEntityAggregate.mock.calls[0][0];
+    expect(pipeline.at(-1).$facet.rows).toEqual([{ $skip: 99_900 }, { $limit: 100 }]);
     expect(result).toMatchObject({
       entities: [],
       total: 0,
@@ -99,8 +95,32 @@ describe('adminAccessReviewService', () => {
       }),
     ).rejects.toThrow('Search query is too long');
 
-    expect(mocks.researchEntityFind).not.toHaveBeenCalled();
+    expect(mocks.researchEntityAggregate).not.toHaveBeenCalled();
     expect(mocks.researchEntityCountDocuments).not.toHaveBeenCalled();
+  });
+
+  it('filters and sorts the queue by aggregate unreviewed work without returning record data', async () => {
+    mocks.researchEntityAggregate.mockReturnValue({
+      exec: vi.fn().mockResolvedValue([{ rows: [{
+        _id: new mongoose.Types.ObjectId('64f111111111111111111111'),
+        name: 'Example Lab', slug: 'example', _pathways: [{ status: 'unreviewed' }],
+        _signals: [], _routes: [], _opportunities: [{ status: 'approved', applicationUrl: 'https://example.edu/apply' }],
+        totalUnreviewed: 1, hasOfficialApplication: true,
+      }], meta: [{ total: 1 }] }]),
+    });
+    mocks.countDocuments.mockResolvedValue(2);
+
+    const result = await listAccessReviewEntities({ hasUnreviewed: 'true', sort: 'official_application' });
+    const pipeline = mocks.researchEntityAggregate.mock.calls[0][0];
+
+    expect(pipeline).toContainEqual({ $match: { totalUnreviewed: { $gt: 0 } } });
+    expect(result.entities[0]).toMatchObject({
+      totalUnreviewed: 1,
+      hasOfficialApplication: true,
+      unreviewedCounts: { entryPathways: 1, postedOpportunities: 0 },
+    });
+    expect(result.entities[0]).not.toHaveProperty('_pathways');
+    expect(result.progress).toEqual({ remaining: 8, reviewedToday: 8 });
   });
 
   it('normalizes access review locked fields as bounded identifiers', () => {
@@ -116,6 +136,16 @@ describe('adminAccessReviewService', () => {
     ]);
 
     expect(normalized).toEqual(['summary', 'review.lockedFields', 'field-name:ok_1']);
+  });
+
+  it('redacts raw contact destinations from access-review responses', () => {
+    expect(redactAccessReviewContactRoute({
+      _id: 'route-1',
+      email: 'private@example.edu',
+      url: 'mailto:private@example.edu',
+      destination: 'private@example.edu',
+      sourceUrl: 'https://example.edu/evidence',
+    })).toEqual({ _id: 'route-1', sourceUrl: 'https://example.edu/evidence' });
   });
 
   it('normalizes access review ObjectIds without arbitrary object coercion', () => {

--- a/server/src/services/adminAccessReviewService.ts
+++ b/server/src/services/adminAccessReviewService.ts
@@ -14,6 +14,8 @@ export interface AccessReviewListInput {
   search?: string;
   page?: unknown;
   pageSize?: unknown;
+  hasUnreviewed?: unknown;
+  sort?: unknown;
 }
 
 export interface AccessReviewCountSummary {
@@ -33,6 +35,14 @@ export interface AccessReviewEntitySummary {
   researchAreas: string[];
   manuallyLockedFields: string[];
   counts: AccessReviewCountSummary;
+  unreviewedCounts: AccessReviewCountSummary;
+  totalUnreviewed: number;
+  hasOfficialApplication: boolean;
+}
+
+export interface AccessReviewProgressSummary {
+  reviewedToday: number;
+  remaining: number;
 }
 
 export type AccessReviewRecordType =
@@ -49,6 +59,7 @@ const MAX_ACCESS_REVIEW_LOCKED_FIELDS = 100;
 const MAX_ACCESS_REVIEW_EVIDENCE_IDS = 100;
 export const MAX_ACCESS_REVIEW_LOCK_FIELD_LENGTH = 120;
 const ACCESS_REVIEW_LOCK_FIELD_PATTERN = /^[A-Za-z0-9_.:-]+$/;
+const ACCESS_REVIEW_SORTS = new Set(['unreviewed', 'official_application', 'updated']);
 
 export class AccessReviewRequestError extends Error {}
 
@@ -114,29 +125,6 @@ export function normalizeAccessReviewLockedFields(input: unknown): string[] | nu
   }
 
   return normalized;
-}
-
-async function countByEntity(
-  model: mongoose.Model<any>,
-  ids: mongoose.Types.ObjectId[],
-): Promise<Map<string, number>> {
-  if (ids.length === 0) return new Map();
-  const rows = await model
-    .aggregate([
-      { $match: { researchEntityId: { $in: ids } } },
-      { $group: { _id: '$researchEntityId', count: { $sum: 1 } } },
-    ])
-    .exec();
-  return new Map(rows.map((row: any) => [accessReviewDocumentId(row._id), Number(row.count) || 0]));
-}
-
-function zeroCounts(): AccessReviewCountSummary {
-  return {
-    entryPathways: 0,
-    accessSignals: 0,
-    contactRoutes: 0,
-    postedOpportunities: 0,
-  };
 }
 
 function hasEvidence(record: any): boolean {
@@ -236,6 +224,11 @@ async function attachEvidenceItems(records: any[]): Promise<any[]> {
   }));
 }
 
+export function redactAccessReviewContactRoute(record: any): any {
+  const { email: _email, url: _url, destination: _destination, ...safeRecord } = record;
+  return safeRecord;
+}
+
 function buildReviewSummary(input: {
   group: any;
   entryPathways: any[];
@@ -268,10 +261,15 @@ export async function listAccessReviewEntities(input: AccessReviewListInput = {}
   page: number;
   pageSize: number;
   totalPages: number;
+  progress: AccessReviewProgressSummary;
 }> {
   const page = normalizePage(input.page);
   const pageSize = normalizePageSize(input.pageSize);
   const filter: Record<string, unknown> = {};
+  const hasUnreviewed = input.hasUnreviewed === true || input.hasUnreviewed === 'true';
+  const sort = typeof input.sort === 'string' && ACCESS_REVIEW_SORTS.has(input.sort)
+    ? input.sort
+    : 'unreviewed';
 
   const searchTerm = normalizeAccessReviewSearchTerm(input.search);
 
@@ -286,33 +284,70 @@ export async function listAccessReviewEntities(input: AccessReviewListInput = {}
     ];
   }
 
-  const [groups, total] = await Promise.all([
-    ResearchEntity.find(filter)
-      .select('name displayName slug entityType kind departments researchAreas manuallyLockedFields updatedAt')
-      .sort({ updatedAt: -1, _id: 1 })
-      .skip((page - 1) * pageSize)
-      .limit(pageSize)
-      .lean(),
-    ResearchEntity.countDocuments(filter),
-  ]);
+  const lookup = (from: string, as: string, includeApplication = false) => ({
+    $lookup: {
+      from,
+      let: { entityId: '$_id' },
+      pipeline: [
+        { $match: { $expr: { $eq: ['$researchEntityId', '$$entityId'] } } },
+        { $project: { _id: 0, status: '$review.status', ...(includeApplication ? { applicationUrl: 1 } : {}) } },
+      ],
+      as,
+    },
+  });
+  const pipeline: any[] = [
+    { $match: filter },
+    lookup('entry_pathways', '_pathways'),
+    lookup('access_signals', '_signals'),
+    lookup('contact_routes', '_routes'),
+    lookup('posted_opportunities', '_opportunities', true),
+    { $set: {
+      totalUnreviewed: { $add: [
+        { $size: { $filter: { input: '$_pathways', as: 'r', cond: { $in: [{ $ifNull: ['$$r.status', 'unreviewed'] }, ['unreviewed', null]] } } } },
+        { $size: { $filter: { input: '$_signals', as: 'r', cond: { $in: [{ $ifNull: ['$$r.status', 'unreviewed'] }, ['unreviewed', null]] } } } },
+        { $size: { $filter: { input: '$_routes', as: 'r', cond: { $in: [{ $ifNull: ['$$r.status', 'unreviewed'] }, ['unreviewed', null]] } } } },
+        { $size: { $filter: { input: '$_opportunities', as: 'r', cond: { $in: [{ $ifNull: ['$$r.status', 'unreviewed'] }, ['unreviewed', null]] } } } },
+      ] },
+      hasOfficialApplication: { $anyElementTrue: { $map: { input: '$_opportunities', as: 'r', in: { $gt: [{ $strLenCP: { $ifNull: ['$$r.applicationUrl', ''] } }, 0] } } } },
+    } },
+    ...(hasUnreviewed ? [{ $match: { totalUnreviewed: { $gt: 0 } } }] : []),
+    { $sort: sort === 'updated' ? { updatedAt: -1, _id: 1 } : sort === 'official_application' ? { hasOfficialApplication: -1, totalUnreviewed: -1, updatedAt: -1, _id: 1 } : { totalUnreviewed: -1, hasOfficialApplication: -1, updatedAt: -1, _id: 1 } },
+    { $facet: {
+      rows: [{ $skip: (page - 1) * pageSize }, { $limit: pageSize }],
+      meta: [{ $count: 'total' }],
+    } },
+  ];
 
-  const ids = groups
-    .map((group: any) => toObjectId(group._id))
-    .filter((id): id is mongoose.Types.ObjectId => !!id);
-  const [pathwayCounts, signalCounts, routeCounts, opportunityCounts] = await Promise.all([
-    countByEntity(EntryPathway, ids),
-    countByEntity(AccessSignal, ids),
-    countByEntity(ContactRoute, ids),
-    countByEntity(PostedOpportunity, ids),
+  const [aggregateResult, progressCounts] = await Promise.all([
+    ResearchEntity.aggregate(pipeline).exec(),
+    Promise.all([EntryPathway, AccessSignal, ContactRoute, PostedOpportunity].map(async (model) => {
+      const start = new Date();
+      start.setHours(0, 0, 0, 0);
+      const [remaining, reviewedToday] = await Promise.all([
+        model.countDocuments({ $or: [{ 'review.status': 'unreviewed' }, { 'review.status': { $exists: false } }] }),
+        model.countDocuments({ 'review.status': { $ne: 'unreviewed' }, 'review.reviewedAt': { $gte: start } }),
+      ]);
+      return { remaining, reviewedToday };
+    })),
   ]);
+  const groups = aggregateResult[0]?.rows || [];
+  const total = Number(aggregateResult[0]?.meta?.[0]?.total || 0);
 
   const entities = groups.map((group: any) => {
     const id = accessReviewDocumentId(group._id);
-    const counts = zeroCounts();
-    counts.entryPathways = pathwayCounts.get(id) || 0;
-    counts.accessSignals = signalCounts.get(id) || 0;
-    counts.contactRoutes = routeCounts.get(id) || 0;
-    counts.postedOpportunities = opportunityCounts.get(id) || 0;
+    const records = [group._pathways || [], group._signals || [], group._routes || [], group._opportunities || []];
+    const counts = {
+      entryPathways: records[0].length,
+      accessSignals: records[1].length,
+      contactRoutes: records[2].length,
+      postedOpportunities: records[3].length,
+    };
+    const unreviewedCounts = {
+      entryPathways: records[0].filter((r: any) => !r.status || r.status === 'unreviewed').length,
+      accessSignals: records[1].filter((r: any) => !r.status || r.status === 'unreviewed').length,
+      contactRoutes: records[2].filter((r: any) => !r.status || r.status === 'unreviewed').length,
+      postedOpportunities: records[3].filter((r: any) => !r.status || r.status === 'unreviewed').length,
+    };
 
     return {
       _id: id,
@@ -324,6 +359,9 @@ export async function listAccessReviewEntities(input: AccessReviewListInput = {}
       researchAreas: group.researchAreas || [],
       manuallyLockedFields: group.manuallyLockedFields || [],
       counts,
+      unreviewedCounts,
+      totalUnreviewed: Number(group.totalUnreviewed) || 0,
+      hasOfficialApplication: group.hasOfficialApplication === true,
     };
   });
 
@@ -333,6 +371,10 @@ export async function listAccessReviewEntities(input: AccessReviewListInput = {}
     page,
     pageSize,
     totalPages: Math.ceil(total / pageSize),
+    progress: progressCounts.reduce((summary, row) => ({
+      remaining: summary.remaining + row.remaining,
+      reviewedToday: summary.reviewedToday + row.reviewedToday,
+    }), { remaining: 0, reviewedToday: 0 }),
   };
 }
 
@@ -357,7 +399,7 @@ export async function getAccessReviewEntity(researchEntityId: string): Promise<a
     group,
     entryPathways: await attachEvidenceItems(entryPathways),
     accessSignals: await attachEvidenceItems(accessSignals),
-    contactRoutes: await attachEvidenceItems(contactRoutes),
+    contactRoutes: (await attachEvidenceItems(contactRoutes)).map(redactAccessReviewContactRoute),
     postedOpportunities: await attachEvidenceItems(postedOpportunities),
     reviewSummary: buildReviewSummary({
       group,


### PR DESCRIPTION
## Summary
- filter and sort admin access-review entities by unreviewed volume and official application priority
- show per-type queue counts plus reviewed-today and remaining progress
- preserve one-record confirmation/rationale review while adding deep links and next-record keyboard focus
- paginate aggregate results server-side with compound review indexes
- redact raw contact destinations from access-review detail responses

## Validation
- yarn lint
- yarn --cwd server test (224 files, 2555 tests)
- yarn --cwd client test:ci (95 files, 773 tests)
- yarn build

Targets beta. No bulk approval behavior is introduced.