### PR TITLE
Scope mobile filter sheet to Programs

### DIFF
--- a/client/src/components/shared/CombinedFilterDropdown.tsx
+++ b/client/src/components/shared/CombinedFilterDropdown.tsx
@@ -67,8 +67,7 @@ const CombinedFilterDropdown = ({
     if (!isOpen) return;
     const handleEscape = (event: KeyboardEvent) => {
       if (event.key !== 'Escape') return;
-      setIsOpen(false);
-      if (mobileSheet) window.setTimeout(() => triggerRef.current?.focus(), 0);
+      closeFilters();
     };
     document.addEventListener('keydown', handleEscape);
     return () => document.removeEventListener('keydown', handleEscape);

--- a/client/src/components/shared/CombinedFilterDropdown.tsx
+++ b/client/src/components/shared/CombinedFilterDropdown.tsx
@@ -20,9 +20,15 @@ export interface FilterTabConfig {
 
 interface CombinedFilterDropdownProps {
   tabs: FilterTabConfig[];
+  mobileSheet?: boolean;
+  dialogLabel?: string;
 }
 
-const CombinedFilterDropdown = ({ tabs }: CombinedFilterDropdownProps) => {
+const CombinedFilterDropdown = ({
+  tabs,
+  mobileSheet = false,
+  dialogLabel = 'Filters',
+}: CombinedFilterDropdownProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [activeTabKey, setActiveTabKey] = useState(tabs[0]?.key || '');
   const [searchTerms, setSearchTerms] = useState<Record<string, string>>({});
@@ -30,6 +36,15 @@ const CombinedFilterDropdown = ({ tabs }: CombinedFilterDropdownProps) => {
   const dropdownRef = useRef<HTMLDivElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const dialogRef = useRef<HTMLDivElement | null>(null);
+
+  const getFocusableElements = () => {
+    const desktop = window.matchMedia?.('(min-width: 640px)').matches ?? false;
+    return Array.from(
+      dialogRef.current?.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ) || [],
+    ).filter((element) => !(desktop && element.dataset.mobileOnly === 'true'));
+  };
 
   const closeFilters = (restoreFocus = true) => {
     setIsOpen(false);
@@ -39,30 +54,32 @@ const CombinedFilterDropdown = ({ tabs }: CombinedFilterDropdownProps) => {
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
       if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
-        closeFilters(false);
-      }
-    };
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        closeFilters();
+        setIsOpen(false);
       }
     };
     document.addEventListener('mousedown', handleClickOutside);
-    document.addEventListener('keydown', handleEscape);
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
-      document.removeEventListener('keydown', handleEscape);
     };
   }, []);
 
   useEffect(() => {
     if (!isOpen) return;
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      setIsOpen(false);
+      if (mobileSheet) window.setTimeout(() => triggerRef.current?.focus(), 0);
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [isOpen, mobileSheet]);
+
+  useEffect(() => {
+    if (!isOpen || !mobileSheet) return;
     window.setTimeout(() => {
-      dialogRef.current
-        ?.querySelector<HTMLElement>('button:not([disabled]), input:not([disabled])')
-        ?.focus();
+      getFocusableElements()[0]?.focus();
     }, 0);
-  }, [isOpen]);
+  }, [isOpen, mobileSheet]);
 
   const totalFilters = tabs.reduce((sum, tab) => sum + tab.selected.length, 0);
   const activeTab = tabs.find((t) => t.key === activeTabKey) || tabs[0];
