### PR TITLE
FR-33: Guard professor-name research discovery

### DIFF
--- a/server/src/services/__tests__/researchEntitySearchIndexService.test.ts
+++ b/server/src/services/__tests__/researchEntitySearchIndexService.test.ts
@@ -6,9 +6,28 @@ import {
   RESEARCH_ENTITY_SEARCH_INDEX_NAME,
   RESEARCH_ENTITY_SEARCH_INDEX_PRIMARY_KEY,
   rebuildResearchEntitySearchIndex,
+  trustedMemberDisplayName,
 } from '../researchEntitySearchIndexService';
 
 describe('researchEntitySearchIndexService', () => {
+  it('indexes only linked person identities and suppresses linked identity collisions', () => {
+    const users = new Map([['user-1', { fname: 'Grace', lname: 'Hopper' }]]);
+    const faculty = new Map([['faculty-1', { name: 'Grace Hopper' }]]);
+
+    expect(trustedMemberDisplayName({ name: 'Unverified Name' }, users, faculty)).toBe('');
+    expect(trustedMemberDisplayName({ userId: 'user-1' }, users, faculty)).toBe('Grace Hopper');
+    expect(
+      trustedMemberDisplayName({ userId: 'user-1', facultyMemberId: 'faculty-1' }, users, faculty),
+    ).toBe('Grace Hopper');
+    expect(
+      trustedMemberDisplayName(
+        { userId: 'user-1', facultyMemberId: 'faculty-1' },
+        users,
+        new Map([['faculty-1', { name: 'Different Person' }]]),
+      ),
+    ).toBe('');
+  });
+
   it('builds Meilisearch-ready research entity documents without internal fields', () => {
     const doc = buildResearchEntitySearchIndexDocument({
       _id: 'entity-1',

--- a/server/src/services/researchEntitySearchIndexService.ts
+++ b/server/src/services/researchEntitySearchIndexService.ts
@@ -222,20 +222,33 @@ const userDisplayName = (user: any): string =>
 const facultyDisplayName = (faculty: any): string =>
   cleanPersonName(faculty?.name) || personNameFromParts(faculty?.firstName, faculty?.lastName);
 
-const memberDisplayName = (
+const normalizedPersonNameKey = (value: string): string =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+export const trustedMemberDisplayName = (
   member: any,
   usersById: Map<string, any>,
   facultyMembersById: Map<string, any>,
 ): string => {
-  const rowName = cleanPersonName(member?.name);
-  if (rowName) return rowName;
-
   const userId = serializedDocumentId(member?.userId);
   const userName = userId ? userDisplayName(usersById.get(userId)) : '';
-  if (userName) return userName;
-
   const facultyMemberId = serializedDocumentId(member?.facultyMemberId);
-  return facultyMemberId ? facultyDisplayName(facultyMembersById.get(facultyMemberId)) : '';
+  const facultyName = facultyMemberId
+    ? facultyDisplayName(facultyMembersById.get(facultyMemberId))
+    : '';
+
+  if (
+    userName &&
+    facultyName &&
+    normalizedPersonNameKey(userName) !== normalizedPersonNameKey(facultyName)
+  ) {
+    return '';
+  }
+  return userName || facultyName;
 };
 
 const normalizedAliasHaystack = (values: unknown[]): string =>
@@ -341,7 +354,7 @@ export async function fetchResearchEntitySearchMemberNames(
       serializedDocumentId(member.researchEntityId) || serializedDocumentId(member.researchGroupId);
     if (!entityId) continue;
 
-    const name = memberDisplayName(member, usersById, facultyMembersById);
+    const name = trustedMemberDisplayName(member, usersById, facultyMembersById);
     if (!name) continue;
 
     const fields = byEntityId.get(entityId) || emptyMemberNameFields();


### PR DESCRIPTION
## Behavior
- Keeps professor and person names searchable through the existing research entity index.
- Person-name matches open the canonical research entity profile route, preserving URL behavior, topic and method ranking, CAS gating, and evidence framing.

## Identity safety rules
- Only current, non-archived professor-role memberships linked to a User or FacultyMember contribute names.
- Free-text membership names are excluded.
- Conflicting linked User and FacultyMember names are suppressed rather than guessed.
- Matching linked identities are deduplicated; contact fields remain excluded by the existing sanitizer.
- No person-only entity is invented and no private contact is exposed.

## Validation
- Focused identity/index and research search: 57 tests passed.
- Full client: 96 files / 779 tests passed; production build passed.
- Server focused suite and production build passed; full suite exercised locally.
- ESLint: 0 errors, four pre-existing warnings.

No data writes. Targets beta. Do not merge automatically.