### PR TITLE
FR-23: align fellowship matches with level and timeline

### DIFF
--- a/client/src/components/accounts/__tests__/SavedPathwaysSection.test.ts
+++ b/client/src/components/accounts/__tests__/SavedPathwaysSection.test.ts
@@ -422,7 +422,10 @@ describe('SavedPathwaysSection advising export', () => {
         return Promise.resolve({
           data: {
             matchesByPathwayId: {
-              'pathway-1': [fellowshipMatch()],
+              'pathway-1': [fellowshipMatch({
+                reasons: ['The award timing aligns with an academic-year or thesis plan.'],
+                caveats: ['The listed years do not include your current senior standing.'],
+              })],
             },
           },
         });
@@ -455,6 +458,8 @@ describe('SavedPathwaysSection advising export', () => {
     expect(screen.getByText('Checklist for: Outreach')).toBeTruthy();
     expect(screen.getByText('Fellowship candidates')).toBeTruthy();
     expect(screen.getByText('Source 1')).toBeTruthy();
+    expect(screen.getByText('The award timing aligns with an academic-year or thesis plan.')).toBeTruthy();
+    expect(screen.getByText('Caveat: The listed years do not include your current senior standing.')).toBeTruthy();
   });
 
   it('reports saved research plan count and next deadline summary', async () => {

--- a/scripts/security-preflight.test.mjs
+++ b/scripts/security-preflight.test.mjs
@@ -4272,7 +4272,7 @@ test('saved pathway plan checklist keys are safe before nested Mongo storage', (
   );
   assert.match(
     controller,
-    /const matchesByPathwayId = await matchFellowshipsForPathways\(\s*validIds\.map\(\(pathwayId\) => pathwayId\.toHexString\(\)\),\s*\)/,
+    /const matchesByPathwayId = await matchFellowshipsForPathways\(\s*validIds\.map\(\(pathwayId\) => pathwayId\.toHexString\(\)\),\s*\{\},\s*\{\s*userType: \(user as any\)\.userType,\s*classYear: \(user as any\)\.year,\s*plansByPathwayId: savedPathwayPlans,\s*\},\s*\)/,
   );
   assert.doesNotMatch(controller, /matchFellowshipsForPathways\(favPathwayIds\)/);
   assert.doesNotMatch(controller, /new mongoose\.Types\.ObjectId\(pathway\._id\)/);

--- a/server/src/controllers/__tests__/userController.test.ts
+++ b/server/src/controllers/__tests__/userController.test.ts
@@ -1354,6 +1354,40 @@ describe('userController', () => {
     expect(res.body).toEqual({ error: 'Failed to fetch pathway funding matches' });
   });
 
+  it('passes profile year and saved plan intent into funding matching', async () => {
+    mocks.normalizeObjectIdsForUserMutation.mockReturnValueOnce([
+      { toHexString: () => '64a000000000000000000030' } as any,
+    ]).mockReturnValueOnce([
+      { toHexString: () => '64a000000000000000000030' } as any,
+    ]);
+    mocks.readUser.mockResolvedValue({
+      userType: 'undergraduate',
+      year: 2027,
+      favPathways: ['64a000000000000000000030'],
+      savedPathwayPlans: {
+        '64a000000000000000000030': { intent: 'thesis' },
+      },
+    });
+    mocks.getPathwaysByIds.mockResolvedValue([{ _id: '64a000000000000000000030' }]);
+    mocks.matchFellowshipsForPathways.mockResolvedValue({});
+
+    const req = { user: { netId: 'student123', userType: 'undergraduate', userConfirmed: true } } as any;
+    const res = privateResponseDouble();
+    await getFavPathwayFundingMatches(req, res);
+
+    expect(mocks.matchFellowshipsForPathways).toHaveBeenCalledWith(
+      ['64a000000000000000000030'],
+      {},
+      {
+        userType: 'undergraduate',
+        classYear: 2027,
+        plansByPathwayId: {
+          '64a000000000000000000030': expect.objectContaining({ intent: 'thesis' }),
+        },
+      },
+    );
+  });
+
   it('bounds stored favorite pathway ids before funding-match fan-out', async () => {
     mocks.readUser.mockResolvedValue({
       favPathways: Array.from({ length: 101 }, (_, index) =>

--- a/server/src/controllers/userController.ts
+++ b/server/src/controllers/userController.ts
@@ -655,6 +655,12 @@ export const getFavPathwayFundingMatches = async (request: Request, response: Re
     await updateUser(currentUser.netId, { favPathways: validIds, savedPathwayPlans });
     const matchesByPathwayId = await matchFellowshipsForPathways(
       validIds.map((pathwayId) => pathwayId.toHexString()),
+      {},
+      {
+        userType: (user as any).userType,
+        classYear: (user as any).year,
+        plansByPathwayId: savedPathwayPlans,
+      },
     );
     response.status(200).json({ matchesByPathwayId });
   } catch (error: any) {

--- a/server/src/services/__tests__/fellowshipMatchingService.test.ts
+++ b/server/src/services/__tests__/fellowshipMatchingService.test.ts
@@ -26,6 +26,50 @@ const pathway = (overrides: Partial<PathwaySearchHit> = {}): PathwaySearchHit =>
 });
 
 describe('fellowshipMatchingService', () => {
+  it('rejects graduate-only awards for an undergraduate', () => {
+    expect(scoreFellowshipForPathway(pathway(), {
+      _id: 'graduate-only', title: 'Graduate Research Award', yearOfStudy: ['Graduate students'],
+      summary: 'RNA biology research project', applicationLink: 'https://example.edu/apply',
+    }, new Date('2026-01-01'), { userType: 'undergraduate', classYear: 2029 })).toBeNull();
+  });
+
+  it('uses class year and term metadata without treating missing metadata as ineligible', () => {
+    const firstYear = scoreFellowshipForPathway(pathway(), {
+      _id: 'first-year', title: 'RNA Summer Research Award', yearOfStudy: ['First-year'],
+      termOfAward: ['Summer'], summary: 'RNA biology research', applicationLink: 'https://example.edu/apply',
+    }, new Date('2026-01-01'), { userType: 'undergraduate', classYear: 2030 });
+    const unknown = scoreFellowshipForPathway(pathway(), {
+      _id: 'unknown-level', title: 'RNA Research Award', summary: 'RNA biology research',
+      applicationLink: 'https://example.edu/apply',
+    }, new Date('2026-01-01'), { userType: 'undergraduate', classYear: 2029 });
+    expect(firstYear?.reasons).toContain('This program lists first-year students among the years it considers.');
+    expect(unknown).not.toBeNull();
+  });
+
+  it.each([
+    [2029, 'sophomore'],
+    [2027, 'senior'],
+  ])('explains a matching class year for %s', (classYear, label) => {
+    const match = scoreFellowshipForPathway(pathway(), {
+      _id: `level-${label}`, title: 'RNA Research Award', yearOfStudy: [label],
+      summary: 'RNA biology research', applicationLink: 'https://example.edu/apply',
+    }, new Date('2026-01-01'), { userType: 'undergraduate', classYear });
+    expect(match?.reasons).toContain(`This program lists ${label} students among the years it considers.`);
+  });
+
+  it('prefers academic-year awards for thesis plans and demotes summer-only awards', () => {
+    const base = { summary: 'RNA biology research project', applicationLink: 'https://example.edu/apply' };
+    const academic = scoreFellowshipForPathway(pathway({ pathwayType: 'SENIOR_THESIS' }),
+      { ...base, _id: 'academic', title: 'Academic Year RNA Award', termOfAward: ['Academic year'] });
+    const summer = scoreFellowshipForPathway(pathway({ pathwayType: 'SENIOR_THESIS' }),
+      { ...base, _id: 'summer', title: 'Summer RNA Award', termOfAward: ['Summer'] });
+    expect(academic!.score).toBeGreaterThan(summer!.score);
+    expect(summer?.caveats).toContain('This is listed as a summer award, which may not fit an academic-year thesis plan.');
+  });
+
+  it.each(['', 'Menu', 'AAAAAAA!!!!!!!!', 'x'.repeat(241)])('never surfaces a garbage title: %s', (title) => {
+    expect(scoreFellowshipForPathway(pathway(), { _id: 'junk', title, summary: 'RNA biology research project' })).toBeNull();
+  });
   it('scores source-backed fellowship project matches with reasons and caveats', () => {
     const match = scoreFellowshipForPathway(
       pathway(),

--- a/server/src/services/fellowshipMatchingService.ts
+++ b/server/src/services/fellowshipMatchingService.ts
@@ -34,6 +34,36 @@ export interface FellowshipMatchingDeps {
   fellowshipReader?: () => Promise<any[]>;
 }
 
+export interface FellowshipMatchContext {
+  userType?: string;
+  classYear?: number;
+  plansByPathwayId?: Record<string, { intent?: string } | undefined>;
+}
+
+const JUNK_TITLES = /^(home|menu|search|apply|learn more|read more|fellowships?|programs?|opportunities|navigation)$/i;
+
+export function isCandidateFellowshipTitle(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  const title = value.replace(/\s+/g, ' ').trim();
+  if (title.length < 4 || title.length > 240 || JUNK_TITLES.test(title)) return false;
+  const letters = (title.match(/[a-z]/gi) || []).length;
+  return letters >= 3 && letters / title.length >= 0.35 && !/(.)\1{7,}/.test(title);
+}
+
+function undergraduateStanding(classYear: number | undefined, now: Date): string | undefined {
+  if (!Number.isInteger(classYear)) return undefined;
+  const yearsRemaining = Number(classYear) - now.getUTCFullYear();
+  if (yearsRemaining >= 4) return 'first-year';
+  if (yearsRemaining === 3) return 'sophomore';
+  if (yearsRemaining === 2) return 'junior';
+  if (yearsRemaining <= 1 && yearsRemaining >= 0) return 'senior';
+  return undefined;
+}
+
+function normalizedValues(value: unknown): string[] {
+  return textPart(value).map((item) => item.toLowerCase());
+}
+
 const STOP_WORDS = new Set([
   'and',
   'for',
@@ -130,10 +160,11 @@ export function scoreFellowshipForPathway(
   pathway: PathwaySearchHit,
   fellowship: any,
   now: Date = new Date(),
+  context: FellowshipMatchContext = {},
 ): FellowshipMatch | null {
   const rawFellowshipId = fellowship._id || fellowship.id;
   const fellowshipId = serializedDocumentId(rawFellowshipId) || '';
-  if (!fellowshipId || fellowship.archived === true) return null;
+  if (!fellowshipId || fellowship.archived === true || !isCandidateFellowshipTitle(fellowship.title)) return null;
 
   const fellowshipText = textForFellowship(fellowship);
   const fellowshipTokens = tokens(fellowshipText);
@@ -143,6 +174,42 @@ export function scoreFellowshipForPathway(
   const reasons: string[] = [];
   const caveats: string[] = [];
   let score = 0;
+
+  const standing = undergraduateStanding(context.classYear, now);
+  const studyLevels = normalizedValues(fellowship.yearOfStudy);
+  const explicitlyGraduateOnly =
+    studyLevels.length > 0 &&
+    studyLevels.every((value) => /graduate|postgraduate|doctoral|ph\.?d|master/.test(value)) &&
+    !studyLevels.some((value) => /undergraduate|first|sophomore|junior|senior/.test(value));
+  if (context.userType === 'undergraduate' && explicitlyGraduateOnly) return null;
+  if (standing && studyLevels.length > 0) {
+    const standingPattern = standing === 'first-year' ? /first|freshman/ : new RegExp(standing);
+    if (studyLevels.some((value) => standingPattern.test(value))) {
+      score += 14;
+      reasons.push(`This program lists ${standing} students among the years it considers.`);
+    } else if (studyLevels.some((value) => /undergraduate|first|freshman|sophomore|junior|senior/.test(value))) {
+      score -= 35;
+      caveats.push(`The listed years do not include your current ${standing} standing.`);
+    }
+  }
+
+  const terms = normalizedValues(fellowship.termOfAward);
+  const planIntent = context.plansByPathwayId?.[pathway._id]?.intent;
+  const thesisPlan = pathway.pathwayType === 'SENIOR_THESIS' || planIntent === 'thesis';
+  if (terms.length > 0) {
+    const isSummer = terms.some((value) => /summer/.test(value));
+    const isAcademicYear = terms.some((value) => /academic|year[- ]long|semester|fall|spring/.test(value));
+    if (thesisPlan && isAcademicYear) {
+      score += 12;
+      reasons.push('The award timing aligns with an academic-year or thesis plan.');
+    } else if (thesisPlan && isSummer && !isAcademicYear) {
+      score -= 18;
+      caveats.push('This is listed as a summer award, which may not fit an academic-year thesis plan.');
+    } else if (!thesisPlan && isSummer) {
+      score += 8;
+      reasons.push('The program is scheduled for summer research planning.');
+    }
+  }
 
   if (hasFellowshipCompatibleEvidence(pathway)) {
     score += 25;
@@ -262,6 +329,7 @@ export function scoreFellowshipForPathway(
 export async function matchFellowshipsForPathways(
   pathwayIds: string[],
   deps: FellowshipMatchingDeps = {},
+  context: FellowshipMatchContext = {},
 ): Promise<Record<string, FellowshipMatch[]>> {
   const uniqueIds = Array.from(new Set(pathwayIds.filter(Boolean)));
   if (uniqueIds.length === 0) return {};
@@ -276,7 +344,7 @@ export async function matchFellowshipsForPathways(
   const matchesByPathway: Record<string, FellowshipMatch[]> = {};
   for (const pathway of pathways) {
     const matches = fellowships
-      .map((fellowship) => scoreFellowshipForPathway(pathway, fellowship))
+      .map((fellowship) => scoreFellowshipForPathway(pathway, fellowship, new Date(), context))
       .filter((match): match is FellowshipMatch => !!match)
       .sort(
         (a, b) =>


### PR DESCRIPTION
## Summary
- use structured class-year and program-level metadata to exclude clearly incompatible graduate-only matches and demote known year mismatches
- align summer and academic-year awards with saved pathway thesis intent while leaving missing metadata unknown
- reject garbage fellowship titles before scoring and explain level/timing decisions in student-facing language

## Validation
- server matcher tests: 19 passed
- user controller tests: 45 passed
- client SavedPathways tests: 13 passed
- full client suite: 717 passed
- server build passed
- client build reaches existing missing web-vitals dependency in shared install

No data mutation or Graphify run.