### PR TITLE
Make research discovery entity-first

### DIFF
--- a/client/src/pages/__tests__/research.test.tsx
+++ b/client/src/pages/__tests__/research.test.tsx
@@ -583,22 +583,7 @@ describe('Research page', () => {
       );
     });
 
-    fireEvent.click(screen.getByLabelText('Has undergraduate evidence'));
-    await waitFor(() => {
-      expect(mockedAxios.post.mock.calls.at(-1)?.[1]).toEqual(
-        expect.objectContaining({
-          filters: {
-            school: ['Yale College'],
-            departments: ['Computer Science'],
-            acceptanceLevel: 'verified-or-likely',
-          },
-          page: 1,
-        }),
-      );
-      expect(screen.getByTestId('location').textContent).toBe(
-        '/research?q=machine+learning&school=Yale+College&department=Computer+Science&undergrad=1',
-      );
-    });
+    expect(screen.queryByLabelText('Undergraduate participation documented')).toBeNull();
   });
 
   it('returns to default research homes when clearing a quick-start search', async () => {
@@ -664,7 +649,7 @@ describe('Research page', () => {
 
     await screen.findByRole('heading', { name: 'AI Safety Lab' });
 
-    expect(container.textContent).toContain('Best next step: Review source context');
+    expect(container.textContent).not.toContain('Best next step: Review source context');
   });
 
   it('lets admins put weakest profiles first only for the default browse', async () => {
@@ -1207,12 +1192,12 @@ describe('Research page', () => {
 
     expect(await screen.findByText("Showing research matches for 'machine learning'")).toBeTruthy();
     expect(await screen.findByRole('heading', { name: 'AI Safety Lab' })).toBeTruthy();
-    expect(
-      mockedAxios.post.mock.calls.filter(([url]) => url === '/research/search'),
-    ).toHaveLength(1);
-    expect(
-      mockedAxios.post.mock.calls.filter(([url]) => url === '/pathways/search'),
-    ).toHaveLength(1);
+    expect(mockedAxios.post.mock.calls.filter(([url]) => url === '/research/search')).toHaveLength(
+      1,
+    );
+    expect(mockedAxios.post.mock.calls.filter(([url]) => url === '/pathways/search')).toHaveLength(
+      0,
+    );
   });
 
   it('reveals one research-home result stream with inline ways-in context after a search', async () => {
@@ -1240,9 +1225,9 @@ describe('Research page', () => {
     await waitFor(() => {
       expect(screen.getByRole('status').textContent).toContain('1 research home, 1 contact');
     });
-    expect(screen.getAllByRole('status')[0].textContent).toContain('1 verified way in');
+    expect(screen.getAllByRole('status')[0].textContent).not.toContain('verified way in');
     expect(screen.queryByRole('link', { name: /Compare .*pathway/i })).toBeNull();
-    expect(container.textContent).toContain('Research homes');
+    expect(container.textContent).toContain('Research profiles');
     expect(container.textContent).not.toContain('How to use this');
     expect(container.textContent).not.toContain('Popular starting points');
     expect(container.textContent).not.toContain('Topic term: protein');
@@ -1260,7 +1245,7 @@ describe('Research page', () => {
     expect(container.textContent).not.toContain('Why it might fit');
     expect(container.textContent).not.toContain('Official Yale source found');
     const researchHomesSection = screen
-      .getByRole('heading', { name: 'Research homes' })
+      .getByRole('heading', { name: 'Research profiles' })
       .closest('section');
     const searchGrid = researchHomesSection?.querySelector('.grid.gap-3');
     expect(searchGrid?.className).toContain('lg:grid-cols-2');
@@ -1272,8 +1257,9 @@ describe('Research page', () => {
         .getAllByRole('link', { name: 'AI Safety Lab' })
         .some((link) => link.getAttribute('href') === '/research/ai-safety-lab'),
     ).toBe(true);
-    expect(container.textContent).toContain('Verified ways in');
-    expect(screen.getByRole('link', { name: 'Review evidence' })).toBeTruthy();
+    expect(container.textContent).not.toContain('Verified ways in');
+    expect(container.textContent).not.toContain('72% confidence');
+    expect(container.textContent).not.toContain('moderate evidence');
     expect(container.textContent).not.toContain('Contact the program manager.');
 
     await waitFor(() => {
@@ -1363,11 +1349,11 @@ describe('Research page', () => {
     expect(screen.queryByRole('button', { name: 'Thesis possible' })).toBeNull();
     expect(container.textContent).toContain('AI Safety Lab');
     expect(container.textContent).toContain('Archives Lab');
-    expect(container.textContent).toContain('Verified ways in');
+    expect(container.textContent).not.toContain('Verified ways in');
     expect(container.textContent).not.toContain('Open role');
     expect(container.textContent).not.toContain('Paid/funded');
     expect(container.textContent).not.toContain('Thesis fit');
-    expect(screen.getByRole('link', { name: 'Review evidence' })).toBeTruthy();
+    expect(mockedAxios.post.mock.calls.some(([url]) => url === '/pathways/search')).toBe(false);
     expect(container.textContent).not.toContain('Pathway Preview');
     expect(container.textContent).not.toContain('Compare pathways');
   });

--- a/client/src/pages/research.tsx
+++ b/client/src/pages/research.tsx
@@ -1,6 +1,6 @@
 import { FormEvent, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { isCancel } from 'axios';
-import { Link, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 
 import ResearchHomeCard from '../components/research/ResearchHomeCard';
 import InfiniteScrollLoadingDots from '../components/shared/InfiniteScrollLoadingDots';
@@ -21,12 +21,7 @@ import {
 } from '../types/researchEntity';
 import { getUniqueDepartmentLabels } from '../utils/departmentNames';
 import useDocumentTitle from '../hooks/useDocumentTitle';
-import type {
-  PathwaySearchFilters,
-  PathwaySearchHit,
-  PathwaySearchResponse,
-} from '../types/pathway';
-import { safeHttpUrl, safeRouteSegment } from '../utils/url';
+import type { PathwaySearchFilters } from '../types/pathway';
 
 interface DepartmentResearchHomeConfig {
   abbreviation?: string;
@@ -181,22 +176,6 @@ const searchResearchEntities = async (
     facetDistribution: normalized.facetDistribution || {},
   };
 };
-
-const searchStudentPathways = async (
-  q: string,
-  signal?: AbortSignal,
-  filters: ResearchSearchFilters = {},
-): Promise<PathwaySearchResponse> => {
-  const response = await axios.post<PathwaySearchResponse>(
-    '/pathways/search',
-    { q, page: 1, pageSize: 12, filters },
-    { signal },
-  );
-  return response.data;
-};
-
-const waysInFromResearchEntities = (researchEntities: ResearchEntity[]): PathwaySearchHit[] =>
-  researchEntities.flatMap((entity) => (Array.isArray(entity.waysIn) ? entity.waysIn : []));
 
 const isResearchEntitySearchExhausted = (page: ResearchEntitySearchPage) =>
   page.researchEntities.length === 0 ||
@@ -605,29 +584,22 @@ const Research = () => {
     }
 
     try {
-      const [pathwayResult, researchEntitiesPage] = await Promise.all([
-        searchStudentPathways(searchQuery.trim(), controller.signal, filters)
-          .then((result) => ({ result, unavailable: false }))
-          .catch(() => ({
-            result: { hits: [], estimatedTotalHits: 0, page: 1, pageSize: 12 },
-            unavailable: true,
-          })),
-        searchResearchEntities(searchQuery.trim(), 24, controller.signal, filters, 1, {
+      const researchEntitiesPage = await searchResearchEntities(
+        searchQuery.trim(),
+        24,
+        controller.signal,
+        filters,
+        1,
+        {
           trustTierFilters: isAdmin ? trustTierFilters : [],
           includeSuppressed: isAdmin && trustTierFilters.includes('suppressed'),
-        }),
-      ]);
+        },
+      );
 
       if (requestId !== searchRequestIdRef.current || controller.signal.aborted) return;
 
       const researchEntities = researchEntitiesPage.researchEntities;
-      const pathways = pathwayResult.result.hits;
-
-      setSearchError(
-        pathwayResult.unavailable
-          ? 'Verified ways in are temporarily unavailable. Research profile results are still current.'
-          : '',
-      );
+      setSearchError('');
       setSearchResultResearchEntities(researchEntities);
       setSearchTotal(researchEntitiesPage.estimatedTotalHits);
       setFacetDistribution(researchEntitiesPage.facetDistribution);
@@ -637,7 +609,7 @@ const Research = () => {
         buildGroupedSearchResults({
           query: resultQueryLabel,
           researchEntities,
-          pathways,
+          pathways: [],
           papers: [],
         }),
       );
@@ -982,7 +954,7 @@ const Research = () => {
       buildGroupedSearchResults({
         query: DEFAULT_RESEARCH_HOME_LABEL,
         researchEntities: defaultResearchEntities,
-        pathways: waysInFromResearchEntities(defaultResearchEntities),
+        pathways: [],
         papers: [],
       }),
     [defaultResearchEntities],
@@ -1324,151 +1296,147 @@ const Research = () => {
                   </div>
                 </div>
 
-                <fieldset className="mt-3 border-0 p-0">
-                  <legend className="sr-only">Narrow research results</legend>
-                  <div className="grid gap-4 rounded-md border border-[var(--yr-line)] bg-[var(--yr-panel)] p-3 sm:grid-cols-2 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto_auto] xl:items-end">
-                    <label className="block text-sm font-medium text-slate-800">
-                      School
-                      <select
-                        aria-label="Filter by school"
-                        value={selectedSchool}
-                        onChange={(event) =>
-                          applyStudentFacets(
-                            event.target.value,
-                            selectedDepartment,
-                            requireUndergradEvidence,
-                          )
-                        }
-                        className="mt-1 min-h-11 w-full rounded-md border border-[var(--yr-line-strong)] bg-white px-3 text-sm text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
-                      >
-                        <option value="">All schools</option>
-                        {schoolOptions.map((school) => (
-                          <option key={school} value={school}>
-                            {school} ({facetDistribution.school?.[school] ?? searchTotal})
-                          </option>
-                        ))}
-                      </select>
-                    </label>
-                    <label className="block text-sm font-medium text-slate-800">
-                      Department
-                      <select
-                        aria-label="Filter by department"
-                        value={selectedDepartment}
-                        onChange={(event) =>
-                          applyStudentFacets(
-                            selectedSchool,
-                            event.target.value,
-                            requireUndergradEvidence,
-                          )
-                        }
-                        className="mt-1 min-h-11 w-full rounded-md border border-[var(--yr-line-strong)] bg-white px-3 text-sm text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
-                      >
-                        <option value="">All departments</option>
-                        {departmentOptions.map((department) => (
-                          <option key={department} value={department}>
-                            {getUniqueDepartmentLabels([department], departments)[0] || department}{' '}
-                            ({facetDistribution.departments?.[department] ?? searchTotal})
-                          </option>
-                        ))}
-                      </select>
-                    </label>
-                    <label className="inline-flex min-h-11 items-center gap-2 rounded-md border border-[var(--yr-line)] bg-white px-3 py-2 text-sm font-medium text-slate-800">
-                      <input
-                        type="checkbox"
-                        checked={requireUndergradEvidence}
-                        onChange={(event) =>
-                          applyStudentFacets(
-                            selectedSchool,
-                            selectedDepartment,
-                            event.target.checked,
-                          )
-                        }
-                        className="h-4 w-4 rounded border-[var(--yr-line-strong)] text-blue-700 focus:ring-blue-200"
-                      />
-                      Has undergraduate evidence
-                    </label>
-                    {hasStudentFacetSelection && (
+                {(schoolOptions.length > 1 ||
+                  departmentOptions.length > 1 ||
+                  hasStudentFacetSelection) && (
+                  <fieldset className="mt-3 border-0 p-0">
+                    <legend className="sr-only">Narrow research results</legend>
+                    <div className="grid gap-4 rounded-md border border-[var(--yr-line)] bg-[var(--yr-panel)] p-3 sm:grid-cols-2 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto_auto] xl:items-end">
+                      {(schoolOptions.length > 1 || selectedSchool) && (
+                        <label className="block text-sm font-medium text-slate-800">
+                          School
+                          <select
+                            aria-label="Filter by school"
+                            value={selectedSchool}
+                            onChange={(event) =>
+                              applyStudentFacets(
+                                event.target.value,
+                                selectedDepartment,
+                                requireUndergradEvidence,
+                              )
+                            }
+                            className="mt-1 min-h-11 w-full rounded-md border border-[var(--yr-line-strong)] bg-white px-3 text-sm text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+                          >
+                            <option value="">All schools</option>
+                            {schoolOptions.map((school) => (
+                              <option key={school} value={school}>
+                                {school} ({facetDistribution.school?.[school] ?? searchTotal})
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                      )}
+                      {(departmentOptions.length > 1 || selectedDepartment) && (
+                        <label className="block text-sm font-medium text-slate-800">
+                          Department
+                          <select
+                            aria-label="Filter by department"
+                            value={selectedDepartment}
+                            onChange={(event) =>
+                              applyStudentFacets(
+                                selectedSchool,
+                                event.target.value,
+                                requireUndergradEvidence,
+                              )
+                            }
+                            className="mt-1 min-h-11 w-full rounded-md border border-[var(--yr-line-strong)] bg-white px-3 text-sm text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+                          >
+                            <option value="">All departments</option>
+                            {departmentOptions.map((department) => (
+                              <option key={department} value={department}>
+                                {getUniqueDepartmentLabels([department], departments)[0] ||
+                                  department}{' '}
+                                ({facetDistribution.departments?.[department] ?? searchTotal})
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                      )}
+                      {requireUndergradEvidence && (
+                        <label className="inline-flex min-h-11 items-center gap-2 rounded-md border border-[var(--yr-line)] bg-white px-3 py-2 text-sm font-medium text-slate-800">
+                          <input
+                            type="checkbox"
+                            checked={requireUndergradEvidence}
+                            onChange={(event) =>
+                              applyStudentFacets(
+                                selectedSchool,
+                                selectedDepartment,
+                                event.target.checked,
+                              )
+                            }
+                            className="h-4 w-4 rounded border-[var(--yr-line-strong)] text-blue-700 focus:ring-blue-200"
+                          />
+                          Undergraduate participation documented
+                        </label>
+                      )}
+                      {hasStudentFacetSelection && (
+                        <button
+                          type="button"
+                          onClick={() => applyStudentFacets('', '', false)}
+                          className="min-h-11 rounded-md border border-[var(--yr-line-strong)] bg-white px-3 text-sm font-semibold text-slate-700 hover:bg-[var(--yr-panel-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+                        >
+                          Clear filters
+                        </button>
+                      )}
+                    </div>
+                  </fieldset>
+                )}
+
+                {hasStudentFacetSelection && (
+                  <div className="mt-3 flex flex-wrap gap-2" aria-label="Active research filters">
+                    {selectedSchool && (
                       <button
                         type="button"
-                        onClick={() => applyStudentFacets('', '', false)}
-                        className="min-h-11 rounded-md border border-[var(--yr-line-strong)] bg-white px-3 text-sm font-semibold text-slate-700 hover:bg-[var(--yr-panel-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+                        onClick={() =>
+                          applyStudentFacets('', selectedDepartment, requireUndergradEvidence)
+                        }
+                        aria-label={`Remove School: ${selectedSchool}`}
+                        className="rounded-md border px-3 py-2 text-sm"
                       >
-                        Clear filters
+                        School: {selectedSchool} ×
+                      </button>
+                    )}
+                    {selectedDepartment && (
+                      <button
+                        type="button"
+                        onClick={() =>
+                          applyStudentFacets(selectedSchool, '', requireUndergradEvidence)
+                        }
+                        aria-label={`Remove Department: ${selectedDepartment}`}
+                        className="rounded-md border px-3 py-2 text-sm"
+                      >
+                        Department:{' '}
+                        {getUniqueDepartmentLabels([selectedDepartment], departments)[0] ||
+                          selectedDepartment}{' '}
+                        ×
+                      </button>
+                    )}
+                    {requireUndergradEvidence && (
+                      <button
+                        type="button"
+                        onClick={() =>
+                          applyStudentFacets(selectedSchool, selectedDepartment, false)
+                        }
+                        aria-label="Remove Undergraduate participation documented"
+                        className="rounded-md border px-3 py-2 text-sm"
+                      >
+                        Undergraduate participation documented ×
                       </button>
                     )}
                   </div>
-                </fieldset>
+                )}
 
                 {searchError && (
                   <div
-                    role={searchError.startsWith('Verified ways in') ? 'status' : 'alert'}
+                    role="alert"
                     className="mt-4 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900"
                   >
                     {searchError}
                   </div>
                 )}
 
-                <section className="mt-5" aria-label="Verified ways in">
-                  <SectionHeading>Verified ways in</SectionHeading>
-                  {searchLoading && activeResults.pathways.length === 0 ? (
-                    <ClusterLoadingCard />
-                  ) : activeResults.pathways.length > 0 ? (
-                    <div className="grid gap-3 lg:grid-cols-2">
-                      {activeResults.pathways.map((pathway) => {
-                        const sourceUrl = safeHttpUrl(
-                          pathway.evidence?.[0]?.sourceUrl || pathway.sourceUrls?.[0],
-                        );
-                        const entityName =
-                          pathway.researchEntity.displayName || pathway.researchEntity.name;
-                        return (
-                          <article key={pathway._id} className="yr-card rounded-md p-4">
-                            <div className="flex flex-wrap items-center gap-2 text-xs font-semibold text-slate-600">
-                              <span>{pathway.evidenceStrength.toLowerCase()} evidence</span>
-                              {typeof pathway.confidence === 'number' && (
-                                <span>{Math.round(pathway.confidence * 100)}% confidence</span>
-                              )}
-                            </div>
-                            <h3 className="mt-2 text-base font-semibold text-slate-950">
-                              {pathway.studentFacingLabel}
-                            </h3>
-                            <p className="mt-1 text-sm text-slate-700">{entityName}</p>
-                            {pathway.explanation && (
-                              <p className="mt-2 text-sm leading-relaxed text-slate-600">
-                                {pathway.explanation}
-                              </p>
-                            )}
-                            <div className="mt-3 flex flex-wrap gap-2">
-                              <Link
-                                to={`/research/${safeRouteSegment(pathway.researchEntity.slug)}`}
-                                className="inline-flex min-h-11 items-center rounded-md bg-[var(--yr-blue)] px-3 py-2 text-sm font-semibold text-white"
-                              >
-                                Open research profile
-                              </Link>
-                              {sourceUrl && (
-                                <a
-                                  href={sourceUrl}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  className="inline-flex min-h-11 items-center rounded-md border border-[var(--yr-line-strong)] px-3 py-2 text-sm font-semibold text-slate-800"
-                                >
-                                  Review evidence
-                                </a>
-                              )}
-                            </div>
-                          </article>
-                        );
-                      })}
-                    </div>
-                  ) : (
-                    <EmptyGroup>
-                      No pathways meet the current evidence and confidence standard for this search.
-                      Research profiles may still provide useful planning context.
-                    </EmptyGroup>
-                  )}
-                </section>
-
                 <section className="mt-5">
-                  <SectionHeading>Research homes</SectionHeading>
+                  <SectionHeading>Research profiles</SectionHeading>
                   {searchLoading && activeResults.clusters.length === 0 ? (
                     <div className="grid gap-3">
                       {Array.from({ length: 3 }).map((_, index) => (


### PR DESCRIPTION
## First coherent tranche
- removes the parallel pathway-search request from ordinary research discovery
- removes the separate Verified ways in cluster, pathway failure warning, generic evidence labels, and confidence percentages
- presents Research profiles as the single primary result collection
- hides school and department controls when their current facet distribution cannot narrow results
- hides the unsupported inactive undergraduate-evidence control; preserves an active URL-synced selection so it can be removed
- adds accessible active-filter chips with specific removal names while retaining active-only Clear filters

## Preserved contracts
- canonical entity profile routes, research relevance, URL synchronization, pagination, admin controls, CAS gating, privacy, safe routes, detail evidence, and saved-plan behavior are unchanged
- internal pathway models and APIs remain available to their legitimate consumers
- no PI-profile provenance is projected as a separate student-facing access card
- no aspirational planning-context enrichment was added without a qualifying server projection

## Regression coverage
- machine-learning search performs zero pathway-search requests
- one entity-first profile stream renders with no Verified ways in heading
- confidence and generic evidence language are absent
- single-value or unavailable filters remain hidden; meaningful school/department facets remain operable
- current research search, URL, pagination, admin, and sparse-enrichment journeys remain covered

## Validation
- focused research page: 25/25 passed
- full client: 96 files / 779 tests passed
- client production build passed
- ESLint: 0 errors, four pre-existing warnings
- browser validation unavailable because chrome-devtools bridge was not installed/ready; no CAS bypass attempted

The governing spec is local-only at /home/qunta/ylabs and is not owned by the beta repository, so it was not copied into this PR. No data writes. Do not merge automatically.