### PR TITLE
FR-40: bound related entity detail payloads

### DIFF
--- a/client/src/pages/__tests__/labDetail.test.tsx
+++ b/client/src/pages/__tests__/labDetail.test.tsx
@@ -996,7 +996,7 @@ describe('LabDetail page', () => {
     );
   });
 
-  it('renders non-public umbrella affiliations without linking to a hidden detail page', async () => {
+  it('does not link an affiliation summary without a navigable slug', async () => {
     renderLabDetail({
       ...basePayload,
       group: {
@@ -1011,11 +1011,10 @@ describe('LabDetail page', () => {
           ...basePayload.group,
           _id: 'entity-umbrella',
           id: 'entity-umbrella',
-          slug: 'center-yale-quantum-institute',
+          slug: '',
           name: 'Yale Quantum Institute',
           kind: 'institute',
           entityType: 'INSTITUTE',
-          studentVisibilityTier: 'operator_review',
           departments: ['Physics'],
           researchAreas: [],
           sourceUrls: [],

--- a/client/src/pages/labDetail.tsx
+++ b/client/src/pages/labDetail.tsx
@@ -32,6 +32,7 @@ import {
   LabEntryPathway,
   LabMember,
   LabPostedOpportunity,
+  LabRelatedResearchEntitySummary,
   LabResearchActivityLink,
 } from '../types/labDetail';
 import type { ResearchEntity, ResearchEntityRepairFlag } from '../types/researchEntity';
@@ -76,7 +77,7 @@ const RelatedResearchEntitiesSection = ({
   relatedResearchEntities,
 }: {
   relationships: LabEntityRelationship[];
-  relatedResearchEntities: ResearchEntity[];
+  relatedResearchEntities: LabRelatedResearchEntitySummary[];
 }) => {
   const relationshipByEntityKey = new Map(
     relationships.flatMap((relationship) =>
@@ -91,9 +92,9 @@ const RelatedResearchEntitiesSection = ({
       <SectionHeading>Related labs and groups</SectionHeading>
       <div className="grid gap-3 sm:grid-cols-2">
         {relatedResearchEntities.map((entity) => {
-          const relationship = relationshipByEntityKey.get(entity.slug || entity.id || entity._id);
+          const relationship = relationshipByEntityKey.get(entity.slug || entity.id);
           const description =
-            entity.shortDescription || entity.fullDescription || entity.description || '';
+            entity.blurb || '';
           const tags = uniqueCompact(
             [
               relationship?.label || relationshipTypeLabel(relationship?.relationshipType),
@@ -104,7 +105,7 @@ const RelatedResearchEntitiesSection = ({
           );
           return (
             <Link
-              key={entity.id || entity._id || entity.slug}
+              key={entity.id || entity.slug}
               to={`/research/${safeRouteSegment(entity.slug)}`}
               className="block rounded-lg border border-[var(--yr-line)] bg-[var(--yr-panel)] p-4 transition hover:border-blue-300 hover:shadow-sm"
             >
@@ -135,7 +136,7 @@ const RelatedResearchEntitiesSection = ({
 const AffiliatedResearchEntitiesSection = ({
   affiliatedResearchEntities,
 }: {
-  affiliatedResearchEntities: ResearchEntity[];
+  affiliatedResearchEntities: LabRelatedResearchEntitySummary[];
 }) => (
   <section>
     <SectionHeading>Affiliated with</SectionHeading>
@@ -162,17 +163,17 @@ const AffiliatedResearchEntitiesSection = ({
         const className =
           'block rounded-lg border border-[var(--yr-line)] bg-[var(--yr-panel)] p-4 transition';
         const canOpenDetail =
-          !entity.studentVisibilityTier || entity.studentVisibilityTier === 'student_ready';
+          Boolean(entity.slug);
         return canOpenDetail ? (
           <Link
-            key={entity.id || entity._id || entity.slug}
+            key={entity.id || entity.slug}
             to={`/research/${safeRouteSegment(entity.slug)}`}
             className={`${className} hover:border-blue-300 hover:shadow-sm`}
           >
             {content}
           </Link>
         ) : (
-          <div key={entity.id || entity._id || entity.slug} className={className}>
+          <div key={entity.id || entity.slug} className={className}>
             {content}
           </div>
         );

--- a/client/src/types/labDetail.ts
+++ b/client/src/types/labDetail.ts
@@ -169,6 +169,21 @@ export interface LabEntityRelationship {
   confidence?: number;
 }
 
+export interface LabRelatedResearchEntitySummary {
+  id: string;
+  slug: string;
+  name: string;
+  kind?: string;
+  entityType?: string;
+  departments: string[];
+  blurb?: string;
+}
+
+export interface LabRelationshipCollectionMeta {
+  returned: number;
+  truncated: boolean;
+}
+
 export interface LabDetailPayload {
   group: ResearchGroup;
   researchEntity?: ResearchEntity;
@@ -185,7 +200,9 @@ export interface LabDetailPayload {
   contactRoutes?: LabContactRoute[];
   postedOpportunities?: LabPostedOpportunity[];
   entityRelationships?: LabEntityRelationship[];
-  relatedResearchEntities?: ResearchEntity[];
+  relatedResearchEntities?: LabRelatedResearchEntitySummary[];
+  relatedResearchEntitiesMeta?: LabRelationshipCollectionMeta;
   affiliatedRelationships?: LabEntityRelationship[];
-  affiliatedResearchEntities?: ResearchEntity[];
+  affiliatedResearchEntities?: LabRelatedResearchEntitySummary[];
+  affiliatedResearchEntitiesMeta?: LabRelationshipCollectionMeta;
 }

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4,6 +4,16 @@ This file records durable product and architecture decisions only.
 Do not append continuation logs, security hardening transcripts, or task progress here.
 Put tactical work in `docs/tasks/priority-roadmap.md` and keep transient artifacts outside `docs/`.
 
+## 2026-07-12: Bound Embedded Research Entity Summaries
+
+Public research detail responses embed related entities as strict card summaries rather than full public profile DTOs.
+The server projects only card fields, caps each relationship direction, reports truncation, and leaves full-profile retrieval to navigation.
+
+Do not add application-level response compression without verifying the deployed web-service topology first.
+The Render web service is managed outside `render.yaml`, so this repository cannot guarantee or configure its edge compression.
+Blanket compression around cookie-backed API responses would also increase BREACH, caching, buffering, and streaming review scope while potentially duplicating the platform edge.
+Prefer bounded public JSON DTOs, and configure compression at the deployment edge when its control-plane settings can be verified.
+
 ## 2026-07-04: Keep Durable Docs Compact
 
 Stale execution plans, worktree plans, UX screenshots, scratch reports, and proposal docs should not live in durable documentation.

--- a/scripts/security-preflight.test.mjs
+++ b/scripts/security-preflight.test.mjs
@@ -612,7 +612,7 @@ test('public research detail queries cap unauthenticated fan-out before serializ
     'MAX_PUBLIC_DETAIL_ACCESS_SIGNALS',
     'MAX_PUBLIC_DETAIL_CONTACT_ROUTES',
     'MAX_PUBLIC_DETAIL_POSTED_OPPORTUNITIES',
-    'MAX_PUBLIC_DETAIL_RELATIONSHIPS',
+    'MAX_PUBLIC_DETAIL_RELATIONSHIP_QUERY_LIMIT',
   ]) {
     assert.match(source, new RegExp(`const ${constant} = \\d+`));
     assert.match(source, new RegExp(`\\.limit\\(${constant}\\)`));

--- a/server/src/services/__tests__/researchGroupService.test.ts
+++ b/server/src/services/__tests__/researchGroupService.test.ts
@@ -1302,8 +1302,10 @@ describe('listResearchEntityRelationshipPayload', () => {
     expect(result).toEqual({
       entityRelationships: [],
       relatedResearchEntities: [],
+      relatedResearchEntitiesMeta: { returned: 0, truncated: false },
       affiliatedRelationships: [],
       affiliatedResearchEntities: [],
+      affiliatedResearchEntitiesMeta: { returned: 0, truncated: false },
     });
     expect(mocks.researchEntityRelationshipFind).not.toHaveBeenCalled();
   });
@@ -1313,8 +1315,9 @@ describe('listResearchEntityRelationshipPayload', () => {
     const publicInstituteId = '67d8928150621bcef434a1d6';
     const reviewInstituteId = '67d8928150621bcef434a1d7';
 
-    mocks.researchEntityRelationshipFind.mockReturnValue(
-      queryResult([
+    mocks.researchEntityRelationshipFind
+      .mockReturnValueOnce(queryResult([]))
+      .mockReturnValueOnce(queryResult([
         {
           _id: 'rel-yqi',
           sourceResearchEntityId: publicInstituteId,
@@ -1335,8 +1338,7 @@ describe('listResearchEntityRelationshipPayload', () => {
           evidenceStrength: 'MODERATE',
           evidenceQuote: 'Held private operator note',
         },
-      ]),
-    );
+      ]));
     mocks.researchEntityFind.mockReturnValue(
       queryResult([
         {
@@ -1362,12 +1364,13 @@ describe('listResearchEntityRelationshipPayload', () => {
 
     const result = await listResearchEntityRelationshipPayload(currentEntityId);
 
-    expect(mocks.researchEntityRelationshipFind).toHaveBeenCalledWith({
+    expect(mocks.researchEntityRelationshipFind).toHaveBeenNthCalledWith(1, {
       archived: { $ne: true },
-      $or: [
-        { sourceResearchEntityId: currentEntityId },
-        { targetResearchEntityId: currentEntityId },
-      ],
+      sourceResearchEntityId: currentEntityId,
+    });
+    expect(mocks.researchEntityRelationshipFind).toHaveBeenNthCalledWith(2, {
+      archived: { $ne: true },
+      targetResearchEntityId: currentEntityId,
     });
     expect(mocks.researchEntityFind).toHaveBeenCalledWith({
       _id: { $in: [publicInstituteId, reviewInstituteId] },
@@ -1377,6 +1380,7 @@ describe('listResearchEntityRelationshipPayload', () => {
     expect(result).toEqual({
       entityRelationships: [],
       relatedResearchEntities: [],
+      relatedResearchEntitiesMeta: { returned: 0, truncated: false },
       affiliatedRelationships: [
         expect.objectContaining({
           relationshipType: 'MEMBER_RESEARCH_AREA',
@@ -1385,16 +1389,68 @@ describe('listResearchEntityRelationshipPayload', () => {
       ],
       affiliatedResearchEntities: [
         expect.objectContaining({
-          _id: 'center-yale-quantum-institute',
+          id: 'center-yale-quantum-institute',
           slug: 'center-yale-quantum-institute',
           name: 'Yale Quantum Institute',
         }),
       ],
+      affiliatedResearchEntitiesMeta: { returned: 1, truncated: false },
     });
     expect(result.affiliatedRelationships[0].sourceUrl).toBeUndefined();
     expect(result.affiliatedRelationships[0]).not.toHaveProperty('evidenceQuote');
     expect(result.affiliatedRelationships[0]).not.toHaveProperty('createdAt');
     expect(JSON.stringify(result)).not.toContain('hidden@example.edu');
+  });
+
+  it('projects an allowlisted card shape and bounds a 99-related hub payload', async () => {
+    const currentEntityId = '67d8928150621bcef434a1d5';
+    const select = vi.fn();
+    const relatedIds = Array.from({ length: 99 }, (_, index) =>
+      `67d8928150621bcef434${String(index).padStart(4, '0')}`,
+    );
+    mocks.researchEntityRelationshipFind
+      .mockReturnValueOnce(queryResult(
+        relatedIds.map((id) => ({
+          sourceResearchEntityId: currentEntityId,
+          targetResearchEntityId: id,
+          relationshipType: 'MEMBER_RESEARCH_AREA',
+          label: 'Related',
+        })),
+      ))
+      .mockReturnValueOnce(queryResult([]));
+    const entityQuery = queryResult(
+      relatedIds.slice(0, 50).map((id, index) => ({
+        _id: id,
+        slug: `entity-${index}`,
+        name: `Entity ${index}`,
+        kind: 'center',
+        departments: ['Physics'],
+        shortDescription: `Safe summary ${index} hidden${index}@example.edu`,
+        studentVisibilityTier: 'student_ready',
+        privateNotes: 'operator only',
+        sourceUrls: ['https://example.edu/private'],
+      })),
+    );
+    entityQuery.select = (value: string) => {
+      select(value);
+      return entityQuery;
+    };
+    mocks.researchEntityFind.mockReturnValue(entityQuery);
+
+    const result = await listResearchEntityRelationshipPayload(currentEntityId);
+
+    expect(select).toHaveBeenCalledWith(
+      '_id slug name displayName kind entityType departments shortDescription description fullDescription studentVisibilityTier',
+    );
+    expect(result.relatedResearchEntities).toHaveLength(50);
+    expect(result.relatedResearchEntitiesMeta).toEqual({ returned: 50, truncated: true });
+    expect(Object.keys(result.relatedResearchEntities[0]).sort()).toEqual(
+      ['blurb', 'departments', 'entityType', 'id', 'kind', 'name', 'slug'].sort(),
+    );
+    const encoded = JSON.stringify(result);
+    expect(encoded).not.toContain('operator only');
+    expect(encoded).not.toContain('@example.edu');
+    expect(Buffer.byteLength(encoded)).toBeLessThan(25_000);
   });
 });
 

--- a/server/src/services/researchEntityDto.ts
+++ b/server/src/services/researchEntityDto.ts
@@ -21,6 +21,16 @@ export interface PublicResearchEntityDto extends Record<string, unknown> {
   sourceUrls: string[];
 }
 
+export interface PublicResearchEntitySummaryDto {
+  id: string;
+  slug: string;
+  name: string;
+  kind?: string;
+  entityType?: string;
+  departments: string[];
+  blurb?: string;
+}
+
 function publicResearchEntityId(group: Record<string, any>): string {
   const slug = publicTextString(group.slug || '');
   if (slug) return slug;
@@ -92,6 +102,28 @@ function publicDepartmentArray(value: unknown): string[] {
     labels.push(label);
   }
   return labels;
+}
+
+/** Strict card-only DTO used when embedding related entities in a detail response. */
+export function toPublicResearchEntitySummaryDto(
+  group: Record<string, any>,
+): PublicResearchEntitySummaryDto {
+  const blurb = publicTextString(
+    group.shortDescription || group.description || group.fullDescription || '',
+  ).slice(0, 280);
+
+  return {
+    id: publicResearchEntityId(group),
+    slug: publicTextString(group.slug || ''),
+    name: publicTextString(group.name || group.displayName || ''),
+    kind: group.kind === undefined ? undefined : publicTextString(group.kind),
+    entityType:
+      group.entityType === undefined
+        ? mapResearchGroupKindToEntityType(group.kind)
+        : publicTextString(group.entityType),
+    departments: publicDepartmentArray(group.departments),
+    ...(blurb ? { blurb } : {}),
+  };
 }
 
 const OPTIONAL_PUBLIC_RESEARCH_ENTITY_FIELDS = [

--- a/server/src/services/researchGroupService.ts
+++ b/server/src/services/researchGroupService.ts
@@ -46,7 +46,9 @@ import {
   addResearchEntityDetailAlias,
   addResearchEntitySearchAliases,
   toPublicResearchEntityDto,
+  toPublicResearchEntitySummaryDto,
   type PublicResearchEntityDto,
+  type PublicResearchEntitySummaryDto,
 } from './researchEntityDto';
 import {
   isPublicResearchPaperLink,
@@ -1198,11 +1200,18 @@ const MAX_PUBLIC_DETAIL_ENTRY_PATHWAYS = 50;
 const MAX_PUBLIC_DETAIL_ACCESS_SIGNALS = 50;
 const MAX_PUBLIC_DETAIL_CONTACT_ROUTES = 50;
 const MAX_PUBLIC_DETAIL_POSTED_OPPORTUNITIES = 50;
-const MAX_PUBLIC_DETAIL_RELATIONSHIPS = 100;
+const MAX_PUBLIC_DETAIL_RELATIONSHIPS_PER_DIRECTION = 50;
+const PUBLIC_RELATED_ENTITY_PROJECTION =
+  '_id slug name displayName kind entityType departments shortDescription description fullDescription studentVisibilityTier';
+
+export interface PublicRelationshipCollectionMeta {
+  returned: number;
+  truncated: boolean;
+}
 
 const publicRelationshipForResearchDetail = (
   relationship: any,
-  relatedResearchEntity?: PublicResearchEntityDto,
+  relatedResearchEntity?: PublicResearchEntitySummaryDto,
 ) => ({
   relatedResearchEntityId: relatedResearchEntity?.id || relatedResearchEntity?.slug,
   relatedResearchEntitySlug: relatedResearchEntity?.slug,
@@ -1216,33 +1225,48 @@ const publicRelationshipForResearchDetail = (
 
 export async function listResearchEntityRelationshipPayload(entityId: unknown): Promise<{
   entityRelationships: any[];
-  relatedResearchEntities: PublicResearchEntityDto[];
+  relatedResearchEntities: PublicResearchEntitySummaryDto[];
+  relatedResearchEntitiesMeta: PublicRelationshipCollectionMeta;
   affiliatedRelationships: any[];
-  affiliatedResearchEntities: PublicResearchEntityDto[];
+  affiliatedResearchEntities: PublicResearchEntitySummaryDto[];
+  affiliatedResearchEntitiesMeta: PublicRelationshipCollectionMeta;
 }> {
   const safeEntityId = normalizeResearchGroupObjectId(entityId);
   if (!safeEntityId) {
     return {
       entityRelationships: [],
       relatedResearchEntities: [],
+      relatedResearchEntitiesMeta: { returned: 0, truncated: false },
       affiliatedRelationships: [],
       affiliatedResearchEntities: [],
+      affiliatedResearchEntitiesMeta: { returned: 0, truncated: false },
     };
   }
 
-  const relationships = await ResearchEntityRelationship.find({
-    archived: { $ne: true },
-    $or: [{ sourceResearchEntityId: safeEntityId }, { targetResearchEntityId: safeEntityId }],
-  })
-    .sort({ confidence: -1, updatedAt: -1 })
-    .limit(MAX_PUBLIC_DETAIL_RELATIONSHIPS)
-    .lean();
-
-  const relatedRelationships = (relationships as any[]).filter((relationship) =>
-    idEquals(relationship.sourceResearchEntityId, safeEntityId),
+  const relationshipLimit = MAX_PUBLIC_DETAIL_RELATIONSHIPS_PER_DIRECTION + 1;
+  const [relatedRelationshipsAll, affiliatedRelationshipsAll] = (await Promise.all([
+    ResearchEntityRelationship.find({
+      archived: { $ne: true },
+      sourceResearchEntityId: safeEntityId,
+    })
+      .sort({ confidence: -1, updatedAt: -1 })
+      .limit(relationshipLimit)
+      .lean(),
+    ResearchEntityRelationship.find({
+      archived: { $ne: true },
+      targetResearchEntityId: safeEntityId,
+    })
+      .sort({ confidence: -1, updatedAt: -1 })
+      .limit(relationshipLimit)
+      .lean(),
+  ])) as [any[], any[]];
+  const relatedRelationships = relatedRelationshipsAll.slice(
+    0,
+    MAX_PUBLIC_DETAIL_RELATIONSHIPS_PER_DIRECTION,
   );
-  const affiliatedRelationships = (relationships as any[]).filter((relationship) =>
-    idEquals(relationship.targetResearchEntityId, safeEntityId),
+  const affiliatedRelationships = affiliatedRelationshipsAll.slice(
+    0,
+    MAX_PUBLIC_DETAIL_RELATIONSHIPS_PER_DIRECTION,
   );
   const relatedEntityIds = relatedRelationships.map(
     (relationship) => relationship.targetResearchEntityId,
@@ -1264,7 +1288,9 @@ export async function listResearchEntityRelationshipPayload(entityId: unknown): 
           _id: { $in: entityIds },
           archived: { $ne: true },
           studentVisibilityTier: { $in: publicStudentVisibilityTiers },
-        }).lean()
+        })
+          .select(PUBLIC_RELATED_ENTITY_PROJECTION)
+          .lean()
       : [];
   const publicRelatedEntities = (relatedEntities as any[]).filter((entity) =>
     publicStudentVisibilityTiers.includes(entity.studentVisibilityTier),
@@ -1273,7 +1299,7 @@ export async function listResearchEntityRelationshipPayload(entityId: unknown): 
   const publicEntitiesByInternalId = new Map(
     publicRelatedEntities.map((entity) => [
       researchGroupDocumentId(entity._id),
-      toPublicResearchEntityDto(sanitizeResearchEntityPublicDescriptionFields(entity)),
+      toPublicResearchEntitySummaryDto(sanitizeResearchEntityPublicDescriptionFields(entity)),
     ]),
   );
 
@@ -1291,7 +1317,13 @@ export async function listResearchEntityRelationshipPayload(entityId: unknown): 
       ),
     relatedResearchEntities: relatedEntityIds
       .map((id) => publicEntitiesByInternalId.get(researchGroupDocumentId(id)))
-      .filter((entity): entity is PublicResearchEntityDto => Boolean(entity)),
+      .filter((entity): entity is PublicResearchEntitySummaryDto => Boolean(entity)),
+    relatedResearchEntitiesMeta: {
+      returned: relatedEntityIds.filter((id) =>
+        publicEntitiesByInternalId.has(researchGroupDocumentId(id)),
+      ).length,
+      truncated: relatedRelationshipsAll.length > relatedRelationships.length,
+    },
     affiliatedRelationships: affiliatedRelationships
       .map((relationship) => ({
         relationship,
@@ -1305,7 +1337,13 @@ export async function listResearchEntityRelationshipPayload(entityId: unknown): 
       ),
     affiliatedResearchEntities: affiliatedEntityIds
       .map((id) => publicEntitiesByInternalId.get(researchGroupDocumentId(id)))
-      .filter((entity): entity is PublicResearchEntityDto => Boolean(entity)),
+      .filter((entity): entity is PublicResearchEntitySummaryDto => Boolean(entity)),
+    affiliatedResearchEntitiesMeta: {
+      returned: affiliatedEntityIds.filter((id) =>
+        publicEntitiesByInternalId.has(researchGroupDocumentId(id)),
+      ).length,
+      truncated: affiliatedRelationshipsAll.length > affiliatedRelationships.length,
+    },
   };
 }
 
@@ -2060,9 +2098,11 @@ export async function getResearchGroupDetail(slug: string): Promise<{
   contactRoutes: any[];
   postedOpportunities: any[];
   entityRelationships: any[];
-  relatedResearchEntities: PublicResearchEntityDto[];
+  relatedResearchEntities: PublicResearchEntitySummaryDto[];
+  relatedResearchEntitiesMeta: PublicRelationshipCollectionMeta;
   affiliatedRelationships: any[];
-  affiliatedResearchEntities: PublicResearchEntityDto[];
+  affiliatedResearchEntities: PublicResearchEntitySummaryDto[];
+  affiliatedResearchEntitiesMeta: PublicRelationshipCollectionMeta;
 } | null> {
   const normalizedSlug = normalizeResearchDetailSlug(slug);
   if (!normalizedSlug) return null;

--- a/server/src/services/researchGroupService.ts
+++ b/server/src/services/researchGroupService.ts
@@ -1201,6 +1201,7 @@ const MAX_PUBLIC_DETAIL_ACCESS_SIGNALS = 50;
 const MAX_PUBLIC_DETAIL_CONTACT_ROUTES = 50;
 const MAX_PUBLIC_DETAIL_POSTED_OPPORTUNITIES = 50;
 const MAX_PUBLIC_DETAIL_RELATIONSHIPS_PER_DIRECTION = 50;
+const MAX_PUBLIC_DETAIL_RELATIONSHIP_QUERY_LIMIT = 51;
 const PUBLIC_RELATED_ENTITY_PROJECTION =
   '_id slug name displayName kind entityType departments shortDescription description fullDescription studentVisibilityTier';
 
@@ -1243,21 +1244,20 @@ export async function listResearchEntityRelationshipPayload(entityId: unknown): 
     };
   }
 
-  const relationshipLimit = MAX_PUBLIC_DETAIL_RELATIONSHIPS_PER_DIRECTION + 1;
   const [relatedRelationshipsAll, affiliatedRelationshipsAll] = (await Promise.all([
     ResearchEntityRelationship.find({
       archived: { $ne: true },
       sourceResearchEntityId: safeEntityId,
     })
       .sort({ confidence: -1, updatedAt: -1 })
-      .limit(relationshipLimit)
+      .limit(MAX_PUBLIC_DETAIL_RELATIONSHIP_QUERY_LIMIT)
       .lean(),
     ResearchEntityRelationship.find({
       archived: { $ne: true },
       targetResearchEntityId: safeEntityId,
     })
       .sort({ confidence: -1, updatedAt: -1 })
-      .limit(relationshipLimit)
+      .limit(MAX_PUBLIC_DETAIL_RELATIONSHIP_QUERY_LIMIT)
       .lean(),
   ])) as [any[], any[]];
   const relatedRelationships = relatedRelationshipsAll.slice(


### PR DESCRIPTION
## Summary
- replace embedded full related ResearchEntity profiles with strict redacted card summaries
- project only card fields and cap each relationship direction at 50 with truncation metadata
- preserve card rendering and detail navigation while documenting the Render edge compression decision

## Payload measurement
Representative 99-related hub fixture:
- before: 1,938,003 bytes
- slim 99: 43,658 bytes
- bounded 50 response: 22,049 bytes (98.9% smaller)

## Validation
- server focused: 49 passed
- client detail: 41 passed
- server full: 2,583 passed
- client full: 778 passed
- server TypeScript: passed
- server and client production builds: passed