### PR TITLE
FR-30: require deliberate admin grant confirmation

### DIFF
--- a/client/src/pages/__tests__/analytics.test.tsx
+++ b/client/src/pages/__tests__/analytics.test.tsx
@@ -541,7 +541,7 @@ describe('Analytics page', () => {
     await waitFor(() => {
       expect(mockedAxios.post).toHaveBeenCalledWith(
         '/admin/admin-grants/fixture-admin/revoke',
-        { note: '' },
+        { note: 'Revoked through the Admin Access panel.' },
         { withCredentials: true },
       );
     });

--- a/client/src/pages/__tests__/analytics.test.tsx
+++ b/client/src/pages/__tests__/analytics.test.tsx
@@ -392,9 +392,8 @@ describe('Analytics page', () => {
     expect(screen.getByText('fixture-admin')).toBeTruthy();
     expect(screen.getByText('Fixture Admin')).toBeTruthy();
     expect(screen.getByText('manual')).toBeTruthy();
-    expect(
-      screen.getByText(/legacy admin profile row without active grants: fixture-legacy-admin/i),
-    ).toBeTruthy();
+    expect(screen.getByText(/profile-derived admin authority is present without/i)).toBeTruthy();
+    expect(screen.queryByText('fixture-legacy-admin')).toBeNull();
   });
 
   it('grants admin access from the analytics admin access section', async () => {
@@ -449,7 +448,12 @@ describe('Analytics page', () => {
     fireEvent.change(screen.getByLabelText('Admin grant note'), {
       target: { value: 'Temporary coverage' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Grant Admin' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Review Grant' }));
+    expect(mockedAxios.post).not.toHaveBeenCalled();
+    fireEvent.change(screen.getByLabelText('Confirm target NetID'), {
+      target: { value: 'fixture-new-admin' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm Grant' }));
 
     await waitFor(() => {
       expect(mockedAxios.post).toHaveBeenCalledWith(

--- a/client/src/pages/analytics.tsx
+++ b/client/src/pages/analytics.tsx
@@ -1,7 +1,7 @@
 /**
  * Analytics dashboard page for admin usage statistics.
  */
-import { FormEvent, useCallback, useContext, useEffect, useReducer, useState } from 'react';
+import { FormEvent, useCallback, useContext, useEffect, useReducer, useRef, useState } from 'react';
 import axios from '../utils/axios';
 import swal from 'sweetalert';
 import AdminPanel from '../components/admin/AdminPanel';
@@ -70,6 +70,10 @@ const Analytics = () => {
   const [adminAccessError, setAdminAccessError] = useState<string | null>(null);
   const [adminGrantNetid, setAdminGrantNetid] = useState('');
   const [adminGrantNote, setAdminGrantNote] = useState('');
+  const [pendingAdminGrantNetid, setPendingAdminGrantNetid] = useState<string | null>(null);
+  const [adminGrantConfirmation, setAdminGrantConfirmation] = useState('');
+  const grantDialogCancelRef = useRef<HTMLButtonElement>(null);
+  const grantReviewButtonRef = useRef<HTMLButtonElement>(null);
   const [adminAccessActionError, setAdminAccessActionError] = useState<string | null>(null);
   const [adminAccessActionMessage, setAdminAccessActionMessage] = useState<string | null>(null);
   const [adminAccessActionNetid, setAdminAccessActionNetid] = useState<string | null>(null);
@@ -154,37 +158,56 @@ const Analytics = () => {
     return clientErrorMessage(error, fallback);
   };
 
-  const handleGrantAdminAccess = useCallback(
-    async (event?: FormEvent, requestedNetid?: string) => {
-      event?.preventDefault();
-      const netid = (requestedNetid || adminGrantNetid).trim().toLowerCase();
-      if (!netid) {
-        setAdminAccessActionError('NetID is required.');
-        return;
-      }
-      setAdminAccessActionNetid(netid);
-      setAdminAccessActionError(null);
-      setAdminAccessActionMessage(null);
-      try {
-        await axios.post(
-          '/admin/admin-grants',
-          { netid, note: requestedNetid ? '' : adminGrantNote.trim() },
-          { withCredentials: true },
-        );
-        setAdminGrantNetid('');
-        if (!requestedNetid) setAdminGrantNote('');
-        setAdminAccessActionMessage(`Admin access granted to ${netid}.`);
-        await fetchAdminAccess();
-      } catch (error) {
-        setAdminAccessActionError(
-          adminAccessErrorMessage(error, `Failed to grant admin access to ${netid}.`),
-        );
-      } finally {
-        setAdminAccessActionNetid(null);
-      }
-    },
-    [adminGrantNetid, adminGrantNote, fetchAdminAccess],
-  );
+  const requestGrantAdminAccess = (event: FormEvent) => {
+    event.preventDefault();
+    const netid = adminGrantNetid.trim().toLowerCase();
+    if (!netid || !adminGrantNote.trim()) {
+      setAdminAccessActionError('NetID and reviewer note are required.');
+      return;
+    }
+    setAdminAccessActionError(null);
+    setAdminGrantConfirmation('');
+    setPendingAdminGrantNetid(netid);
+  };
+  const closeGrantDialog = () => {
+    setPendingAdminGrantNetid(null);
+    setAdminGrantConfirmation('');
+    window.setTimeout(() => grantReviewButtonRef.current?.focus(), 0);
+  };
+
+  const handleGrantAdminAccess = useCallback(async () => {
+    const netid = pendingAdminGrantNetid || '';
+    if (!netid) {
+      setAdminAccessActionError('NetID is required.');
+      return;
+    }
+    setAdminAccessActionNetid(netid);
+    setAdminAccessActionError(null);
+    setAdminAccessActionMessage(null);
+    try {
+      await axios.post(
+        '/admin/admin-grants',
+        { netid, note: adminGrantNote.trim() },
+        { withCredentials: true },
+      );
+      setAdminGrantNetid('');
+      setAdminGrantNote('');
+      setPendingAdminGrantNetid(null);
+      setAdminGrantConfirmation('');
+      setAdminAccessActionMessage(`Admin access granted to ${netid}.`);
+      await fetchAdminAccess();
+    } catch (error) {
+      setAdminAccessActionError(
+        adminAccessErrorMessage(error, `Failed to grant admin access to ${netid}.`),
+      );
+    } finally {
+      setAdminAccessActionNetid(null);
+    }
+  }, [pendingAdminGrantNetid, adminGrantNote, fetchAdminAccess]);
+
+  useEffect(() => {
+    if (pendingAdminGrantNetid) grantDialogCancelRef.current?.focus();
+  }, [pendingAdminGrantNetid]);
 
   const handleRevokeAdminAccess = useCallback(
     async (netid: string) => {
@@ -204,7 +227,7 @@ const Analytics = () => {
       try {
         await axios.post(
           `/admin/admin-grants/${encodeURIComponent(normalizedNetid)}/revoke`,
-          { note: '' },
+          { note: 'Revoked through the Admin Access panel.' },
           { withCredentials: true },
         );
         setAdminAccessActionMessage(`Admin access revoked for ${normalizedNetid}.`);
@@ -743,9 +766,7 @@ const Analytics = () => {
 
           <form
             className="mb-4 grid gap-3 rounded-lg border border-[var(--yr-line)] bg-[var(--yr-panel)] p-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1.5fr)_auto]"
-            onSubmit={(event) => {
-              void handleGrantAdminAccess(event);
-            }}
+            onSubmit={requestGrantAdminAccess}
           >
             <label className="block">
               <span className="mb-1 block text-xs font-semibold uppercase text-gray-500">
@@ -766,15 +787,17 @@ const Analytics = () => {
                 className="min-h-[44px] w-full rounded-md border border-[var(--yr-line-strong)] px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
                 value={adminGrantNote}
                 onChange={(event) => setAdminGrantNote(event.target.value)}
-                placeholder="Optional"
+                placeholder="Required reason for this grant"
+                maxLength={512}
               />
             </label>
             <button
+              ref={grantReviewButtonRef}
               className="inline-flex min-h-[44px] items-center justify-center self-end rounded-md bg-[var(--yr-blue)] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-900 disabled:cursor-not-allowed disabled:bg-blue-300"
               type="submit"
               disabled={adminAccessActionNetid !== null}
             >
-              Grant Admin
+              Review Grant
             </button>
           </form>
 
@@ -792,9 +815,10 @@ const Analytics = () => {
 
           {adminAccess.legacyAdminsWithoutGrant.length > 0 && (
             <div className="mb-4 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
-              {adminAccess.legacyAdminsWithoutGrant.length} legacy admin profile row
-              {adminAccess.legacyAdminsWithoutGrant.length === 1 ? '' : 's'} without active grants:{' '}
-              {adminAccess.legacyAdminsWithoutGrant.map((user) => user.netid).join(', ')}
+              {adminAccess.legacyAdminsWithoutGrant.length} profile-derived admin authorit
+              {adminAccess.legacyAdminsWithoutGrant.length === 1 ? 'y is' : 'ies are'} present
+              without an active grant. These records are shown separately and do not silently change
+              the production authorization policy.
               <div className="mt-3 flex flex-wrap gap-2">
                 {adminAccess.legacyAdminsWithoutGrant.map((user) => (
                   <button
@@ -803,10 +827,11 @@ const Analytics = () => {
                     className="rounded-md border border-amber-300 bg-white px-3 py-1 text-xs font-semibold text-amber-900 hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-60"
                     disabled={adminAccessActionNetid !== null}
                     onClick={() => {
-                      void handleGrantAdminAccess(undefined, user.netid);
+                      setAdminGrantNetid(user.netid);
+                      setAdminGrantNote('');
                     }}
                   >
-                    Grant {user.netid}
+                    Review profile authority
                   </button>
                 ))}
               </div>
@@ -910,6 +935,61 @@ const Analytics = () => {
               </table>
             </div>
           </div>
+          {pendingAdminGrantNetid && (
+            <div
+              className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+              role="presentation"
+              onKeyDown={(event) => {
+                if (event.key === 'Escape') closeGrantDialog();
+              }}
+            >
+              <div
+                aria-describedby="admin-grant-confirm-description"
+                aria-labelledby="admin-grant-confirm-title"
+                aria-modal="true"
+                className="w-full max-w-lg rounded-md bg-white p-6 shadow-xl"
+                role="dialog"
+              >
+                <h3 id="admin-grant-confirm-title" className="text-lg font-bold text-gray-900">
+                  Confirm admin grant
+                </h3>
+                <p id="admin-grant-confirm-description" className="mt-2 text-sm text-gray-700">
+                  Grant admin authority to <strong>{pendingAdminGrantNetid}</strong>. Enter the
+                  target NetID again to confirm this deliberate access change.
+                </p>
+                <label className="mt-4 block text-sm font-semibold text-gray-700">
+                  Confirm target NetID
+                  <input
+                    autoComplete="off"
+                    className="mt-1 min-h-[44px] w-full rounded-md border px-3 py-2"
+                    value={adminGrantConfirmation}
+                    onChange={(event) => setAdminGrantConfirmation(event.target.value)}
+                  />
+                </label>
+                <div className="mt-5 flex justify-end gap-3">
+                  <button
+                    ref={grantDialogCancelRef}
+                    type="button"
+                    className="rounded-md border px-4 py-2 text-sm font-semibold"
+                    onClick={closeGrantDialog}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-md bg-[var(--yr-blue)] px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+                    disabled={
+                      adminAccessActionNetid !== null ||
+                      adminGrantConfirmation.trim().toLowerCase() !== pendingAdminGrantNetid
+                    }
+                    onClick={() => void handleGrantAdminAccess()}
+                  >
+                    Confirm Grant
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
         </section>
 
         <DetailSectionHeader

--- a/scripts/security-preflight.test.mjs
+++ b/scripts/security-preflight.test.mjs
@@ -4910,7 +4910,8 @@ test('admin grant notes are bounded before persistence', () => {
   assert.doesNotMatch(source, /const normalizeNetid = \(netid: unknown\) => String\(netid \|\| ''\)/);
   assert.match(source, /MAX_ADMIN_GRANT_NOTE_LENGTH = 512/);
   assert.match(source, /const normalizeAdminGrantNote = \(note: unknown\): string =>/);
-  assert.match(source, /note\.trim\(\)\.slice\(0, MAX_ADMIN_GRANT_NOTE_LENGTH\)/);
+  assert.match(source, /const normalized = note\.trim\(\)/);
+  assert.match(source, /!normalized \|\| normalized\.length > MAX_ADMIN_GRANT_NOTE_LENGTH/);
   assert.match(source, /note: normalizeAdminGrantNote\(note\)/);
   assert.match(source, /revokeNote: normalizeAdminGrantNote\(note\)/);
   assert.doesNotMatch(source, /note: typeof note === 'string' \? note\.trim\(\) : ''/);

--- a/server/src/models/adminGrant.ts
+++ b/server/src/models/adminGrant.ts
@@ -49,6 +49,18 @@ const adminGrantSchema = new mongoose.Schema(
       type: String,
       default: '',
     },
+    history: {
+      type: [
+        {
+          action: { type: String, enum: ['granted', 'revoked'], required: true },
+          actorNetid: { type: String, required: true, lowercase: true, trim: true },
+          note: { type: String, required: true },
+          at: { type: Date, required: true },
+          _id: false,
+        },
+      ],
+      default: [],
+    },
   },
   {
     collection: 'admin_grants',

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -39,6 +39,7 @@ import {
 } from '../services/adminAccessReviewService';
 import {
   AdminGrantValidationError,
+  AdminGrantConflictError,
   grantAdminAccess,
   listAdminGrants,
   revokeAdminAccess,
@@ -532,8 +533,13 @@ export const normalizeAdminDepartmentCategories = (
 
 const sendAdminGrantError = (res: Response, error: unknown, fallbackMessage: string) => {
   const isValidationFailure = error instanceof AdminGrantValidationError;
-  res.status(isValidationFailure ? 400 : 500).json({
-    error: isValidationFailure ? 'Invalid admin grant request' : fallbackMessage,
+  const isConflict = error instanceof AdminGrantConflictError;
+  res.status(isValidationFailure ? 400 : isConflict ? 409 : 500).json({
+    error: isValidationFailure
+      ? 'Invalid admin grant request'
+      : isConflict
+        ? 'Admin access is already active'
+        : fallbackMessage,
   });
 };
 

--- a/server/src/services/__tests__/adminGrantService.test.ts
+++ b/server/src/services/__tests__/adminGrantService.test.ts
@@ -60,35 +60,44 @@ describe('admin grant note persistence', () => {
     vi.restoreAllMocks();
   });
 
-  it('caps grant notes before persistence', async () => {
+  it('rejects missing and oversized grant notes', async () => {
     const findOneAndUpdate = vi
       .spyOn(AdminGrant, 'findOneAndUpdate')
       .mockReturnValue({ lean: vi.fn().mockResolvedValue({}) } as any);
 
-    await grantAdminAccess({
-      netid: 'abc123',
-      actorNetid: 'admin1',
-      note: ` ${'x'.repeat(MAX_ADMIN_GRANT_NOTE_LENGTH + 50)} `,
-    });
-
-    const update = findOneAndUpdate.mock.calls[0][1] as any;
-    expect(update.$set.note).toHaveLength(MAX_ADMIN_GRANT_NOTE_LENGTH);
-    expect(update.$set.note).toBe('x'.repeat(MAX_ADMIN_GRANT_NOTE_LENGTH));
+    await expect(
+      grantAdminAccess({ netid: 'abc123', actorNetid: 'admin1', note: '   ' }),
+    ).rejects.toThrow();
+    await expect(
+      grantAdminAccess({
+        netid: 'abc123',
+        actorNetid: 'admin1',
+        note: 'x'.repeat(MAX_ADMIN_GRANT_NOTE_LENGTH + 1),
+      }),
+    ).rejects.toThrow();
+    expect(findOneAndUpdate).not.toHaveBeenCalled();
   });
 
-  it('caps revoke notes before persistence', async () => {
+  it('rejects self grants before persistence', async () => {
+    const findOneAndUpdate = vi.spyOn(AdminGrant, 'findOneAndUpdate');
+    await expect(
+      grantAdminAccess({ netid: 'admin1', actorNetid: 'ADMIN1', note: 'reviewed' }),
+    ).rejects.toThrow();
+    expect(findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('rejects oversized revoke notes before persistence', async () => {
     const findOneAndUpdate = vi
       .spyOn(AdminGrant, 'findOneAndUpdate')
       .mockReturnValue({ lean: vi.fn().mockResolvedValue({}) } as any);
 
-    await revokeAdminAccess({
-      netid: 'abc123',
-      actorNetid: 'admin1',
-      note: ` ${'y'.repeat(MAX_ADMIN_GRANT_NOTE_LENGTH + 50)} `,
-    });
-
-    const update = findOneAndUpdate.mock.calls[0][1] as any;
-    expect(update.$set.revokeNote).toHaveLength(MAX_ADMIN_GRANT_NOTE_LENGTH);
-    expect(update.$set.revokeNote).toBe('y'.repeat(MAX_ADMIN_GRANT_NOTE_LENGTH));
+    await expect(
+      revokeAdminAccess({
+        netid: 'abc123',
+        actorNetid: 'admin1',
+        note: 'y'.repeat(MAX_ADMIN_GRANT_NOTE_LENGTH + 1),
+      }),
+    ).rejects.toThrow();
+    expect(findOneAndUpdate).not.toHaveBeenCalled();
   });
 });

--- a/server/src/services/adminGrantService.ts
+++ b/server/src/services/adminGrantService.ts
@@ -9,6 +9,7 @@ const NETID_RE = /^[A-Za-z0-9]{2,12}$/;
 export const MAX_ADMIN_GRANT_NOTE_LENGTH = 512;
 
 export class AdminGrantValidationError extends Error {}
+export class AdminGrantConflictError extends Error {}
 
 export interface AdminGrantResponse {
   activeCount: number;
@@ -25,8 +26,14 @@ const assertValidNetid = (netid: string) => {
   }
 };
 
-const normalizeAdminGrantNote = (note: unknown): string =>
-  typeof note === 'string' ? note.trim().slice(0, MAX_ADMIN_GRANT_NOTE_LENGTH) : '';
+const normalizeAdminGrantNote = (note: unknown): string => {
+  if (typeof note !== 'string') throw new AdminGrantValidationError('Reviewer note is required');
+  const normalized = note.trim();
+  if (!normalized || normalized.length > MAX_ADMIN_GRANT_NOTE_LENGTH) {
+    throw new AdminGrantValidationError('Reviewer note is required and must be bounded');
+  }
+  return normalized;
+};
 
 export const allowsLegacyAdminUserType = (env: NodeJS.ProcessEnv = process.env): boolean =>
   isLocalDevelopmentRuntime(env);
@@ -115,27 +122,50 @@ export const grantAdminAccess = async ({
   const normalizedActor = normalizeNetid(actorNetid);
   assertValidNetid(normalizedNetid);
   assertValidNetid(normalizedActor);
-  adminGrantCache.delete(normalizedNetid);
+  if (normalizedNetid === normalizedActor) {
+    throw new AdminGrantValidationError('Administrators cannot grant access to themselves');
+  }
+  const normalizedNote = normalizeAdminGrantNote(note);
+  const now = new Date();
 
-  return AdminGrant.findOneAndUpdate(
-    { netid: normalizedNetid },
-    {
-      $set: {
-        netid: normalizedNetid,
-        status: 'active',
-        source,
-        grantedBy: normalizedActor,
-        grantedAt: new Date(),
-        note: normalizeAdminGrantNote(note),
+  let grant;
+  try {
+    grant = await AdminGrant.findOneAndUpdate(
+      { netid: normalizedNetid, status: { $ne: 'active' } },
+      {
+        $set: {
+          netid: normalizedNetid,
+          status: 'active',
+          source,
+          grantedBy: normalizedActor,
+          grantedAt: now,
+          note: normalizeAdminGrantNote(note),
+        },
+        $unset: {
+          revokedBy: '',
+          revokedAt: '',
+          revokeNote: '',
+        },
+        $push: {
+          history: {
+            action: 'granted',
+            actorNetid: normalizedActor,
+            note: normalizedNote,
+            at: now,
+          },
+        },
       },
-      $unset: {
-        revokedBy: '',
-        revokedAt: '',
-        revokeNote: '',
-      },
-    },
-    { new: true, upsert: true, setDefaultsOnInsert: true },
-  ).lean();
+      { new: true, upsert: true, setDefaultsOnInsert: true },
+    ).lean();
+  } catch (error: any) {
+    if (error?.code === 11000) {
+      throw new AdminGrantConflictError('Admin access is already active');
+    }
+    throw error;
+  }
+  if (!grant) throw new AdminGrantConflictError('Admin access is already active');
+  adminGrantCache.delete(normalizedNetid);
+  return grant;
 };
 
 export const revokeAdminAccess = async ({
@@ -151,18 +181,24 @@ export const revokeAdminAccess = async ({
   const normalizedActor = normalizeNetid(actorNetid);
   assertValidNetid(normalizedNetid);
   assertValidNetid(normalizedActor);
-  adminGrantCache.delete(normalizedNetid);
+  const normalizedNote = normalizeAdminGrantNote(note);
+  const now = new Date();
 
-  return AdminGrant.findOneAndUpdate(
+  const grant = await AdminGrant.findOneAndUpdate(
     { netid: normalizedNetid, status: 'active' },
     {
       $set: {
         status: 'revoked',
         revokedBy: normalizedActor,
-        revokedAt: new Date(),
+        revokedAt: now,
         revokeNote: normalizeAdminGrantNote(note),
+      },
+      $push: {
+        history: { action: 'revoked', actorNetid: normalizedActor, note: normalizedNote, at: now },
       },
     },
     { new: true },
   ).lean();
+  if (grant) adminGrantCache.delete(normalizedNetid);
+  return grant;
 };


### PR DESCRIPTION
## Summary
- require bounded reviewer notes and typed NetID confirmation before admin grants
- reject self and duplicate grants atomically while preserving audit history and cache correctness
- distinguish active grants from profile-derived authority without exposing legacy NetIDs in panel copy

## Validation
- server typecheck
- server tests: 2583 passed
- client tests: 778 passed
- security policy
- server and client production builds
- focused FR-30 server/client tests

## Notes
- repository-wide format check remains red on 430 pre-existing files; all changed files were formatted and git diff --check passes