### PR TITLE
Fix initial research search race

### DIFF
--- a/client/src/pages/__tests__/research.test.tsx
+++ b/client/src/pages/__tests__/research.test.tsx
@@ -1181,6 +1181,61 @@ describe('Research page', () => {
     );
   });
 
+  it('preserves a draft query when startup config settles before submission', async () => {
+    const searchResponse = createDeferred<ReturnType<typeof researchSearchResponse>>();
+    mockedAxios.post.mockImplementation((url: string, body: { q?: string }) => {
+      if (url === '/research/search' && body.q === 'machine learning') {
+        return searchResponse.promise;
+      }
+      if (url === '/research/search' && body.q === '')
+        return Promise.resolve(researchSearchResponse());
+      return Promise.reject(unexpectedSearchEndpoint(url));
+    });
+
+    const researchTree = (departmentList: typeof departments) => (
+      <MemoryRouter initialEntries={['/research']}>
+        <UserContext.Provider
+          value={{
+            ...defaultUserContext,
+            isLoading: false,
+            isAuthenticated: false,
+            user: undefined,
+          }}
+        >
+          <ConfigContext.Provider
+            value={{
+              ...defaultConfigContext,
+              isLoading: false,
+              isLoaded: true,
+              departments: departmentList,
+              departmentCategories: ['Computing & AI', 'Humanities & Arts', 'Life Sciences'],
+            }}
+          >
+            <Research />
+          </ConfigContext.Provider>
+        </UserContext.Provider>
+      </MemoryRouter>
+    );
+
+    const view = render(researchTree([]));
+    const input = screen.getByLabelText('Search Yale research') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'machine learning' } });
+
+    view.rerender(researchTree(departments));
+
+    expect(input.value).toBe('machine learning');
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+    view.rerender(researchTree([...departments]));
+
+    expect(screen.getByText("Showing research matches for 'machine learning'")).toBeTruthy();
+    expect(input.value).toBe('machine learning');
+
+    searchResponse.resolve(researchSearchResponse([researchEntity]));
+
+    expect(await screen.findByText("Showing research matches for 'machine learning'")).toBeTruthy();
+    expect(await screen.findByRole('heading', { name: 'AI Safety Lab' })).toBeTruthy();
+  });
+
   it('keeps initial q searches alive under StrictMode effect cleanup', async () => {
     mockSearchResponses((url) =>
       url === '/research/search'

--- a/client/src/pages/__tests__/research.test.tsx
+++ b/client/src/pages/__tests__/research.test.tsx
@@ -186,6 +186,15 @@ const LocationDisplay = () => {
   return <div data-testid="location">{`${location.pathname}${location.search}`}</div>;
 };
 
+const ClearResearchLocation = () => {
+  const navigate = useNavigate();
+  return (
+    <button type="button" onClick={() => navigate('/research')}>
+      Clear research location
+    </button>
+  );
+};
+
 const renderResearchWithDetailRoute = () =>
   render(
     <StrictMode>
@@ -1234,6 +1243,50 @@ describe('Research page', () => {
 
     expect(await screen.findByText("Showing research matches for 'machine learning'")).toBeTruthy();
     expect(await screen.findByRole('heading', { name: 'AI Safety Lab' })).toBeTruthy();
+  });
+
+  it('resets promptly when navigation clears the URL during an active search', async () => {
+    const searchResponse = createDeferred<ReturnType<typeof researchSearchResponse>>();
+    mockedAxios.post.mockImplementation((url: string, body: { q?: string }) => {
+      if (url === '/research/search' && body.q === 'machine learning') {
+        return searchResponse.promise;
+      }
+      if (url === '/research/search' && body.q === '') {
+        return Promise.resolve(researchSearchResponse());
+      }
+      return Promise.reject(unexpectedSearchEndpoint(url));
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/research?q=machine+learning']}>
+        <ConfigContext.Provider
+          value={{
+            ...defaultConfigContext,
+            isLoading: false,
+            isLoaded: true,
+            departments,
+            departmentCategories: ['Computing & AI', 'Humanities & Arts', 'Life Sciences'],
+          }}
+        >
+          <ClearResearchLocation />
+          <LocationDisplay />
+          <Research />
+        </ConfigContext.Provider>
+      </MemoryRouter>,
+    );
+
+    await screen.findByText("Showing research matches for 'machine learning'");
+    fireEvent.click(screen.getByRole('button', { name: 'Clear research location' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location').textContent).toBe('/research');
+      expect(screen.queryByText("Showing research matches for 'machine learning'")).toBeNull();
+      expect((screen.getByLabelText('Search Yale research') as HTMLInputElement).value).toBe('');
+    });
+
+    searchResponse.resolve(researchSearchResponse([researchEntity]));
+    await act(async () => searchResponse.promise);
+    expect(screen.queryByRole('heading', { name: 'AI Safety Lab' })).toBeNull();
   });
 
   it('keeps initial q searches alive under StrictMode effect cleanup', async () => {

--- a/client/src/pages/__tests__/research.test.tsx
+++ b/client/src/pages/__tests__/research.test.tsx
@@ -195,6 +195,15 @@ const ClearResearchLocation = () => {
   );
 };
 
+const NavigateToResearchQuery = ({ query }: { query: string }) => {
+  const navigate = useNavigate();
+  return (
+    <button type="button" onClick={() => navigate(`/research?q=${encodeURIComponent(query)}`)}>
+      Navigate to {query}
+    </button>
+  );
+};
+
 const renderResearchWithDetailRoute = () =>
   render(
     <StrictMode>
@@ -1286,6 +1295,53 @@ describe('Research page', () => {
 
     searchResponse.resolve(researchSearchResponse([researchEntity]));
     await act(async () => searchResponse.promise);
+    expect(screen.queryByRole('heading', { name: 'AI Safety Lab' })).toBeNull();
+  });
+
+  it('resets after another URL query supersedes a pending search navigation', async () => {
+    const responses = new Map([
+      ['first query', createDeferred<ReturnType<typeof researchSearchResponse>>()],
+      ['second query', createDeferred<ReturnType<typeof researchSearchResponse>>()],
+    ]);
+    mockedAxios.post.mockImplementation((url: string, body: { q?: string }) => {
+      if (url === '/research/search' && body.q && responses.has(body.q)) {
+        return responses.get(body.q)!.promise;
+      }
+      if (url === '/research/search' && body.q === '') {
+        return Promise.resolve(researchSearchResponse());
+      }
+      return Promise.reject(unexpectedSearchEndpoint(url));
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/research']}>
+        <NavigateToResearchQuery query="second query" />
+        <ClearResearchLocation />
+        <LocationDisplay />
+        <Research />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByLabelText('Search Yale research'), {
+      target: { value: 'first query' },
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Navigate to second query' }));
+    });
+
+    expect(await screen.findByText("Showing research matches for 'second query'")).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Clear research location' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location').textContent).toBe('/research');
+      expect(screen.queryByText("Showing research matches for 'second query'")).toBeNull();
+      expect((screen.getByLabelText('Search Yale research') as HTMLInputElement).value).toBe('');
+    });
+
+    responses.get('first query')!.resolve(researchSearchResponse([researchEntity]));
+    responses.get('second query')!.resolve(researchSearchResponse([researchEntity]));
+    await act(async () => Promise.all([...responses.values()].map(({ promise }) => promise)));
     expect(screen.queryByRole('heading', { name: 'AI Safety Lab' })).toBeNull();
   });
 

--- a/client/src/pages/__tests__/research.test.tsx
+++ b/client/src/pages/__tests__/research.test.tsx
@@ -1345,6 +1345,45 @@ describe('Research page', () => {
     expect(screen.queryByRole('heading', { name: 'AI Safety Lab' })).toBeNull();
   });
 
+  it('resets when navigation returns to the pending search source location', async () => {
+    const searchResponse = createDeferred<ReturnType<typeof researchSearchResponse>>();
+    mockedAxios.post.mockImplementation((url: string, body: { q?: string }) => {
+      if (url === '/research/search' && body.q === 'machine learning') {
+        return searchResponse.promise;
+      }
+      if (url === '/research/search' && body.q === '') {
+        return Promise.resolve(researchSearchResponse());
+      }
+      return Promise.reject(unexpectedSearchEndpoint(url));
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/research']}>
+        <ClearResearchLocation />
+        <LocationDisplay />
+        <Research />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByLabelText('Search Yale research'), {
+      target: { value: 'machine learning' },
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Clear research location' }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location').textContent).toBe('/research');
+      expect(screen.queryByText("Showing research matches for 'machine learning'")).toBeNull();
+      expect((screen.getByLabelText('Search Yale research') as HTMLInputElement).value).toBe('');
+    });
+
+    searchResponse.resolve(researchSearchResponse([researchEntity]));
+    await act(async () => searchResponse.promise);
+    expect(screen.queryByRole('heading', { name: 'AI Safety Lab' })).toBeNull();
+  });
+
   it('keeps initial q searches alive under StrictMode effect cleanup', async () => {
     mockSearchResponses((url) =>
       url === '/research/search'

--- a/client/src/pages/research.tsx
+++ b/client/src/pages/research.tsx
@@ -1,6 +1,6 @@
 import { FormEvent, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { isCancel } from 'axios';
-import { useSearchParams } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'react-router-dom';
 
 import ResearchHomeCard from '../components/research/ResearchHomeCard';
 import InfiniteScrollLoadingDots from '../components/shared/InfiniteScrollLoadingDots';
@@ -297,6 +297,7 @@ const scrollResearchViewportToTop = () => {
 };
 
 const Research = () => {
+  const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
   const { user } = useContext(UserContext);
   const { departments } = useConfig();
@@ -402,6 +403,7 @@ const Research = () => {
   const activeSearchKeyRef = useRef<string | null>(null);
   const pendingSearchParamsRef = useRef<string | null>(null);
   const pendingSearchSourceParamsRef = useRef<string | null>(null);
+  const pendingSearchSourceLocationKeyRef = useRef<string | null>(null);
   const effectGenerationRef = useRef(0);
   const restoredSnapshotSyncKeyRef = useRef(
     restoredSnapshotRef.current
@@ -450,6 +452,7 @@ const Research = () => {
     if (options.markPending) {
       pendingSearchParamsRef.current = params.toString();
       pendingSearchSourceParamsRef.current = searchParams.toString();
+      pendingSearchSourceLocationKeyRef.current = location.key;
     }
     setSearchParams(params, { replace: Boolean(options.replace) });
   };
@@ -761,12 +764,15 @@ const Research = () => {
     if (pendingSearchParamsRef.current === observedSearchParams) {
       pendingSearchParamsRef.current = null;
       pendingSearchSourceParamsRef.current = null;
+      pendingSearchSourceLocationKeyRef.current = null;
     } else if (
       pendingSearchParamsRef.current !== null &&
-      pendingSearchSourceParamsRef.current !== observedSearchParams
+      (pendingSearchSourceParamsRef.current !== observedSearchParams ||
+        pendingSearchSourceLocationKeyRef.current !== location.key)
     ) {
       pendingSearchParamsRef.current = null;
       pendingSearchSourceParamsRef.current = null;
+      pendingSearchSourceLocationKeyRef.current = null;
     }
     const urlQuery = searchParams.get('q') || '';
     const urlDepartmentLabel = searchParams.get('dept') || '';
@@ -901,6 +907,7 @@ const Research = () => {
     void runDefaultResearchHomeSearchRef.current(1);
   }, [
     searchParams,
+    location.key,
     pageSnapshotKey,
     isAdmin,
     showWeakestProfilesFirst,

--- a/client/src/pages/research.tsx
+++ b/client/src/pages/research.tsx
@@ -851,7 +851,15 @@ const Research = () => {
       return;
     }
 
-    setQuery('');
+    // A search submission updates component state and the URL in the same
+    // transition. Do not let an effect that still observes the previous empty
+    // URL overwrite that active search with the default browse state.
+    if (activeSearchKeyRef.current !== null) return;
+
+    // Preserve an in-progress draft while startup context (for example config or
+    // user state) settles. Only clear the input when an existing URL-backed
+    // search is actually being reset.
+    if (hasSubmittedSearch) setQuery('');
     setSubmittedQuery('');
     setDepartmentSearch(null);
     setGroupedResults(emptyGroupedResults(''));

--- a/client/src/pages/research.tsx
+++ b/client/src/pages/research.tsx
@@ -400,6 +400,7 @@ const Research = () => {
   const searchAbortRef = useRef<AbortController | null>(null);
   const defaultSearchAbortRef = useRef<AbortController | null>(null);
   const activeSearchKeyRef = useRef<string | null>(null);
+  const pendingSearchParamsRef = useRef<string | null>(null);
   const effectGenerationRef = useRef(0);
   const restoredSnapshotSyncKeyRef = useRef(
     restoredSnapshotRef.current
@@ -428,7 +429,7 @@ const Research = () => {
       department?: string;
       requireUndergradEvidence?: boolean;
     },
-    options: { replace?: boolean } = {},
+    options: { replace?: boolean; markPending?: boolean } = {},
   ) => {
     const params = new URLSearchParams();
     const nextQuery = (nextState.query || '').trim();
@@ -445,6 +446,7 @@ const Research = () => {
       if (nextState.trustTiers?.length) params.set('tier', nextState.trustTiers.join(','));
     }
 
+    if (options.markPending) pendingSearchParamsRef.current = params.toString();
     setSearchParams(params, { replace: Boolean(options.replace) });
   };
 
@@ -571,16 +573,19 @@ const Research = () => {
     setSearchError('');
     setGroupedResults(emptyGroupedResults(resultQueryLabel));
     if (options.syncUrl !== false) {
-      writeResearchSearchParams({
-        query: trimmed,
-        departmentLabel: options.departmentSearch?.label,
-        school: filters.school?.[0],
-        department: filters.departments?.[0],
-        requireUndergradEvidence: filters.acceptanceLevel === 'verified-or-likely',
-        showWeakest: showWeakestProfilesFirst,
-        quality: qualityFilters,
-        trustTiers: trustTierFilters,
-      });
+      writeResearchSearchParams(
+        {
+          query: trimmed,
+          departmentLabel: options.departmentSearch?.label,
+          school: filters.school?.[0],
+          department: filters.departments?.[0],
+          requireUndergradEvidence: filters.acceptanceLevel === 'verified-or-likely',
+          showWeakest: showWeakestProfilesFirst,
+          quality: qualityFilters,
+          trustTiers: trustTierFilters,
+        },
+        { markPending: true },
+      );
     }
 
     try {
@@ -748,6 +753,9 @@ const Research = () => {
   const hasSubmittedSearch = submittedQuery.trim().length > 0;
 
   useEffect(() => {
+    if (pendingSearchParamsRef.current === searchParams.toString()) {
+      pendingSearchParamsRef.current = null;
+    }
     const urlQuery = searchParams.get('q') || '';
     const urlDepartmentLabel = searchParams.get('dept') || '';
     const urlSchool = searchParams.get('school') || '';
@@ -852,9 +860,13 @@ const Research = () => {
     }
 
     // A search submission updates component state and the URL in the same
-    // transition. Do not let an effect that still observes the previous empty
-    // URL overwrite that active search with the default browse state.
-    if (activeSearchKeyRef.current !== null) return;
+    // transition. Do not let an effect that still observes the previous URL
+    // overwrite that active search before its pending URL write is observed.
+    if (activeSearchKeyRef.current !== null && pendingSearchParamsRef.current !== null) return;
+
+    searchAbortRef.current?.abort();
+    searchRequestIdRef.current += 1;
+    activeSearchKeyRef.current = null;
 
     // Preserve an in-progress draft while startup context (for example config or
     // user state) settles. Only clear the input when an existing URL-backed

--- a/client/src/pages/research.tsx
+++ b/client/src/pages/research.tsx
@@ -401,6 +401,7 @@ const Research = () => {
   const defaultSearchAbortRef = useRef<AbortController | null>(null);
   const activeSearchKeyRef = useRef<string | null>(null);
   const pendingSearchParamsRef = useRef<string | null>(null);
+  const pendingSearchSourceParamsRef = useRef<string | null>(null);
   const effectGenerationRef = useRef(0);
   const restoredSnapshotSyncKeyRef = useRef(
     restoredSnapshotRef.current
@@ -446,7 +447,10 @@ const Research = () => {
       if (nextState.trustTiers?.length) params.set('tier', nextState.trustTiers.join(','));
     }
 
-    if (options.markPending) pendingSearchParamsRef.current = params.toString();
+    if (options.markPending) {
+      pendingSearchParamsRef.current = params.toString();
+      pendingSearchSourceParamsRef.current = searchParams.toString();
+    }
     setSearchParams(params, { replace: Boolean(options.replace) });
   };
 
@@ -753,8 +757,16 @@ const Research = () => {
   const hasSubmittedSearch = submittedQuery.trim().length > 0;
 
   useEffect(() => {
-    if (pendingSearchParamsRef.current === searchParams.toString()) {
+    const observedSearchParams = searchParams.toString();
+    if (pendingSearchParamsRef.current === observedSearchParams) {
       pendingSearchParamsRef.current = null;
+      pendingSearchSourceParamsRef.current = null;
+    } else if (
+      pendingSearchParamsRef.current !== null &&
+      pendingSearchSourceParamsRef.current !== observedSearchParams
+    ) {
+      pendingSearchParamsRef.current = null;
+      pendingSearchSourceParamsRef.current = null;
     }
     const urlQuery = searchParams.get('q') || '';
     const urlDepartmentLabel = searchParams.get('dept') || '';


### PR DESCRIPTION
## Summary

- Preserve a research search draft while startup user and configuration state settles.
- Prevent stale URL synchronization effects from reverting an active search to the default browse state.
- Keep genuine URL resets and superseding navigations working correctly.
- Add regression coverage for draft preservation, active submissions, and URL navigation races.

## Verification

- Full client suite: 96 files, 783 tests passed before pipeline review fixes.
- Focused Research search regression suite passed after navigation-race fixes.
- Browser reproduction confirmed the search heading paints immediately and 24 result cards render after the response.
- No-mistakes review, test, documentation, and lint stages passed.