### PR TITLE
FR-45: save research profiles independently of pathways

### DIFF
--- a/client/src/components/accounts/SavedPathwaysSection.tsx
+++ b/client/src/components/accounts/SavedPathwaysSection.tsx
@@ -60,22 +60,67 @@ export interface FellowshipFundingMatch {
 
 type FundingMatchesByPathway = Record<string, FellowshipFundingMatch[]>;
 
+interface SavedResearchEntitySummary {
+  _id: string;
+  slug: string;
+  name: string;
+  displayName?: string;
+  kind?: string;
+  entityType?: string;
+  departments?: string[];
+  school?: string;
+  shortDescription?: string;
+  description?: string;
+}
+
+const savedEntityAsPlanningItem = (entity: SavedResearchEntitySummary): PathwaySearchHit => ({
+  _id: entity._id,
+  pathwayType: 'RESEARCH_ENTITY',
+  status: 'SAVED',
+  evidenceStrength: 'UNKNOWN',
+  studentFacingLabel: entity.displayName || entity.name,
+  explanation: entity.shortDescription || entity.description,
+  bestNextStepCategory: 'save-for-later',
+  sourceUrls: [],
+  evidence: [],
+  researchEntity: {
+    _id: entity._id,
+    slug: entity.slug,
+    name: entity.name,
+    displayName: entity.displayName,
+    kind: entity.kind,
+    entityType: entity.entityType,
+    departments: entity.departments || [],
+    researchAreas: [],
+    school: entity.school,
+  },
+});
+
 type DashboardResponse = Awaited<ReturnType<typeof axios.get>>;
 type OptionalDashboardResponse =
   | { value: DashboardResponse; error: false }
   | { value: null; error: true };
-type SavedPlanDashboardLoad = [DashboardResponse, OptionalDashboardResponse, OptionalDashboardResponse];
+type SavedPlanDashboardLoad = [
+  DashboardResponse,
+  OptionalDashboardResponse,
+  OptionalDashboardResponse,
+];
 const savedPlanDashboardLoads = new Map<string, Promise<SavedPlanDashboardLoad>>();
 
 const loadSavedPlanDashboard = (owner: string): Promise<SavedPlanDashboardLoad> => {
   const existing = savedPlanDashboardLoads.get(owner);
   if (existing) return existing;
   const request = Promise.all([
-    axios.get('/users/savedResearchPlans', { withCredentials: true }),
-    axios.get('/users/savedResearchPlanDetails', { withCredentials: true }).then(
-      (value) => ({ value, error: false as const }),
-      () => ({ value: null, error: true as const }),
-    ),
+    axios
+      .get('/users/savedResearchEntities', { withCredentials: true })
+      .catch(() => axios.get('/users/savedResearchPlans', { withCredentials: true })),
+    axios
+      .get('/users/savedResearchEntityPlans', { withCredentials: true })
+      .catch(() => axios.get('/users/savedResearchPlanDetails', { withCredentials: true }))
+      .then(
+        (value) => ({ value, error: false as const }),
+        () => ({ value: null, error: true as const }),
+      ),
     axios.get('/users/savedResearchPlanFundingMatches', { withCredentials: true }).then(
       (value) => ({ value, error: false as const }),
       () => ({ value: null, error: true as const }),
@@ -161,12 +206,15 @@ const normalizeDateOnly = (value: unknown): string | null => {
   if (typeof value !== 'string' || !DATE_ONLY_RE.test(value)) return null;
   const [year, month, day] = value.split('-').map(Number);
   const parsed = new Date(year, month - 1, day);
-  return parsed.getFullYear() === year && parsed.getMonth() === month - 1 && parsed.getDate() === day
+  return parsed.getFullYear() === year &&
+    parsed.getMonth() === month - 1 &&
+    parsed.getDate() === day
     ? value
     : null;
 };
 const normalizeFollowUpInterval = (value: unknown): number | null =>
-  typeof value === 'number' && FOLLOW_UP_INTERVALS.includes(value as (typeof FOLLOW_UP_INTERVALS)[number])
+  typeof value === 'number' &&
+  FOLLOW_UP_INTERVALS.includes(value as (typeof FOLLOW_UP_INTERVALS)[number])
     ? value
     : null;
 const localToday = (now = new Date()): string =>
@@ -197,15 +245,20 @@ export const planningCueForPlan = (
       priority: 1,
     });
   }
-  return cues.sort((a, b) =>
-    a.date.localeCompare(b.date) || a.priority - b.priority || a.detail.localeCompare(b.detail),
-  )[0] || null;
+  return (
+    cues.sort(
+      (a, b) =>
+        a.date.localeCompare(b.date) || a.priority - b.priority || a.detail.localeCompare(b.detail),
+    )[0] || null
+  );
 };
 
 const formatDateOnly = (value: string): string => {
   const [year, month, day] = value.split('-').map(Number);
   return new Date(year, month - 1, day).toLocaleDateString(undefined, {
-    month: 'short', day: 'numeric', year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
   });
 };
 
@@ -747,12 +800,20 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
         ownerAtLoad || 'authenticated-account',
       );
       if (!isCurrentOwnerLoad()) return;
-      const savedPathways = response.data.savedResearchPlans || [];
+      const responseData = (response as any).data;
+      const savedPathways: PathwaySearchHit[] = responseData.savedResearchEntities
+        ? (responseData.savedResearchEntities as SavedResearchEntitySummary[]).map(
+            savedEntityAsPlanningItem,
+          )
+        : responseData.savedResearchPlans || [];
       setPathways(savedPathways);
       if (!plansResult.error && plansResult.value) {
-        const plansResponse = plansResult.value;
+        const plansResponse: any = plansResult.value;
         if (!isCurrentOwnerLoad()) return;
-        const serverPlans = plansResponse.data.savedResearchPlanDetails || {};
+        const serverPlans =
+          plansResponse.data.savedResearchEntityPlans ||
+          plansResponse.data.savedResearchPlanDetails ||
+          {};
         const localPlans = readStoredPlans(ownerAtLoad);
         const savedPathwayIds = savedPathways.map((pathway: PathwaySearchHit) => pathway._id);
         const localPlansForSavedPathways = filterStoredPlansForSavedPathways(
@@ -773,7 +834,7 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
         await Promise.all(
           localOnlyPlanIds.map((id) =>
             axios.put(
-              `/users/savedResearchPlanDetails/${id}`,
+              `/users/savedResearchEntityPlans/${id}`,
               { data: { plan: localPlansForSavedPathways[id] } },
               { withCredentials: true },
             ),
@@ -783,12 +844,8 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
         console.error('Error loading saved research plan details.');
       }
       if (!matchesResult.error && matchesResult.value) {
-        const matchesResponse = matchesResult.value;
-        if (!isCurrentOwnerLoad()) return;
-        setFundingMatches(matchesResponse.data.matchesByPathwayId || {});
+        setFundingMatches((matchesResult.value as any).data.matchesByPathwayId || {});
       } else {
-        console.error('Error loading saved research-plan funding matches.');
-        if (!isCurrentOwnerLoad()) return;
         setFundingMatches({});
       }
     } catch {
@@ -836,9 +893,11 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
         priority: 2,
         tie: reminder.title,
       })),
-    ].sort((a, b) =>
-      new Date(a.date).getTime() - new Date(b.date).getTime() ||
-      a.priority - b.priority || a.tie.localeCompare(b.tie),
+    ].sort(
+      (a, b) =>
+        new Date(a.date).getTime() - new Date(b.date).getTime() ||
+        a.priority - b.priority ||
+        a.tie.localeCompare(b.tie),
     );
 
     onSummaryChange?.({
@@ -886,7 +945,7 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
       setPlanSaveStatus((statuses) => ({ ...statuses, [pathwayId]: 'Saving plan...' }));
       axios
         .put(
-          `/users/savedResearchPlanDetails/${pathwayId}`,
+          `/users/savedResearchEntityPlans/${pathwayId}`,
           { data: { plan: nextPlan } },
           { withCredentials: true },
         )
@@ -972,16 +1031,16 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
       return next;
     });
     try {
-      await axios.delete('/users/savedResearchPlans', {
+      await axios.delete('/users/savedResearchEntities', {
         withCredentials: true,
-        data: { savedResearchPlans: [pathwayId] },
+        data: { savedResearchEntities: [pathwayId] },
       });
       setPlans((current) => {
         const next = { ...current };
         delete next[pathwayId];
         return next;
       });
-      await axios.delete(`/users/savedResearchPlanDetails/${pathwayId}`, { withCredentials: true });
+      await axios.delete(`/users/savedResearchEntityPlans/${pathwayId}`, { withCredentials: true });
     } catch {
       console.error('Error removing saved research plan.');
       setPathways(previous);
@@ -1324,7 +1383,7 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
           <h3 className="text-base font-semibold text-gray-950">No saved research plans yet</h3>
           <p className="mt-2 max-w-2xl text-sm leading-relaxed text-gray-600">
             Start with Yale Research, open profiles that look promising, then save a plan when you
-            find a route worth tracking for outreach, credit, funding, or an application.
+            find a profile worth tracking for outreach, credit, funding, or an application.
           </p>
           <div className="mt-4 flex flex-wrap gap-2">
             <Link
@@ -1365,12 +1424,6 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
                 <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
                   <div className="min-w-0">
                     <div className="mb-2 flex flex-wrap gap-1.5">
-                      <span className="rounded bg-[var(--yr-blue-soft)] px-2 py-0.5 text-xs font-semibold text-blue-700">
-                        {labelize(pathway.pathwayType)}
-                      </span>
-                      <span className="rounded bg-[var(--yr-panel-muted)] px-2 py-0.5 text-xs font-semibold text-gray-700">
-                        {labelize(pathway.evidenceStrength)} evidence
-                      </span>
                       <span className="rounded bg-slate-100 px-2 py-0.5 text-xs font-semibold text-gray-700">
                         {stage}
                       </span>
@@ -1566,29 +1619,72 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
                       <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
                         <label className="text-xs font-semibold text-gray-600">
                           Target deadline
-                          <input type="date" value={plan.targetDeadline || ''} disabled={!planIsHydrated}
-                            onChange={(event) => updatePlan(pathway._id, { targetDeadline: normalizeDateOnly(event.target.value) })}
-                            className="mt-1 block min-h-[44px] w-full rounded-md border border-[var(--yr-line-strong)] px-2 text-sm font-normal text-gray-900 focus:ring-2 focus:ring-blue-500" />
-                          {plan.targetDeadline && <button type="button" disabled={!planIsHydrated}
-                            onClick={() => updatePlan(pathway._id, { targetDeadline: null })}
-                            className="mt-1 text-xs font-medium text-blue-700 underline underline-offset-2">Clear deadline</button>}
+                          <input
+                            type="date"
+                            value={plan.targetDeadline || ''}
+                            disabled={!planIsHydrated}
+                            onChange={(event) =>
+                              updatePlan(pathway._id, {
+                                targetDeadline: normalizeDateOnly(event.target.value),
+                              })
+                            }
+                            className="mt-1 block min-h-[44px] w-full rounded-md border border-[var(--yr-line-strong)] px-2 text-sm font-normal text-gray-900 focus:ring-2 focus:ring-blue-500"
+                          />
+                          {plan.targetDeadline && (
+                            <button
+                              type="button"
+                              disabled={!planIsHydrated}
+                              onClick={() => updatePlan(pathway._id, { targetDeadline: null })}
+                              className="mt-1 text-xs font-medium text-blue-700 underline underline-offset-2"
+                            >
+                              Clear deadline
+                            </button>
+                          )}
                         </label>
                         <label className="text-xs font-semibold text-gray-600">
                           Acted on
-                          <input type="date" value={plan.actedOnDate || ''} disabled={!planIsHydrated}
-                            onChange={(event) => updatePlan(pathway._id, { actedOnDate: normalizeDateOnly(event.target.value) })}
-                            className="mt-1 block min-h-[44px] w-full rounded-md border border-[var(--yr-line-strong)] px-2 text-sm font-normal text-gray-900 focus:ring-2 focus:ring-blue-500" />
-                          {plan.actedOnDate && <button type="button" disabled={!planIsHydrated}
-                            onClick={() => updatePlan(pathway._id, { actedOnDate: null })}
-                            className="mt-1 text-xs font-medium text-blue-700 underline underline-offset-2">Clear acted date</button>}
+                          <input
+                            type="date"
+                            value={plan.actedOnDate || ''}
+                            disabled={!planIsHydrated}
+                            onChange={(event) =>
+                              updatePlan(pathway._id, {
+                                actedOnDate: normalizeDateOnly(event.target.value),
+                              })
+                            }
+                            className="mt-1 block min-h-[44px] w-full rounded-md border border-[var(--yr-line-strong)] px-2 text-sm font-normal text-gray-900 focus:ring-2 focus:ring-blue-500"
+                          />
+                          {plan.actedOnDate && (
+                            <button
+                              type="button"
+                              disabled={!planIsHydrated}
+                              onClick={() => updatePlan(pathway._id, { actedOnDate: null })}
+                              className="mt-1 text-xs font-medium text-blue-700 underline underline-offset-2"
+                            >
+                              Clear acted date
+                            </button>
+                          )}
                         </label>
                         <label className="text-xs font-semibold text-gray-600">
                           Follow up after
-                          <select value={plan.followUpIntervalDays || ''} disabled={!planIsHydrated}
-                            onChange={(event) => updatePlan(pathway._id, { followUpIntervalDays: event.target.value ? Number(event.target.value) : null })}
-                            className="mt-1 block min-h-[44px] w-full rounded-md border border-[var(--yr-line-strong)] bg-white px-2 text-sm font-normal text-gray-900 focus:ring-2 focus:ring-blue-500">
+                          <select
+                            value={plan.followUpIntervalDays || ''}
+                            disabled={!planIsHydrated}
+                            onChange={(event) =>
+                              updatePlan(pathway._id, {
+                                followUpIntervalDays: event.target.value
+                                  ? Number(event.target.value)
+                                  : null,
+                              })
+                            }
+                            className="mt-1 block min-h-[44px] w-full rounded-md border border-[var(--yr-line-strong)] bg-white px-2 text-sm font-normal text-gray-900 focus:ring-2 focus:ring-blue-500"
+                          >
                             <option value="">No reminder</option>
-                            {FOLLOW_UP_INTERVALS.map((days) => <option key={days} value={days}>{days} days</option>)}
+                            {FOLLOW_UP_INTERVALS.map((days) => (
+                              <option key={days} value={days}>
+                                {days} days
+                              </option>
+                            ))}
                           </select>
                         </label>
                       </div>

--- a/client/src/hooks/__tests__/useFavorites.test.tsx
+++ b/client/src/hooks/__tests__/useFavorites.test.tsx
@@ -62,15 +62,15 @@ describe('useFavorites', () => {
   });
 
   it('uses saved research plan endpoints for canonical research plan favorites', async () => {
-    mockedAxios.get.mockResolvedValueOnce({ data: { savedResearchPlanIds: ['plan-1'] } });
+    mockedAxios.get.mockResolvedValueOnce({ data: { savedResearchEntityIds: ['entity-1'] } });
 
     const { result } = renderHook(() => useFavorites('researchPlans'));
 
     await waitFor(() => {
-      expect(result.current.favIds).toEqual(['plan-1']);
+      expect(result.current.favIds).toEqual(['entity-1']);
     });
 
-    expect(mockedAxios.get).toHaveBeenCalledWith('/users/savedResearchPlanIds', {
+    expect(mockedAxios.get).toHaveBeenCalledWith('/users/savedResearchEntityIds', {
       withCredentials: true,
     });
   });

--- a/client/src/hooks/useFavorites.ts
+++ b/client/src/hooks/useFavorites.ts
@@ -35,10 +35,10 @@ const ENDPOINTS: Record<FavoritesKind, Endpoints> = {
     warnOnMutationError: false,
   },
   researchPlans: {
-    load: '/users/savedResearchPlanIds',
-    responseKey: 'savedResearchPlanIds',
-    collectionPath: '/users/savedResearchPlans',
-    payloadKey: 'savedResearchPlans',
+    load: '/users/savedResearchEntityIds',
+    responseKey: 'savedResearchEntityIds',
+    collectionPath: '/users/savedResearchEntities',
+    payloadKey: 'savedResearchEntities',
     warnOnLoadError: false,
     warnOnMutationError: false,
   },
@@ -65,29 +65,46 @@ export const useFavorites = (kind: FavoritesKind) => {
     reload();
   }, [reload]);
 
-  const setFavorite = useCallback(async (id: string, favorite: boolean) => {
-    const previous = favIds;
-    setFavIds((prev) => (favorite ? [id, ...prev.filter((x) => x !== id)] : prev.filter((x) => x !== id)));
-    try {
-      if (favorite) {
-        await axios.put(config.collectionPath, { withCredentials: true, data: { [config.payloadKey]: [id] } });
-      } else {
-        await axios.delete(config.collectionPath, { withCredentials: true, data: { [config.payloadKey]: [id] } });
+  const setFavorite = useCallback(
+    async (id: string, favorite: boolean) => {
+      const previous = favIds;
+      setFavIds((prev) =>
+        favorite ? [id, ...prev.filter((x) => x !== id)] : prev.filter((x) => x !== id),
+      );
+      try {
+        if (favorite) {
+          await axios.put(config.collectionPath, {
+            withCredentials: true,
+            data: { [config.payloadKey]: [id] },
+          });
+        } else {
+          await axios.delete(config.collectionPath, {
+            withCredentials: true,
+            data: { [config.payloadKey]: [id] },
+          });
+        }
+      } catch {
+        console.error(`Error ${favorite ? 'favoriting' : 'unfavoriting'} ${kind.slice(0, -1)}.`);
+        setFavIds(previous);
+        if (config.warnOnMutationError) {
+          swal({
+            text: `Unable to ${favorite ? 'favorite' : 'unfavorite'} ${kind.slice(0, -1)}`,
+            icon: 'warning',
+          });
+        }
+        reload();
       }
-    } catch {
-      console.error(`Error ${favorite ? 'favoriting' : 'unfavoriting'} ${kind.slice(0, -1)}.`);
-      setFavIds(previous);
-      if (config.warnOnMutationError) {
-        swal({ text: `Unable to ${favorite ? 'favorite' : 'unfavorite'} ${kind.slice(0, -1)}`, icon: 'warning' });
-      }
-      reload();
-    }
-  }, [favIds, kind, config.collectionPath, config.payloadKey, config.warnOnMutationError, reload]);
+    },
+    [favIds, kind, config.collectionPath, config.payloadKey, config.warnOnMutationError, reload],
+  );
 
-  const toggleFavorite = useCallback((id: string, e?: MouseEvent) => {
-    e?.stopPropagation();
-    setFavorite(id, !favIds.includes(id));
-  }, [favIds, setFavorite]);
+  const toggleFavorite = useCallback(
+    (id: string, e?: MouseEvent) => {
+      e?.stopPropagation();
+      setFavorite(id, !favIds.includes(id));
+    },
+    [favIds, setFavorite],
+  );
 
   return { favIds, setFavorite, toggleFavorite, reloadFavorites: reload };
 };

--- a/client/src/pages/__tests__/labDetail.test.tsx
+++ b/client/src/pages/__tests__/labDetail.test.tsx
@@ -74,8 +74,8 @@ const basePayload: LabDetailPayload = {
 
 function renderLabDetail(payload: LabDetailPayload = basePayload) {
   mockedAxios.get.mockImplementation((url: string) => {
-    if (url === '/users/savedResearchPlanIds') {
-      return Promise.resolve({ data: { savedResearchPlanIds: [] } });
+    if (url === '/users/savedResearchEntityIds') {
+      return Promise.resolve({ data: { savedResearchEntityIds: [] } });
     }
     if (url === `/research/${DEFAULT_SLUG}`) {
       return Promise.resolve({ data: payload });
@@ -105,7 +105,9 @@ describe('LabDetail page', () => {
     await screen.findByText(DEFAULT_ENTITY_NAME);
 
     expect(
-      screen.getByText('Review the official profile first, then use the source details to plan what to verify next.'),
+      screen.getByText(
+        'Review the official profile first, then use the source details to plan what to verify next.',
+      ),
     ).toBeTruthy();
     expect(screen.getByRole('link', { name: 'Open official profile' }).getAttribute('href')).toBe(
       OFFICIAL_PROFILE_URL,
@@ -113,9 +115,7 @@ describe('LabDetail page', () => {
     expect(screen.getByText('Profile status')).toBeTruthy();
     expect(screen.getByText('Source-backed details')).toBeTruthy();
     expect(screen.getByText('Still missing')).toBeTruthy();
-    expect(
-      screen.getByText('No indexed planning routes are attached yet.'),
-    ).toBeTruthy();
+    expect(screen.getByText('No indexed planning routes are attached yet.')).toBeTruthy();
     expect(screen.queryByText('Ways In')).toBeNull();
     expect(screen.queryByText('Evidence')).toBeNull();
   });
@@ -144,9 +144,9 @@ describe('LabDetail page', () => {
     const saveButton = screen.getByRole('button', { name: 'Save research plan' });
     fireEvent.click(saveButton);
 
-    expect(mockedAxios.put).toHaveBeenCalledWith('/users/savedResearchPlans', {
+    expect(mockedAxios.put).toHaveBeenCalledWith('/users/savedResearchEntities', {
       withCredentials: true,
-      data: { savedResearchPlans: ['pathway-1'] },
+      data: { savedResearchEntities: ['entity-1'] },
     });
     expect(screen.getByRole('button', { name: 'Saved to Dashboard' })).toBeTruthy();
     expect(screen.getByRole('status').textContent).toContain('Research plan saved');
@@ -175,9 +175,9 @@ describe('LabDetail page', () => {
 
     fireEvent.click(screen.getByText('Save research plan'));
 
-    expect(mockedAxios.put).toHaveBeenCalledWith('/users/savedResearchPlans', {
+    expect(mockedAxios.put).toHaveBeenCalledWith('/users/savedResearchEntities', {
       withCredentials: true,
-      data: { savedResearchPlans: ['pathway-1'] },
+      data: { savedResearchEntities: ['entity-1'] },
     });
     expect(screen.getByRole('button', { name: 'Saved to Dashboard' })).toBeTruthy();
   });
@@ -203,6 +203,19 @@ describe('LabDetail page', () => {
 
     expect(screen.getByRole('button', { name: 'Save research plan' })).toBeTruthy();
     expect(screen.getByText('Research summary')).toBeTruthy();
+  });
+
+  it('saves a research entity even when it has no indexed pathway', async () => {
+    mockedAxios.put.mockResolvedValue({ data: {} });
+    renderLabDetail();
+
+    await screen.findByText(DEFAULT_ENTITY_NAME);
+    fireEvent.click(screen.getByRole('button', { name: 'Save research plan' }));
+
+    expect(mockedAxios.put).toHaveBeenCalledWith('/users/savedResearchEntities', {
+      withCredentials: true,
+      data: { savedResearchEntities: ['entity-1'] },
+    });
   });
 
   it('renders specific ways-to-approach guidance without crashing', async () => {
@@ -294,7 +307,9 @@ describe('LabDetail page', () => {
     await screen.findByText(DEFAULT_ENTITY_NAME);
 
     expect(
-      screen.getByText('Studies specific mechanisms of neurological disease in source-backed terms.'),
+      screen.getByText(
+        'Studies specific mechanisms of neurological disease in source-backed terms.',
+      ),
     ).toBeTruthy();
     expect(screen.getByText('Plan from source-backed context.')).toBeTruthy();
     expect(
@@ -303,9 +318,15 @@ describe('LabDetail page', () => {
       ),
     ).toBeTruthy();
     expect(screen.getByText('Why')).toBeTruthy();
-    expect(screen.getByText('The access evidence points to an official profile route.')).toBeTruthy();
+    expect(
+      screen.getByText('The access evidence points to an official profile route.'),
+    ).toBeTruthy();
     expect(screen.getByText('What this page is')).toBeTruthy();
-    expect(screen.getByText('This page summarizes the research context and source evidence, not a posted opening.')).toBeTruthy();
+    expect(
+      screen.getByText(
+        'This page summarizes the research context and source evidence, not a posted opening.',
+      ),
+    ).toBeTruthy();
     expect(container.textContent?.indexOf('Studies specific mechanisms')).toBeLessThan(
       container.textContent?.indexOf('Plan from source-backed context.'),
     );
@@ -456,7 +477,9 @@ describe('LabDetail page', () => {
     expect(screen.queryByRole('button', { name: 'Draft outreach email' })).toBeNull();
     expect(screen.queryByText('jordan.researcher@yale.edu')).toBeNull();
     expect(
-      screen.queryByText(`Inquiry from a Yale undergraduate about research in ${DEFAULT_ENTITY_NAME}`),
+      screen.queryByText(
+        `Inquiry from a Yale undergraduate about research in ${DEFAULT_ENTITY_NAME}`,
+      ),
     ).toBeNull();
   });
 
@@ -507,7 +530,9 @@ describe('LabDetail page', () => {
     await screen.findByText(DEFAULT_ENTITY_NAME);
 
     expect(
-      screen.getAllByText('Review the listed route and verify whether it has current instructions.'),
+      screen.getAllByText(
+        'Review the listed route and verify whether it has current instructions.',
+      ),
     ).toHaveLength(1);
     expect(screen.getByRole('link', { name: 'Open official route' }).getAttribute('href')).toBe(
       OFFICIAL_ROUTE_URL,
@@ -525,11 +550,7 @@ describe('LabDetail page', () => {
         slug: 'example-field-lab',
         name: 'Example Field Lab',
         websiteUrl: RESEARCH_WEBSITE_URL,
-        sourceUrls: [
-          FACULTY_ROSTER_URL,
-          FACULTY_AFFILIATED_PROFILE_URL,
-          RESEARCH_WEBSITE_URL,
-        ],
+        sourceUrls: [FACULTY_ROSTER_URL, FACULTY_AFFILIATED_PROFILE_URL, RESEARCH_WEBSITE_URL],
       },
       entryPathways: [
         {
@@ -540,10 +561,7 @@ describe('LabDetail page', () => {
           studentFacingLabel: 'Explore the PI profile',
           explanation: 'An official Yale faculty profile is available.',
           bestNextStep: 'Review the PI profile and lab site first.',
-          sourceUrls: [
-            FACULTY_AFFILIATED_PROFILE_URL,
-            RESEARCH_WEBSITE_URL,
-          ],
+          sourceUrls: [FACULTY_AFFILIATED_PROFILE_URL, RESEARCH_WEBSITE_URL],
         },
       ],
       contactRoutes: [
@@ -585,11 +603,7 @@ describe('LabDetail page', () => {
         kind: 'lab',
         entityType: 'LAB',
         websiteUrl: RESEARCH_WEBSITE_URL,
-        sourceUrls: [
-          FACULTY_ROSTER_URL,
-          FACULTY_PROFILE_URL,
-          RESEARCH_WEBSITE_URL,
-        ],
+        sourceUrls: [FACULTY_ROSTER_URL, FACULTY_PROFILE_URL, RESEARCH_WEBSITE_URL],
       },
       contactRoutes: [
         {
@@ -712,10 +726,7 @@ describe('LabDetail page', () => {
         entityType: 'LAB',
         websiteUrl: RESEARCH_WEBSITE_URL,
         shortDescription: 'Co-Director of Graduate Studies',
-        sourceUrls: [
-          FACULTY_PROFILE_URL,
-          RESEARCH_WEBSITE_URL,
-        ],
+        sourceUrls: [FACULTY_PROFILE_URL, RESEARCH_WEBSITE_URL],
         departments: ['Statistics & Data Science'],
         researchAreas: ['Mathematical Statistics', 'Machine Learning'],
       },
@@ -729,10 +740,7 @@ describe('LabDetail page', () => {
           explanation: 'An official Yale faculty profile is available.',
           bestNextStep:
             'Review the PI profile and lab site first, then decide whether targeted exploratory outreach is appropriate.',
-          sourceUrls: [
-            FACULTY_PROFILE_URL,
-            RESEARCH_WEBSITE_URL,
-          ],
+          sourceUrls: [FACULTY_PROFILE_URL, RESEARCH_WEBSITE_URL],
         },
       ],
       contactRoutes: [
@@ -780,10 +788,7 @@ describe('LabDetail page', () => {
         kind: 'lab',
         entityType: 'LAB',
         websiteUrl: RESEARCH_WEBSITE_URL,
-        sourceUrls: [
-          FACULTY_PROFILE_URL,
-          RESEARCH_WEBSITE_URL,
-        ],
+        sourceUrls: [FACULTY_PROFILE_URL, RESEARCH_WEBSITE_URL],
         departments: ['Psychology'],
         researchAreas: ['Decision neuroscience'],
       },
@@ -828,10 +833,7 @@ describe('LabDetail page', () => {
         kind: 'lab',
         entityType: 'LAB',
         websiteUrl: RESEARCH_WEBSITE_URL,
-        sourceUrls: [
-          FACULTY_PROFILE_URL,
-          RESEARCH_WEBSITE_URL,
-        ],
+        sourceUrls: [FACULTY_PROFILE_URL, RESEARCH_WEBSITE_URL],
         departments: ['Biomedical Engineering'],
         researchAreas: ['Optical Microscopy'],
       },
@@ -867,10 +869,7 @@ describe('LabDetail page', () => {
         kind: 'lab',
         entityType: 'LAB',
         websiteUrl: JOIN_LAB_WEBSITE_URL,
-        sourceUrls: [
-          FACULTY_PROFILE_URL,
-          JOIN_LAB_WEBSITE_URL,
-        ],
+        sourceUrls: [FACULTY_PROFILE_URL, JOIN_LAB_WEBSITE_URL],
         departments: ['Psychology'],
         researchAreas: ['Social cognition'],
       },
@@ -907,7 +906,9 @@ describe('LabDetail page', () => {
     // already shown in the research summary.
     const officialRouteLinks = screen.getAllByRole('link', { name: 'Open official route' });
     expect(officialRouteLinks).toHaveLength(1);
-    expect(officialRouteLinks.every((link) => link.getAttribute('href') === JOIN_PAGE_URL)).toBe(true);
+    expect(officialRouteLinks.every((link) => link.getAttribute('href') === JOIN_PAGE_URL)).toBe(
+      true,
+    );
     expect(screen.queryByRole('link', { name: 'Open contact route' })).toBeNull();
     expect(screen.queryByRole('link', { name: 'Open official profile' })).toBeNull();
   });
@@ -1035,7 +1036,8 @@ describe('LabDetail page', () => {
         ...basePayload.group,
         slug: 'example-health-systems-profile',
         name: 'Example Health Systems Profile',
-        description: 'Studies emergency medicine, health disparities, data systems, and public health research.',
+        description:
+          'Studies emergency medicine, health disparities, data systems, and public health research.',
         departments: ['Fixture School of Medicine'],
         researchAreas: [
           'Emergency Medicine',
@@ -1075,9 +1077,7 @@ describe('LabDetail page', () => {
 
     expect(screen.getByText('Profile status')).toBeTruthy();
     expect(screen.getByText('Source-backed details')).toBeTruthy();
-    expect(
-      screen.getByText('No indexed planning routes are attached yet.'),
-    ).toBeTruthy();
+    expect(screen.getByText('No indexed planning routes are attached yet.')).toBeTruthy();
   });
 
   it('does not render legacy active listings as a public detail section', async () => {
@@ -1085,10 +1085,7 @@ describe('LabDetail page', () => {
 
     await screen.findByText(DEFAULT_ENTITY_NAME);
     await waitFor(() => {
-      expect(mockedAxios.get).toHaveBeenCalledWith(
-        `/research/${DEFAULT_SLUG}`,
-        expect.any(Object),
-      );
+      expect(mockedAxios.get).toHaveBeenCalledWith(`/research/${DEFAULT_SLUG}`, expect.any(Object));
     });
 
     const text = container.textContent || '';
@@ -1158,9 +1155,11 @@ describe('LabDetail page', () => {
     await screen.findByText(DEFAULT_ENTITY_NAME);
 
     expect(
-      screen.getByRole('link', {
-        name: 'Biomass gasification tar removal using catalyst assisted Dielectric Barrier discharge reactor',
-      }).getAttribute('href'),
+      screen
+        .getByRole('link', {
+          name: 'Biomass gasification tar removal using catalyst assisted Dielectric Barrier discharge reactor',
+        })
+        .getAttribute('href'),
     ).toBe(EXAMPLE_MECHANISM_DOI);
     expect(document.body.textContent).not.toContain('<p><b><span>');
   });
@@ -1232,9 +1231,9 @@ describe('LabDetail page', () => {
 
     await screen.findByText(DEFAULT_ENTITY_NAME);
 
-    expect(
-      consoleError.mock.calls.some((call) => String(call[0]).includes('same key')),
-    ).toBe(false);
+    expect(consoleError.mock.calls.some((call) => String(call[0]).includes('same key'))).toBe(
+      false,
+    );
     consoleError.mockRestore();
   });
 
@@ -1317,10 +1316,7 @@ describe('LabDetail page', () => {
       researchEntity: {
         ...basePayload.group,
         researchAreas: [],
-        profileResearchAreas: [
-          'Fixture Delivery Systems',
-          'Synthetic Signal Transfer',
-        ],
+        profileResearchAreas: ['Fixture Delivery Systems', 'Synthetic Signal Transfer'],
         researchAreaSource: 'PI_PROFILE_FALLBACK',
       },
     } as unknown as LabDetailPayload);
@@ -1343,10 +1339,7 @@ describe('LabDetail page', () => {
         fullDescription: '',
         departments: ['Behavioral Studies'],
         researchAreas: [],
-        profileResearchAreas: [
-          'Fixture Care Pathway Design',
-          'Synthetic Adherence Workflow',
-        ],
+        profileResearchAreas: ['Fixture Care Pathway Design', 'Synthetic Adherence Workflow'],
         researchAreaSource: 'PI_PROFILE_FALLBACK',
       },
       entryPathways: [
@@ -1381,9 +1374,7 @@ describe('LabDetail page', () => {
     expect(text).not.toContain('PI research interests');
     expect(text).not.toContain('Fixture Care Pathway Design');
     expect(text).toContain('A Yale research profile with limited public description.');
-    expect(text).not.toContain(
-      'Research connected to Fixture Care Pathway Design',
-    );
+    expect(text).not.toContain('Research connected to Fixture Care Pathway Design');
     expect(text).not.toContain('Research connected to Behavioral Studies.');
     expect(screen.queryByText('Plan your next step')).toBeNull();
     expect(screen.queryByText('Ways to approach this lab')).toBeNull();
@@ -1402,10 +1393,7 @@ describe('LabDetail page', () => {
         fullDescription: '',
         departments: ['Statistics & Data Science'],
         researchAreas: [],
-        profileResearchAreas: [
-          'High-Dimensional Statistics',
-          'Probability Theory',
-        ],
+        profileResearchAreas: ['High-Dimensional Statistics', 'Probability Theory'],
         researchAreaSource: 'PI_PROFILE_FALLBACK',
         profileSynthesisDescription:
           'It appears to center on High-Dimensional Statistics and Probability Theory.',
@@ -1577,11 +1565,7 @@ describe('LabDetail page', () => {
         ...basePayload.group,
         name: 'Example Sparse Profile Lab',
         websiteUrl: DEPARTMENT_HOME_URL,
-        sourceUrls: [
-          DEPARTMENT_PEOPLE_URL,
-          FACULTY_PROFILE_URL,
-          DEPARTMENT_HOME_URL,
-        ],
+        sourceUrls: [DEPARTMENT_PEOPLE_URL, FACULTY_PROFILE_URL, DEPARTMENT_HOME_URL],
         departments: ['Public Policy'],
         researchAreas: [],
       },

--- a/client/src/pages/labDetail.tsx
+++ b/client/src/pages/labDetail.tsx
@@ -35,7 +35,7 @@ import {
   LabRelatedResearchEntitySummary,
   LabResearchActivityLink,
 } from '../types/labDetail';
-import type { ResearchEntity, ResearchEntityRepairFlag } from '../types/researchEntity';
+import type { ResearchEntityRepairFlag } from '../types/researchEntity';
 import { normalizeResearchEntityDetailPayload } from '../types/researchEntity';
 import {
   buildResearchDetailSources,
@@ -93,8 +93,7 @@ const RelatedResearchEntitiesSection = ({
       <div className="grid gap-3 sm:grid-cols-2">
         {relatedResearchEntities.map((entity) => {
           const relationship = relationshipByEntityKey.get(entity.slug || entity.id);
-          const description =
-            entity.blurb || '';
+          const description = entity.blurb || '';
           const tags = uniqueCompact(
             [
               relationship?.label || relationshipTypeLabel(relationship?.relationshipType),
@@ -162,8 +161,7 @@ const AffiliatedResearchEntitiesSection = ({
         );
         const className =
           'block rounded-lg border border-[var(--yr-line)] bg-[var(--yr-panel)] p-4 transition';
-        const canOpenDetail =
-          Boolean(entity.slug);
+        const canOpenDetail = Boolean(entity.slug);
         return canOpenDetail ? (
           <Link
             key={entity.id || entity.slug}
@@ -1116,17 +1114,14 @@ const LabDetail = () => {
   const primaryRecentWorkMemberName = primaryRecentWorkMember
     ? memberDisplayName(primaryRecentWorkMember)
     : 'the lead professor';
-  const primaryPathway = entryPathways[0];
-  const isPrimaryPathwaySaved = primaryPathway
-    ? savedResearchPlanIds.includes(primaryPathway._id)
-    : false;
+  const isResearchEntitySaved = savedResearchPlanIds.includes(group._id);
   const canRequestListingReview =
     Boolean(user?.userConfirmed) &&
     ['professor', 'faculty', 'staff'].includes(user?.userType || '') &&
     activeListings.length > 0;
 
-  const handleToggleSavedResearchPlan = (pathwayId: string, shouldSave: boolean) => {
-    setSavedResearchPlanFavorite(pathwayId, shouldSave);
+  const handleToggleSavedResearchPlan = (entityId: string, shouldSave: boolean) => {
+    setSavedResearchPlanFavorite(entityId, shouldSave);
     if (shouldSave && !window.localStorage.getItem(FIRST_RESEARCH_PLAN_SAVE_KEY)) {
       window.localStorage.setItem(FIRST_RESEARCH_PLAN_SAVE_KEY, 'true');
       setShowResearchPlanSavedCallout(true);
@@ -1149,15 +1144,13 @@ const LabDetail = () => {
             dedupeWebsiteUrls={[decisionProfileUrl, decisionOfficialRoute?.url]}
             hasActivePostedOpportunity={hasActivePostedOpportunity}
             actions={
-              primaryPathway ? (
-                <ResearchPlanSaveButton
-                  isSaved={isPrimaryPathwaySaved}
-                  onToggle={(e) => {
-                    e.stopPropagation();
-                    handleToggleSavedResearchPlan(primaryPathway._id, !isPrimaryPathwaySaved);
-                  }}
-                />
-              ) : undefined
+              <ResearchPlanSaveButton
+                isSaved={isResearchEntitySaved}
+                onToggle={(e) => {
+                  e.stopPropagation();
+                  handleToggleSavedResearchPlan(group._id, !isResearchEntitySaved);
+                }}
+              />
             }
           />
 
@@ -1206,9 +1199,15 @@ const LabDetail = () => {
           <section>
             <SectionHeading>Principal Investigator</SectionHeading>
             {leadIdentityUnderReview ? (
-              <div className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950" role="status">
+              <div
+                className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950"
+                role="status"
+              >
                 <p className="font-semibold">Lead identity under review</p>
-                <p className="mt-1">The research information remains available, but this lead and profile link are not shown until their sources agree.</p>
+                <p className="mt-1">
+                  The research information remains available, but this lead and profile link are not
+                  shown until their sources agree.
+                </p>
               </div>
             ) : (
               <LabMembersList members={principalInvestigators} />

--- a/scripts/security-preflight.test.mjs
+++ b/scripts/security-preflight.test.mjs
@@ -4171,7 +4171,10 @@ test('saved pathway plan checklist keys are safe before nested Mongo storage', (
   assert.match(source, /import \{ sanitizeLogValue \} from '\.\.\/utils\/logSanitizer'/);
   assert.match(source, /const recordFavoriteCounterSideEffect = async \(/);
   assert.match(source, /console\.error\(`\$\{label\} failed:`, sanitizeLogValue\(error\)\)/);
-  assert.match(source, /type FavoriteObjectIdArrayField = 'favListings' \| 'favFellowships' \| 'favPathways'/);
+  assert.match(
+    source,
+    /type FavoriteObjectIdArrayField =[\s\S]*'favListings'[\s\S]*'favFellowships'[\s\S]*'favPathways'[\s\S]*'savedResearchEntities'/,
+  );
   assert.match(source, /const addFavoriteObjectIdIfMissing = async \(/);
   assert.match(source, /User\.findOneAndUpdate\(\s*\{ \.\.\.baseFilter, \[fieldName\]: \{ \$ne: value \} \},\s*\{ \$addToSet: \{ \[fieldName\]: value \} \}/);
   assert.match(source, /const removeFavoriteObjectIdIfPresent = async \(/);

--- a/server/src/controllers/userController.ts
+++ b/server/src/controllers/userController.ts
@@ -55,10 +55,7 @@ const publicHttpUrl = (value: unknown): string | undefined => {
 
 const publicHttpUrls = (values: unknown): string[] =>
   Array.isArray(values)
-    ? values
-        .slice(0, MAX_ACCOUNT_LISTING_URLS)
-        .map(publicHttpUrl)
-        .filter((value): value is string => Boolean(value))
+    ? values.slice(0, MAX_ACCOUNT_LISTING_URLS).map(publicHttpUrl).filter((value): value is string => Boolean(value))
     : [];
 
 const MAX_ACCOUNT_LISTING_URLS = 20;

--- a/server/src/controllers/userController.ts
+++ b/server/src/controllers/userController.ts
@@ -25,6 +25,14 @@ import {
   deleteSavedPathwayPlan as deleteSavedPathwayPlanService,
   getSavedProgramTracking as getSavedProgramTrackingService,
   updateSavedProgramTracking as updateSavedProgramTrackingService,
+  getSavedResearchEntities as getSavedResearchEntitiesService,
+  getSavedResearchEntityIds as getSavedResearchEntityIdsService,
+  getSavedResearchEntityPlans as getSavedResearchEntityPlansService,
+  addSavedResearchEntities as addSavedResearchEntitiesService,
+  removeSavedResearchEntities as removeSavedResearchEntitiesService,
+  updateSavedResearchEntityPlan as updateSavedResearchEntityPlanService,
+  deleteSavedResearchEntityPlan as deleteSavedResearchEntityPlanService,
+  exportSavedResearchEntities as exportSavedResearchEntitiesService,
 } from '../services/userService';
 import { publicProgramForReader } from './programPayload';
 import { isPublicHttpUrl } from '../utils/urlSafety';
@@ -47,7 +55,10 @@ const publicHttpUrl = (value: unknown): string | undefined => {
 
 const publicHttpUrls = (values: unknown): string[] =>
   Array.isArray(values)
-    ? values.slice(0, MAX_ACCOUNT_LISTING_URLS).map(publicHttpUrl).filter((value): value is string => Boolean(value))
+    ? values
+        .slice(0, MAX_ACCOUNT_LISTING_URLS)
+        .map(publicHttpUrl)
+        .filter((value): value is string => Boolean(value))
     : [];
 
 const MAX_ACCOUNT_LISTING_URLS = 20;
@@ -96,9 +107,7 @@ const publicAccountListingText = (value: unknown): string | undefined =>
   typeof value === 'string' ? redactDirectContactInfo(value) : undefined;
 
 const publicAccountListingTextArray = (values: unknown): string[] =>
-  Array.isArray(values)
-    ? values.flatMap((value) => publicAccountListingText(value) ?? [])
-    : [];
+  Array.isArray(values) ? values.flatMap((value) => publicAccountListingText(value) ?? []) : [];
 
 const publicAccountListing = (listing: any) => {
   const id = serializedDocumentId(listing._id) || serializedDocumentId(listing.id) || '';
@@ -160,13 +169,15 @@ const CURRENT_USER_RESPONSE_FIELDS = [
 
 const publicProfileUrlMap = (value: unknown): Record<string, string> | undefined => {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
-  const entries = Object.entries(value as Record<string, unknown>).flatMap(([key, rawUrl]) => {
-    const normalizedKey = publicProfileUrlKey(key);
-    const url = publicHttpUrl(rawUrl);
-    return normalizedKey && url && url.length <= MAX_CURRENT_USER_PROFILE_URL_LENGTH
-      ? [[normalizedKey, url] as const]
-      : [];
-  }).slice(0, MAX_CURRENT_USER_PROFILE_URLS);
+  const entries = Object.entries(value as Record<string, unknown>)
+    .flatMap(([key, rawUrl]) => {
+      const normalizedKey = publicProfileUrlKey(key);
+      const url = publicHttpUrl(rawUrl);
+      return normalizedKey && url && url.length <= MAX_CURRENT_USER_PROFILE_URL_LENGTH
+        ? [[normalizedKey, url] as const]
+        : [];
+    })
+    .slice(0, MAX_CURRENT_USER_PROFILE_URLS);
   return entries.length > 0 ? Object.fromEntries(entries) : undefined;
 };
 
@@ -193,7 +204,13 @@ const sanitizeSelfEditableTextFields = (update: Record<string, any>) => {
     }
   }
 
-  for (const field of ['major', 'departments', 'secondaryDepartments', 'researchInterests', 'topics']) {
+  for (const field of [
+    'major',
+    'departments',
+    'secondaryDepartments',
+    'researchInterests',
+    'topics',
+  ]) {
     if (field in update) {
       const values = boundedAccountStringArray(update[field]);
       if (values !== undefined) update[field] = values;
@@ -205,7 +222,10 @@ const sanitizeSelfEditableTextFields = (update: Record<string, any>) => {
 const sanitizeUnknownBootstrapFields = (update: Record<string, any>) => {
   for (const field of UNKNOWN_BOOTSTRAP_FIELDS) {
     if (field in update) {
-      const value = boundedAccountString(update[field], field === 'email' ? 254 : MAX_CURRENT_USER_SHORT_TEXT_LENGTH);
+      const value = boundedAccountString(
+        update[field],
+        field === 'email' ? 254 : MAX_CURRENT_USER_SHORT_TEXT_LENGTH,
+      );
       if (value !== undefined) update[field] = value;
       else delete update[field];
     }
@@ -291,7 +311,11 @@ const sendPrivateAccountError = (response: Response, error: any, fallbackMessage
 
 export const getFavListingsIds = async (request: Request, response: Response) => {
   try {
-    const currentUser = request.user as { netId?: string; userType: string; userConfirmed: boolean };
+    const currentUser = request.user as {
+      netId?: string;
+      userType: string;
+      userConfirmed: boolean;
+    };
     const user = await readUser(currentUser.netId);
     const favListingIds = normalizeStoredObjectIdsForAccountRead(user.favListings, 'favListings');
     const favListings = await readPublicListings(favListingIds);
@@ -309,7 +333,11 @@ export const getFavListingsIds = async (request: Request, response: Response) =>
 
 export const addFavListings = async (request: Request, response: Response) => {
   try {
-    const currentUser = request.user as { netId?: string; userType: string; userConfirmed: boolean };
+    const currentUser = request.user as {
+      netId?: string;
+      userType: string;
+      userConfirmed: boolean;
+    };
 
     if (!request.body.data?.favListings) {
       const error: any = new Error('No favListings provided');
@@ -331,7 +359,11 @@ export const addFavListings = async (request: Request, response: Response) => {
 
 export const removeFavListings = async (request: Request, response: Response) => {
   try {
-    const currentUser = request.user as { netId?: string; userType: string; userConfirmed: boolean };
+    const currentUser = request.user as {
+      netId?: string;
+      userType: string;
+      userConfirmed: boolean;
+    };
 
     if (!request.body.favListings) {
       const error: any = new Error('No favListings provided');
@@ -353,7 +385,11 @@ export const removeFavListings = async (request: Request, response: Response) =>
 
 export const getFavFellowshipIds = async (request: Request, response: Response) => {
   try {
-    const currentUser = request.user as { netId?: string; userType: string; userConfirmed: boolean };
+    const currentUser = request.user as {
+      netId?: string;
+      userType: string;
+      userConfirmed: boolean;
+    };
     const user = await readUser(currentUser.netId);
     const favFellowshipIds = normalizeStoredObjectIdsForAccountRead(
       user.favFellowships,
@@ -374,7 +410,11 @@ export const getFavFellowshipIds = async (request: Request, response: Response) 
 
 export const getSavedProgramIds = async (request: Request, response: Response) => {
   try {
-    const currentUser = request.user as { netId?: string; userType: string; userConfirmed: boolean };
+    const currentUser = request.user as {
+      netId?: string;
+      userType: string;
+      userConfirmed: boolean;
+    };
     const user = await readUser(currentUser.netId);
     const savedProgramIds = normalizeStoredObjectIdsForAccountRead(
       user.favFellowships,
@@ -395,7 +435,11 @@ export const getSavedProgramIds = async (request: Request, response: Response) =
 
 export const getFavFellowships = async (request: Request, response: Response) => {
   try {
-    const currentUser = request.user as { netId?: string; userType: string; userConfirmed: boolean };
+    const currentUser = request.user as {
+      netId?: string;
+      userType: string;
+      userConfirmed: boolean;
+    };
     const user = await readUser(currentUser.netId);
     const favFellowshipIds = normalizeStoredObjectIdsForAccountRead(
       user.favFellowships,
@@ -418,7 +462,11 @@ export const getFavFellowships = async (request: Request, response: Response) =>
 
 export const getSavedPrograms = async (request: Request, response: Response) => {
   try {
-    const currentUser = request.user as { netId?: string; userType: string; userConfirmed: boolean };
+    const currentUser = request.user as {
+      netId?: string;
+      userType: string;
+      userConfirmed: boolean;
+    };
     const user = await readUser(currentUser.netId);
     const savedProgramIds = normalizeStoredObjectIdsForAccountRead(
       user.favFellowships,
@@ -441,7 +489,11 @@ export const getSavedPrograms = async (request: Request, response: Response) => 
 
 export const addFavFellowships = async (request: Request, response: Response) => {
   try {
-    const currentUser = request.user as { netId?: string; userType: string; userConfirmed: boolean };
+    const currentUser = request.user as {
+      netId?: string;
+      userType: string;
+      userConfirmed: boolean;
+    };
 
     if (!request.body.data?.favFellowships) {
       const error: any = new Error('No favFellowships provided');
@@ -463,7 +515,11 @@ export const addFavFellowships = async (request: Request, response: Response) =>
 
 export const addSavedPrograms = async (request: Request, response: Response) => {
   try {
-    const currentUser = request.user as { netId?: string; userType: string; userConfirmed: boolean };
+    const currentUser = request.user as {
+      netId?: string;
+      userType: string;
+      userConfirmed: boolean;
+    };
     const ids = request.body.data?.savedPrograms ?? request.body.data?.favFellowships;
 
     if (!ids) {
@@ -483,7 +539,11 @@ export const addSavedPrograms = async (request: Request, response: Response) => 
 
 export const removeFavFellowships = async (request: Request, response: Response) => {
   try {
-    const currentUser = request.user as { netId?: string; userType: string; userConfirmed: boolean };
+    const currentUser = request.user as {
+      netId?: string;
+      userType: string;
+      userConfirmed: boolean;
+    };
 
     if (!request.body.favFellowships) {
       const error: any = new Error('No favFellowships provided');
@@ -505,7 +565,11 @@ export const removeFavFellowships = async (request: Request, response: Response)
 
 export const removeSavedPrograms = async (request: Request, response: Response) => {
   try {
-    const currentUser = request.user as { netId?: string; userType: string; userConfirmed: boolean };
+    const currentUser = request.user as {
+      netId?: string;
+      userType: string;
+      userConfirmed: boolean;
+    };
     const ids = request.body.savedPrograms ?? request.body.favFellowships;
 
     if (!ids) {
@@ -558,7 +622,11 @@ export const updateSavedProgramTracking = async (request: Request, response: Res
 
 export const getFavPathwayIds = async (request: Request, response: Response) => {
   try {
-    const currentUser = request.user as { netId?: string; userType: string; userConfirmed: boolean };
+    const currentUser = request.user as {
+      netId?: string;
+      userType: string;
+      userConfirmed: boolean;
+    };
     const user = await readUser(currentUser.netId);
     const favPathwayIds = normalizeStoredPathwayIdsForAccountRead(user.favPathways);
     const favPathways = await getPathwaysByIds(favPathwayIds);
@@ -576,7 +644,11 @@ export const getFavPathwayIds = async (request: Request, response: Response) => 
 
 export const getSavedResearchPlanIds = async (request: Request, response: Response) => {
   try {
-    const currentUser = request.user as { netId?: string; userType: string; userConfirmed: boolean };
+    const currentUser = request.user as {
+      netId?: string;
+      userType: string;
+      userConfirmed: boolean;
+    };
     const user = await readUser(currentUser.netId);
     const savedResearchPlanIds = normalizeStoredPathwayIdsForAccountRead(user.favPathways);
     const savedResearchPlans = await getPathwaysByIds(savedResearchPlanIds);
@@ -594,7 +666,11 @@ export const getSavedResearchPlanIds = async (request: Request, response: Respon
 
 export const getFavPathways = async (request: Request, response: Response) => {
   try {
-    const currentUser = request.user as { netId?: string; userType: string; userConfirmed: boolean };
+    const currentUser = request.user as {
+      netId?: string;
+      userType: string;
+      userConfirmed: boolean;
+    };
     const user = await readUser(currentUser.netId);
     const favPathwayIds = normalizeStoredPathwayIdsForAccountRead(user.favPathways);
     const favPathways = await getPathwaysByIds(favPathwayIds);
@@ -617,7 +693,11 @@ export const getFavPathways = async (request: Request, response: Response) => {
 
 export const getSavedResearchPlans = async (request: Request, response: Response) => {
   try {
-    const currentUser = request.user as { netId?: string; userType: string; userConfirmed: boolean };
+    const currentUser = request.user as {
+      netId?: string;
+      userType: string;
+      userConfirmed: boolean;
+    };
     const user = await readUser(currentUser.netId);
     const savedResearchPlanIds = normalizeStoredPathwayIdsForAccountRead(user.favPathways);
     const savedResearchPlans = await getPathwaysByIds(savedResearchPlanIds);
@@ -640,7 +720,11 @@ export const getSavedResearchPlans = async (request: Request, response: Response
 
 export const getFavPathwayFundingMatches = async (request: Request, response: Response) => {
   try {
-    const currentUser = request.user as { netId?: string; userType: string; userConfirmed: boolean };
+    const currentUser = request.user as {
+      netId?: string;
+      userType: string;
+      userConfirmed: boolean;
+    };
     const user = await readUser(currentUser.netId);
     const favPathwayIds = normalizeStoredPathwayIdsForAccountRead(user.favPathways);
     const favPathways = await getPathwaysByIds(favPathwayIds);
@@ -673,7 +757,11 @@ export const getSavedResearchPlanFundingMatches = getFavPathwayFundingMatches;
 
 export const addFavPathways = async (request: Request, response: Response) => {
   try {
-    const currentUser = request.user as { netId?: string; userType: string; userConfirmed: boolean };
+    const currentUser = request.user as {
+      netId?: string;
+      userType: string;
+      userConfirmed: boolean;
+    };
 
     if (!request.body.data?.favPathways) {
       const error: any = new Error('No favPathways provided');
@@ -695,7 +783,11 @@ export const addFavPathways = async (request: Request, response: Response) => {
 
 export const addSavedResearchPlans = async (request: Request, response: Response) => {
   try {
-    const currentUser = request.user as { netId?: string; userType: string; userConfirmed: boolean };
+    const currentUser = request.user as {
+      netId?: string;
+      userType: string;
+      userConfirmed: boolean;
+    };
 
     if (!request.body.data?.savedResearchPlans) {
       const error: any = new Error('No savedResearchPlans provided');
@@ -717,7 +809,11 @@ export const addSavedResearchPlans = async (request: Request, response: Response
 
 export const removeFavPathways = async (request: Request, response: Response) => {
   try {
-    const currentUser = request.user as { netId?: string; userType: string; userConfirmed: boolean };
+    const currentUser = request.user as {
+      netId?: string;
+      userType: string;
+      userConfirmed: boolean;
+    };
 
     if (!request.body.favPathways) {
       const error: any = new Error('No favPathways provided');
@@ -739,7 +835,11 @@ export const removeFavPathways = async (request: Request, response: Response) =>
 
 export const removeSavedResearchPlans = async (request: Request, response: Response) => {
   try {
-    const currentUser = request.user as { netId?: string; userType: string; userConfirmed: boolean };
+    const currentUser = request.user as {
+      netId?: string;
+      userType: string;
+      userConfirmed: boolean;
+    };
 
     if (!request.body.savedResearchPlans) {
       const error: any = new Error('No savedResearchPlans provided');
@@ -761,7 +861,11 @@ export const removeSavedResearchPlans = async (request: Request, response: Respo
 
 export const getSavedPathwayPlans = async (request: Request, response: Response) => {
   try {
-    const currentUser = request.user as { netId?: string; userType: string; userConfirmed: boolean };
+    const currentUser = request.user as {
+      netId?: string;
+      userType: string;
+      userConfirmed: boolean;
+    };
     const savedPathwayPlans = await getSavedPathwayPlansService(currentUser.netId);
     setPrivateAccountResponseHeaders(response);
     response.status(200).json({ savedPathwayPlans });
@@ -773,7 +877,11 @@ export const getSavedPathwayPlans = async (request: Request, response: Response)
 
 export const getSavedResearchPlanDetails = async (request: Request, response: Response) => {
   try {
-    const currentUser = request.user as { netId?: string; userType: string; userConfirmed: boolean };
+    const currentUser = request.user as {
+      netId?: string;
+      userType: string;
+      userConfirmed: boolean;
+    };
     const savedResearchPlanDetails = await getSavedPathwayPlansService(currentUser.netId);
     setPrivateAccountResponseHeaders(response);
     response.status(200).json({ savedResearchPlanDetails });
@@ -785,7 +893,11 @@ export const getSavedResearchPlanDetails = async (request: Request, response: Re
 
 export const exportSavedPathwayPlans = async (request: Request, response: Response) => {
   try {
-    const currentUser = request.user as { netId?: string; userType: string; userConfirmed: boolean };
+    const currentUser = request.user as {
+      netId?: string;
+      userType: string;
+      userConfirmed: boolean;
+    };
     const includePrivateNotes =
       request.method === 'POST' &&
       request.body &&
@@ -808,7 +920,11 @@ export const exportSavedResearchPlanDetails = exportSavedPathwayPlans;
 
 export const updateSavedPathwayPlan = async (request: Request, response: Response) => {
   try {
-    const currentUser = request.user as { netId?: string; userType: string; userConfirmed: boolean };
+    const currentUser = request.user as {
+      netId?: string;
+      userType: string;
+      userConfirmed: boolean;
+    };
     const savedPathwayPlans = await updateSavedPathwayPlanService(
       currentUser.netId,
       request.params.pathwayId,
@@ -824,7 +940,11 @@ export const updateSavedPathwayPlan = async (request: Request, response: Respons
 
 export const updateSavedResearchPlanDetail = async (request: Request, response: Response) => {
   try {
-    const currentUser = request.user as { netId?: string; userType: string; userConfirmed: boolean };
+    const currentUser = request.user as {
+      netId?: string;
+      userType: string;
+      userConfirmed: boolean;
+    };
     const savedResearchPlanDetails = await updateSavedPathwayPlanService(
       currentUser.netId,
       request.params.pathwayId,
@@ -840,7 +960,11 @@ export const updateSavedResearchPlanDetail = async (request: Request, response: 
 
 export const deleteSavedPathwayPlan = async (request: Request, response: Response) => {
   try {
-    const currentUser = request.user as { netId?: string; userType: string; userConfirmed: boolean };
+    const currentUser = request.user as {
+      netId?: string;
+      userType: string;
+      userConfirmed: boolean;
+    };
     const savedPathwayPlans = await deleteSavedPathwayPlanService(
       currentUser.netId,
       request.params.pathwayId,
@@ -855,7 +979,11 @@ export const deleteSavedPathwayPlan = async (request: Request, response: Respons
 
 export const deleteSavedResearchPlanDetail = async (request: Request, response: Response) => {
   try {
-    const currentUser = request.user as { netId?: string; userType: string; userConfirmed: boolean };
+    const currentUser = request.user as {
+      netId?: string;
+      userType: string;
+      userConfirmed: boolean;
+    };
     const savedResearchPlanDetails = await deleteSavedPathwayPlanService(
       currentUser.netId,
       request.params.pathwayId,
@@ -868,9 +996,139 @@ export const deleteSavedResearchPlanDetail = async (request: Request, response: 
   }
 };
 
+export const getSavedResearchEntityIds = async (request: Request, response: Response) => {
+  try {
+    const currentUser = request.user as { netId?: string };
+    response.status(200).json({
+      savedResearchEntityIds: await getSavedResearchEntityIdsService(currentUser.netId),
+    });
+  } catch (error) {
+    console.error('Saved research entity id fetch failed:', sanitizeLogValue(error));
+    sendAccountMutationError(response, error, 'Failed to fetch saved research entity ids');
+  }
+};
+
+export const getSavedResearchEntities = async (request: Request, response: Response) => {
+  try {
+    const currentUser = request.user as { netId?: string };
+    response.status(200).json({
+      savedResearchEntities: await getSavedResearchEntitiesService(currentUser.netId),
+    });
+  } catch (error) {
+    console.error('Saved research entity fetch failed:', sanitizeLogValue(error));
+    sendAccountMutationError(response, error, 'Failed to fetch saved research entities');
+  }
+};
+
+export const addSavedResearchEntities = async (request: Request, response: Response) => {
+  try {
+    const currentUser = request.user as { netId?: string };
+    const values = request.body?.data?.savedResearchEntities;
+    if (!values) {
+      const error: any = new Error('No savedResearchEntities provided');
+      error.status = 400;
+      throw error;
+    }
+    const ids = await addSavedResearchEntitiesService(
+      currentUser.netId,
+      Array.isArray(values) ? values : [values],
+    );
+    response.status(200).json({ savedResearchEntityIds: ids });
+  } catch (error) {
+    console.error('Saved research entity mutation failed:', sanitizeLogValue(error));
+    sendAccountMutationError(response, error, 'Failed to save research entities');
+  }
+};
+
+export const removeSavedResearchEntities = async (request: Request, response: Response) => {
+  try {
+    const currentUser = request.user as { netId?: string };
+    const values = request.body?.savedResearchEntities;
+    if (!values) {
+      const error: any = new Error('No savedResearchEntities provided');
+      error.status = 400;
+      throw error;
+    }
+    const ids = await removeSavedResearchEntitiesService(
+      currentUser.netId,
+      Array.isArray(values) ? values : [values],
+    );
+    response.status(200).json({ savedResearchEntityIds: ids });
+  } catch (error) {
+    console.error('Saved research entity removal failed:', sanitizeLogValue(error));
+    sendAccountMutationError(response, error, 'Failed to remove saved research entities');
+  }
+};
+
+export const getSavedResearchEntityPlans = async (request: Request, response: Response) => {
+  try {
+    const currentUser = request.user as { netId?: string };
+    setPrivateAccountResponseHeaders(response);
+    response.status(200).json({
+      savedResearchEntityPlans: await getSavedResearchEntityPlansService(currentUser.netId),
+    });
+  } catch (error) {
+    console.error('Saved research entity plan fetch failed:', sanitizeLogValue(error));
+    sendPrivateAccountError(response, error, 'Failed to fetch saved research entity plans');
+  }
+};
+
+export const updateSavedResearchEntityPlan = async (request: Request, response: Response) => {
+  try {
+    const currentUser = request.user as { netId?: string };
+    const plans = await updateSavedResearchEntityPlanService(
+      currentUser.netId,
+      request.params.entityId,
+      request.body?.data?.plan || request.body?.plan || {},
+    );
+    setPrivateAccountResponseHeaders(response);
+    response.status(200).json({ savedResearchEntityPlans: plans });
+  } catch (error) {
+    console.error('Saved research entity plan update failed:', sanitizeLogValue(error));
+    sendPrivateAccountError(response, error, 'Failed to update saved research entity plan');
+  }
+};
+
+export const deleteSavedResearchEntityPlan = async (request: Request, response: Response) => {
+  try {
+    const currentUser = request.user as { netId?: string };
+    const plans = await deleteSavedResearchEntityPlanService(
+      currentUser.netId,
+      request.params.entityId,
+    );
+    setPrivateAccountResponseHeaders(response);
+    response.status(200).json({ savedResearchEntityPlans: plans });
+  } catch (error) {
+    console.error('Saved research entity plan delete failed:', sanitizeLogValue(error));
+    sendPrivateAccountError(response, error, 'Failed to delete saved research entity plan');
+  }
+};
+
+export const exportSavedResearchEntities = async (request: Request, response: Response) => {
+  try {
+    const currentUser = request.user as { netId?: string };
+    const payload = await exportSavedResearchEntitiesService(currentUser.netId, {
+      includePrivateNotes: request.method === 'POST' && request.body?.includePrivateNotes === true,
+    });
+    setPrivateAccountResponseHeaders(response);
+    response.setHeader(
+      'Content-Disposition',
+      'attachment; filename="saved-research-entities.json"',
+    );
+    response.status(200).json(payload);
+  } catch (error) {
+    console.error('Saved research entity export failed:', sanitizeLogValue(error));
+    sendPrivateAccountError(response, error, 'Failed to export saved research entities');
+  }
+};
+
 export const getUserListings = async (request: Request, response: Response) => {
   try {
-    const currentUser = request.user as { netId?: string; userType: string; userConfirmed: boolean };
+    const currentUser = request.user as {
+      netId?: string;
+      userType: string;
+      userConfirmed: boolean;
+    };
     const user = await readUser(currentUser.netId);
     const ownListingIds = normalizeStoredObjectIdsForAccountRead(user.ownListings, 'ownListings');
     const favListingIds = normalizeStoredObjectIdsForAccountRead(user.favListings, 'favListings');
@@ -917,12 +1175,7 @@ const SELF_UPDATABLE_FIELDS = [
   'profileUrls',
 ] as const;
 
-const ALLOWED_SELF_USER_TYPES = new Set([
-  'undergraduate',
-  'graduate',
-  'professor',
-  'faculty',
-]);
+const ALLOWED_SELF_USER_TYPES = new Set(['undergraduate', 'graduate', 'professor', 'faculty']);
 
 // Identity fields can only be set during the unknown-user bootstrap flow,
 // then become admin-only to prevent impersonation of established accounts.

--- a/server/src/models/user.ts
+++ b/server/src/models/user.ts
@@ -4,7 +4,9 @@
 import mongoose from 'mongoose';
 
 export const normalizeUserType = (value: unknown): string => {
-  const normalized = String(value || 'unknown').trim().toLowerCase();
+  const normalized = String(value || 'unknown')
+    .trim()
+    .toLowerCase();
   return normalized === 'faculty' ? 'professor' : normalized || 'unknown';
 };
 
@@ -35,15 +37,7 @@ const userSchema = new mongoose.Schema(
     userType: {
       type: String,
       set: normalizeUserType,
-      enum: [
-        'undergraduate',
-        'graduate',
-        'student',
-        'professor',
-        'staff',
-        'unknown',
-        'admin',
-      ],
+      enum: ['undergraduate', 'graduate', 'student', 'professor', 'staff', 'unknown', 'admin'],
       default: 'unknown',
     },
     facultyMemberId: {
@@ -137,6 +131,20 @@ const userSchema = new mongoose.Schema(
     favPathways: {
       type: [mongoose.Schema.ObjectId],
       default: [],
+    },
+    savedResearchEntities: {
+      type: [mongoose.Schema.ObjectId],
+      ref: 'ResearchEntity',
+      default: [],
+    },
+    savedResearchEntityPlans: {
+      type: mongoose.Schema.Types.Mixed,
+      default: {},
+    },
+    savedResearchEntityPlanMigrationConflicts: {
+      type: mongoose.Schema.Types.Mixed,
+      default: {},
+      select: false,
     },
     savedPathwayPlans: {
       type: mongoose.Schema.Types.Mixed,

--- a/server/src/routes/__tests__/userRoutes.test.ts
+++ b/server/src/routes/__tests__/userRoutes.test.ts
@@ -20,4 +20,29 @@ describe('user routes', () => {
       expect(route.stack.length).toBeGreaterThanOrEqual(3);
     }
   });
+
+  it('keeps entity-owned planning routes authenticated and validates entity ids', () => {
+    for (const [path, method] of [
+      ['/savedResearchEntityPlans/:entityId', 'put'],
+      ['/savedResearchEntityPlans/:entityId', 'delete'],
+    ]) {
+      const route = routeByPathAndMethod(path, method);
+      expect(route).toBeTruthy();
+      expect(route.stack.length).toBeGreaterThanOrEqual(3);
+    }
+
+    for (const [path, method] of [
+      ['/savedResearchEntityIds', 'get'],
+      ['/savedResearchEntities', 'get'],
+      ['/savedResearchEntities', 'put'],
+      ['/savedResearchEntities', 'delete'],
+      ['/savedResearchEntityPlans', 'get'],
+      ['/savedResearchEntityPlans/export', 'get'],
+      ['/savedResearchEntityPlans/export', 'post'],
+    ]) {
+      const route = routeByPathAndMethod(path, method);
+      expect(route).toBeTruthy();
+      expect(route.stack.length).toBeGreaterThanOrEqual(2);
+    }
+  });
 });

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -58,14 +58,14 @@ const parseFavoriteAnalyticsResponse = (data: unknown): Record<string, any> | un
     try {
       const parsed = JSON.parse(data);
       return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
-        ? parsed as Record<string, any>
+        ? (parsed as Record<string, any>)
         : undefined;
     } catch {
       return undefined;
     }
   }
   return typeof data === 'object' && !Array.isArray(data)
-    ? data as Record<string, any>
+    ? (data as Record<string, any>)
     : undefined;
 };
 
@@ -118,7 +118,10 @@ const logFavoriteEvent = (
           ? visibleFavoriteAnalyticsIdsFromResponse(data, kind, requestedIds)
           : [];
 
-        if (currentUser?.netId && (visibleIds.length > 0 || (!isFavorite && requestedIds.length > 0))) {
+        if (
+          currentUser?.netId &&
+          (visibleIds.length > 0 || (!isFavorite && requestedIds.length > 0))
+        ) {
           const eventType =
             kind === 'listing'
               ? isFavorite
@@ -134,7 +137,9 @@ const logFavoriteEvent = (
               netid: currentUser.netId!,
               userType: currentUser.userType,
               metadata: { entityType: kind, itemIdsRedacted: true },
-            }).catch((err) => console.error('Error logging favorite event:', sanitizeLogValue(err)));
+            }).catch((err) =>
+              console.error('Error logging favorite event:', sanitizeLogValue(err)),
+            );
           }
 
           const researchEntityType = kind === 'listing' ? 'listing' : 'fellowship';
@@ -159,7 +164,9 @@ const logFavoriteEvent = (
               listingId: kind === 'listing' ? itemId : undefined,
               fellowshipId: kind !== 'listing' ? itemId : undefined,
               metadata: { entityType: kind },
-            }).catch((err) => console.error('Error logging favorite event:', sanitizeLogValue(err)));
+            }).catch((err) =>
+              console.error('Error logging favorite event:', sanitizeLogValue(err)),
+            );
           });
         }
       }
@@ -192,7 +199,9 @@ const logProfileUpdateEvent = async (req: Request, res: Response, next: NextFunc
           metadata: {
             fields,
           },
-        }).catch((err) => console.error('Error logging profile update event:', sanitizeLogValue(err)));
+        }).catch((err) =>
+          console.error('Error logging profile update event:', sanitizeLogValue(err)),
+        );
       }
     }
 
@@ -273,12 +282,51 @@ router.get('/savedResearchPlanIds', isAuthenticated, userController.getSavedRese
 router.get('/savedResearchPlans', isAuthenticated, userController.getSavedResearchPlans);
 router.put('/savedResearchPlans', isAuthenticated, userController.addSavedResearchPlans);
 router.delete('/savedResearchPlans', isAuthenticated, userController.removeSavedResearchPlans);
+router.get('/savedResearchEntityIds', isAuthenticated, userController.getSavedResearchEntityIds);
+router.get('/savedResearchEntities', isAuthenticated, userController.getSavedResearchEntities);
+router.put('/savedResearchEntities', isAuthenticated, userController.addSavedResearchEntities);
+router.delete(
+  '/savedResearchEntities',
+  isAuthenticated,
+  userController.removeSavedResearchEntities,
+);
+router.get(
+  '/savedResearchEntityPlans',
+  isAuthenticated,
+  userController.getSavedResearchEntityPlans,
+);
+router.get(
+  '/savedResearchEntityPlans/export',
+  isAuthenticated,
+  userController.exportSavedResearchEntities,
+);
+router.post(
+  '/savedResearchEntityPlans/export',
+  isAuthenticated,
+  userController.exportSavedResearchEntities,
+);
+router.put(
+  '/savedResearchEntityPlans/:entityId',
+  isAuthenticated,
+  validateObjectId('entityId'),
+  userController.updateSavedResearchEntityPlan,
+);
+router.delete(
+  '/savedResearchEntityPlans/:entityId',
+  isAuthenticated,
+  validateObjectId('entityId'),
+  userController.deleteSavedResearchEntityPlan,
+);
 router.get(
   '/savedResearchPlanFundingMatches',
   isAuthenticated,
   userController.getSavedResearchPlanFundingMatches,
 );
-router.get('/savedResearchPlanDetails', isAuthenticated, userController.getSavedResearchPlanDetails);
+router.get(
+  '/savedResearchPlanDetails',
+  isAuthenticated,
+  userController.getSavedResearchPlanDetails,
+);
 router.get(
   '/savedResearchPlanDetails/export',
   isAuthenticated,
@@ -302,16 +350,8 @@ router.delete(
   userController.deleteSavedResearchPlanDetail,
 );
 router.get('/favPathwayPlans', isAuthenticated, userController.getSavedPathwayPlans);
-router.get(
-  '/favPathwayPlans/export',
-  isAuthenticated,
-  userController.exportSavedPathwayPlans,
-);
-router.post(
-  '/favPathwayPlans/export',
-  isAuthenticated,
-  userController.exportSavedPathwayPlans,
-);
+router.get('/favPathwayPlans/export', isAuthenticated, userController.exportSavedPathwayPlans);
+router.post('/favPathwayPlans/export', isAuthenticated, userController.exportSavedPathwayPlans);
 router.put(
   '/favPathwayPlans/:pathwayId',
   isAuthenticated,

--- a/server/src/services/__tests__/userService.test.ts
+++ b/server/src/services/__tests__/userService.test.ts
@@ -6,6 +6,7 @@ import {
   buildCaseInsensitiveNetidFilter,
   buildSavedPathwayPlanUnsetForIds,
   buildSavedPathwayPlansExport,
+  buildSavedResearchEntityMigration,
   normalizeObjectIdStringForUserMutation,
   normalizeObjectIdsForUserMutation,
   normalizeUserLookupObjectId,
@@ -158,20 +159,24 @@ describe('pruneSavedPathwayPlansForExistingPathways', () => {
 
 describe('sanitizeSavedPathwayPlanForStorage', () => {
   it('keeps valid date-only reminders and rejects invalid dates and intervals', () => {
-    expect(sanitizeSavedPathwayPlanForStorage({
-      targetDeadline: '2026-09-30',
-      actedOnDate: '2026-02-29',
-      followUpIntervalDays: 14,
-    })).toMatchObject({
+    expect(
+      sanitizeSavedPathwayPlanForStorage({
+        targetDeadline: '2026-09-30',
+        actedOnDate: '2026-02-29',
+        followUpIntervalDays: 14,
+      }),
+    ).toMatchObject({
       targetDeadline: '2026-09-30',
       actedOnDate: null,
       followUpIntervalDays: 14,
     });
-    expect(sanitizeSavedPathwayPlanForStorage({
-      targetDeadline: '09/30/2026',
-      actedOnDate: '2026-07-12T00:00:00Z',
-      followUpIntervalDays: 15,
-    })).toMatchObject({ targetDeadline: null, actedOnDate: null, followUpIntervalDays: null });
+    expect(
+      sanitizeSavedPathwayPlanForStorage({
+        targetDeadline: '09/30/2026',
+        actedOnDate: '2026-07-12T00:00:00Z',
+        followUpIntervalDays: 15,
+      }),
+    ).toMatchObject({ targetDeadline: null, actedOnDate: null, followUpIntervalDays: null });
   });
 
   it('normalizes create/update payloads before persisting a saved pathway plan', () => {
@@ -493,5 +498,40 @@ describe('buildSavedPathwayPlansExport', () => {
       stage: 'saved',
       checklist: {},
     });
+  });
+});
+
+describe('buildSavedResearchEntityMigration', () => {
+  it('deduplicates pathways by entity and preserves every colliding private plan', () => {
+    const firstId = '665f0b0c0b0c0b0c0b0c0b0c';
+    const secondId = '665f0b0c0b0c0b0c0b0c0b0f';
+    const entityId = '665f0b0c0b0c0b0c0b0c0b0d';
+    const first = sanitizeSavedPathwayPlanForStorage({ note: 'First private note' });
+    const second = sanitizeSavedPathwayPlanForStorage({ note: 'Second private note' });
+
+    const result = buildSavedResearchEntityMigration(
+      [pathway({ _id: secondId }), pathway({ _id: firstId })],
+      { [firstId]: first, [secondId]: second },
+    );
+
+    expect(result.entityIds).toEqual([entityId]);
+    expect(result.plans[entityId].note).toBe('First private note');
+    expect(result.conflicts[entityId]).toEqual({
+      [firstId]: first,
+      [secondId]: second,
+    });
+  });
+
+  it('never overwrites an existing entity-owned plan during lazy migration', () => {
+    const entityId = '665f0b0c0b0c0b0c0b0c0b0d';
+    const existing = sanitizeSavedPathwayPlanForStorage({ note: 'Canonical entity note' });
+    const result = buildSavedResearchEntityMigration(
+      [pathway()],
+      { [pathway()._id]: sanitizeSavedPathwayPlanForStorage({ note: 'Legacy note' }) },
+      [entityId],
+      { [entityId]: existing },
+    );
+
+    expect(result.plans[entityId]).toEqual(existing);
   });
 });

--- a/server/src/services/userService.ts
+++ b/server/src/services/userService.ts
@@ -1,7 +1,8 @@
 /**
  * Service layer for user account CRUD and favorites management.
  */
-import { User } from '../models/index';
+import { ResearchEntity, User } from '../models/index';
+import { publicStudentVisibilityTiers } from '../models/studentVisibility';
 import { NotFoundError } from '../utils/errors';
 import {
   readListing,
@@ -42,7 +43,11 @@ export const MAX_SAVED_PROGRAM_NOTE_LENGTH = 2000;
 const NETID_LOOKUP_RE = /^[A-Za-z0-9]{2,12}$/;
 const USER_UPDATE_OPERATORS = new Set(['$set', '$unset', '$addToSet']);
 const USER_UPDATE_PATH_SEGMENT_RE = /^[A-Za-z0-9_-]+$/;
-type FavoriteObjectIdArrayField = 'favListings' | 'favFellowships' | 'favPathways';
+type FavoriteObjectIdArrayField =
+  | 'favListings'
+  | 'favFellowships'
+  | 'favPathways'
+  | 'savedResearchEntities';
 
 export interface SavedProgramTrackingInput {
   note?: unknown;
@@ -168,11 +173,8 @@ const sanitizeSavedPathwayChecklistKey = (key: unknown): string | undefined => {
   return trimmed.replace(/^\$+/, '_').replace(/\./g, '_');
 };
 
-export function sanitizeSavedPathwayPlanForStorage(
-  plan: unknown,
-): Required<SavedPathwayPlanInput> {
-  const candidate =
-    plan && typeof plan === 'object' ? (plan as SavedPathwayPlanInput) : {};
+export function sanitizeSavedPathwayPlanForStorage(plan: unknown): Required<SavedPathwayPlanInput> {
+  const candidate = plan && typeof plan === 'object' ? (plan as SavedPathwayPlanInput) : {};
   const dateOnly = (value: unknown): string | null => {
     if (typeof value !== 'string' || !DATE_ONLY_RE.test(value)) return null;
     const [year, month, day] = value.split('-').map(Number);
@@ -304,7 +306,9 @@ const exportTextWithoutDirectContact = (value: unknown): string =>
 const exportUserTextForSpreadsheet = (value: unknown): string =>
   safeSpreadsheetCell(String(value || ''));
 
-const exportChecklistForSpreadsheet = (checklist: Record<string, boolean>): Record<string, boolean> =>
+const exportChecklistForSpreadsheet = (
+  checklist: Record<string, boolean>,
+): Record<string, boolean> =>
   Object.fromEntries(
     Object.entries(checklist).map(([key, value]) => [exportUserTextForSpreadsheet(key), value]),
   );
@@ -1036,7 +1040,9 @@ export const updateSavedProgramTracking = async (
 
 export const addFavPathways = async (id: any, pathways: [mongoose.Types.ObjectId]) => {
   const pathwayIds = normalizeObjectIdsForUserMutation(pathways, 'favPathways');
-  const visiblePathways = await getPathwaysByIds(pathwayIds.map((pathwayId) => pathwayId.toHexString()));
+  const visiblePathways = await getPathwaysByIds(
+    pathwayIds.map((pathwayId) => pathwayId.toHexString()),
+  );
   const visiblePathwayIds = normalizeObjectIdsForUserMutation(
     visiblePathways.map((pathway) => pathway._id),
     'favPathways',
@@ -1114,4 +1120,239 @@ export const deleteSavedPathwayPlan = async (id: any, pathwayId: string) => {
     },
   });
   return sanitizeSavedPathwayPlansForResponse(user.savedPathwayPlans);
+};
+
+export interface SavedResearchEntitySummary {
+  _id: string;
+  slug: string;
+  name: string;
+  displayName?: string;
+  kind: string;
+  entityType?: string;
+  departments: string[];
+  school?: string;
+  shortDescription?: string;
+  description?: string;
+}
+
+const savedResearchEntityProjection =
+  '_id slug name displayName kind entityType departments school shortDescription description';
+
+const sanitizeEntityPlanMap = (value: unknown): Record<string, Required<SavedPathwayPlanInput>> => {
+  if (!isPlainRecord(value)) return {};
+  const result: Record<string, Required<SavedPathwayPlanInput>> = {};
+  for (const [id, plan] of Object.entries(value).slice(0, MAX_ACCOUNT_MUTATION_IDS)) {
+    try {
+      const key = normalizeObjectIdStringForUserMutation(id, 'researchEntity');
+      result[key] = sanitizeSavedPathwayPlanForStorage(plan);
+    } catch {
+      continue;
+    }
+  }
+  return result;
+};
+
+const visibleSavedResearchEntities = async (
+  ids: Array<string | mongoose.Types.ObjectId>,
+): Promise<SavedResearchEntitySummary[]> => {
+  const normalized = normalizeObjectIdsForUserMutation(ids, 'savedResearchEntities');
+  if (!normalized.length) return [];
+  const entities = await ResearchEntity.find({
+    _id: { $in: normalized },
+    archived: { $ne: true },
+    studentVisibilityTier: { $in: publicStudentVisibilityTiers },
+  })
+    .select(savedResearchEntityProjection)
+    .lean();
+  const byId = new Map(entities.map((entity: any) => [String(entity._id), entity]));
+  return normalized.flatMap((id) => {
+    const entity: any = byId.get(String(id));
+    if (!entity) return [];
+    return [
+      {
+        _id: String(entity._id),
+        slug: String(entity.slug || ''),
+        name: String(entity.name || entity.displayName || 'Research profile'),
+        ...(entity.displayName ? { displayName: String(entity.displayName) } : {}),
+        kind: String(entity.kind || 'group'),
+        ...(entity.entityType ? { entityType: String(entity.entityType) } : {}),
+        departments: Array.isArray(entity.departments)
+          ? entity.departments.slice(0, 20).map(String)
+          : [],
+        ...(entity.school ? { school: String(entity.school) } : {}),
+        ...(entity.shortDescription ? { shortDescription: String(entity.shortDescription) } : {}),
+        ...(entity.description ? { description: String(entity.description) } : {}),
+      },
+    ];
+  });
+};
+
+export const buildSavedResearchEntityMigration = (
+  pathways: PathwaySearchHit[],
+  legacyPlans: Record<string, Required<SavedPathwayPlanInput>>,
+  existingIds: string[] = [],
+  existingPlans: Record<string, Required<SavedPathwayPlanInput>> = {},
+) => {
+  const entityIds = new Set(existingIds);
+  const plans = { ...existingPlans };
+  const conflicts: Record<string, Record<string, Required<SavedPathwayPlanInput>>> = {};
+  const grouped = new Map<string, PathwaySearchHit[]>();
+  for (const pathway of pathways) {
+    const entityId = normalizeObjectIdStringForUserMutation(
+      pathway.researchEntity?._id,
+      'researchEntity',
+    );
+    grouped.set(entityId, [...(grouped.get(entityId) || []), pathway]);
+  }
+  for (const [entityId, entityPathways] of grouped) {
+    entityIds.add(entityId);
+    const legacy = [...entityPathways]
+      .sort((a, b) => a._id.localeCompare(b._id))
+      .flatMap((pathway) =>
+        legacyPlans[pathway._id]
+          ? [{ pathwayId: pathway._id, plan: legacyPlans[pathway._id] }]
+          : [],
+      );
+    if (!plans[entityId] && legacy[0]) plans[entityId] = legacy[0].plan;
+    if (legacy.length > 1) {
+      conflicts[entityId] = Object.fromEntries(
+        legacy.map(({ pathwayId, plan }) => [pathwayId, plan]),
+      );
+    }
+  }
+  return { entityIds: [...entityIds], plans, conflicts };
+};
+
+/** Lazily moves pathway-owned saves to entity ownership without deleting rollback data. */
+export const migrateSavedResearchEntitiesForUser = async (id: any) => {
+  const user = await readUser(id);
+  const existingIds = storedObjectIdStringsForUserMutation(
+    user.savedResearchEntities || [],
+    'savedResearchEntities',
+  );
+  const entityPlans = sanitizeEntityPlanMap(user.savedResearchEntityPlans);
+  const pathwayIds = storedObjectIdStringsForUserMutation(user.favPathways, 'favPathways');
+  const pathways = await getPathwaysByIds(pathwayIds);
+  const legacyPlans = sanitizeSavedPathwayPlansForResponse(user.savedPathwayPlans);
+  const migration = buildSavedResearchEntityMigration(
+    pathways,
+    legacyPlans,
+    existingIds,
+    entityPlans,
+  );
+  const visible = await visibleSavedResearchEntities(migration.entityIds);
+  const visibleIds = visible.map((entity) => entity._id);
+  const visibleSet = new Set(visibleIds);
+  const prunedPlans = Object.fromEntries(
+    Object.entries(migration.plans).filter(([entityId]) => visibleSet.has(entityId)),
+  );
+  const currentIds = existingIds.join(',');
+  const nextIds = visibleIds.join(',');
+  if (
+    currentIds !== nextIds ||
+    JSON.stringify(sanitizeEntityPlanMap(user.savedResearchEntityPlans)) !==
+      JSON.stringify(prunedPlans) ||
+    Object.keys(migration.conflicts).length
+  ) {
+    await updateUser(id, {
+      $set: {
+        savedResearchEntities: visibleIds,
+        savedResearchEntityPlans: prunedPlans,
+        ...(Object.keys(migration.conflicts).length
+          ? { savedResearchEntityPlanMigrationConflicts: migration.conflicts }
+          : {}),
+      },
+    });
+  }
+  return { entities: visible, plans: prunedPlans };
+};
+
+export const getSavedResearchEntities = async (id: any) =>
+  (await migrateSavedResearchEntitiesForUser(id)).entities;
+
+export const getSavedResearchEntityIds = async (id: any) =>
+  (await migrateSavedResearchEntitiesForUser(id)).entities.map((entity) => entity._id);
+
+export const getSavedResearchEntityPlans = async (id: any) =>
+  (await migrateSavedResearchEntitiesForUser(id)).plans;
+
+export const addSavedResearchEntities = async (id: any, values: unknown[]) => {
+  const ids = normalizeObjectIdsForUserMutation(values, 'savedResearchEntities');
+  const visible = await visibleSavedResearchEntities(ids);
+  for (const entity of visible) {
+    await addFavoriteObjectIdIfMissing(
+      id,
+      'savedResearchEntities',
+      new mongoose.Types.ObjectId(entity._id),
+    );
+  }
+  return getSavedResearchEntityIds(id);
+};
+
+export const removeSavedResearchEntities = async (id: any, values: unknown[]) => {
+  const ids = normalizeObjectIdsForUserMutation(values, 'savedResearchEntities');
+  const unset = Object.fromEntries(
+    ids.map((entityId) => [`savedResearchEntityPlans.${entityId}`, '']),
+  );
+  const user = await User.findOneAndUpdate(
+    userLookupFilterForMutation(id),
+    { $pull: { savedResearchEntities: { $in: ids } }, ...(ids.length ? { $unset: unset } : {}) },
+    { new: true, runValidators: true },
+  );
+  if (!user) throw new NotFoundError('User not found');
+  return getSavedResearchEntityIds(id);
+};
+
+export const updateSavedResearchEntityPlan = async (
+  id: any,
+  entityId: string,
+  plan: SavedPathwayPlanInput,
+) => {
+  const key = normalizeObjectIdStringForUserMutation(entityId, 'researchEntity');
+  const savedIds = new Set(await getSavedResearchEntityIds(id));
+  if (!savedIds.has(key)) throw new NotFoundError('Saved research entity not found');
+  const user = await updateUser(id, {
+    $set: { [`savedResearchEntityPlans.${key}`]: sanitizeSavedPathwayPlanForStorage(plan) },
+  });
+  return sanitizeEntityPlanMap(user.savedResearchEntityPlans);
+};
+
+export const deleteSavedResearchEntityPlan = async (id: any, entityId: string) => {
+  const key = normalizeObjectIdStringForUserMutation(entityId, 'researchEntity');
+  const user = await updateUser(id, { $unset: { [`savedResearchEntityPlans.${key}`]: '' } });
+  return sanitizeEntityPlanMap(user.savedResearchEntityPlans);
+};
+
+export const exportSavedResearchEntities = async (
+  id: any,
+  options: SavedPathwayPlansExportOptions = {},
+) => {
+  const { entities, plans } = await migrateSavedResearchEntitiesForUser(id);
+  const includePrivateNotes = options.includePrivateNotes === true;
+  return {
+    schemaVersion: 2 as const,
+    exportedAt: (options.exportedAt || new Date()).toISOString(),
+    itemCount: entities.length,
+    privacy: {
+      includesPrivateNotes: includePrivateNotes,
+      includesContactRoutes: false as const,
+      includesNonPublicContactEmails: false as const,
+    },
+    items: entities.map((entity) => {
+      const plan = plans[entity._id] || sanitizeSavedPathwayPlanForStorage({});
+      return {
+        researchEntity: {
+          id: entity._id,
+          slug: entity.slug,
+          name: exportTextWithoutDirectContact(entity.displayName || entity.name),
+        },
+        intent: plan.intent,
+        stage: plan.stage,
+        checklist: exportChecklistForSpreadsheet(plan.checklist as Record<string, boolean>),
+        ...(includePrivateNotes && plan.note
+          ? { privateNote: exportUserTextForSpreadsheet(plan.note) }
+          : {}),
+      };
+    }),
+  };
 };

--- a/server/src/services/userService.ts
+++ b/server/src/services/userService.ts
@@ -306,9 +306,7 @@ const exportTextWithoutDirectContact = (value: unknown): string =>
 const exportUserTextForSpreadsheet = (value: unknown): string =>
   safeSpreadsheetCell(String(value || ''));
 
-const exportChecklistForSpreadsheet = (
-  checklist: Record<string, boolean>,
-): Record<string, boolean> =>
+const exportChecklistForSpreadsheet = (checklist: Record<string, boolean>): Record<string, boolean> =>
   Object.fromEntries(
     Object.entries(checklist).map(([key, value]) => [exportUserTextForSpreadsheet(key), value]),
   );
@@ -1040,9 +1038,7 @@ export const updateSavedProgramTracking = async (
 
 export const addFavPathways = async (id: any, pathways: [mongoose.Types.ObjectId]) => {
   const pathwayIds = normalizeObjectIdsForUserMutation(pathways, 'favPathways');
-  const visiblePathways = await getPathwaysByIds(
-    pathwayIds.map((pathwayId) => pathwayId.toHexString()),
-  );
+  const visiblePathways = await getPathwaysByIds(pathwayIds.map((pathwayId) => pathwayId.toHexString()));
   const visiblePathwayIds = normalizeObjectIdsForUserMutation(
     visiblePathways.map((pathway) => pathway._id),
     'favPathways',


### PR DESCRIPTION
## Summary

- make saved research profiles entity-owned instead of depending on `EntryPathway`
- add authenticated entity save, planning-detail, and privacy-aware export APIs
- lazily migrate legacy pathway saves without deleting rollback data or losing colliding private plans
- keep pathway and funding data as optional account enrichment
- allow every visible research profile to be saved, including profiles with no pathway

## Migration safety

- additive user fields only
- legacy `favPathways` and `savedPathwayPlans` remain intact
- deterministic canonical plan selection by pathway id
- all multi-pathway plans are retained in a private, `select: false` conflict archive
- hidden, archived, and deleted entities are pruned from the active entity-owned view

## Validation

- client focused: 65 tests passed
- server focused: 78 tests passed
- client full: 96 files, 781 tests passed
- server full: passed
- client and server production builds passed
- server TypeScript passed
- changed-file ESLint passed with no errors

Client TypeScript continues to report four pre-existing `beta` errors in `labDetail` types/tests unrelated to this change.

## Product scope

This is FR-45 and the prerequisite for FR-17 finalist comparison. Search UI is unchanged.
