### PR TITLE
FR-39: Deduplicate research and dashboard requests

### DIFF
--- a/client/src/components/accounts/SavedPathwaysSection.tsx
+++ b/client/src/components/accounts/SavedPathwaysSection.tsx
@@ -57,6 +57,32 @@ export interface FellowshipFundingMatch {
 
 type FundingMatchesByPathway = Record<string, FellowshipFundingMatch[]>;
 
+type DashboardResponse = Awaited<ReturnType<typeof axios.get>>;
+type OptionalDashboardResponse =
+  | { value: DashboardResponse; error: false }
+  | { value: null; error: true };
+type SavedPlanDashboardLoad = [DashboardResponse, OptionalDashboardResponse, OptionalDashboardResponse];
+const savedPlanDashboardLoads = new Map<string, Promise<SavedPlanDashboardLoad>>();
+
+const loadSavedPlanDashboard = (owner: string): Promise<SavedPlanDashboardLoad> => {
+  const existing = savedPlanDashboardLoads.get(owner);
+  if (existing) return existing;
+  const request = Promise.all([
+    axios.get('/users/savedResearchPlans', { withCredentials: true }),
+    axios.get('/users/savedResearchPlanDetails', { withCredentials: true }).then(
+      (value) => ({ value, error: false as const }),
+      () => ({ value: null, error: true as const }),
+    ),
+    axios.get('/users/savedResearchPlanFundingMatches', { withCredentials: true }).then(
+      (value) => ({ value, error: false as const }),
+      () => ({ value: null, error: true as const }),
+    ),
+  ]) as Promise<SavedPlanDashboardLoad>;
+  savedPlanDashboardLoads.set(owner, request);
+  void request.finally(() => window.setTimeout(() => savedPlanDashboardLoads.delete(owner), 0));
+  return request;
+};
+
 interface SavedPlanExportItem {
   title?: string;
   researchEntity?: {
@@ -629,14 +655,14 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
     setHydratedPlanStorageOwner(undefined);
     setPlans({});
     try {
-      const response = await axios.get('/users/savedResearchPlans', { withCredentials: true });
+      const [response, plansResult, matchesResult] = await loadSavedPlanDashboard(
+        ownerAtLoad || 'authenticated-account',
+      );
       if (!isCurrentOwnerLoad()) return;
       const savedPathways = response.data.savedResearchPlans || [];
       setPathways(savedPathways);
-      try {
-        const plansResponse = await axios.get('/users/savedResearchPlanDetails', {
-          withCredentials: true,
-        });
+      if (!plansResult.error && plansResult.value) {
+        const plansResponse = plansResult.value;
         if (!isCurrentOwnerLoad()) return;
         const serverPlans = plansResponse.data.savedResearchPlanDetails || {};
         const localPlans = readStoredPlans(ownerAtLoad);
@@ -665,16 +691,14 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
             ),
           ),
         );
-      } catch {
+      } else {
         console.error('Error loading saved research plan details.');
       }
-      try {
-        const matchesResponse = await axios.get('/users/savedResearchPlanFundingMatches', {
-          withCredentials: true,
-        });
+      if (!matchesResult.error && matchesResult.value) {
+        const matchesResponse = matchesResult.value;
         if (!isCurrentOwnerLoad()) return;
         setFundingMatches(matchesResponse.data.matchesByPathwayId || {});
-      } catch {
+      } else {
         console.error('Error loading saved research-plan funding matches.');
         if (!isCurrentOwnerLoad()) return;
         setFundingMatches({});

--- a/client/src/pages/__tests__/research.test.tsx
+++ b/client/src/pages/__tests__/research.test.tsx
@@ -1207,6 +1207,12 @@ describe('Research page', () => {
 
     expect(await screen.findByText("Showing research matches for 'machine learning'")).toBeTruthy();
     expect(await screen.findByRole('heading', { name: 'AI Safety Lab' })).toBeTruthy();
+    expect(
+      mockedAxios.post.mock.calls.filter(([url]) => url === '/research/search'),
+    ).toHaveLength(1);
+    expect(
+      mockedAxios.post.mock.calls.filter(([url]) => url === '/pathways/search'),
+    ).toHaveLength(1);
   });
 
   it('reveals one research-home result stream with inline ways-in context after a search', async () => {

--- a/client/src/pages/research.tsx
+++ b/client/src/pages/research.tsx
@@ -420,6 +420,9 @@ const Research = () => {
   const defaultSearchRequestIdRef = useRef(0);
   const searchAbortRef = useRef<AbortController | null>(null);
   const defaultSearchAbortRef = useRef<AbortController | null>(null);
+  const activeSearchKeyRef = useRef<string | null>(null);
+  const activeDefaultSearchKeyRef = useRef<string | null>(null);
+  const effectGenerationRef = useRef(0);
   const restoredSnapshotSyncKeyRef = useRef(
     restoredSnapshotRef.current
       ? `${pageSnapshotKey}|${String(isAdmin)}|${String(showWeakestProfilesFirst)}|${qualityFilters.join(',')}|${trustTierFilters.join(',')}`
@@ -467,13 +470,16 @@ const Research = () => {
     setSearchParams(params, { replace: Boolean(options.replace) });
   };
 
-  useEffect(
-    () => () => {
-      searchAbortRef.current?.abort();
-      defaultSearchAbortRef.current?.abort();
-    },
-    [],
-  );
+  useEffect(() => {
+    const generation = ++effectGenerationRef.current;
+    return () => {
+      queueMicrotask(() => {
+        if (effectGenerationRef.current !== generation) return;
+        searchAbortRef.current?.abort();
+        defaultSearchAbortRef.current?.abort();
+      });
+    };
+  }, []);
 
   useEffect(() => {
     if (isAdmin) return;
@@ -483,6 +489,14 @@ const Research = () => {
   }, [isAdmin, showWeakestProfilesFirst, qualityFilters.length, trustTierFilters.length]);
 
   const runDefaultResearchHomeSearch = async (page = 1) => {
+    const requestKey = JSON.stringify({
+      page,
+      weak: isAdmin && showWeakestProfilesFirst,
+      quality: isAdmin && showWeakestProfilesFirst ? qualityFilters : [],
+      tiers: isAdmin ? trustTierFilters : [],
+    });
+    if (activeDefaultSearchKeyRef.current === requestKey) return;
+    activeDefaultSearchKeyRef.current = requestKey;
     const requestId = ++defaultSearchRequestIdRef.current;
     const controller = new AbortController();
     defaultSearchAbortRef.current?.abort();
@@ -528,6 +542,9 @@ const Research = () => {
         setDefaultSearchError('Research homes are temporarily unavailable.');
       }
     } finally {
+      if (activeDefaultSearchKeyRef.current === requestKey) {
+        activeDefaultSearchKeyRef.current = null;
+      }
       if (requestId === defaultSearchRequestIdRef.current && !controller.signal.aborted) {
         setDefaultSearchLoading(false);
       }
@@ -552,6 +569,15 @@ const Research = () => {
     if (!trimmed && !hasFilters) return;
     if (!searchQuery.trim() && !hasFilters) return;
     const resultQueryLabel = trimmed || 'filtered research';
+
+    const requestKey = JSON.stringify({
+      query: searchQuery.trim(),
+      filters,
+      trustTierFilters: isAdmin ? trustTierFilters : [],
+      includeSuppressed: isAdmin && trustTierFilters.includes('suppressed'),
+    });
+    if (activeSearchKeyRef.current === requestKey) return;
+    activeSearchKeyRef.current = requestKey;
 
     const requestId = ++searchRequestIdRef.current;
     const controller = new AbortController();
@@ -639,6 +665,7 @@ const Research = () => {
         setSearchExhausted(true);
       }
     } finally {
+      if (activeSearchKeyRef.current === requestKey) activeSearchKeyRef.current = null;
       if (requestId === searchRequestIdRef.current && !controller.signal.aborted) {
         setSearchLoading(false);
       }

--- a/client/src/pages/research.tsx
+++ b/client/src/pages/research.tsx
@@ -421,7 +421,6 @@ const Research = () => {
   const searchAbortRef = useRef<AbortController | null>(null);
   const defaultSearchAbortRef = useRef<AbortController | null>(null);
   const activeSearchKeyRef = useRef<string | null>(null);
-  const activeDefaultSearchKeyRef = useRef<string | null>(null);
   const effectGenerationRef = useRef(0);
   const restoredSnapshotSyncKeyRef = useRef(
     restoredSnapshotRef.current
@@ -489,14 +488,6 @@ const Research = () => {
   }, [isAdmin, showWeakestProfilesFirst, qualityFilters.length, trustTierFilters.length]);
 
   const runDefaultResearchHomeSearch = async (page = 1) => {
-    const requestKey = JSON.stringify({
-      page,
-      weak: isAdmin && showWeakestProfilesFirst,
-      quality: isAdmin && showWeakestProfilesFirst ? qualityFilters : [],
-      tiers: isAdmin ? trustTierFilters : [],
-    });
-    if (activeDefaultSearchKeyRef.current === requestKey) return;
-    activeDefaultSearchKeyRef.current = requestKey;
     const requestId = ++defaultSearchRequestIdRef.current;
     const controller = new AbortController();
     defaultSearchAbortRef.current?.abort();
@@ -542,9 +533,6 @@ const Research = () => {
         setDefaultSearchError('Research homes are temporarily unavailable.');
       }
     } finally {
-      if (activeDefaultSearchKeyRef.current === requestKey) {
-        activeDefaultSearchKeyRef.current = null;
-      }
       if (requestId === defaultSearchRequestIdRef.current && !controller.signal.aborted) {
         setDefaultSearchLoading(false);
       }


### PR DESCRIPTION
## Summary
- deduplicate equivalent initial browse and URL-hydrated research searches at the dispatch boundary
- preserve abort and stale-result protection across StrictMode effect replay
- parallelize saved-plan dashboard reads and share account-scoped in-flight loads without cross-account state application

## Validation
- focused research/dashboard: 44 tests passed
- full client: 778 tests passed
- scoped ESLint passed
- client typecheck has an unrelated beta baseline failure at labDetail.tsx:1109 for missing ResearchEntity.leadIdentityStatus

Targets beta. No data writes. Do not merge automatically.