### PR TITLE
Add qualified research planning context projection

### DIFF
--- a/docs/research-student-journey-delivery-plan.md
+++ b/docs/research-student-journey-delivery-plan.md
@@ -90,11 +90,11 @@ The count-fallback and final adaptive documented-way-in distribution contract re
 
 #### EF-03 - Sparse Documented-Way-In Signal
 
-- **Status:** Not started.
+- **Status:** Active.
 - **Depends on:** QA-01 qualifying-action policy and a bounded server summary plus distribution.
 - **Acceptance criteria:** the server returns at most one allowlisted positive signal per entity; the client renders no access label when the signal is absent; PI profiles, publications, provenance URLs, generic participation, and exploratory outreach never create the signal; a filter appears only when documented and undocumented homes both exist and the split is materially useful; no client-side access inference or reranking occurs.
 - **Validation evidence:** current Beta deliberately removed the prior parallel `Verified ways in` presentation in PR `#171`.
-No replacement summary is present yet.
+The qualified-planning-context implementation adds a bounded, optional server projection with one deterministic signal per entity and deny-by-default policy tests; query-scoped distribution and client presentation remain separate work.
 - **PRs:** [#171](https://github.com/YaleComputerSociety/ylabs/pull/171) establishes the baseline only.
 
 #### EF-04 - Stable And Efficient Discovery Requests
@@ -107,7 +107,7 @@ No replacement summary is present yet.
 
 #### EF-05 - Quiet Research-Activity Ranking Input - FR-44
 
-- **Status:** Blocked.
+- **Status:** Active.
 - **Depends on:** EP-06 / FR-42.2 activity rollups.
 - **Acceptance criteria:** a bounded, freshness-aware activity signal may order otherwise comparable entity matches or choose quiet signal precedence; relevance remains primary; no publication count, activity score, or separate activity cluster competes with the entity result; missing activity is neutral rather than negative.
 - **Validation evidence:** current Beta has attribution guards but does not have the required cached entity rollups.
@@ -253,10 +253,10 @@ PR `#171` only simplified Research filters and must not be credited with FR-37.
 - **Status:** Blocked.
 - **Depends on:** approved product contract, reviewed public contact routes, actionable source evidence, and EF-03.
 - **Acceptance criteria:** a positive action requires a current/recurring non-formalization record and explicit proof such as an open application, recurring official program, or approved non-PI public contact route; PI profiles and generic source pages remain source review only; the card shows at most one claim-specific action; absence renders no negative label; server policy and client analytics share the same qualifying enum.
-- **Validation evidence:** current publication policy and access-review infrastructure exist, but Beta still permits broader publishable pathways than this action contract.
-PR `#171` removed the misleading student-facing stream while the replacement policy is designed.
+- **Validation evidence:** current publication policy and access-review infrastructure exist, and PR `#171` removed the misleading student-facing stream.
+The qualified-planning-context implementation establishes a narrower public projection: reviewed current opportunities with safe application URLs, approved application or recurring-program instructions, and approved safe public non-PI routes qualify; profile provenance, generic source material, exploratory contact, formalization-only records, unsafe URLs, and unreviewed claims do not.
 - **PRs:** [#161](https://github.com/YaleComputerSociety/ylabs/pull/161), [#171](https://github.com/YaleComputerSociety/ylabs/pull/171).
-- **Blocker:** a human must accept the qualifying-action enum and evidence threshold, then operators must review routes that will be represented as actionable.
+- **Blocker:** operators must review routes and source-backed claims before they can be represented as actionable; query-scoped distribution, client presentation, and analytics still depend on the stable projection.
 The operational program is named the **evidence and route review rollout**.
 Its acceptance measures are claim quality, reviewed-action precision, false-positive rate, and explainable rejection reasons, not a minimum number of published pathways.
 PI-profile provenance can never qualify as an action.

--- a/server/src/services/__tests__/planningContextService.test.ts
+++ b/server/src/services/__tests__/planningContextService.test.ts
@@ -1,12 +1,37 @@
 import { describe, expect, it } from 'vitest';
 import { Types } from 'mongoose';
-import { selectPlanningContexts } from '../planningContextService';
+import { actionablePlanningUrl, selectPlanningContexts } from '../planningContextService';
 
 const approved = { status: 'approved' };
 const entityId = new Types.ObjectId();
 const pathwayId = new Types.ObjectId();
 
 describe('planningContextService qualification policy', () => {
+  it.each([
+    'https://research.yale.edu/apply',
+    'https://research.yale.edu/programs/summer-fellowship',
+    'https://research.yale.edu/opportunities/undergraduate-research',
+    'https://research.yale.edu/get-involved/participation?registration=open',
+  ])('accepts actionable planning destination %s', (url) => {
+    expect(actionablePlanningUrl(url)).toBe(url);
+  });
+
+  it.each([
+    'https://medicine.yale.edu/profile/person',
+    'https://research.yale.edu/labs/neuroscience',
+    'https://research.yale.edu/publications/applications-of-ai',
+    'https://research.yale.edu/grants/program-evaluation',
+    'https://research.yale.edu/team/members',
+    'https://research.yale.edu/faculty-directory',
+    'https://research.yale.edu/about',
+  ])('rejects provenance-only planning destination %s', (url) => {
+    expect(actionablePlanningUrl(url)).toBeUndefined();
+  });
+
+  it('requires a positive actionable cue', () => {
+    expect(actionablePlanningUrl('https://research.yale.edu/undergraduate')).toBeUndefined();
+  });
+
   it('selects one deterministic signal with open-position precedence', () => {
     const contexts = selectPlanningContexts({
       pathways: [
@@ -166,5 +191,42 @@ describe('planningContextService qualification policy', () => {
     expect(
       selectPlanningContexts({ pathways: [validPathway], opportunities, routes: [] }).size,
     ).toBe(0);
+  });
+
+  it('rejects generic opportunity destinations and skips generic pathway sources', () => {
+    const recurringPathway = {
+      _id: pathwayId,
+      researchEntityId: entityId,
+      pathwayType: 'RECURRING_PROGRAM',
+      status: 'RECURRING',
+      bestNextStep: 'Register for the summer program.',
+      sourceUrls: [
+        'https://research.yale.edu/labs/neuroscience',
+        'https://research.yale.edu/programs/summer-research',
+      ],
+      evidenceStrength: 'DIRECT',
+      confidence: 0.9,
+      review: approved,
+    };
+    const contexts = selectPlanningContexts({
+      pathways: [recurringPathway],
+      opportunities: [
+        {
+          _id: new Types.ObjectId(),
+          researchEntityId: entityId,
+          entryPathwayId: pathwayId,
+          status: 'OPEN',
+          applicationUrl: 'https://research.yale.edu/labs/neuroscience',
+          review: approved,
+        },
+      ],
+      routes: [],
+    });
+
+    expect(contexts.get(entityId.toString())).toEqual({
+      category: 'qualified_participation',
+      label: 'Participation instructions',
+      url: 'https://research.yale.edu/programs/summer-research',
+    });
   });
 });

--- a/server/src/services/__tests__/planningContextService.test.ts
+++ b/server/src/services/__tests__/planningContextService.test.ts
@@ -32,6 +32,12 @@ describe('planningContextService qualification policy', () => {
     expect(actionablePlanningUrl('https://research.yale.edu/undergraduate')).toBeUndefined();
   });
 
+  it('ignores positive cues in tracking parameters', () => {
+    expect(
+      actionablePlanningUrl('https://research.yale.edu/?utm_campaign=summer-program'),
+    ).toBeUndefined();
+  });
+
   it('selects one deterministic signal with open-position precedence', () => {
     const contexts = selectPlanningContexts({
       pathways: [

--- a/server/src/services/__tests__/planningContextService.test.ts
+++ b/server/src/services/__tests__/planningContextService.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+import { Types } from 'mongoose';
+import { selectPlanningContexts } from '../planningContextService';
+
+const approved = { status: 'approved' };
+const entityId = new Types.ObjectId();
+const pathwayId = new Types.ObjectId();
+
+describe('planningContextService qualification policy', () => {
+  it('selects one deterministic signal with open-position precedence', () => {
+    const contexts = selectPlanningContexts({
+      pathways: [
+        {
+          _id: pathwayId,
+          researchEntityId: entityId,
+          pathwayType: 'POSTED_ROLE',
+          status: 'ACTIVE',
+          bestNextStep: 'Apply through the official form.',
+          sourceUrls: ['https://research.yale.edu/apply'],
+          evidenceStrength: 'DIRECT',
+          confidence: 0.9,
+          review: approved,
+        },
+      ],
+      opportunities: [
+        {
+          _id: new Types.ObjectId(),
+          researchEntityId: entityId,
+          entryPathwayId: pathwayId,
+          status: 'OPEN',
+          applicationUrl: 'https://research.yale.edu/jobs/1',
+          review: approved,
+        },
+      ],
+      routes: [
+        {
+          _id: new Types.ObjectId(),
+          researchEntityId: entityId,
+          routeType: 'PROGRAM_MANAGER',
+          visibility: 'PUBLIC',
+          url: 'https://research.yale.edu/contact',
+          sourceUrl: 'https://research.yale.edu/contact-policy',
+          contactPolicy: 'OFFICIAL_ROUTE_PREFERRED',
+          review: approved,
+        },
+      ],
+    });
+
+    expect(contexts.get(entityId.toString())).toEqual({
+      category: 'open_position',
+      label: 'Open position',
+      url: 'https://research.yale.edu/jobs/1',
+    });
+    expect(contexts.size).toBe(1);
+  });
+
+  it('rejects PI provenance, generic pages, inferred outreach, and unapproved records', () => {
+    const contexts = selectPlanningContexts({
+      pathways: [
+        {
+          _id: pathwayId,
+          researchEntityId: entityId,
+          pathwayType: 'EXPLORATORY_CONTACT',
+          status: 'ACTIVE',
+          bestNextStep: 'Email the professor.',
+          sourceUrls: ['https://medicine.yale.edu/profile/person'],
+          review: approved,
+        },
+        {
+          _id: new Types.ObjectId(),
+          researchEntityId: entityId,
+          pathwayType: 'RECURRING_PROGRAM',
+          status: 'RECURRING',
+          bestNextStep: 'Apply each spring.',
+          sourceUrls: ['https://research.yale.edu/program'],
+          review: { status: 'unreviewed' },
+        },
+      ],
+      opportunities: [],
+      routes: [
+        {
+          _id: new Types.ObjectId(),
+          researchEntityId: entityId,
+          routeType: 'FACULTY_PI',
+          visibility: 'PUBLIC',
+          email: 'private@yale.edu',
+          url: 'https://medicine.yale.edu/profile/person',
+          sourceUrl: 'https://medicine.yale.edu/profile/person',
+          contactPolicy: 'DIRECT_CONTACT_OK',
+          review: approved,
+        },
+        {
+          _id: new Types.ObjectId(),
+          researchEntityId: entityId,
+          routeType: 'PROGRAM_MANAGER',
+          visibility: 'ADMIN_ONLY',
+          url: 'https://research.yale.edu/contact',
+          review: approved,
+        },
+      ],
+    });
+
+    expect(contexts.size).toBe(0);
+  });
+
+  it('requires a safe URL and emits no private details or review metadata', () => {
+    const contexts = selectPlanningContexts({
+      pathways: [],
+      opportunities: [],
+      routes: [
+        {
+          _id: new Types.ObjectId(),
+          researchEntityId: entityId,
+          routeType: 'PROGRAM_MANAGER',
+          visibility: 'PUBLIC',
+          email: 'private@yale.edu',
+          personName: 'Private Person',
+          rationale: 'Internal review note',
+          url: 'https://research.yale.edu/contact',
+          sourceUrl: 'https://research.yale.edu/contact',
+          contactPolicy: 'OFFICIAL_ROUTE_PREFERRED',
+          review: { ...approved, note: 'Do not expose' },
+        },
+      ],
+    });
+
+    const context = contexts.get(entityId.toString());
+    expect(context).toEqual({
+      category: 'reviewed_route',
+      label: 'Official contact route',
+      url: 'https://research.yale.edu/contact',
+    });
+    expect(JSON.stringify(context)).not.toContain('private@yale.edu');
+    expect(JSON.stringify(context)).not.toContain('Do not expose');
+    expect(JSON.stringify(context)).not.toContain('Private Person');
+  });
+
+  it('rejects expired, unsafe, orphaned, and unreviewed opportunities', () => {
+    const validPathway = {
+      _id: pathwayId,
+      researchEntityId: entityId,
+      pathwayType: 'POSTED_ROLE',
+      status: 'ACTIVE',
+      sourceUrls: ['https://research.yale.edu/apply'],
+      evidenceStrength: 'DIRECT',
+      confidence: 0.9,
+      review: approved,
+    };
+    const opportunities = ['CLOSED', 'ARCHIVED'].map((status) => ({
+      _id: new Types.ObjectId(),
+      researchEntityId: entityId,
+      entryPathwayId: pathwayId,
+      status,
+      applicationUrl: 'https://research.yale.edu/apply',
+      review: approved,
+    }));
+    opportunities.push({
+      _id: new Types.ObjectId(),
+      researchEntityId: entityId,
+      entryPathwayId: pathwayId,
+      status: 'OPEN',
+      applicationUrl: 'http://localhost/apply',
+      review: approved,
+    });
+
+    expect(
+      selectPlanningContexts({ pathways: [validPathway], opportunities, routes: [] }).size,
+    ).toBe(0);
+  });
+});

--- a/server/src/services/__tests__/researchGroupService.test.ts
+++ b/server/src/services/__tests__/researchGroupService.test.ts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   postedOpportunityFind: vi.fn(),
   getAccessSummaryForResearchEntity: vi.fn(),
   listAccessSummariesForResearchEntities: vi.fn(),
+  listPlanningContextsForResearchEntities: vi.fn(),
 }));
 
 vi.mock('../../utils/meiliClient', () => ({
@@ -112,6 +113,10 @@ vi.mock('../accessSummaryService', () => ({
   listAccessSummariesForResearchEntities: mocks.listAccessSummariesForResearchEntities,
 }));
 
+vi.mock('../planningContextService', () => ({
+  listPlanningContextsForResearchEntities: mocks.listPlanningContextsForResearchEntities,
+}));
+
 import {
   buildLeadPiOutreachContactRoute,
   buildResearchActivityLinkPayload,
@@ -155,6 +160,7 @@ beforeEach(() => {
   mocks.researchEntityFindOne.mockReset();
   mocks.researchEntityFind.mockReset();
   mocks.listAccessSummariesForResearchEntities.mockReset();
+  mocks.listPlanningContextsForResearchEntities.mockReset();
   mocks.researchEntityRelationshipFind.mockReset();
   mocks.researchGroupMemberFind.mockReset();
   mocks.userFind.mockReset();
@@ -183,6 +189,7 @@ beforeEach(() => {
   mocks.postedOpportunityFind.mockReturnValue(queryResult([]));
   mocks.getAccessSummaryForResearchEntity.mockResolvedValue(undefined);
   mocks.listAccessSummariesForResearchEntities.mockResolvedValue(new Map());
+  mocks.listPlanningContextsForResearchEntities.mockResolvedValue(new Map());
 });
 
 describe('searchResearchGroupsViaMeili', () => {
@@ -359,6 +366,38 @@ describe('searchResearchGroupsViaMeili', () => {
     const result = await searchResearchGroupsViaMeili('AI', {}, 1, 24);
 
     expect(result.researchEntities).toEqual([expect.objectContaining({ slug: 'actual-ai-lab' })]);
+  });
+
+  it('keeps base research results usable when optional planning context fails', async () => {
+    const entityId = '67d8928150621bcef434a1d5';
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    mocks.search.mockResolvedValueOnce({ hits: [{ id: entityId }], estimatedTotalHits: 1 });
+    mocks.researchEntityFind.mockReturnValue(
+      queryResult([
+        {
+          _id: entityId,
+          slug: 'reilly-lab',
+          name: 'Reilly Lab',
+          kind: 'lab',
+          departments: ['Chemistry'],
+          researchAreas: [],
+          sourceUrls: [],
+        },
+      ]),
+    );
+    mocks.listPlanningContextsForResearchEntities.mockRejectedValueOnce(
+      new Error('optional store unavailable'),
+    );
+
+    const result = await searchResearchGroupsViaMeili('reilly', {}, 1, 1);
+
+    expect(result.researchEntities).toHaveLength(1);
+    expect(result.researchEntities[0]).not.toHaveProperty('planningContext');
+    expect(consoleError).toHaveBeenCalledWith(
+      'Optional research planning-context enrichment failed:',
+      expect.any(String),
+    );
+    consoleError.mockRestore();
   });
 
   it('drops object-shaped Meili hit ids before Mongo visibility filtering', async () => {
@@ -1315,9 +1354,8 @@ describe('listResearchEntityRelationshipPayload', () => {
     const publicInstituteId = '67d8928150621bcef434a1d6';
     const reviewInstituteId = '67d8928150621bcef434a1d7';
 
-    mocks.researchEntityRelationshipFind
-      .mockReturnValueOnce(queryResult([]))
-      .mockReturnValueOnce(queryResult([
+    mocks.researchEntityRelationshipFind.mockReturnValueOnce(queryResult([])).mockReturnValueOnce(
+      queryResult([
         {
           _id: 'rel-yqi',
           sourceResearchEntityId: publicInstituteId,
@@ -1338,7 +1376,8 @@ describe('listResearchEntityRelationshipPayload', () => {
           evidenceStrength: 'MODERATE',
           evidenceQuote: 'Held private operator note',
         },
-      ]));
+      ]),
+    );
     mocks.researchEntityFind.mockReturnValue(
       queryResult([
         {
@@ -1405,18 +1444,21 @@ describe('listResearchEntityRelationshipPayload', () => {
   it('projects an allowlisted card shape and bounds a 99-related hub payload', async () => {
     const currentEntityId = '67d8928150621bcef434a1d5';
     const select = vi.fn();
-    const relatedIds = Array.from({ length: 99 }, (_, index) =>
-      `67d8928150621bcef434${String(index).padStart(4, '0')}`,
+    const relatedIds = Array.from(
+      { length: 99 },
+      (_, index) => `67d8928150621bcef434${String(index).padStart(4, '0')}`,
     );
     mocks.researchEntityRelationshipFind
-      .mockReturnValueOnce(queryResult(
-        relatedIds.map((id) => ({
-          sourceResearchEntityId: currentEntityId,
-          targetResearchEntityId: id,
-          relationshipType: 'MEMBER_RESEARCH_AREA',
-          label: 'Related',
-        })),
-      ))
+      .mockReturnValueOnce(
+        queryResult(
+          relatedIds.map((id) => ({
+            sourceResearchEntityId: currentEntityId,
+            targetResearchEntityId: id,
+            relationshipType: 'MEMBER_RESEARCH_AREA',
+            label: 'Related',
+          })),
+        ),
+      )
       .mockReturnValueOnce(queryResult([]));
     const entityQuery = queryResult(
       relatedIds.slice(0, 50).map((id, index) => ({

--- a/server/src/services/planningContextService.ts
+++ b/server/src/services/planningContextService.ts
@@ -56,7 +56,12 @@ export const actionablePlanningUrl = (value: unknown): string | undefined => {
   const url = publicHttpUrl(value);
   if (!url) return undefined;
   const parsed = new URL(url);
-  const destination = `${parsed.pathname} ${parsed.searchParams.toString()}`;
+  let destination: string;
+  try {
+    destination = decodeURIComponent(parsed.pathname);
+  } catch {
+    return undefined;
+  }
   if (PROVENANCE_ONLY_URL_CUE_RE.test(destination)) return undefined;
   return ACTIONABLE_URL_CUE_RE.test(destination) ? url : undefined;
 };

--- a/server/src/services/planningContextService.ts
+++ b/server/src/services/planningContextService.ts
@@ -32,6 +32,10 @@ const MAX_ENTITY_IDS = 100;
 const APPLICATION_PATHWAY_TYPES = new Set(['POSTED_ROLE', 'CENTER_INTERNSHIP', 'STUDENT_JOB']);
 const PARTICIPATION_PATHWAY_TYPES = new Set(['RECURRING_PROGRAM']);
 const DISALLOWED_ROUTE_TYPES = new Set(['FACULTY_PI', 'UNKNOWN']);
+const ACTIONABLE_URL_CUE_RE =
+  /(?:^|[^a-z0-9])(?:apply|application|applications|career|careers|internship|internships|job|jobs|opportunities|opportunity|participate|participation|program|programs|register|registration|submit)(?:[^a-z0-9]|$)/i;
+const PROVENANCE_ONLY_URL_CUE_RE =
+  /(?:^|[^a-z0-9])(?:about|article|articles|bio|bios|directory|directories|faculty|grant|grants|lab|labs|laboratory|laboratories|member|members|news|people|person|persons|profile|profiles|publication|publications|roster|rosters|staff|team|teams)(?:[^a-z0-9]|$)/i;
 
 const entityId = (value: unknown): string | undefined => {
   const id = serializedDocumentId(value);
@@ -43,6 +47,23 @@ const approved = (record: any): boolean => record?.review?.status === 'approved'
 const usableUrl = (...values: unknown[]): string | undefined => {
   for (const value of values) {
     const url = publicHttpUrl(value);
+    if (url) return url;
+  }
+  return undefined;
+};
+
+export const actionablePlanningUrl = (value: unknown): string | undefined => {
+  const url = publicHttpUrl(value);
+  if (!url) return undefined;
+  const parsed = new URL(url);
+  const destination = `${parsed.pathname} ${parsed.searchParams.toString()}`;
+  if (PROVENANCE_ONLY_URL_CUE_RE.test(destination)) return undefined;
+  return ACTIONABLE_URL_CUE_RE.test(destination) ? url : undefined;
+};
+
+const usableActionableUrl = (...values: unknown[]): string | undefined => {
+  for (const value of values) {
+    const url = actionablePlanningUrl(value);
     if (url) return url;
   }
   return undefined;
@@ -76,7 +97,7 @@ export function selectPlanningContexts(input: {
   for (const opportunity of input.opportunities) {
     const pathway = pathwaysById.get(serializedDocumentId(opportunity.entryPathwayId));
     const id = entityId(opportunity.researchEntityId) || entityId(pathway?.researchEntityId);
-    const url = usableUrl(opportunity.applicationUrl);
+    const url = usableActionableUrl(opportunity.applicationUrl);
     if (
       !id ||
       !url ||
@@ -102,7 +123,9 @@ export function selectPlanningContexts(input: {
 
   for (const pathway of input.pathways) {
     const id = entityId(pathway.researchEntityId);
-    const url = usableUrl(...(Array.isArray(pathway.sourceUrls) ? pathway.sourceUrls : []));
+    const url = usableActionableUrl(
+      ...(Array.isArray(pathway.sourceUrls) ? pathway.sourceUrls : []),
+    );
     if (
       !id ||
       !url ||

--- a/server/src/services/planningContextService.ts
+++ b/server/src/services/planningContextService.ts
@@ -1,0 +1,207 @@
+import mongoose from 'mongoose';
+import { ContactRoute } from '../models/contactRoute';
+import { EntryPathway } from '../models/entryPathway';
+import { PostedOpportunity } from '../models/postedOpportunity';
+import { serializedDocumentId } from '../utils/idSerialization';
+import { publicHttpUrl } from '../utils/urlSafety';
+import {
+  isApprovedPublicContactRoute,
+  isStudentPublishablePathway,
+} from './studentAccessPublicationPolicy';
+
+export type PlanningContextCategory =
+  | 'open_position'
+  | 'official_application'
+  | 'reviewed_route'
+  | 'qualified_participation';
+
+export interface PublicPlanningContext {
+  category: PlanningContextCategory;
+  label: string;
+  url: string;
+}
+
+interface Candidate extends PublicPlanningContext {
+  entityId: string;
+  stableId: string;
+  precedence: number;
+}
+
+const OBJECT_ID_RE = /^[a-f0-9]{24}$/i;
+const MAX_ENTITY_IDS = 100;
+const APPLICATION_PATHWAY_TYPES = new Set(['POSTED_ROLE', 'CENTER_INTERNSHIP', 'STUDENT_JOB']);
+const PARTICIPATION_PATHWAY_TYPES = new Set(['RECURRING_PROGRAM']);
+const DISALLOWED_ROUTE_TYPES = new Set(['FACULTY_PI', 'UNKNOWN']);
+
+const entityId = (value: unknown): string | undefined => {
+  const id = serializedDocumentId(value);
+  return id && OBJECT_ID_RE.test(id) ? id : undefined;
+};
+
+const approved = (record: any): boolean => record?.review?.status === 'approved';
+
+const usableUrl = (...values: unknown[]): string | undefined => {
+  for (const value of values) {
+    const url = publicHttpUrl(value);
+    if (url) return url;
+  }
+  return undefined;
+};
+
+const hasExplicitInstructions = (pathway: any): boolean =>
+  Boolean(String(pathway?.bestNextStep || '').trim() || String(pathway?.explanation || '').trim());
+
+const hasApplicationInstructions = (pathway: any): boolean =>
+  /\b(apply|application|register|submit)\b/i.test(
+    `${String(pathway?.bestNextStep || '')} ${String(pathway?.explanation || '')}`,
+  );
+
+const isCurrentOpportunity = (opportunity: any): boolean => {
+  if (!['OPEN', 'ROLLING'].includes(opportunity.status)) return false;
+  if (!opportunity.deadline) return true;
+  const deadline = new Date(opportunity.deadline);
+  return !Number.isNaN(deadline.getTime()) && deadline.getTime() >= Date.now();
+};
+
+export function selectPlanningContexts(input: {
+  pathways: any[];
+  opportunities: any[];
+  routes: any[];
+}): Map<string, PublicPlanningContext> {
+  const pathwaysById = new Map(
+    input.pathways.map((pathway) => [serializedDocumentId(pathway._id), pathway]),
+  );
+  const candidates: Candidate[] = [];
+
+  for (const opportunity of input.opportunities) {
+    const pathway = pathwaysById.get(serializedDocumentId(opportunity.entryPathwayId));
+    const id = entityId(opportunity.researchEntityId) || entityId(pathway?.researchEntityId);
+    const url = usableUrl(opportunity.applicationUrl);
+    if (
+      !id ||
+      !url ||
+      opportunity.archived === true ||
+      !isCurrentOpportunity(opportunity) ||
+      !approved(opportunity) ||
+      !pathway ||
+      pathway.archived === true ||
+      !approved(pathway) ||
+      !isStudentPublishablePathway(pathway) ||
+      !APPLICATION_PATHWAY_TYPES.has(pathway.pathwayType)
+    )
+      continue;
+    candidates.push({
+      entityId: id,
+      stableId: serializedDocumentId(opportunity._id) || '',
+      precedence: 0,
+      category: 'open_position',
+      label: 'Open position',
+      url: url!,
+    });
+  }
+
+  for (const pathway of input.pathways) {
+    const id = entityId(pathway.researchEntityId);
+    const url = usableUrl(...(Array.isArray(pathway.sourceUrls) ? pathway.sourceUrls : []));
+    if (
+      !id ||
+      !url ||
+      pathway.archived === true ||
+      !approved(pathway) ||
+      !isStudentPublishablePathway(pathway) ||
+      !hasExplicitInstructions(pathway)
+    )
+      continue;
+    if (APPLICATION_PATHWAY_TYPES.has(pathway.pathwayType) && hasApplicationInstructions(pathway)) {
+      candidates.push({
+        entityId: id,
+        stableId: serializedDocumentId(pathway._id) || '',
+        precedence: 1,
+        category: 'official_application',
+        label: 'Official application',
+        url: url!,
+      });
+    } else if (PARTICIPATION_PATHWAY_TYPES.has(pathway.pathwayType)) {
+      candidates.push({
+        entityId: id,
+        stableId: serializedDocumentId(pathway._id) || '',
+        precedence: 3,
+        category: 'qualified_participation',
+        label: 'Participation instructions',
+        url: url!,
+      });
+    }
+  }
+
+  for (const route of input.routes) {
+    const id = entityId(route.researchEntityId);
+    const url = usableUrl(route.url);
+    if (
+      !id ||
+      !url ||
+      route.archived === true ||
+      !isApprovedPublicContactRoute(route) ||
+      DISALLOWED_ROUTE_TYPES.has(route.routeType)
+    )
+      continue;
+    candidates.push({
+      entityId: id,
+      stableId: serializedDocumentId(route._id) || '',
+      precedence: route.routeType === 'OFFICIAL_APPLICATION' ? 1 : 2,
+      category:
+        route.routeType === 'OFFICIAL_APPLICATION' ? 'official_application' : 'reviewed_route',
+      label:
+        route.routeType === 'OFFICIAL_APPLICATION'
+          ? 'Official application'
+          : 'Official contact route',
+      url: url!,
+    });
+  }
+
+  candidates.sort((a, b) => a.precedence - b.precedence || a.stableId.localeCompare(b.stableId));
+  const selected = new Map<string, PublicPlanningContext>();
+  for (const {
+    entityId: id,
+    stableId: _stableId,
+    precedence: _precedence,
+    ...context
+  } of candidates) {
+    if (!selected.has(id)) selected.set(id, context);
+  }
+  return selected;
+}
+
+export async function listPlanningContextsForResearchEntities(
+  researchEntityIds: Array<string | mongoose.Types.ObjectId>,
+): Promise<Map<string, PublicPlanningContext>> {
+  const ids = Array.from(
+    new Set(researchEntityIds.slice(0, MAX_ENTITY_IDS).flatMap((value) => entityId(value) || [])),
+  );
+  if (ids.length === 0) return new Map();
+  const objectIds = ids.map((id) => new mongoose.Types.ObjectId(id));
+  const [pathways, routes] = await Promise.all([
+    EntryPathway.find({ researchEntityId: { $in: objectIds }, archived: false }).lean(),
+    ContactRoute.find({
+      researchEntityId: { $in: objectIds },
+      archived: false,
+      'review.status': 'approved',
+    }).lean(),
+  ]);
+  const pathwayIds = (pathways as any[]).flatMap((pathway) => {
+    const id = entityId(pathway._id);
+    return id ? [new mongoose.Types.ObjectId(id)] : [];
+  });
+  const opportunities = await PostedOpportunity.find({
+    $or: [
+      { researchEntityId: { $in: objectIds } },
+      ...(pathwayIds.length > 0 ? [{ entryPathwayId: { $in: pathwayIds } }] : []),
+    ],
+    archived: false,
+    status: { $in: ['OPEN', 'ROLLING'] },
+  }).lean();
+  return selectPlanningContexts({
+    pathways: pathways as any[],
+    opportunities: opportunities as any[],
+    routes: routes as any[],
+  });
+}

--- a/server/src/services/researchEntityDto.ts
+++ b/server/src/services/researchEntityDto.ts
@@ -163,14 +163,12 @@ const OPTIONAL_PUBLIC_RESEARCH_ENTITY_FIELDS = [
   'accessSummary',
   'searchMatch',
   'waysIn',
+  'planningContext',
   'profileResearchAreas',
   'researchAreaSource',
 ] as const;
 
-const OPERATOR_PUBLIC_RESEARCH_ENTITY_FIELDS = [
-  'qualitySummary',
-  'studentVisibilityTier',
-] as const;
+const OPERATOR_PUBLIC_RESEARCH_ENTITY_FIELDS = ['qualitySummary', 'studentVisibilityTier'] as const;
 
 export interface PublicResearchEntityDtoOptions {
   includeOperatorFields?: boolean;
@@ -257,9 +255,7 @@ export function addResearchEntitySearchAliases<T extends { hits: Record<string, 
   };
 }
 
-export function addResearchEntityDetailAlias<
-  T extends { group: Record<string, any> },
->(
+export function addResearchEntityDetailAlias<T extends { group: Record<string, any> }>(
   detail: T,
   options: PublicResearchEntityDtoOptions = {},
 ): Omit<T, 'group'> & {

--- a/server/src/services/researchGroupService.ts
+++ b/server/src/services/researchGroupService.ts
@@ -1396,7 +1396,9 @@ const OFFICIAL_PROFILE_URL_KEYS = [
 const safeProfileUrlObject = (value: unknown): Record<string, string> => {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
   return Object.fromEntries(
-    Object.entries(value as Record<string, unknown>).filter(([, url]) => publicHttpUrl(url)),
+    Object.entries(value as Record<string, unknown>).filter(
+      ([, url]) => publicHttpUrl(url),
+    ),
   ) as Record<string, string>;
 };
 

--- a/server/src/services/researchGroupService.ts
+++ b/server/src/services/researchGroupService.ts
@@ -74,6 +74,17 @@ import {
   evaluateResearchActivityIntegrity,
   type ResearchActivityCandidate,
 } from './researchActivityIntegrity';
+import { sanitizeLogValue } from '../utils/logSanitizer';
+import { listPlanningContextsForResearchEntities } from './planningContextService';
+
+const optionalPlanningContexts = async (entityIds: any[]) => {
+  try {
+    return await listPlanningContextsForResearchEntities(entityIds);
+  } catch (error) {
+    console.error('Optional research planning-context enrichment failed:', sanitizeLogValue(error));
+    return new Map();
+  }
+};
 
 const NON_LAB_CATEGORIES = new Set<string>([
   DepartmentCategory.SOCIAL_SCIENCES,
@@ -581,7 +592,10 @@ export async function searchResearchGroupsViaMeili(
     const activeListingGroupIdSet = new Set(
       activeListingGroupIds.map((id: any) => researchGroupDocumentId(id)).filter(Boolean),
     );
-    const accessSummaries = await listAccessSummariesForResearchEntities(pageEntityIds);
+    const [accessSummaries, planningContexts] = await Promise.all([
+      listAccessSummariesForResearchEntities(pageEntityIds),
+      optionalPlanningContexts(pageEntityIds),
+    ]);
     return addResearchEntitySearchAliases(
       {
         hits: pageEntities.map((entity) => ({
@@ -589,6 +603,7 @@ export async function searchResearchGroupsViaMeili(
           _id: researchGroupDocumentId(entity._id),
           hasActiveListing: activeListingGroupIdSet.has(researchGroupDocumentId(entity._id)),
           accessSummary: accessSummaries.get(researchGroupDocumentId(entity._id)),
+          planningContext: planningContexts.get(researchGroupDocumentId(entity._id)),
         })),
         estimatedTotalHits: filteredCandidates.length,
         page: safePage,
@@ -717,7 +732,10 @@ export async function searchResearchGroupsViaMeili(
   );
 
   // Map Meilisearch's `id` back to `_id` for client backward compatibility.
-  const accessSummaries = await listAccessSummariesForResearchEntities(visibleHitIds);
+  const [accessSummaries, planningContexts] = await Promise.all([
+    listAccessSummariesForResearchEntities(visibleHitIds),
+    optionalPlanningContexts(visibleHitIds),
+  ]);
   const normalizedHits = (hits || []).flatMap((hit: any) => {
     const id = hit.id || hit._id;
     const entityId = researchGroupDocumentId(id);
@@ -728,6 +746,7 @@ export async function searchResearchGroupsViaMeili(
       _id: id,
       hasActiveListing: activeListingGroupIdSet.has(entityId),
       accessSummary: accessSummaries.get(entityId),
+      planningContext: planningContexts.get(entityId),
       ...(hit.searchMatch ? { searchMatch: hit.searchMatch } : {}),
     };
   });
@@ -1377,9 +1396,7 @@ const OFFICIAL_PROFILE_URL_KEYS = [
 const safeProfileUrlObject = (value: unknown): Record<string, string> => {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
   return Object.fromEntries(
-    Object.entries(value as Record<string, unknown>).filter(
-      ([, url]) => publicHttpUrl(url),
-    ),
+    Object.entries(value as Record<string, unknown>).filter(([, url]) => publicHttpUrl(url)),
   ) as Record<string, string>;
 };
 
@@ -2271,6 +2288,7 @@ export async function getResearchGroupDetail(slug: string): Promise<{
     contactRoutes,
     postedOpportunities,
     accessSummary,
+    planningContexts,
   ] = await Promise.all([
     memberUserIds.length
       ? Paper.find({
@@ -2343,6 +2361,7 @@ export async function getResearchGroupDetail(slug: string): Promise<{
       .limit(MAX_PUBLIC_DETAIL_POSTED_OPPORTUNITIES)
       .lean(),
     getAccessSummaryForResearchEntity((group as any)._id),
+    optionalPlanningContexts([(group as any)._id]),
   ]);
   const recentPapers = (recentPapersRaw as any[]).map(publicPaperForResearchDetail);
   const recentArxivPreprints = (recentArxivPreprintsRaw as any[]).map(publicPaperForResearchDetail);
@@ -2426,11 +2445,13 @@ export async function getResearchGroupDetail(slug: string): Promise<{
   return addResearchEntityDetailAlias({
     group: {
       ...publicGroupForResponse,
-      leadIdentityStatus: Array.isArray((publicGroupForResponse as any).qualitySummary?.repairFlags) &&
+      leadIdentityStatus:
+        Array.isArray((publicGroupForResponse as any).qualitySummary?.repairFlags) &&
         (publicGroupForResponse as any).qualitySummary.repairFlags.includes('pi_identity_conflict')
-        ? 'under_review'
-        : 'verified',
+          ? 'under_review'
+          : 'verified',
       accessSummary,
+      planningContext: planningContexts.get(researchGroupDocumentId((group as any)._id)),
       studentDecisionExplanation: studentDecisionExplanation || undefined,
     },
     members,


### PR DESCRIPTION
## Summary
- add a server-owned, optional planning-context projection to research search and detail responses
- qualify at most one reviewed, source-backed action per entity with deterministic precedence
- fail closed for PI/profile provenance, generic pages, exploratory contact, private routes, unsafe destinations, expired opportunities, and unreviewed claims
- keep base entity results usable when optional enrichment fails
- update EF-03 and QA-01 delivery tracking without claiming the client/filter/analytics follow-ups are complete

## Public contract

`planningContext` is optional and contains only:

- `category`: `open_position`, `official_application`, `reviewed_route`, or `qualified_participation`
- `label`: bounded claim-specific copy
- `url`: safe HTTP(S) destination

No direct contact details, confidence, evidence-strength, review metadata, or internal IDs are exposed. Selection precedence is open position, official application, reviewed route, then recurring participation.

## Validation
- server: 228 files, 2,618 tests passed
- focused planning-context and research-service tests passed
- server TypeScript passed
- server production build passed
- security policy and secret scan passed
- no-mistakes outcome: passed

## Remaining product work
- query-scoped documented-action distribution and adaptive filter
- quiet client card presentation and signal precedence with activity
- action-specific analytics
- operational evidence and route review rollout

This PR does not add another result cluster, parallel pathway request, client-side access inference, or ranking change.