@@ -95,8 +112,8 @@ const CombinedFilterDropdown = ({ tabs }: CombinedFilterDropdownProps) => {
         ref={triggerRef}
         type="button"
         aria-expanded={isOpen}
-        aria-haspopup="dialog"
-        onClick={() => (isOpen ? closeFilters() : setIsOpen(true))}
+        aria-haspopup={mobileSheet ? 'dialog' : undefined}
+        onClick={() => (isOpen ? closeFilters(mobileSheet) : setIsOpen(true))}
         className="flex min-h-[44px] items-center rounded-md border border-[var(--yr-line-strong)] bg-[var(--yr-panel)] px-3 text-sm transition-colors hover:bg-[var(--yr-panel-muted)] focus:outline-none focus:ring-2 focus:ring-blue-500 whitespace-nowrap"
         style={{ color: '#374151' }}
       >
@@ -132,17 +149,13 @@ const CombinedFilterDropdown = ({ tabs }: CombinedFilterDropdownProps) => {
       {isOpen && (
         <div
           ref={dialogRef}
-          role="dialog"
-          aria-modal="true"
-          aria-label="Program filters"
+          role={mobileSheet ? 'dialog' : undefined}
+          aria-modal={mobileSheet ? 'true' : undefined}
+          aria-label={mobileSheet ? dialogLabel : undefined}
           tabIndex={-1}
           onKeyDown={(event) => {
-            if (event.key !== 'Tab') return;
-            const focusable = Array.from(
-              dialogRef.current?.querySelectorAll<HTMLElement>(
-                'button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
-              ) || [],
-            );
+            if (!mobileSheet || event.key !== 'Tab') return;
+            const focusable = getFocusableElements();
             if (focusable.length === 0) return;
             const first = focusable[0];
             const last = focusable[focusable.length - 1];
@@ -154,19 +167,26 @@ const CombinedFilterDropdown = ({ tabs }: CombinedFilterDropdownProps) => {
               first.focus();
             }
           }}
-          className="fixed inset-x-0 bottom-0 z-50 max-h-[85dvh] w-full overflow-hidden rounded-t-md border border-[var(--yr-line)] bg-[var(--yr-panel)] shadow-lg sm:absolute sm:inset-x-auto sm:bottom-auto sm:left-0 sm:top-full sm:mt-1 sm:w-[340px] sm:max-w-[calc(100vw-2rem)] sm:rounded-md"
+          className={
+            mobileSheet
+              ? 'fixed inset-x-0 bottom-0 z-50 max-h-[85dvh] w-full overflow-hidden rounded-t-md border border-[var(--yr-line)] bg-[var(--yr-panel)] shadow-lg sm:absolute sm:inset-x-auto sm:bottom-auto sm:left-0 sm:top-full sm:mt-1 sm:w-[340px] sm:max-w-[calc(100vw-2rem)] sm:rounded-md'
+              : 'absolute left-0 top-full z-50 mt-1 w-[calc(100vw-2rem)] max-w-[340px] overflow-hidden rounded-lg border border-[var(--yr-line)] bg-[var(--yr-panel)] shadow-lg'
+          }
         >
-          <div className="flex items-center justify-between border-b border-[var(--yr-line)] px-3 py-2 sm:hidden">
-            <h2 className="text-base font-semibold text-slate-900">Filters</h2>
-            <button
-              type="button"
-              aria-label="Close filters"
-              onClick={() => closeFilters()}
-              className="flex h-11 w-11 items-center justify-center rounded-md text-2xl text-slate-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
-            >
-              <span aria-hidden="true">×</span>
-            </button>
-          </div>
+          {mobileSheet && (
+            <div className="flex items-center justify-between border-b border-[var(--yr-line)] px-3 py-2 sm:hidden">
+              <h2 className="text-base font-semibold text-slate-900">Filters</h2>
+              <button
+                type="button"
+                aria-label="Close filters"
+                data-mobile-only="true"
+                onClick={() => closeFilters()}
+                className="flex h-11 w-11 items-center justify-center rounded-md text-2xl text-slate-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              >
+                <span aria-hidden="true">×</span>
+              </button>
+            </div>
+          )}
           <div className="flex border-b border-[var(--yr-line)] bg-[var(--yr-panel-muted)] overflow-x-auto">
             {tabs.map((tab) => (
               <button
@@ -196,7 +216,13 @@ const CombinedFilterDropdown = ({ tabs }: CombinedFilterDropdownProps) => {
             ))}
           </div>
 
-          <div className="max-h-[calc(85dvh-7rem)] overflow-y-auto p-3 sm:max-h-none sm:overflow-visible">
+          <div
+            className={
+              mobileSheet
+                ? 'max-h-[calc(85dvh-7rem)] overflow-y-auto p-3 sm:max-h-none sm:overflow-visible'
+                : 'p-3'
+            }
+          >
             {activeTab.filterMode && activeTab.setFilterMode && activeTab.selected.length >= 2 && (
               <div className="mb-3">
                 <VennDiagramToggle mode={activeTab.filterMode} setMode={activeTab.setFilterMode} />

--- a/client/src/components/shared/CombinedFilterDropdown.tsx
+++ b/client/src/components/shared/CombinedFilterDropdown.tsx
@@ -1,5 +1,8 @@
 /**
- * Multi-category filter dropdown for browse pages.
+ * Multi-category browse filter.
+ *
+ * The default presentation is an anchored, non-modal dropdown for shared listing filters.
+ * Set `mobileSheet` for the Programs surface to use the labelled, focus-contained mobile sheet.
  */
 import { useState, useRef, useEffect } from 'react';
 import { FilterMode } from '../../contexts/SearchContext';
@@ -20,7 +23,9 @@ export interface FilterTabConfig {
 
 interface CombinedFilterDropdownProps {
   tabs: FilterTabConfig[];
+  /** Enables the Programs mobile modal-sheet presentation and focus management. */
   mobileSheet?: boolean;
+  /** Accessible name for the modal sheet. Used only when `mobileSheet` is enabled. */
   dialogLabel?: string;
 }
 

--- a/client/src/components/shared/__tests__/CombinedFilterDropdown.test.tsx
+++ b/client/src/components/shared/__tests__/CombinedFilterDropdown.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import CombinedFilterDropdown from '../CombinedFilterDropdown';
+
+describe('CombinedFilterDropdown', () => {
+  it('preserves the anchored non-modal presentation for listing filters by default', async () => {
+    render(
+      <CombinedFilterDropdown
+        tabs={[
+          {
+            key: 'department',
+            label: 'Department',
+            options: ['Physics'],
+            selected: [],
+            setSelected: vi.fn(),
+          },
+        ]}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Filters' }));
+
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(screen.getByText('Physics').closest('.absolute')).not.toBeNull();
+    expect(screen.queryByRole('button', { name: 'Close filters' })).toBeNull();
+  });
+});

--- a/client/src/components/shared/__tests__/CombinedFilterDropdown.test.tsx
+++ b/client/src/components/shared/__tests__/CombinedFilterDropdown.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -25,5 +25,28 @@ describe('CombinedFilterDropdown', () => {
     expect(screen.queryByRole('dialog')).toBeNull();
     expect(screen.getByText('Physics').closest('.absolute')).not.toBeNull();
     expect(screen.queryByRole('button', { name: 'Close filters' })).toBeNull();
+  });
+
+  it('restores the listing filter trigger on Escape', async () => {
+    render(
+      <CombinedFilterDropdown
+        tabs={[
+          {
+            key: 'department',
+            label: 'Department',
+            options: ['Physics'],
+            selected: [],
+            setSelected: vi.fn(),
+          },
+        ]}
+      />,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Filters' });
+    await userEvent.click(trigger);
+    await userEvent.keyboard('{Escape}');
+
+    expect(screen.queryByText('Physics')).toBeNull();
+    await waitFor(() => expect(trigger).toHaveFocus());
   });
 });

--- a/client/src/pages/__tests__/fellowships.test.tsx
+++ b/client/src/pages/__tests__/fellowships.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -428,6 +428,45 @@ describe('Programs page', () => {
     await userEvent.keyboard('{Escape}');
     expect(screen.queryByRole('dialog', { name: 'Program filters' })).toBeNull();
     await waitFor(() => expect(trigger).toHaveFocus());
+
+    const searchInput = screen.getByLabelText('Search programs and fellowships');
+    searchInput.focus();
+    expect(searchInput).toHaveFocus();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(searchInput).toHaveFocus();
+  });
+
+  it('starts desktop filter focus on the first visible tab', async () => {
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = vi.fn().mockReturnValue({ matches: true }) as typeof window.matchMedia;
+
+    try {
+      renderPage(
+        [baseFellowship({ id: 'open', title: 'Open Fellowship', isAcceptingApplications: true })],
+        {
+          filterOptions: {
+            programCategory: [],
+            programKind: ['STRUCTURED_PROGRAM'],
+            entryMode: [],
+            studentFacingCategory: [],
+            yearOfStudy: [],
+            termOfAward: [],
+            purpose: [],
+            globalRegions: [],
+            citizenshipStatus: [],
+          },
+        },
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: /filters/i }));
+      const dialog = screen.getByRole('dialog', { name: 'Program filters' });
+      await waitFor(() =>
+        expect(within(dialog).getByRole('button', { name: 'Journey' })).toHaveFocus(),
+      );
+      expect(within(dialog).getByRole('button', { name: 'Close filters' })).not.toHaveFocus();
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
   });
 
   it('sorts visible program cards inside their cycle section from local sort controls', async () => {

--- a/client/src/pages/fellowships.tsx
+++ b/client/src/pages/fellowships.tsx
@@ -705,7 +705,11 @@ const Fellowships = () => {
               <div className="flex w-full min-w-0 flex-wrap items-center gap-2 sm:w-auto xl:flex-col xl:items-stretch">
                 <FellowshipSortDropdown />
                 <ViewModeToggle />
-                <CombinedFilterDropdown tabs={fellowshipFilterTabs} />
+                <CombinedFilterDropdown
+                  tabs={fellowshipFilterTabs}
+                  mobileSheet
+                  dialogLabel="Program filters"
+                />
               </div>
             </div>
             <ActiveFilters

--- a/docs/research-student-journey-delivery-plan.md
+++ b/docs/research-student-journey-delivery-plan.md
@@ -231,12 +231,13 @@ That contract cannot represent a research home with no pathway and is not a safe
 
 #### CP-08 - Shared Mobile Filter-Sheet Pattern - FR-37
 
-- **Status:** Not started on Beta.
+- **Status:** Active.
 - **Depends on:** surface-specific facet contracts and accessible focus management.
 - **Acceptance criteria:** Research and Programs use one shared filter-sheet interaction pattern on small viewports while retaining their own facets; opening moves focus into a labelled modal/sheet; Escape, close, apply, and focus return work by keyboard and screen reader; selected-count and clear behavior are honest; desktop remains quiet; no horizontal overflow.
-- **Validation evidence:** FR-37 exists as local-only implemented work but is not merged into Beta.
+- **Validation evidence:** PR `#175` added the bounded, labelled Programs mobile sheet with focus entry, containment, Escape close, and focus restoration.
+The shared listing filters intentionally retain their anchored non-modal presentation, so Research does not yet satisfy the cross-surface acceptance criterion.
 PR `#171` only simplified Research filters and must not be credited with FR-37.
-- **PRs:** none on Beta.
+- **PRs:** [#175](https://github.com/YaleComputerSociety/ylabs/pull/175) completed the Programs portion; Research remains outstanding.
 
 #### CP-09 - Honest Logged-Out Saving - FR-14
 
@@ -441,7 +442,7 @@ Its evidence is therefore current Beta source, routes, tests, and merged history
 | Claim | Current support | Delivery interpretation |
 | --- | --- | --- |
 | Entity-first discovery is the correct current baseline. | **Supported.** PR `#171` removes the parallel pathway request and stream and keeps research profiles primary. | Keep EF-01 Complete and protect it with regression tests. |
-| Discovery filters are fully adaptive and progressively disclosed. | **Disputed as complete.** Current controls are inline, have no shared mobile disclosure pattern, and missing facet counts may fall back to the total. | Keep EF-02 Active and CP-08 / FR-37 Not started on Beta. |
+| Discovery filters are fully adaptive and progressively disclosed. | **Disputed as complete.** Programs has a bounded mobile filter sheet, while shared Research/listing filters remain anchored and missing facet counts may fall back to the total. | Keep EF-02 and CP-08 / FR-37 Active until the remaining Research behavior and facet-count gaps are resolved. |
 | A server-qualified sparse planning summary exists. | **Not supported.** No bounded claim-specific summary or useful-state distribution exists. | Keep EF-03 Not started and dependent on QA-01. |
 | Research homes can be saved independently of pathways. | **Not supported.** Current saves are pathway favorites, details are keyed by pathway ID, and detail chooses an entry pathway. | Keep CP-05 / FR-45 Not started and ahead of FR-17 and FR-24. |
 | Canonical research analytics distinguish search, profile, source, filters, save, and qualified action. | **Not supported.** The current taxonomy is broader and canonical browse/detail lacks the complete invisible journey emissions. | Keep IM-01 Not started and IM-02 Active until QA-01 stabilizes conversion meaning. |
@@ -449,7 +450,7 @@ Its evidence is therefore current Beta source, routes, tests, and merged history
 | Historical persona findings describe current Beta behavior. | **Validation pending.** Several cited defects were changed by merged PRs, while the referenced transcript and fresh browser replay were unavailable. | Use historical observations as discovery inputs only; require current code, test, data, or CAS-preserving browser evidence before changing status or rationale. |
 
 Unresolved UX choices remain validation-pending even when engineering dependencies are known.
-These include the anonymous-save policy, final qualified-action enum and thresholds, exact material-use threshold for a documented-way-in filter, comparison layout, and the shared mobile filter-sheet presentation.
+These include the anonymous-save policy, final qualified-action enum and thresholds, exact material-use threshold for a documented-way-in filter, comparison layout, and the Research-side mobile filter-sheet presentation.
 An implementing PR must resolve only the choice in its accepted scope and update the corresponding requirement and decision evidence.
 
 ## Maintenance Protocol


### PR DESCRIPTION
## Summary

- scope the FR-37 mobile sheet and modal semantics to Programs instead of changing the shared Navbar listing filter
- keep Escape inert while filters are closed and restore focus only for the Programs modal workflow
- exclude the mobile-only close control from desktop focus entry and containment
- add regression coverage for listing presentation, closed Escape, and desktop focus order

## Context

Follow-up to #175 for findings identified by the no-mistakes review after that PR merged.

## Validation

- focused Programs/shared filter tests: 11/11
- full client suite: 97 files, 784 tests
- client production build
- scoped ESLint
- `git diff --check`

Browser validation remains blocked because `chrome-devtools-axi` could not start its bridge (`BRIDGE_NOT_READY` after 30 seconds).
