### PR TITLE
feat: expand research discovery and preserve saved planning data

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -349,13 +349,13 @@ Route-level middleware logs successful server-observed events by wrapping `res.s
 
 Research-surface analytics cover the canonical research entities (`profile`, `listing`, and `fellowship`) and use these event types:
 
-| Event type            | Meaning                                                                   |
-| --------------------- | ------------------------------------------------------------------------- |
-| `research_view`       | A profile, listing, or fellowship detail surface opened                   |
-| `pathway_save`        | A listing or fellowship was saved, unsaved, or re-staged                  |
+| Event type            | Meaning                                                                             |
+| --------------------- | ----------------------------------------------------------------------------------- |
+| `research_view`       | A profile, listing, or fellowship detail surface opened                             |
+| `pathway_save`        | A listing or fellowship was saved, unsaved, or re-staged                            |
 | `ways_in_click`       | A best-next-step, apply, planning, listings, courses, or similar action was clicked |
-| `contact_route_click` | A guarded route such as an official application or public source route was clicked |
-| `source_link_click`   | A source link such as a lab site, publication, or application was clicked |
+| `contact_route_click` | A guarded route such as an official application or public source route was clicked  |
+| `source_link_click`   | A source link such as a lab site, publication, or application was clicked           |
 
 Client-only interactions are sent to `POST /api/analytics/research` for authenticated users.
 Server-observed views and save/favorite actions are emitted from route middleware in listings, fellowships, profiles, and users.
@@ -394,20 +394,20 @@ The public browse surfaces (`/api/research`, `/api/opportunities`) follow the sa
 
 All mount under `/api`.
 
-| Prefix            | Description                                                            | Auth                                                   |
-| ----------------- | ---------------------------------------------------------------------- | ------------------------------------------------------ |
+| Prefix            | Description                                                                             | Auth                                                   |
+| ----------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------ |
 | `/research`       | Yale Research search/detail, including profile evidence and planning-context enrichment | Varies                                                 |
-| `/programs`       | Programs & Fellowships browse/search and saved-program support         | Varies                                                 |
-| `/opportunities`  | Real posted opportunity detail workflows                               | Varies                                                 |
-| `/listings`       | Retired legacy API, returns `410 Gone`                                 | Varies                                                 |
-| `/fellowships`    | Compatibility alias around program/fellowship storage during migration | Varies                                                 |
-| `/users`          | User CRUD                                                              | Yes                                                    |
-| `/profiles`       | Faculty profiles                                                       | Varies                                                 |
-| `/analytics`      | Analytics dashboard + research event writes                            | Admin for dashboard, authenticated for research writes |
-| `/config`         | Departments + research areas                                           | No                                                     |
-| `/research-areas` | Research area CRUD                                                     | Admin for writes                                       |
-| `/admin`          | Admin operations                                                       | Admin                                                  |
-| `/seed`           | Dev seeding routes                                                     | Dev mode only                                          |
+| `/programs`       | Programs & Fellowships browse/search and saved-program support                          | Varies                                                 |
+| `/opportunities`  | Real posted opportunity detail workflows                                                | Varies                                                 |
+| `/listings`       | Retired legacy API, returns `410 Gone`                                                  | Varies                                                 |
+| `/fellowships`    | Compatibility alias around program/fellowship storage during migration                  | Varies                                                 |
+| `/users`          | User CRUD                                                                               | Yes                                                    |
+| `/profiles`       | Faculty profiles                                                                        | Varies                                                 |
+| `/analytics`      | Analytics dashboard + research event writes                                             | Admin for dashboard, authenticated for research writes |
+| `/config`         | Departments + research areas                                                            | No                                                     |
+| `/research-areas` | Research area CRUD                                                                      | Admin for writes                                       |
+| `/admin`          | Admin operations                                                                        | Admin                                                  |
+| `/seed`           | Dev seeding routes                                                                      | Dev mode only                                          |
 
 ---
 
@@ -479,12 +479,12 @@ Client `tsc --noEmit` is still not part of CI; the client has known pre-existing
 
 ## Troubleshooting
 
-| Issue                                          | Solution                                                                                                                             |
-| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| CAS login not working locally                  | Use dev-login: `http://localhost:4000/api/dev-login`                                                                                 |
-| Search returns no results                      | Check Meilisearch is running: `curl http://localhost:7700/health`                                                                    |
-| Meilisearch connection refused                 | Start Docker container or check `MEILISEARCH_HOST` in `.env`                                                                         |
-| CORS errors                                    | Add origin to `allowList` in `app.ts` or use dev mode                                                                                |
-| `/api/listings` returns `410`                  | Expected; Listings is retired. Use Research, Programs, or PostedOpportunity workflows.                                               |
-| Retired practical-routes URL returns not found | Expected; public Pathways search is retired. Planning context appears inside Yale Research, research detail, and Dashboard planning. |
-| A client needs pathway data                    | Use `/api/research/search`, research detail, or saved research-plan APIs. Standalone pathway search is not a public/client contract. |
+| Issue                                          | Solution                                                                                                                                                                                                                                           |
+| ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CAS login not working locally                  | Use dev-login: `http://localhost:4000/api/dev-login`                                                                                                                                                                                               |
+| Search returns no results                      | Check Meilisearch is running: `curl http://localhost:7700/health`                                                                                                                                                                                  |
+| Meilisearch connection refused                 | Start Docker container or check `MEILISEARCH_HOST` in `.env`                                                                                                                                                                                       |
+| CORS errors                                    | Add origin to `allowList` in `app.ts` or use dev mode                                                                                                                                                                                              |
+| `/api/listings` returns `410`                  | Expected; Listings is retired. Use Research, Programs, or PostedOpportunity workflows.                                                                                                                                                             |
+| Retired practical-routes URL returns not found | Expected; public Pathways search is retired. Planning context appears inside Yale Research, research detail, and Dashboard planning.                                                                                                               |
+| A client needs pathway data                    | Use `/api/research/search` or research detail. Saved planning uses entity-owned `/api/users/savedResearchEntities` and `/api/users/savedResearchEntityPlans`; legacy pathway-owned endpoints are compatibility support, not a new client contract. |

--- a/client/src/components/accounts/SavedPathwaysSection.tsx
+++ b/client/src/components/accounts/SavedPathwaysSection.tsx
@@ -98,10 +98,11 @@ const savedEntityAsPlanningItem = (entity: SavedResearchEntitySummary): PathwayS
 
 type DashboardResponse = Awaited<ReturnType<typeof axios.get>>;
 type OptionalDashboardResponse =
-  | { value: DashboardResponse; error: false }
+  | { value: DashboardResponse; error: false; apiMode?: SavedPlanApiMode }
   | { value: null; error: true };
 type SavedPlanDashboardLoad = [
   DashboardResponse,
+  OptionalDashboardResponse,
   OptionalDashboardResponse,
   OptionalDashboardResponse,
 ];
@@ -110,21 +111,38 @@ const savedPlanDashboardLoads = new Map<string, Promise<SavedPlanDashboardLoad>>
 const loadSavedPlanDashboard = (owner: string): Promise<SavedPlanDashboardLoad> => {
   const existing = savedPlanDashboardLoads.get(owner);
   if (existing) return existing;
+  const legacyPathwaysRequest = axios
+    .get('/users/savedResearchPlans', { withCredentials: true })
+    .then(
+      (value) => ({ value, error: false as const }),
+      () => ({ value: null, error: true as const }),
+    );
   const request = Promise.all([
-    axios
-      .get('/users/savedResearchEntities', { withCredentials: true })
-      .catch(() => axios.get('/users/savedResearchPlans', { withCredentials: true })),
+    axios.get('/users/savedResearchEntities', { withCredentials: true }).catch(async () => {
+      const legacyResult = await legacyPathwaysRequest;
+      if (legacyResult.error || !legacyResult.value) {
+        throw new Error('Saved research plans unavailable');
+      }
+      return legacyResult.value;
+    }),
     axios
       .get('/users/savedResearchEntityPlans', { withCredentials: true })
-      .catch(() => axios.get('/users/savedResearchPlanDetails', { withCredentials: true }))
       .then(
-        (value) => ({ value, error: false as const }),
+        (value) => ({ value, apiMode: 'entity' as const }),
+        () =>
+          axios
+            .get('/users/savedResearchPlanDetails', { withCredentials: true })
+            .then((value) => ({ value, apiMode: 'pathway' as const })),
+      )
+      .then(
+        ({ value, apiMode }) => ({ value, error: false as const, apiMode }),
         () => ({ value: null, error: true as const }),
       ),
     axios.get('/users/savedResearchPlanFundingMatches', { withCredentials: true }).then(
       (value) => ({ value, error: false as const }),
       () => ({ value: null, error: true as const }),
     ),
+    legacyPathwaysRequest,
   ]) as Promise<SavedPlanDashboardLoad>;
   savedPlanDashboardLoads.set(owner, request);
   void request.finally(() => window.setTimeout(() => savedPlanDashboardLoads.delete(owner), 0));
@@ -686,6 +704,105 @@ export const filterStoredPlansForSavedPathways = (
   return filtered;
 };
 
+export const researchEntityIdsByLegacyPathway = (
+  pathways: PathwaySearchHit[],
+): Record<string, string> =>
+  Object.fromEntries(
+    pathways.flatMap((pathway) => {
+      const pathwayId = String(pathway?._id || '');
+      const entityId = String(pathway?.researchEntity?._id || '');
+      return STORAGE_PLAN_ID_RE.test(pathwayId) && STORAGE_PLAN_ID_RE.test(entityId)
+        ? [[pathwayId, entityId] as const]
+        : [];
+    }),
+  );
+
+export const uniqueLegacyPathwayIdsByResearchEntity = (
+  pathways: PathwaySearchHit[],
+): Record<string, string> => {
+  const pathwayIdsByEntity = new Map<string, string[]>();
+  for (const [pathwayId, entityId] of Object.entries(
+    researchEntityIdsByLegacyPathway(pathways),
+  )) {
+    pathwayIdsByEntity.set(entityId, [...(pathwayIdsByEntity.get(entityId) || []), pathwayId]);
+  }
+  return Object.fromEntries(
+    [...pathwayIdsByEntity].flatMap(([entityId, pathwayIds]) =>
+      pathwayIds.length === 1 ? [[entityId, pathwayIds[0]] as const] : [],
+    ),
+  );
+};
+
+export const remapLegacyPathwayPlansToResearchEntities = (
+  plans: PathwayPlanMap,
+  entityIdByPathwayId: Record<string, string>,
+  savedResearchEntityIds: Iterable<string>,
+): PathwayPlanMap => {
+  const savedIds = new Set(savedResearchEntityIds);
+  const normalizedPlans = normalizePathwayPlanMap(plans);
+  const remapped: PathwayPlanMap = {};
+  const sourceIdsByTarget = new Map<string, string[]>();
+
+  for (const id of Object.keys(normalizedPlans).sort()) {
+    const targetId = savedIds.has(id) ? id : entityIdByPathwayId[id];
+    if (!targetId || !savedIds.has(targetId)) continue;
+    sourceIdsByTarget.set(targetId, [...(sourceIdsByTarget.get(targetId) || []), id]);
+  }
+  for (const [targetId, sourceIds] of sourceIdsByTarget) {
+    if (sourceIds.length === 1) remapped[targetId] = normalizedPlans[sourceIds[0]];
+  }
+
+  return remapped;
+};
+
+export const legacyPathwayPlanTargetsAreUnique = (
+  plans: PathwayPlanMap,
+  entityIdByPathwayId: Record<string, string>,
+  savedResearchEntityIds: Iterable<string>,
+): boolean => {
+  const savedIds = new Set(savedResearchEntityIds);
+  const targetIds = Object.keys(normalizePathwayPlanMap(plans)).flatMap((id) => {
+    if (savedIds.has(id)) return [id];
+    const entityId = entityIdByPathwayId[id];
+    return entityId && savedIds.has(entityId) ? [entityId] : [];
+  });
+  return targetIds.length === new Set(targetIds).size;
+};
+
+export const remapFundingMatchesToResearchEntities = (
+  matchesByPathwayId: FundingMatchesByPathway,
+  entityIdByPathwayId: Record<string, string>,
+  savedResearchEntityIds: Iterable<string>,
+): FundingMatchesByPathway => {
+  const savedIds = new Set(savedResearchEntityIds);
+  const matchesByEntity: FundingMatchesByPathway = {};
+
+  for (const [pathwayId, matches] of Object.entries(matchesByPathwayId || {})) {
+    const entityId = savedIds.has(pathwayId) ? pathwayId : entityIdByPathwayId[pathwayId];
+    if (!entityId || !savedIds.has(entityId) || !Array.isArray(matches)) continue;
+    matchesByEntity[entityId] = [...(matchesByEntity[entityId] || []), ...matches];
+  }
+
+  for (const [entityId, matches] of Object.entries(matchesByEntity)) {
+    const bestByFellowship = new Map<string, FellowshipFundingMatch>();
+    for (const match of matches) {
+      const key = match.fellowshipId || `${match.pathwayId}:${match.title}`;
+      const current = bestByFellowship.get(key);
+      if (!current || match.score > current.score) bestByFellowship.set(key, match);
+    }
+    matchesByEntity[entityId] = [...bestByFellowship.values()]
+      .sort(
+        (a, b) =>
+          b.score - a.score ||
+          String(a.deadline || '').localeCompare(String(b.deadline || '')) ||
+          a.title.localeCompare(b.title),
+      )
+      .slice(0, 5);
+  }
+
+  return matchesByEntity;
+};
+
 const sourceUrlsForPathway = (pathway: PathwaySearchHit): string[] =>
   safeHttpUrlList([
     ...(pathway.sourceUrls || []),
@@ -758,6 +875,8 @@ interface SavedPathwaysSectionProps {
   }) => void;
 }
 
+type SavedPlanApiMode = 'entity' | 'pathway';
+
 const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) => {
   const { user } = useContext(UserContext);
   const planStorageOwner = normalizeSavedPlanStorageOwner(user?.netId);
@@ -776,6 +895,10 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
   const exportTriggerRef = useRef<HTMLButtonElement>(null);
   const [expandedPlanIds, setExpandedPlanIds] = useState<Record<string, boolean>>({});
   const [hydratedPlanStorageOwner, setHydratedPlanStorageOwner] = useState<string | undefined>();
+  const [canRewriteStoredPlans, setCanRewriteStoredPlans] = useState(false);
+  const [planApiMode, setPlanApiMode] = useState<SavedPlanApiMode | null>(null);
+  const [planApiIdBySavedId, setPlanApiIdBySavedId] = useState<Record<string, string>>({});
+  const [planMigrationNotice, setPlanMigrationNotice] = useState('');
   const [planSaveStatus, setPlanSaveStatus] = useState<Record<string, string>>({});
   const [pendingIntentChange, setPendingIntentChange] = useState<{
     pathwayId: string;
@@ -794,11 +917,14 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
     setError('');
     setExportError('');
     setHydratedPlanStorageOwner(undefined);
+    setCanRewriteStoredPlans(false);
+    setPlanApiMode(null);
+    setPlanApiIdBySavedId({});
+    setPlanMigrationNotice('');
     setPlans({});
     try {
-      const [response, plansResult, matchesResult] = await loadSavedPlanDashboard(
-        ownerAtLoad || 'authenticated-account',
-      );
+      const [response, plansResult, matchesResult, legacyPathwaysResult] =
+        await loadSavedPlanDashboard(ownerAtLoad || 'authenticated-account');
       if (!isCurrentOwnerLoad()) return;
       const responseData = (response as any).data;
       const savedPathways: PathwaySearchHit[] = responseData.savedResearchEntities
@@ -806,45 +932,107 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
             savedEntityAsPlanningItem,
           )
         : responseData.savedResearchPlans || [];
+      const legacyPathways =
+        !legacyPathwaysResult.error && legacyPathwaysResult.value
+          ? (legacyPathwaysResult.value as any).data.savedResearchPlans || []
+          : responseData.savedResearchPlans || [];
+      const entityIdByPathwayId = researchEntityIdsByLegacyPathway(legacyPathways);
+      const pathwayIdByEntityId = uniqueLegacyPathwayIdsByResearchEntity(legacyPathways);
+      const savedResearchEntityIds = savedPathways.map((pathway: PathwaySearchHit) => pathway._id);
+      const hasCanonicalEntityResponse = Array.isArray(responseData.savedResearchEntities);
+      const legacyMappingIsComplete = !hasCanonicalEntityResponse || !legacyPathwaysResult.error;
       setPathways(savedPathways);
       if (!plansResult.error && plansResult.value) {
         const plansResponse: any = plansResult.value;
         if (!isCurrentOwnerLoad()) return;
-        const serverPlans =
+        const rawServerPlans =
           plansResponse.data.savedResearchEntityPlans ||
           plansResponse.data.savedResearchPlanDetails ||
           {};
+        const activePlanApiMode = plansResult.apiMode || 'pathway';
+        const activePlanApiIdBySavedId =
+          activePlanApiMode === 'entity'
+            ? {}
+            : hasCanonicalEntityResponse
+              ? pathwayIdByEntityId
+              : Object.fromEntries(savedResearchEntityIds.map((id) => [id, id]));
+        const planApiMappingIsComplete =
+          activePlanApiMode === 'entity' ||
+          savedResearchEntityIds.every((id) => activePlanApiIdBySavedId[id]);
+        const serverPlans =
+          activePlanApiMode === 'pathway' && hasCanonicalEntityResponse
+            ? remapLegacyPathwayPlansToResearchEntities(
+                rawServerPlans,
+                entityIdByPathwayId,
+                savedResearchEntityIds,
+              )
+            : rawServerPlans;
         const localPlans = readStoredPlans(ownerAtLoad);
-        const savedPathwayIds = savedPathways.map((pathway: PathwaySearchHit) => pathway._id);
-        const localPlansForSavedPathways = filterStoredPlansForSavedPathways(
+        const localPlanTargetsAreUnique = legacyPathwayPlanTargetsAreUnique(
           localPlans,
-          savedPathwayIds,
+          entityIdByPathwayId,
+          savedResearchEntityIds,
+        );
+        const localPlansForSavedPathways = remapLegacyPathwayPlansToResearchEntities(
+          localPlans,
+          entityIdByPathwayId,
+          savedResearchEntityIds,
         );
         const mergedPlans = mergeSavedPathwayPlansForHydration(
           localPlansForSavedPathways,
           serverPlans,
         );
-        setPlans(mergedPlans);
-        setHydratedPlanStorageOwner(ownerAtLoad);
         const localOnlyPlanIds = getLocalOnlySavedPathwayPlanIds(
           localPlansForSavedPathways,
           serverPlans,
-          savedPathwayIds,
+          savedResearchEntityIds,
         );
         await Promise.all(
-          localOnlyPlanIds.map((id) =>
-            axios.put(
-              `/users/savedResearchEntityPlans/${id}`,
-              { data: { plan: localPlansForSavedPathways[id] } },
-              { withCredentials: true },
-            ),
-          ),
+          localOnlyPlanIds.flatMap((id) => {
+            const apiId =
+              activePlanApiMode === 'entity' ? id : activePlanApiIdBySavedId[id];
+            return apiId
+              ? [
+                  axios.put(
+                    activePlanApiMode === 'entity'
+                      ? `/users/savedResearchEntityPlans/${apiId}`
+                      : `/users/savedResearchPlanDetails/${apiId}`,
+                    { data: { plan: localPlansForSavedPathways[id] } },
+                    { withCredentials: true },
+                  ),
+                ]
+              : [];
+          }),
         );
+        if (!isCurrentOwnerLoad()) return;
+        setPlans(mergedPlans);
+        setHydratedPlanStorageOwner(ownerAtLoad);
+        setPlanApiMode(activePlanApiMode);
+        setPlanApiIdBySavedId(activePlanApiIdBySavedId);
+        setCanRewriteStoredPlans(
+          legacyMappingIsComplete && localPlanTargetsAreUnique && planApiMappingIsComplete,
+        );
+        if (!localPlanTargetsAreUnique) {
+          setPlanMigrationNotice(
+            'Multiple browser-only plans map to the same research profile. Your original browser records were kept so no plan was chosen or overwritten automatically.',
+          );
+        } else if (!planApiMappingIsComplete) {
+          setPlanMigrationNotice(
+            'A saved research profile does not have one safe legacy pathway for fallback updates. Your original browser records were kept and no fallback write was attempted.',
+          );
+        }
       } else {
         console.error('Error loading saved research plan details.');
       }
       if (!matchesResult.error && matchesResult.value) {
-        setFundingMatches((matchesResult.value as any).data.matchesByPathwayId || {});
+        const matchesData = (matchesResult.value as any).data;
+        setFundingMatches(
+          remapFundingMatchesToResearchEntities(
+            matchesData.matchesByResearchEntityId || matchesData.matchesByPathwayId || {},
+            entityIdByPathwayId,
+            savedResearchEntityIds,
+          ),
+        );
       } else {
         setFundingMatches({});
       }
@@ -854,6 +1042,9 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
       setPathways([]);
       setFundingMatches({});
       setPlans({});
+      setCanRewriteStoredPlans(false);
+      setPlanApiMode(null);
+      setPlanApiIdBySavedId({});
       setError('Saved research plans could not be loaded.');
     } finally {
       if (isCurrentOwnerLoad()) setLoading(false);
@@ -865,9 +1056,15 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
   }, [loadPathways]);
 
   useEffect(() => {
-    if (!planStorageOwner || hydratedPlanStorageOwner !== planStorageOwner) return;
+    if (
+      !canRewriteStoredPlans ||
+      !planStorageOwner ||
+      hydratedPlanStorageOwner !== planStorageOwner
+    ) {
+      return;
+    }
     writeStoredPlans(plans, planStorageOwner);
-  }, [hydratedPlanStorageOwner, planStorageOwner, plans]);
+  }, [canRewriteStoredPlans, hydratedPlanStorageOwner, planStorageOwner, plans]);
 
   useEffect(() => {
     const watchedReminders = pathways
@@ -937,7 +1134,15 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
   };
 
   const updatePlan = (pathwayId: string, patch: Partial<PathwayPlan>) => {
-    if (hydratedPlanStorageOwner !== planStorageOwner || !plans[pathwayId]) return;
+    const planApiId = planApiMode === 'entity' ? pathwayId : planApiIdBySavedId[pathwayId];
+    if (
+      hydratedPlanStorageOwner !== planStorageOwner ||
+      !plans[pathwayId] ||
+      !planApiMode ||
+      !planApiId
+    ) {
+      return;
+    }
     setPlans((current) => {
       const currentPlan = current[pathwayId];
       if (!currentPlan) return current;
@@ -945,7 +1150,9 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
       setPlanSaveStatus((statuses) => ({ ...statuses, [pathwayId]: 'Saving plan...' }));
       axios
         .put(
-          `/users/savedResearchEntityPlans/${pathwayId}`,
+          planApiMode === 'entity'
+            ? `/users/savedResearchEntityPlans/${planApiId}`
+            : `/users/savedResearchPlanDetails/${planApiId}`,
           { data: { plan: nextPlan } },
           { withCredentials: true },
         )
@@ -1023,6 +1230,11 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
   }, [pendingIntentChange]);
 
   const removePathway = async (pathwayId: string) => {
+    const planApiId = planApiMode === 'entity' ? pathwayId : planApiIdBySavedId[pathwayId];
+    if (!planApiMode || !planApiId) {
+      setError('This saved research plan cannot be changed safely while compatibility data is unavailable.');
+      return;
+    }
     const previous = pathways;
     setPathways((current) => current.filter((pathway) => pathway._id !== pathwayId));
     setExpandedPlanIds((current) => {
@@ -1031,16 +1243,28 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
       return next;
     });
     try {
-      await axios.delete('/users/savedResearchEntities', {
-        withCredentials: true,
-        data: { savedResearchEntities: [pathwayId] },
-      });
+      if (planApiMode === 'pathway') {
+        await axios.delete('/users/savedResearchPlans', {
+          withCredentials: true,
+          data: { savedResearchPlans: [planApiId] },
+        });
+      } else {
+        await axios.delete('/users/savedResearchEntities', {
+          withCredentials: true,
+          data: { savedResearchEntities: [pathwayId] },
+        });
+      }
       setPlans((current) => {
         const next = { ...current };
         delete next[pathwayId];
         return next;
       });
-      await axios.delete(`/users/savedResearchEntityPlans/${pathwayId}`, { withCredentials: true });
+      await axios.delete(
+        planApiMode === 'pathway'
+          ? `/users/savedResearchPlanDetails/${planApiId}`
+          : `/users/savedResearchEntityPlans/${planApiId}`,
+        { withCredentials: true },
+      );
     } catch {
       console.error('Error removing saved research plan.');
       setPathways(previous);
@@ -1367,6 +1591,15 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
       {exportNotice && (
         <div className="mb-4 rounded-md border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800">
           {exportNotice}
+        </div>
+      )}
+
+      {planMigrationNotice && (
+        <div
+          role="status"
+          className="mb-4 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900"
+        >
+          {planMigrationNotice}
         </div>
       )}
 

--- a/client/src/components/accounts/SavedPathwaysSection.tsx
+++ b/client/src/components/accounts/SavedPathwaysSection.tsx
@@ -721,9 +721,7 @@ export const uniqueLegacyPathwayIdsByResearchEntity = (
   pathways: PathwaySearchHit[],
 ): Record<string, string> => {
   const pathwayIdsByEntity = new Map<string, string[]>();
-  for (const [pathwayId, entityId] of Object.entries(
-    researchEntityIdsByLegacyPathway(pathways),
-  )) {
+  for (const [pathwayId, entityId] of Object.entries(researchEntityIdsByLegacyPathway(pathways))) {
     pathwayIdsByEntity.set(entityId, [...(pathwayIdsByEntity.get(entityId) || []), pathwayId]);
   }
   return Object.fromEntries(
@@ -989,8 +987,7 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
         );
         await Promise.all(
           localOnlyPlanIds.flatMap((id) => {
-            const apiId =
-              activePlanApiMode === 'entity' ? id : activePlanApiIdBySavedId[id];
+            const apiId = activePlanApiMode === 'entity' ? id : activePlanApiIdBySavedId[id];
             return apiId
               ? [
                   axios.put(
@@ -1232,7 +1229,9 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
   const removePathway = async (pathwayId: string) => {
     const planApiId = planApiMode === 'entity' ? pathwayId : planApiIdBySavedId[pathwayId];
     if (!planApiMode || !planApiId) {
-      setError('This saved research plan cannot be changed safely while compatibility data is unavailable.');
+      setError(
+        'This saved research plan cannot be changed safely while compatibility data is unavailable.',
+      );
       return;
     }
     const previous = pathways;

--- a/client/src/components/accounts/__tests__/SavedPathwaysSection.test.ts
+++ b/client/src/components/accounts/__tests__/SavedPathwaysSection.test.ts
@@ -146,13 +146,22 @@ afterEach(() => {
 describe('saved research plan hydration helpers', () => {
   it('uses local calendar dates for upcoming deadlines and overdue follow-ups', () => {
     const now = new Date(2026, 6, 12, 23, 30);
-    expect(planningCueForPlan(pathway(), plan({ targetDeadline: '2026-07-13' }), now)).toMatchObject({
+    expect(
+      planningCueForPlan(pathway(), plan({ targetDeadline: '2026-07-13' }), now),
+    ).toMatchObject({
       date: '2026-07-13',
       priority: 1,
     });
-    expect(planningCueForPlan(pathway(), plan({
-      actedOnDate: '2026-06-01', followUpIntervalDays: 30,
-    }), now)).toMatchObject({
+    expect(
+      planningCueForPlan(
+        pathway(),
+        plan({
+          actedOnDate: '2026-06-01',
+          followUpIntervalDays: 30,
+        }),
+        now,
+      ),
+    ).toMatchObject({
       date: '2026-07-01',
       priority: 0,
     });
@@ -738,10 +747,12 @@ describe('SavedPathwaysSection advising export', () => {
         return Promise.resolve({
           data: {
             matchesByPathwayId: {
-              'pathway-1': [fellowshipMatch({
-                reasons: ['The award timing aligns with an academic-year or thesis plan.'],
-                caveats: ['The listed years do not include your current senior standing.'],
-              })],
+              'pathway-1': [
+                fellowshipMatch({
+                  reasons: ['The award timing aligns with an academic-year or thesis plan.'],
+                  caveats: ['The listed years do not include your current senior standing.'],
+                }),
+              ],
             },
           },
         });
@@ -774,8 +785,12 @@ describe('SavedPathwaysSection advising export', () => {
     expect(screen.getByText('Checklist for: Outreach')).toBeTruthy();
     expect(screen.getByText('Fellowship candidates')).toBeTruthy();
     expect(screen.getByText('Source 1')).toBeTruthy();
-    expect(screen.getByText('The award timing aligns with an academic-year or thesis plan.')).toBeTruthy();
-    expect(screen.getByText('Caveat: The listed years do not include your current senior standing.')).toBeTruthy();
+    expect(
+      screen.getByText('The award timing aligns with an academic-year or thesis plan.'),
+    ).toBeTruthy();
+    expect(
+      screen.getByText('Caveat: The listed years do not include your current senior standing.'),
+    ).toBeTruthy();
   });
 
   it('reports saved research plan count and next deadline summary', async () => {

--- a/client/src/components/accounts/__tests__/SavedPathwaysSection.test.ts
+++ b/client/src/components/accounts/__tests__/SavedPathwaysSection.test.ts
@@ -3,6 +3,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import UserContext from '../../../contexts/UserContext';
 import type { PathwaySearchHit } from '../../../types/pathway';
 import axios from '../../../utils/axios';
 import SavedPathwaysSection, {
@@ -11,8 +12,13 @@ import SavedPathwaysSection, {
   deadlineReminderForPathway,
   defaultIntentForPathway,
   fundingCueForPathway,
+  legacyPathwayPlanTargetsAreUnique,
   planningCueForPlan,
   readStoredPlans,
+  remapFundingMatchesToResearchEntities,
+  remapLegacyPathwayPlansToResearchEntities,
+  researchEntityIdsByLegacyPathway,
+  uniqueLegacyPathwayIdsByResearchEntity,
   type FellowshipFundingMatch,
   writeStoredPlans,
 } from '../SavedPathwaysSection';
@@ -92,6 +98,26 @@ const fellowshipMatch = (
   applicationLink: 'https://example.edu/fellowship/apply',
   ...overrides,
 });
+
+const renderAuthenticatedSavedPlans = () =>
+  render(
+    createElement(
+      UserContext.Provider,
+      {
+        value: {
+          isLoading: false,
+          isAuthenticated: true,
+          user: {
+            netId: 'avery1',
+            userType: 'undergraduate',
+            userConfirmed: true,
+          },
+          checkContext: vi.fn(),
+        },
+      },
+      createElement(MemoryRouter, null, createElement(SavedPathwaysSection)),
+    ),
+  );
 
 beforeEach(() => {
   localStorage.clear();
@@ -240,6 +266,66 @@ describe('saved research plan hydration helpers', () => {
       currentUserPathway: plan({ note: 'current account draft' }),
     });
   });
+
+  it('translates legacy pathway-owned plans to their saved research entity', () => {
+    const entityIdsByPathway = researchEntityIdsByLegacyPathway([pathway()]);
+    const localPlan = plan({ intent: 'outreach', note: 'Browser-only planning note' });
+    const collidingPlans = {
+      'pathway-1': localPlan,
+      'pathway-2': plan({ intent: 'thesis' }),
+    };
+    const collidingMappings = { ...entityIdsByPathway, 'pathway-2': 'entity-1' };
+
+    expect(
+      remapLegacyPathwayPlansToResearchEntities({ 'pathway-1': localPlan }, entityIdsByPathway, [
+        'entity-1',
+      ]),
+    ).toEqual({ 'entity-1': localPlan });
+    expect(legacyPathwayPlanTargetsAreUnique(collidingPlans, collidingMappings, ['entity-1'])).toBe(
+      false,
+    );
+    expect(
+      remapLegacyPathwayPlansToResearchEntities(collidingPlans, collidingMappings, ['entity-1']),
+    ).toEqual({});
+    expect(uniqueLegacyPathwayIdsByResearchEntity([pathway()])).toEqual({
+      'entity-1': 'pathway-1',
+    });
+    expect(
+      uniqueLegacyPathwayIdsByResearchEntity([pathway(), pathway({ _id: 'pathway-2' })]),
+    ).toEqual({});
+  });
+
+  it('groups and deduplicates legacy funding matches under saved entity ids', () => {
+    const result = remapFundingMatchesToResearchEntities(
+      {
+        'pathway-1': [fellowshipMatch({ score: 0.4 })],
+        'pathway-2': [
+          fellowshipMatch({ pathwayId: 'pathway-2', score: 0.9 }),
+          ...[0.7, 0.6, 0.5, 0.4, 0.3].map((score, index) =>
+            fellowshipMatch({
+              fellowshipId: `fellowship-${index + 2}`,
+              pathwayId: 'pathway-2',
+              title: `Research Grant ${index + 2}`,
+              score,
+            }),
+          ),
+        ],
+      },
+      { 'pathway-1': 'entity-1', 'pathway-2': 'entity-1' },
+      ['entity-1'],
+    );
+
+    expect(result['entity-1']).toHaveLength(5);
+    expect(result['entity-1'][0]).toMatchObject({
+      fellowshipId: 'fellowship-1',
+      pathwayId: 'pathway-2',
+      score: 0.9,
+    });
+    expect(
+      result['entity-1'].filter((match) => match.fellowshipId === 'fellowship-1'),
+    ).toHaveLength(1);
+    expect(result['entity-1'].map((match) => match.fellowshipId)).not.toContain('fellowship-6');
+  });
 });
 
 describe('saved research planning helpers', () => {
@@ -324,6 +410,174 @@ describe('SavedPathwaysSection advising export', () => {
     });
   };
 
+  it('migrates a browser-only pathway plan and funding match to its entity-owned card', async () => {
+    const user = userEvent.setup();
+    const browserPlan = plan({
+      intent: 'outreach',
+      stage: 'researching',
+      note: 'Browser-only planning note',
+    });
+    localStorage.setItem(
+      `${PLAN_STORAGE_KEY}.avery1`,
+      JSON.stringify({ 'pathway-1': browserPlan }),
+    );
+    mockedAxios.put.mockImplementationOnce(async () => {
+      expect(JSON.parse(localStorage.getItem(`${PLAN_STORAGE_KEY}.avery1`) || '{}')).toEqual({
+        'pathway-1': browserPlan,
+      });
+      return { data: {} };
+    });
+    mockedAxios.get.mockImplementation((url) => {
+      if (url === '/users/savedResearchEntities') {
+        return Promise.resolve({
+          data: {
+            savedResearchEntities: [
+              {
+                _id: 'entity-1',
+                slug: 'climate-archive',
+                name: 'Climate Archive',
+                kind: 'group',
+                departments: ['History'],
+              },
+            ],
+          },
+        });
+      }
+      if (url === '/users/savedResearchEntityPlans') {
+        return Promise.resolve({ data: { savedResearchEntityPlans: {} } });
+      }
+      if (url === '/users/savedResearchPlans') {
+        return Promise.resolve({ data: { savedResearchPlans: [pathway()] } });
+      }
+      if (url === '/users/savedResearchPlanFundingMatches') {
+        return Promise.resolve({
+          data: { matchesByPathwayId: { 'pathway-1': [fellowshipMatch()] } },
+        });
+      }
+      return Promise.reject(new Error(`Unexpected URL: ${url}`));
+    });
+
+    renderAuthenticatedSavedPlans();
+
+    await screen.findByRole('heading', { name: 'Climate Archive' });
+    await waitFor(() => {
+      expect(mockedAxios.put).toHaveBeenCalledWith(
+        '/users/savedResearchEntityPlans/entity-1',
+        { data: { plan: browserPlan } },
+        { withCredentials: true },
+      );
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Plan details' }));
+    expect(screen.getByLabelText('Note')).toHaveValue('Browser-only planning note');
+    expect(await screen.findByText('Summer Research Grant')).toBeTruthy();
+    await waitFor(() => {
+      expect(JSON.parse(localStorage.getItem(`${PLAN_STORAGE_KEY}.avery1`) || '{}')).toEqual({
+        'entity-1': plan({ intent: 'outreach', stage: 'researching' }),
+      });
+    });
+  });
+
+  it('keeps the legacy browser record when its private-plan upload fails', async () => {
+    const browserPlan = plan({ note: 'Keep this private note' });
+    localStorage.setItem(
+      `${PLAN_STORAGE_KEY}.avery1`,
+      JSON.stringify({ 'pathway-1': browserPlan }),
+    );
+    mockedAxios.put.mockRejectedValueOnce(new Error('offline'));
+    mockedAxios.get.mockImplementation((url) => {
+      if (url === '/users/savedResearchEntities') {
+        return Promise.resolve({
+          data: {
+            savedResearchEntities: [
+              {
+                _id: 'entity-1',
+                slug: 'climate-archive',
+                name: 'Climate Archive',
+                kind: 'group',
+                departments: ['History'],
+              },
+            ],
+          },
+        });
+      }
+      if (url === '/users/savedResearchEntityPlans') {
+        return Promise.resolve({ data: { savedResearchEntityPlans: {} } });
+      }
+      if (url === '/users/savedResearchPlans') {
+        return Promise.resolve({ data: { savedResearchPlans: [pathway()] } });
+      }
+      if (url === '/users/savedResearchPlanFundingMatches') {
+        return Promise.resolve({ data: { matchesByPathwayId: {} } });
+      }
+      return Promise.reject(new Error(`Unexpected URL: ${url}`));
+    });
+
+    renderAuthenticatedSavedPlans();
+
+    expect(await screen.findByText('Saved research plans could not be loaded.')).toBeTruthy();
+    expect(JSON.parse(localStorage.getItem(`${PLAN_STORAGE_KEY}.avery1`) || '{}')).toEqual({
+      'pathway-1': browserPlan,
+    });
+    expect(mockedAxios.put).toHaveBeenCalledWith(
+      '/users/savedResearchEntityPlans/entity-1',
+      { data: { plan: browserPlan } },
+      { withCredentials: true },
+    );
+  });
+
+  it('keeps and surfaces colliding legacy plans without uploading either one', async () => {
+    const browserPlans = {
+      'pathway-1': plan({ note: 'First private note' }),
+      'pathway-2': plan({ intent: 'thesis', note: 'Second private note' }),
+    };
+    localStorage.setItem(`${PLAN_STORAGE_KEY}.avery1`, JSON.stringify(browserPlans));
+    mockedAxios.get.mockImplementation((url) => {
+      if (url === '/users/savedResearchEntities') {
+        return Promise.resolve({
+          data: {
+            savedResearchEntities: [
+              {
+                _id: 'entity-1',
+                slug: 'climate-archive',
+                name: 'Climate Archive',
+                kind: 'group',
+                departments: ['History'],
+              },
+            ],
+          },
+        });
+      }
+      if (url === '/users/savedResearchEntityPlans') {
+        return Promise.resolve({ data: { savedResearchEntityPlans: {} } });
+      }
+      if (url === '/users/savedResearchPlans') {
+        return Promise.resolve({
+          data: {
+            savedResearchPlans: [pathway(), pathway({ _id: 'pathway-2' })],
+          },
+        });
+      }
+      if (url === '/users/savedResearchPlanFundingMatches') {
+        return Promise.resolve({ data: { matchesByPathwayId: {} } });
+      }
+      return Promise.reject(new Error(`Unexpected URL: ${url}`));
+    });
+
+    renderAuthenticatedSavedPlans();
+
+    await screen.findByRole('heading', { name: 'Climate Archive' });
+    expect(
+      screen.getByText(
+        'Multiple browser-only plans map to the same research profile. Your original browser records were kept so no plan was chosen or overwritten automatically.',
+      ),
+    ).toBeTruthy();
+    expect(mockedAxios.put).not.toHaveBeenCalled();
+    expect(JSON.parse(localStorage.getItem(`${PLAN_STORAGE_KEY}.avery1`) || '{}')).toEqual(
+      browserPlans,
+    );
+  });
+
   it('preserves hydrated intent and stage on the first checklist interaction', async () => {
     const user = userEvent.setup();
     mockSavedPlanLoad(plan({ intent: 'outreach', stage: 'ready' }));
@@ -333,6 +587,7 @@ describe('SavedPathwaysSection advising export', () => {
     await user.click(screen.getByLabelText('Review the official contact route or policy'));
 
     await waitFor(() => expect(mockedAxios.put).toHaveBeenCalledTimes(1));
+    expect(mockedAxios.put.mock.calls[0][0]).toBe('/users/savedResearchPlanDetails/pathway-1');
     expect(mockedAxios.put.mock.calls[0][1]).toEqual({
       data: {
         plan: plan({
@@ -344,6 +599,49 @@ describe('SavedPathwaysSection advising export', () => {
     });
     expect(screen.getByText('Checklist for: Outreach')).toBeTruthy();
     expect(screen.getByRole('status').textContent).toBe('Plan saved.');
+  });
+
+  it('uses the mapped pathway id when only canonical plan loading falls back', async () => {
+    const user = userEvent.setup();
+    mockedAxios.get.mockImplementation((url) => {
+      if (url === '/users/savedResearchEntities') {
+        return Promise.resolve({
+          data: {
+            savedResearchEntities: [
+              {
+                _id: 'entity-1',
+                slug: 'climate-archive',
+                name: 'Climate Archive',
+                kind: 'group',
+                departments: ['History'],
+              },
+            ],
+          },
+        });
+      }
+      if (url === '/users/savedResearchEntityPlans') return Promise.reject(new Error('missing'));
+      if (url === '/users/savedResearchPlanDetails') {
+        return Promise.resolve({
+          data: { savedResearchPlanDetails: { 'pathway-1': plan({ intent: 'outreach' }) } },
+        });
+      }
+      if (url === '/users/savedResearchPlans') {
+        return Promise.resolve({ data: { savedResearchPlans: [pathway()] } });
+      }
+      if (url === '/users/savedResearchPlanFundingMatches') {
+        return Promise.resolve({ data: { matchesByPathwayId: {} } });
+      }
+      return Promise.reject(new Error(`Unexpected URL: ${url}`));
+    });
+
+    renderAuthenticatedSavedPlans();
+    await user.click(await screen.findByRole('button', { name: 'Plan details' }));
+    await user.type(screen.getByLabelText('Note'), 'Updated');
+
+    await waitFor(() => expect(mockedAxios.put).toHaveBeenCalled());
+    expect(mockedAxios.put.mock.calls.at(-1)?.[0]).toBe(
+      '/users/savedResearchPlanDetails/pathway-1',
+    );
   });
 
   it('never PUTs fallback plan state when plan hydration fails', async () => {

--- a/docs/research-model.md
+++ b/docs/research-model.md
@@ -269,8 +269,9 @@ Current behavior:
 - Saved profile cards link back to `/research/:slug` rather than introducing a separate planning-detail route.
 
 Legacy `favPathways`, `savedPathwayPlans`, and their compatibility endpoints remain as rollback data and API support.
-On the first canonical saved-entity read, an idempotent lazy migration resolves each visible saved pathway to its `ResearchEntity`, deduplicates multiple pathways for the same entity, and preserves every conflicting legacy plan in private migration-conflict storage without deleting the legacy fields.
-Once marked complete, later reads do not re-import removed legacy pathway saves.
+On the first canonical saved-entity read, an idempotent lazy migration resolves each visible saved pathway to its `ResearchEntity`, deduplicates multiple pathways for the same entity, and preserves every conflicting legacy plan in private migration-conflict storage without choosing a winner or deleting the legacy fields.
+The server claims that migration atomically against the legacy pathway ids and plans it read, retries if those inputs changed concurrently, and records a one-time completion marker.
+Once marked complete, later reads, plan deletes, and entity removals do not re-import removed legacy pathway saves.
 Account hydration uses the authenticated legacy pathway read as a bounded compatibility bridge for browser-only plans and pathway-keyed funding matches.
 It rewrites owner-scoped browser storage only after legacy keys map to saved entity ids and local-only plans upload successfully, and it retains the legacy browser record when multiple plans collide on one entity.
 If canonical entity reads or plan endpoints are unavailable, the account workspace keeps legacy pathway reads, writes, and deletes paired instead of writing entity ids through pathway endpoints.

--- a/docs/research-model.md
+++ b/docs/research-model.md
@@ -251,27 +251,42 @@ Contact-route ordering should prefer official applications, program/department/f
 
 Legacy active listings may still appear inside public research detail payloads for backwards compatibility, but those embedded listing summaries must be field allowlisted. Do not expose listing owner ids, creator ids, owner emails, collaborator emails, view counts, favorite counts, audit flags, or other authenticated/admin-oriented fields through `/api/research/:slug`.
 
-## Saved Pathways
+## Saved Research Entities
 
-Student workflow depth starts with saved research plans. User accounts can now store `favPathways` as references to `EntryPathway` records, and `/account` hydrates them through the same guarded pathway projection used by research surfaces.
+Student workflow depth starts with saved research profiles.
+User accounts store `savedResearchEntities` as references to first-class `ResearchEntity` records, so a student can save a research home even when it has no `EntryPathway`.
+The `/account` planning workspace hydrates bounded entity summaries and treats pathway and fellowship data as optional enrichment.
 
-First-slice behavior:
+Current behavior:
 
-- `/api/users/savedResearchPlanIds` returns saved ids for optimistic UI state.
-- `/api/users/savedResearchPlans` returns hydrated saved pathways and prunes archived or otherwise hidden pathways from the saved list.
-- `/api/users/savedResearchPlanDetails` stores the authenticated student's sanitized planning details.
-- Saved pathway cards link back to `/research/:slug` rather than introducing a dedicated pathway detail route.
-- User-owned saved pathway plans store intent, stage, notes, and checklist state.
-- Saved pathway fellowship matches expose cautious source-backed reasons, caveats, public source links, and deadline/application context.
-- Authenticated saved pathway export omits non-public contacts and private notes by default.
+- `/api/users/savedResearchEntityIds` returns canonical entity ids for optimistic UI state.
+- `/api/users/savedResearchEntities` returns allowlisted entity summaries, bounds `shortDescription` to 300 characters and `description` to 1,000 characters, and prunes archived, hidden, or deleted entities.
+- `PUT` and `DELETE /api/users/savedResearchEntities` add and remove entity-owned saves for the authenticated account.
+- `/api/users/savedResearchEntityPlans` stores the owning student's sanitized planning details, keyed by entity id.
+- `GET /api/users/savedResearchEntityPlans/export` exports saved entities without private notes.
+- `POST /api/users/savedResearchEntityPlans/export` includes private notes only when `includePrivateNotes: true` is explicitly supplied.
+- Private plan and export responses use private no-store handling, and exports never include contact routes or non-public contact emails.
+- Saved profile cards link back to `/research/:slug` rather than introducing a separate planning-detail route.
 
-Keep saved-pathway planning and matching separate from the legacy listing/fellowship favorites board.
+Legacy `favPathways`, `savedPathwayPlans`, and their compatibility endpoints remain as rollback data and API support.
+On the first canonical saved-entity read, an idempotent lazy migration resolves each visible saved pathway to its `ResearchEntity`, deduplicates multiple pathways for the same entity, and preserves every conflicting legacy plan in private migration-conflict storage without deleting the legacy fields.
+Once marked complete, later reads do not re-import removed legacy pathway saves.
+Account hydration uses the authenticated legacy pathway read as a bounded compatibility bridge for browser-only plans and pathway-keyed funding matches.
+It rewrites owner-scoped browser storage only after legacy keys map to saved entity ids and local-only plans upload successfully, and it retains the legacy browser record when multiple plans collide on one entity.
+If canonical entity reads or plan endpoints are unavailable, the account workspace keeps legacy pathway reads, writes, and deletes paired instead of writing entity ids through pathway endpoints.
+Pathway-keyed fellowship matches are remapped to saved entity ids, deduplicated by fellowship using the best score, sorted deterministically, and capped at five matches per entity.
 
-Planning note: saved Pathways now support user-owned planning state for intent, stage, note, and checklist data, with best-effort migration from the earlier local browser record. Keep these notes private to the owning account unless a future advising-share flow adds explicit visibility controls.
+Keep saved-entity planning separate from the legacy listing and fellowship favorites board.
+Entity plans support user-owned intent, stage, note, checklist state and history, target deadline, acted-on date, and follow-up interval.
+Keep these notes private to the owning account unless a future advising-share flow adds explicit visibility controls.
 
-Saved Pathway cards also include route-specific checklist templates keyed by planning intent. Checklist state uses stable item ids so copy edits do not erase checked state.
+Saved research cards include route-specific checklist templates keyed by planning intent.
+Checklist state uses stable item ids so copy edits do not erase checked state.
 
-Saved-pathway fellowship matching should stay source-cautious. The backend normalizes fellowship application-cycle evidence from `applicationLink`, official link rows, accepting status, dates, deadlines, and office contact context. Public match payloads may expose source URLs, application route flags, deadline status, and contact office, but should not expose direct contact emails without a guarded contact-route policy. Standalone fellowship rows usually support funding/formalization matches, not entry pathways; structured mentor-matching fellowship programs can support pathways or posted opportunities when the source describes a hosted application into the program.
+Saved-research fellowship matching should stay source-cautious.
+The backend normalizes fellowship application-cycle evidence from `applicationLink`, official link rows, accepting status, dates, deadlines, and office contact context.
+Public match payloads may expose source URLs, application route flags, deadline status, and contact office, but should not expose direct contact emails without a guarded contact-route policy.
+Standalone fellowship rows usually support funding/formalization matches, not entry pathways; structured mentor-matching fellowship programs can support pathways or posted opportunities when the source describes a hosted application into the program.
 
 ## AccessSignal
 

--- a/docs/research-student-journey-delivery-plan.md
+++ b/docs/research-student-journey-delivery-plan.md
@@ -43,17 +43,17 @@ Progressive disclosure should keep early discovery quiet and move detail into th
 ### Evidence Honesty
 
 - Provenance proves where a claim came from.
-It does not prove that a student can act through that source.
+  It does not prove that a student can act through that source.
 - A faculty profile, publication, directory page, or generic entity website is not a documented way in by itself.
 - Unknown means the product lacks sufficient evidence.
-It does not mean unavailable, closed, or unsuitable.
+  It does not mean unavailable, closed, or unsuitable.
 - Identity, research activity, access, and availability are separate claims with separate evidence.
 
 ### Progressive Disclosure
 
 - The plain entity-first research list is the discovery baseline.
 - Relevance remains primary.
-Access context may only break close relevance ties within a bounded server-owned rule.
+  Access context may only break close relevance ties within a bounded server-owned rule.
 - Show at most one sparse, claim-specific, positive planning signal on an entity card.
 - Do not add a parallel results stream, persistent access controls, generic scores, or negative unknown labels.
 - Offer a `Documented way in` filter only when both states exist and the filter materially narrows the current result set.
@@ -85,7 +85,7 @@ An open or draft PR is evidence of work in progress, never evidence that a requi
 - **Depends on:** accurate query-scoped facet distributions.
 - **Acceptance criteria:** school and department controls appear only when their positive buckets can narrow the current results; selected filters remain visible and clearable; missing facet counts never fall back to the total result count; mobile controls do not overflow; a future documented-way-in control follows EF-03 rather than reviving the retired undergraduate-evidence filter.
 - **Validation evidence:** PR `#171` hides school and department controls when current distributions cannot narrow and removes the unsupported inactive undergraduate-evidence control.
-The count-fallback and final adaptive documented-way-in distribution contract remain to be completed.
+  The count-fallback and final adaptive documented-way-in distribution contract remain to be completed.
 - **PRs:** [#171](https://github.com/YaleComputerSociety/ylabs/pull/171).
 
 #### EF-03 - Sparse Documented-Way-In Signal
@@ -94,7 +94,7 @@ The count-fallback and final adaptive documented-way-in distribution contract re
 - **Depends on:** QA-01 qualifying-action policy and a bounded server summary plus distribution.
 - **Acceptance criteria:** the server returns at most one allowlisted positive signal per entity; the client renders no access label when the signal is absent; PI profiles, publications, provenance URLs, generic participation, and exploratory outreach never create the signal; a filter appears only when documented and undocumented homes both exist and the split is materially useful; no client-side access inference or reranking occurs.
 - **Validation evidence:** current Beta deliberately removed the prior parallel `Verified ways in` presentation in PR `#171`.
-The qualified-planning-context implementation adds a bounded, optional server projection with one deterministic signal per entity and deny-by-default policy tests; query-scoped distribution and client presentation remain separate work.
+  The qualified-planning-context implementation adds a bounded, optional server projection with one deterministic signal per entity and deny-by-default policy tests; query-scoped distribution and client presentation remain separate work.
 - **PRs:** [#171](https://github.com/YaleComputerSociety/ylabs/pull/171) establishes the baseline only.
 
 #### EF-04 - Stable And Efficient Discovery Requests
@@ -130,7 +130,7 @@ The qualified-planning-context implementation adds a bounded, optional server pr
 - **Depends on:** source-safe DTO shaping, publication attribution, and QA-01.
 - **Acceptance criteria:** research description, identity, research activity, undergraduate participation, and action availability remain distinct claims; source labels explain provenance without implying access; duplicate or identity-conflicting publications do not appear as current entity activity; no generic confidence score substitutes for claim language.
 - **Validation evidence:** detail source ledger and evidence components exist; PR `#158` separates current, earlier, conflicting, and duplicate research activity; PR `#171` removes generic discovery evidence/confidence labels.
-Action-specific provenance still depends on QA-01.
+  Action-specific provenance still depends on QA-01.
 - **PRs:** [#158](https://github.com/YaleComputerSociety/ylabs/pull/158), [#171](https://github.com/YaleComputerSociety/ylabs/pull/171).
 
 #### EP-03 - Bounded Related-Entity Detail Payload
@@ -165,7 +165,7 @@ Action-specific provenance still depends on QA-01.
 - **Depends on:** canonical scholarly identifiers, current membership attribution, and cache refresh ownership.
 - **Acceptance criteria:** detail activity is newest-first; current and earlier work remain separate; duplicate and identity-conflicting work is excluded; entity rollups expose bounded recency/count facts with deterministic refresh and invalidation; missing activity is unknown, not inactive; rollups can support EF-05 without exposing generic scores.
 - **Validation evidence:** PR `#158` completed contamination, duplicate, and current-versus-earlier guards.
-Cached rollups and their refresh path are not implemented on Beta.
+  Cached rollups and their refresh path are not implemented on Beta.
 - **PRs:** [#158](https://github.com/YaleComputerSociety/ylabs/pull/158) covers the completed portion only.
 
 ### Comparison And Planning
@@ -173,18 +173,18 @@ Cached rollups and their refresh path are not implemented on Beta.
 #### CP-01 - Saved Research Plans
 
 - **Status:** Complete.
-- **Depends on:** CAS-authenticated user routes and publishable pathway IDs.
+- **Depends on:** CAS-authenticated user routes and canonical ResearchEntity IDs.
 - **Acceptance criteria:** a student can save and remove a research plan; reads and writes are owner-scoped; saved-plan details hydrate from the server; malformed or oversized values are bounded; optimistic UI failures remain recoverable.
-- **Validation evidence:** authenticated `/api/users/savedResearchPlans` and `/api/users/savedResearchPlanDetails` routes, `SavedPathwaysSection`, user-service sanitization, and focused route/service/client tests.
-- **PRs:** capability predates the reconciled `#156`-`#171` tranche; [#164](https://github.com/YaleComputerSociety/ylabs/pull/164) extends its persisted planning contract.
+- **Validation evidence:** authenticated `/api/users/savedResearchEntities` and `/api/users/savedResearchEntityPlans` routes, `SavedPathwaysSection`, user-service sanitization and migration guards, and focused route/service/client tests.
+- **PRs:** capability predates the reconciled `#156`-`#171` tranche; [#164](https://github.com/YaleComputerSociety/ylabs/pull/164) extended its persisted planning contract, and [#191](https://github.com/YaleComputerSociety/ylabs/pull/191) moved ownership to ResearchEntity.
 
 #### CP-02 - Private Notes, Stage, Deadlines, And Follow-Up
 
 - **Status:** Complete.
 - **Depends on:** CP-01 and owner-scoped revision-safe persistence.
 - **Acceptance criteria:** research-plan details persist bounded notes and stage; optional target deadlines, acted-on dates, and follow-up intervals use sanitized date-only values; save status and failures are honest; due cues derive deterministically; removal clears associated detail.
-- **Validation evidence:** `server/src/services/userService.ts`, `/api/users/savedResearchPlanDetails/:pathwayId`, `SavedPathwaysSection`, and deadline/follow-up tests.
-- **PRs:** [#164](https://github.com/YaleComputerSociety/ylabs/pull/164).
+- **Validation evidence:** `server/src/services/userService.ts`, `/api/users/savedResearchEntityPlans/:entityId`, `SavedPathwaysSection`, and deadline/follow-up tests.
+- **PRs:** [#164](https://github.com/YaleComputerSociety/ylabs/pull/164), [#191](https://github.com/YaleComputerSociety/ylabs/pull/191).
 
 #### CP-03 - Private-By-Default Comparison And Advising Export
 
@@ -204,13 +204,12 @@ Cached rollups and their refresh path are not implemented on Beta.
 
 #### CP-05 - Entity-Level Saving - FR-45
 
-- **Status:** Not started.
+- **Status:** Complete.
 - **Depends on:** canonical ResearchEntity identity and CAS-authenticated owner-scoped persistence.
 - **Acceptance criteria:** a student can save a research entity even when it has no indexed pathway; save identity is the entity, not `entryPathways[0]`; existing pathway plans migrate or coexist without duplication; detail and search cards show server-confirmed state; authorization and privacy remain unchanged.
-- **Validation evidence:** current saves are `favPathways`, saved details are keyed by `pathwayId`, and `labDetail.tsx` selects the first entry pathway.
-That contract cannot represent a research home with no pathway and is not a safe comparison identity.
-- **PRs:** none.
-- **Dependency note:** CP-06 / FR-17 and CP-07 / FR-24 must not ship on pathway identity.
+- **Validation evidence:** `savedResearchEntities` and `savedResearchEntityPlans` use canonical entity ids; `labDetail.tsx` saves the entity directly; the account workspace preserves owner-scoped browser plans during migration; and the server atomically claims one-time legacy migration while retaining collisions for private review.
+- **PRs:** [#191](https://github.com/YaleComputerSociety/ylabs/pull/191).
+- **Dependency note:** CP-06 / FR-17 and CP-07 / FR-24 can build on canonical entity identity.
 
 #### CP-06 - Compare Shortlisted Research Homes - FR-17
 
@@ -223,11 +222,11 @@ That contract cannot represent a research home with no pathway and is not a safe
 
 #### CP-07 - Dashboard Entity Names And Live Counts - FR-24
 
-- **Status:** Active.
-- **Depends on:** CP-05 / FR-45 for correct entity identity.
+- **Status:** Complete.
+- **Depends on:** CP-05 / FR-45.
 - **Acceptance criteria:** dashboard cards lead with canonical research-home names; section and selected counts reflect hydrated server state; stale pathway aliases do not masquerade as entity names; loading, empty, and failure counts are honest; entity saves without pathways remain visible.
-- **Validation evidence:** current dashboard planning and server hydration are useful, but the identity contract remains pathway-first.
-- **PRs:** [#165](https://github.com/YaleComputerSociety/ylabs/pull/165) improved load behavior but did not complete FR-24.
+- **Validation evidence:** `SavedPathwaysSection` hydrates bounded ResearchEntity summaries, keys planning state and counts by entity id, and uses legacy pathways only as optional migration and fellowship context.
+- **PRs:** [#165](https://github.com/YaleComputerSociety/ylabs/pull/165), [#191](https://github.com/YaleComputerSociety/ylabs/pull/191).
 
 #### CP-08 - Shared Mobile Filter-Sheet Pattern - FR-37
 
@@ -235,8 +234,8 @@ That contract cannot represent a research home with no pathway and is not a safe
 - **Depends on:** surface-specific facet contracts and accessible focus management.
 - **Acceptance criteria:** Research and Programs use one shared filter-sheet interaction pattern on small viewports while retaining their own facets; opening moves focus into a labelled modal/sheet; Escape, close, apply, and focus return work by keyboard and screen reader; selected-count and clear behavior are honest; desktop remains quiet; no horizontal overflow.
 - **Validation evidence:** PR `#175` added the bounded, labelled Programs mobile sheet with focus entry, containment, Escape close, and focus restoration.
-The shared listing filters intentionally retain their anchored non-modal presentation, so Research does not yet satisfy the cross-surface acceptance criterion.
-PR `#171` only simplified Research filters and must not be credited with FR-37.
+  The shared listing filters intentionally retain their anchored non-modal presentation, so Research does not yet satisfy the cross-surface acceptance criterion.
+  PR `#171` only simplified Research filters and must not be credited with FR-37.
 - **PRs:** [#175](https://github.com/YaleComputerSociety/ylabs/pull/175) completed the Programs portion; Research remains outstanding.
 
 #### CP-09 - Honest Logged-Out Saving - FR-14
@@ -255,12 +254,12 @@ PR `#171` only simplified Research filters and must not be credited with FR-37.
 - **Depends on:** approved product contract, reviewed public contact routes, actionable source evidence, and EF-03.
 - **Acceptance criteria:** a positive action requires a current/recurring non-formalization record and explicit proof such as an open application, recurring official program, or approved non-PI public contact route; PI profiles and generic source pages remain source review only; the card shows at most one claim-specific action; absence renders no negative label; server policy and client analytics share the same qualifying enum.
 - **Validation evidence:** current publication policy and access-review infrastructure exist, and PR `#171` removed the misleading student-facing stream.
-The qualified-planning-context implementation establishes a narrower public projection: reviewed current opportunities with safe application URLs, approved application or recurring-program instructions, and approved safe public non-PI routes qualify; profile provenance, generic source material, exploratory contact, formalization-only records, unsafe URLs, and unreviewed claims do not.
+  The qualified-planning-context implementation establishes a narrower public projection: reviewed current opportunities with safe application URLs, approved application or recurring-program instructions, and approved safe public non-PI routes qualify; profile provenance, generic source material, exploratory contact, formalization-only records, unsafe URLs, and unreviewed claims do not.
 - **PRs:** [#161](https://github.com/YaleComputerSociety/ylabs/pull/161), [#171](https://github.com/YaleComputerSociety/ylabs/pull/171).
 - **Blocker:** operators must review routes and source-backed claims before they can be represented as actionable; query-scoped distribution, client presentation, and analytics still depend on the stable projection.
-The operational program is named the **evidence and route review rollout**.
-Its acceptance measures are claim quality, reviewed-action precision, false-positive rate, and explainable rejection reasons, not a minimum number of published pathways.
-PI-profile provenance can never qualify as an action.
+  The operational program is named the **evidence and route review rollout**.
+  Its acceptance measures are claim quality, reviewed-action precision, false-positive rate, and explainable rejection reasons, not a minimum number of published pathways.
+  PI-profile provenance can never qualify as an action.
 
 #### QA-02 - Accessible And Honest Account Onboarding
 
@@ -276,7 +275,7 @@ PI-profile provenance can never qualify as an action.
 - **Depends on:** route-by-route keyboard, focus, error-association, landmark, and responsive validation.
 - **Acceptance criteria:** canonical student flows have labelled controls, programmatically associated errors, announced async states, logical focus movement, unique landmarks/headings, 44-pixel primary targets, and no 320/375-pixel overflow; fixes use shared primitives where behavior is shared.
 - **Validation evidence:** PRs `#154` and `#169` completed major Programs and onboarding slices, and `#171` simplified Research.
-The cross-surface audit remains incomplete.
+  The cross-surface audit remains incomplete.
 - **PRs:** [#154](https://github.com/YaleComputerSociety/ylabs/pull/154), [#169](https://github.com/YaleComputerSociety/ylabs/pull/169), [#171](https://github.com/YaleComputerSociety/ylabs/pull/171).
 
 ### Supply And Moderation
@@ -295,7 +294,7 @@ The cross-surface audit remains incomplete.
 - **Depends on:** confirmed faculty/staff authorization and admin review.
 - **Acceptance criteria:** eligible users can submit a claim or correction from a linked research profile; duplicate pending requests are prevented; students, unknown users, and unconfirmed accounts are denied; admins can review with rationale and audit history; an approved decision hands off to a separately guarded mutation rather than silently changing data.
 - **Validation evidence:** listing-linked claim/correction and non-mutating admin review are merged.
-Entity-wide correction coverage beyond linked listings remains future work.
+  Entity-wide correction coverage beyond linked listings remains future work.
 - **PRs:** [#160](https://github.com/YaleComputerSociety/ylabs/pull/160).
 
 #### SM-03 - Scalable Human Review Without Bulk Approval
@@ -355,7 +354,7 @@ Entity-wide correction coverage beyond linked listings remains future work.
 - **Depends on:** QA-01 server-owned qualifying signal and an accepted privacy-safe analytics taxonomy.
 - **Acceptance criteria:** invisible events distinguish search, research-profile open, source review, qualified action, filter-panel open/close, filter apply/remove, and save/unsave; only a qualified action counts as access conversion; faculty profile, website, ORCID, publication, filter, and save events never count as action; analytics does not delay navigation or alter UI; payloads exclude raw URLs, queries on downstream events, and free-text notes.
 - **Validation evidence:** current analytics distinguishes generic source, contact, pathway, save, and research-view events but canonical research browse/detail lacks the required complete taxonomy.
-One existing program filter-navigation event is still classified too broadly as `ways_in_click`.
+  One existing program filter-navigation event is still classified too broadly as `ways_in_click`.
 - **PRs:** none.
 
 #### IM-02 - Search Quality, Zero Results, And Funnel Integrity
@@ -439,15 +438,15 @@ This matrix separates current Beta evidence from older persona observations and 
 The 2026-07-13 validation lane could not retrieve the referenced historical Claude transcript and could not start the Chrome bridge.
 Its evidence is therefore current Beta source, routes, tests, and merged history rather than a fresh authenticated browser replay.
 
-| Claim | Current support | Delivery interpretation |
-| --- | --- | --- |
-| Entity-first discovery is the correct current baseline. | **Supported.** PR `#171` removes the parallel pathway request and stream and keeps research profiles primary. | Keep EF-01 Complete and protect it with regression tests. |
-| Discovery filters are fully adaptive and progressively disclosed. | **Disputed as complete.** Programs has a bounded mobile filter sheet, while shared Research/listing filters remain anchored and missing facet counts may fall back to the total. | Keep EF-02 and CP-08 / FR-37 Active until the remaining Research behavior and facet-count gaps are resolved. |
-| A server-qualified sparse planning summary exists. | **Not supported.** No bounded claim-specific summary or useful-state distribution exists. | Keep EF-03 Not started and dependent on QA-01. |
-| Research homes can be saved independently of pathways. | **Not supported.** Current saves are pathway favorites, details are keyed by pathway ID, and detail chooses an entry pathway. | Keep CP-05 / FR-45 Not started and ahead of FR-17 and FR-24. |
-| Canonical research analytics distinguish search, profile, source, filters, save, and qualified action. | **Not supported.** The current taxonomy is broader and canonical browse/detail lacks the complete invisible journey emissions. | Keep IM-01 Not started and IM-02 Active until QA-01 stabilizes conversion meaning. |
-| Publishing a target number of pathways establishes trustworthy access coverage. | **Disputed.** Quantity does not establish claim or route quality and can reward false positives. | The evidence and route review rollout uses claim precision, false-positive rate, rejection reasons, and reviewed-action quality instead. |
-| Historical persona findings describe current Beta behavior. | **Validation pending.** Several cited defects were changed by merged PRs, while the referenced transcript and fresh browser replay were unavailable. | Use historical observations as discovery inputs only; require current code, test, data, or CAS-preserving browser evidence before changing status or rationale. |
+| Claim                                                                                                  | Current support                                                                                                                                                                  | Delivery interpretation                                                                                                                                         |
+| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Entity-first discovery is the correct current baseline.                                                | **Supported.** PR `#171` removes the parallel pathway request and stream and keeps research profiles primary.                                                                    | Keep EF-01 Complete and protect it with regression tests.                                                                                                       |
+| Discovery filters are fully adaptive and progressively disclosed.                                      | **Disputed as complete.** Programs has a bounded mobile filter sheet, while shared Research/listing filters remain anchored and missing facet counts may fall back to the total. | Keep EF-02 and CP-08 / FR-37 Active until the remaining Research behavior and facet-count gaps are resolved.                                                    |
+| A server-qualified sparse planning summary exists.                                                     | **Not supported.** No bounded claim-specific summary or useful-state distribution exists.                                                                                        | Keep EF-03 Not started and dependent on QA-01.                                                                                                                  |
+| Research homes can be saved independently of pathways.                                                 | **Not supported.** Current saves are pathway favorites, details are keyed by pathway ID, and detail chooses an entry pathway.                                                    | Keep CP-05 / FR-45 Not started and ahead of FR-17 and FR-24.                                                                                                    |
+| Canonical research analytics distinguish search, profile, source, filters, save, and qualified action. | **Not supported.** The current taxonomy is broader and canonical browse/detail lacks the complete invisible journey emissions.                                                   | Keep IM-01 Not started and IM-02 Active until QA-01 stabilizes conversion meaning.                                                                              |
+| Publishing a target number of pathways establishes trustworthy access coverage.                        | **Disputed.** Quantity does not establish claim or route quality and can reward false positives.                                                                                 | The evidence and route review rollout uses claim precision, false-positive rate, rejection reasons, and reviewed-action quality instead.                        |
+| Historical persona findings describe current Beta behavior.                                            | **Validation pending.** Several cited defects were changed by merged PRs, while the referenced transcript and fresh browser replay were unavailable.                             | Use historical observations as discovery inputs only; require current code, test, data, or CAS-preserving browser evidence before changing status or rationale. |
 
 Unresolved UX choices remain validation-pending even when engineering dependencies are known.
 These include the anonymous-save policy, final qualified-action enum and thresholds, exact material-use threshold for a documented-way-in filter, comparison layout, and the Research-side mobile filter-sheet presentation.

--- a/server/src/controllers/__tests__/userController.test.ts
+++ b/server/src/controllers/__tests__/userController.test.ts
@@ -264,10 +264,7 @@ const privateResponseDouble = () =>
   }) as any;
 
 const expectPrivateNoStore = (res: any) => {
-  expect(res.setHeader).toHaveBeenCalledWith(
-    'Cache-Control',
-    'no-store, private, max-age=0',
-  );
+  expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store, private, max-age=0');
   expect(res.setHeader).toHaveBeenCalledWith('Pragma', 'no-cache');
 };
 
@@ -429,9 +426,7 @@ describe('userController', () => {
       ownListings: ['64a000000000000000000001'],
       favListings: ['64a000000000000000000002'],
     });
-    mocks.readListings.mockRejectedValue(
-      new Error('mongodb://user:pass@example.invalid leaked'),
-    );
+    mocks.readListings.mockRejectedValue(new Error('mongodb://user:pass@example.invalid leaked'));
 
     const req = {
       user: { netId: 'owner123', userType: 'professor', userConfirmed: true },
@@ -464,9 +459,7 @@ describe('userController', () => {
   });
 
   it('does not leak internal service errors when adding favorited listings fails', async () => {
-    mocks.addFavListings.mockRejectedValue(
-      new Error('mongodb://user:pass@example.invalid leaked'),
-    );
+    mocks.addFavListings.mockRejectedValue(new Error('mongodb://user:pass@example.invalid leaked'));
 
     const req = {
       user: { netId: 'student123', userType: 'undergraduate', userConfirmed: true },
@@ -761,9 +754,7 @@ describe('userController', () => {
   });
 
   it('does not leak internal service errors when saving research plans fails', async () => {
-    mocks.addFavPathways.mockRejectedValue(
-      new Error('mongodb://user:pass@example.invalid leaked'),
-    );
+    mocks.addFavPathways.mockRejectedValue(new Error('mongodb://user:pass@example.invalid leaked'));
 
     const req = {
       user: { netId: 'student123', userType: 'undergraduate', userConfirmed: true },
@@ -789,9 +780,7 @@ describe('userController', () => {
   });
 
   it('does not leak internal service errors when adding favorite pathways fails', async () => {
-    mocks.addFavPathways.mockRejectedValue(
-      new Error('mongodb://user:pass@example.invalid leaked'),
-    );
+    mocks.addFavPathways.mockRejectedValue(new Error('mongodb://user:pass@example.invalid leaked'));
 
     const req = {
       user: { netId: 'student123', userType: 'undergraduate', userConfirmed: true },
@@ -987,7 +976,7 @@ describe('userController', () => {
     Object.assign(profileUrls, {
       yale: 'https://example.yale.edu/profile/student123',
       ' research.profile ': 'https://example.yale.edu/research/student123',
-      '$source': 'https://example.yale.edu/source/student123',
+      $source: 'https://example.yale.edu/source/student123',
       constructor: 'https://example.yale.edu/constructor',
       prototype: 'https://example.yale.edu/prototype',
       personal: 'mailto:student123@yale.edu',
@@ -1008,7 +997,7 @@ describe('userController', () => {
       profileUrls: {
         yale: 'https://example.yale.edu/profile/student123',
         'research.profile': 'https://example.yale.edu/research/student123',
-        '$source': 'https://example.yale.edu/source/student123',
+        $source: 'https://example.yale.edu/source/student123',
         constructor: 'https://example.yale.edu/constructor',
       },
       bio: 'I study public health.',
@@ -1045,8 +1034,12 @@ describe('userController', () => {
       },
     });
     expect(res.body.user).not.toHaveProperty('imageUrl');
-    expect(Object.prototype.hasOwnProperty.call(res.body.user.profileUrls, 'constructor')).toBe(false);
-    expect(Object.prototype.hasOwnProperty.call(res.body.user.profileUrls, 'prototype')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(res.body.user.profileUrls, 'constructor')).toBe(
+      false,
+    );
+    expect(Object.prototype.hasOwnProperty.call(res.body.user.profileUrls, 'prototype')).toBe(
+      false,
+    );
   });
 
   it('bounds self-edit account text and array fields before persisting the current user', async () => {
@@ -1156,10 +1149,7 @@ describe('userController', () => {
 
     await getSavedResearchPlanDetails(req, res);
 
-    expect(res.setHeader).toHaveBeenCalledWith(
-      'Cache-Control',
-      'no-store, private, max-age=0',
-    );
+    expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store, private, max-age=0');
     expect(res.setHeader).toHaveBeenCalledWith('Pragma', 'no-cache');
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json.mock.calls[0][0]).toEqual({
@@ -1207,10 +1197,7 @@ describe('userController', () => {
 
     await exportSavedResearchPlanDetails(req, res);
 
-    expect(res.setHeader).toHaveBeenCalledWith(
-      'Cache-Control',
-      'no-store, private, max-age=0',
-    );
+    expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store, private, max-age=0');
     expect(res.setHeader).toHaveBeenCalledWith('Pragma', 'no-cache');
     expect(res.setHeader).toHaveBeenCalledWith(
       'Content-Disposition',
@@ -1300,9 +1287,7 @@ describe('userController', () => {
     [getFavPathwayIds, 'Failed to fetch favorite pathway ids'],
     [getSavedResearchPlanIds, 'Failed to fetch saved research plan ids'],
   ])('does not leak internal read errors from account id readers', async (handler, message) => {
-    mocks.readUser.mockRejectedValue(
-      new Error('mongodb://user:pass@example.invalid leaked'),
-    );
+    mocks.readUser.mockRejectedValue(new Error('mongodb://user:pass@example.invalid leaked'));
 
     const req = {
       user: { netId: 'student123', userType: 'undergraduate', userConfirmed: true },
@@ -1320,21 +1305,22 @@ describe('userController', () => {
     [getSavedPrograms, 'Failed to fetch saved programs'],
     [getFavPathways, 'Failed to fetch favorite pathways'],
     [getSavedResearchPlans, 'Failed to fetch saved research plans'],
-  ])('does not leak internal read errors from hydrated account readers', async (handler, message) => {
-    mocks.readUser.mockRejectedValue(
-      new Error('mongodb://user:pass@example.invalid leaked'),
-    );
+  ])(
+    'does not leak internal read errors from hydrated account readers',
+    async (handler, message) => {
+      mocks.readUser.mockRejectedValue(new Error('mongodb://user:pass@example.invalid leaked'));
 
-    const req = {
-      user: { netId: 'student123', userType: 'undergraduate', userConfirmed: true },
-    } as any;
-    const res = privateResponseDouble();
+      const req = {
+        user: { netId: 'student123', userType: 'undergraduate', userConfirmed: true },
+      } as any;
+      const res = privateResponseDouble();
 
-    await handler(req, res);
+      await handler(req, res);
 
-    expect(res.statusCode).toBe(500);
-    expect(res.body).toEqual({ error: message });
-  });
+      expect(res.statusCode).toBe(500);
+      expect(res.body).toEqual({ error: message });
+    },
+  );
 
   it('bounds stored program ids before program reader fan-out', async () => {
     mocks.readUser.mockResolvedValue({
@@ -1376,11 +1362,9 @@ describe('userController', () => {
   });
 
   it('passes profile year and saved plan intent into funding matching', async () => {
-    mocks.normalizeObjectIdsForUserMutation.mockReturnValueOnce([
-      { toHexString: () => '64a000000000000000000030' } as any,
-    ]).mockReturnValueOnce([
-      { toHexString: () => '64a000000000000000000030' } as any,
-    ]);
+    mocks.normalizeObjectIdsForUserMutation
+      .mockReturnValueOnce([{ toHexString: () => '64a000000000000000000030' } as any])
+      .mockReturnValueOnce([{ toHexString: () => '64a000000000000000000030' } as any]);
     mocks.readUser.mockResolvedValue({
       userType: 'undergraduate',
       year: 2027,
@@ -1392,7 +1376,9 @@ describe('userController', () => {
     mocks.getPathwaysByIds.mockResolvedValue([{ _id: '64a000000000000000000030' }]);
     mocks.matchFellowshipsForPathways.mockResolvedValue({});
 
-    const req = { user: { netId: 'student123', userType: 'undergraduate', userConfirmed: true } } as any;
+    const req = {
+      user: { netId: 'student123', userType: 'undergraduate', userConfirmed: true },
+    } as any;
     const res = privateResponseDouble();
     await getFavPathwayFundingMatches(req, res);
 
@@ -1411,9 +1397,7 @@ describe('userController', () => {
 
   it('bounds stored favorite pathway ids before funding-match fan-out', async () => {
     mocks.readUser.mockResolvedValue({
-      favPathways: Array.from({ length: 101 }, (_, index) =>
-        index.toString(16).padStart(24, '0'),
-      ),
+      favPathways: Array.from({ length: 101 }, (_, index) => index.toString(16).padStart(24, '0')),
     });
 
     const req = {

--- a/server/src/controllers/__tests__/userController.test.ts
+++ b/server/src/controllers/__tests__/userController.test.ts
@@ -36,6 +36,13 @@ const mocks = vi.hoisted(() => ({
   }),
   updateSavedPathwayPlan: vi.fn(),
   deleteSavedPathwayPlan: vi.fn(),
+  getSavedResearchEntities: vi.fn(),
+  getSavedResearchEntityPlans: vi.fn(),
+  addSavedResearchEntities: vi.fn(),
+  removeSavedResearchEntities: vi.fn(),
+  updateSavedResearchEntityPlan: vi.fn(),
+  deleteSavedResearchEntityPlan: vi.fn(),
+  exportSavedResearchEntities: vi.fn(),
 }));
 
 vi.mock('../../services/listingService', () => ({
@@ -74,6 +81,13 @@ vi.mock('../../services/userService', () => ({
   pruneSavedPathwayPlansForExistingPathways: vi.fn((plans) => plans),
   updateSavedPathwayPlan: mocks.updateSavedPathwayPlan,
   deleteSavedPathwayPlan: mocks.deleteSavedPathwayPlan,
+  getSavedResearchEntities: mocks.getSavedResearchEntities,
+  getSavedResearchEntityPlans: mocks.getSavedResearchEntityPlans,
+  addSavedResearchEntities: mocks.addSavedResearchEntities,
+  removeSavedResearchEntities: mocks.removeSavedResearchEntities,
+  updateSavedResearchEntityPlan: mocks.updateSavedResearchEntityPlan,
+  deleteSavedResearchEntityPlan: mocks.deleteSavedResearchEntityPlan,
+  exportSavedResearchEntities: mocks.exportSavedResearchEntities,
 }));
 
 import {
@@ -81,8 +95,11 @@ import {
   addFavListings,
   addFavPathways,
   addSavedPrograms,
+  addSavedResearchEntities,
   addSavedResearchPlans,
+  deleteSavedResearchEntityPlan,
   deleteSavedResearchPlanDetail,
+  exportSavedResearchEntities,
   exportSavedResearchPlanDetails,
   getFavFellowshipIds,
   getFavFellowships,
@@ -91,6 +108,8 @@ import {
   getFavPathwayFundingMatches,
   getFavPathways,
   getSavedProgramIds,
+  getSavedResearchEntities,
+  getSavedResearchEntityPlans,
   getSavedResearchPlanDetails,
   getSavedResearchPlanIds,
   getSavedResearchPlans,
@@ -100,8 +119,10 @@ import {
   removeFavListings,
   removeFavPathways,
   removeSavedPrograms,
+  removeSavedResearchEntities,
   removeSavedResearchPlans,
   updateCurrentUser,
+  updateSavedResearchEntityPlan,
   updateSavedResearchPlanDetail,
 } from '../userController';
 
@@ -1423,5 +1444,80 @@ describe('userController', () => {
     expect(res.statusCode).toBe(400);
     expect(res.body).toEqual({ error: 'Bad request' });
     expect(mocks.getPathwaysByIds).not.toHaveBeenCalled();
+  });
+
+  it('scopes saved-entity reads and private exports to the authenticated owner', async () => {
+    const req = {
+      user: { netId: 'student123', userType: 'undergraduate', userConfirmed: true },
+      method: 'POST',
+      body: { accountOwner: 'other-student', includePrivateNotes: true },
+    } as any;
+    mocks.getSavedResearchEntities.mockResolvedValue([]);
+    mocks.getSavedResearchEntityPlans.mockResolvedValue({});
+    mocks.exportSavedResearchEntities.mockResolvedValue({ items: [] });
+
+    await getSavedResearchEntities(req, privateResponseDouble());
+    const plansResponse = privateResponseDouble();
+    await getSavedResearchEntityPlans(req, plansResponse);
+    const exportResponse = privateResponseDouble();
+    await exportSavedResearchEntities(req, exportResponse);
+
+    expect(mocks.getSavedResearchEntities).toHaveBeenCalledWith('student123');
+    expect(mocks.getSavedResearchEntityPlans).toHaveBeenCalledWith('student123');
+    expect(mocks.exportSavedResearchEntities).toHaveBeenCalledWith('student123', {
+      includePrivateNotes: true,
+    });
+    expectPrivateNoStore(plansResponse);
+    expectPrivateNoStore(exportResponse);
+  });
+
+  it('scopes saved-entity writes and deletes to the authenticated owner', async () => {
+    const entityId = '64a000000000000000000030';
+    const owner = { netId: 'student123', userType: 'undergraduate', userConfirmed: true };
+    mocks.addSavedResearchEntities.mockResolvedValue([entityId]);
+    mocks.removeSavedResearchEntities.mockResolvedValue([]);
+    mocks.updateSavedResearchEntityPlan.mockResolvedValue({});
+    mocks.deleteSavedResearchEntityPlan.mockResolvedValue({});
+
+    await addSavedResearchEntities(
+      {
+        user: owner,
+        body: {
+          accountOwner: 'other-student',
+          data: { savedResearchEntities: [entityId] },
+        },
+      } as any,
+      privateResponseDouble(),
+    );
+    await removeSavedResearchEntities(
+      {
+        user: owner,
+        body: { accountOwner: 'other-student', savedResearchEntities: [entityId] },
+      } as any,
+      privateResponseDouble(),
+    );
+    await updateSavedResearchEntityPlan(
+      {
+        user: owner,
+        params: { entityId },
+        body: { accountOwner: 'other-student', data: { plan: { note: 'Private note' } } },
+      } as any,
+      privateResponseDouble(),
+    );
+    await deleteSavedResearchEntityPlan(
+      {
+        user: owner,
+        params: { entityId },
+        body: { accountOwner: 'other-student' },
+      } as any,
+      privateResponseDouble(),
+    );
+
+    expect(mocks.addSavedResearchEntities).toHaveBeenCalledWith('student123', [entityId]);
+    expect(mocks.removeSavedResearchEntities).toHaveBeenCalledWith('student123', [entityId]);
+    expect(mocks.updateSavedResearchEntityPlan).toHaveBeenCalledWith('student123', entityId, {
+      note: 'Private note',
+    });
+    expect(mocks.deleteSavedResearchEntityPlan).toHaveBeenCalledWith('student123', entityId);
   });
 });

--- a/server/src/models/user.ts
+++ b/server/src/models/user.ts
@@ -146,6 +146,10 @@ const userSchema = new mongoose.Schema(
       default: {},
       select: false,
     },
+    savedResearchEntityMigrationCompleted: {
+      type: Boolean,
+      default: false,
+    },
     savedPathwayPlans: {
       type: mongoose.Schema.Types.Mixed,
       default: {},

--- a/server/src/services/__tests__/userService.test.ts
+++ b/server/src/services/__tests__/userService.test.ts
@@ -16,6 +16,7 @@ import {
   pruneSavedPathwayPlansForExistingPathways,
   sanitizeSavedPathwayPlanForStorage,
   sanitizeSavedProgramTrackingForResponse,
+  savedResearchEntityLegacyMigrationClaimFilter,
   savedResearchEntityLegacyMigrationInputs,
   type SavedPathwayPlanInput,
 } from '../userService';
@@ -567,6 +568,30 @@ describe('savedResearchEntityLegacyMigrationInputs', () => {
     expect(result.legacyPlans[pathwayId]).toMatchObject({
       intent: 'outreach',
       note: 'Legacy note',
+    });
+  });
+});
+
+describe('savedResearchEntityLegacyMigrationClaimFilter', () => {
+  it('claims only the legacy snapshot used to build the migration', () => {
+    const pathwayId = new mongoose.Types.ObjectId('665f0b0c0b0c0b0c0b0c0b0c');
+    const savedPathwayPlans = {
+      [pathwayId.toHexString()]: { intent: 'outreach', note: 'Legacy note' },
+    };
+
+    expect(
+      savedResearchEntityLegacyMigrationClaimFilter({
+        favPathways: [pathwayId],
+        savedPathwayPlans,
+      }),
+    ).toEqual({
+      savedResearchEntityMigrationCompleted: { $ne: true },
+      $expr: {
+        $and: [
+          { $eq: [{ $ifNull: ['$favPathways', []] }, [pathwayId]] },
+          { $eq: [{ $ifNull: ['$savedPathwayPlans', {}] }, savedPathwayPlans] },
+        ],
+      },
     });
   });
 });

--- a/server/src/services/__tests__/userService.test.ts
+++ b/server/src/services/__tests__/userService.test.ts
@@ -3,6 +3,9 @@ import mongoose from 'mongoose';
 import {
   MAX_SAVED_PATHWAY_NOTE_LENGTH,
   MAX_SAVED_PROGRAM_NOTE_LENGTH,
+  MAX_SAVED_RESEARCH_ENTITY_DESCRIPTION_LENGTH,
+  MAX_SAVED_RESEARCH_ENTITY_SHORT_DESCRIPTION_LENGTH,
+  boundSavedResearchEntitySummaryText,
   buildCaseInsensitiveNetidFilter,
   buildSavedPathwayPlanUnsetForIds,
   buildSavedPathwayPlansExport,
@@ -13,6 +16,7 @@ import {
   pruneSavedPathwayPlansForExistingPathways,
   sanitizeSavedPathwayPlanForStorage,
   sanitizeSavedProgramTrackingForResponse,
+  savedResearchEntityLegacyMigrationInputs,
   type SavedPathwayPlanInput,
 } from '../userService';
 import type { PathwaySearchHit } from '../pathwaySearchService';
@@ -515,7 +519,7 @@ describe('buildSavedResearchEntityMigration', () => {
     );
 
     expect(result.entityIds).toEqual([entityId]);
-    expect(result.plans[entityId].note).toBe('First private note');
+    expect(result.plans[entityId]).toBeUndefined();
     expect(result.conflicts[entityId]).toEqual({
       [firstId]: first,
       [secondId]: second,
@@ -533,5 +537,53 @@ describe('buildSavedResearchEntityMigration', () => {
     );
 
     expect(result.plans[entityId]).toEqual(existing);
+  });
+});
+
+describe('savedResearchEntityLegacyMigrationInputs', () => {
+  it('never re-imports legacy pathway state after migration completes', () => {
+    const pathwayId = '665f0b0c0b0c0b0c0b0c0b0c';
+    expect(
+      savedResearchEntityLegacyMigrationInputs({
+        savedResearchEntityMigrationCompleted: true,
+        favPathways: [pathwayId],
+        savedPathwayPlans: {
+          [pathwayId]: { note: 'Legacy note that must not resurrect' },
+        },
+      }),
+    ).toEqual({ migrationCompleted: true, pathwayIds: [], legacyPlans: {} });
+  });
+
+  it('returns bounded legacy inputs before the one-time migration', () => {
+    const pathwayId = '665f0b0c0b0c0b0c0b0c0b0c';
+    const result = savedResearchEntityLegacyMigrationInputs({
+      savedResearchEntityMigrationCompleted: false,
+      favPathways: [pathwayId],
+      savedPathwayPlans: { [pathwayId]: { intent: 'outreach', note: 'Legacy note' } },
+    });
+
+    expect(result.migrationCompleted).toBe(false);
+    expect(result.pathwayIds).toEqual([pathwayId]);
+    expect(result.legacyPlans[pathwayId]).toMatchObject({
+      intent: 'outreach',
+      note: 'Legacy note',
+    });
+  });
+});
+
+describe('boundSavedResearchEntitySummaryText', () => {
+  it('bounds both saved-entity summary description variants', () => {
+    expect(
+      boundSavedResearchEntitySummaryText(
+        's'.repeat(MAX_SAVED_RESEARCH_ENTITY_SHORT_DESCRIPTION_LENGTH + 1),
+        MAX_SAVED_RESEARCH_ENTITY_SHORT_DESCRIPTION_LENGTH,
+      ),
+    ).toHaveLength(MAX_SAVED_RESEARCH_ENTITY_SHORT_DESCRIPTION_LENGTH);
+    expect(
+      boundSavedResearchEntitySummaryText(
+        'd'.repeat(MAX_SAVED_RESEARCH_ENTITY_DESCRIPTION_LENGTH + 1),
+        MAX_SAVED_RESEARCH_ENTITY_DESCRIPTION_LENGTH,
+      ),
+    ).toHaveLength(MAX_SAVED_RESEARCH_ENTITY_DESCRIPTION_LENGTH);
   });
 });

--- a/server/src/services/userService.ts
+++ b/server/src/services/userService.ts
@@ -38,6 +38,8 @@ const MAX_SAVED_PATHWAY_PLAN_RESPONSE_ITEMS = 100;
 const MAX_USER_UPDATE_VALUE_DEPTH = 20;
 const MAX_USER_UPDATE_VALUE_ARRAY_ITEMS = 200;
 const MAX_USER_UPDATE_VALUE_OBJECT_KEYS = 200;
+export const MAX_SAVED_RESEARCH_ENTITY_SHORT_DESCRIPTION_LENGTH = 300;
+export const MAX_SAVED_RESEARCH_ENTITY_DESCRIPTION_LENGTH = 1000;
 export const MAX_SAVED_PATHWAY_NOTE_LENGTH = 5000;
 export const MAX_SAVED_PROGRAM_NOTE_LENGTH = 2000;
 const NETID_LOOKUP_RE = /^[A-Za-z0-9]{2,12}$/;
@@ -1131,6 +1133,14 @@ export interface SavedResearchEntitySummary {
   description?: string;
 }
 
+export const boundSavedResearchEntitySummaryText = (
+  value: unknown,
+  maxLength: number,
+): string | undefined => {
+  if (typeof value !== 'string' || !value) return undefined;
+  return value.slice(0, maxLength);
+};
+
 const savedResearchEntityProjection =
   '_id slug name displayName kind entityType departments school shortDescription description';
 
@@ -1164,6 +1174,14 @@ const visibleSavedResearchEntities = async (
   return normalized.flatMap((id) => {
     const entity: any = byId.get(String(id));
     if (!entity) return [];
+    const shortDescription = boundSavedResearchEntitySummaryText(
+      entity.shortDescription,
+      MAX_SAVED_RESEARCH_ENTITY_SHORT_DESCRIPTION_LENGTH,
+    );
+    const description = boundSavedResearchEntitySummaryText(
+      entity.description,
+      MAX_SAVED_RESEARCH_ENTITY_DESCRIPTION_LENGTH,
+    );
     return [
       {
         _id: String(entity._id),
@@ -1176,8 +1194,8 @@ const visibleSavedResearchEntities = async (
           ? entity.departments.slice(0, 20).map(String)
           : [],
         ...(entity.school ? { school: String(entity.school) } : {}),
-        ...(entity.shortDescription ? { shortDescription: String(entity.shortDescription) } : {}),
-        ...(entity.description ? { description: String(entity.description) } : {}),
+        ...(shortDescription ? { shortDescription } : {}),
+        ...(description ? { description } : {}),
       },
     ];
   });
@@ -1209,7 +1227,7 @@ export const buildSavedResearchEntityMigration = (
           ? [{ pathwayId: pathway._id, plan: legacyPlans[pathway._id] }]
           : [],
       );
-    if (!plans[entityId] && legacy[0]) plans[entityId] = legacy[0].plan;
+    if (!plans[entityId] && legacy.length === 1) plans[entityId] = legacy[0].plan;
     if (legacy.length > 1) {
       conflicts[entityId] = Object.fromEntries(
         legacy.map(({ pathwayId, plan }) => [pathwayId, plan]),
@@ -1219,46 +1237,98 @@ export const buildSavedResearchEntityMigration = (
   return { entityIds: [...entityIds], plans, conflicts };
 };
 
+export const savedResearchEntityLegacyMigrationInputs = (user: {
+  savedResearchEntityMigrationCompleted?: unknown;
+  favPathways?: unknown;
+  savedPathwayPlans?: unknown;
+}) => {
+  const migrationCompleted = user.savedResearchEntityMigrationCompleted === true;
+  return {
+    migrationCompleted,
+    pathwayIds: migrationCompleted
+      ? []
+      : storedObjectIdStringsForUserMutation(user.favPathways, 'favPathways'),
+    legacyPlans: migrationCompleted
+      ? {}
+      : sanitizeSavedPathwayPlansForResponse(user.savedPathwayPlans),
+  };
+};
+
 /** Lazily moves pathway-owned saves to entity ownership without deleting rollback data. */
 export const migrateSavedResearchEntitiesForUser = async (id: any) => {
-  const user = await readUser(id);
+  let user = await readUser(id);
+  const { migrationCompleted, pathwayIds, legacyPlans } =
+    savedResearchEntityLegacyMigrationInputs(user);
+  if (!migrationCompleted) {
+    const pathways = await getPathwaysByIds(pathwayIds);
+    const migration = buildSavedResearchEntityMigration(pathways, legacyPlans);
+    const visibleMigrated = await visibleSavedResearchEntities(migration.entityIds);
+    const visibleMigratedIds = new Set(visibleMigrated.map((entity) => entity._id));
+    const migratedPlans = Object.fromEntries(
+      Object.entries(migration.plans).filter(([entityId]) => visibleMigratedIds.has(entityId)),
+    );
+    await User.findOneAndUpdate(
+      {
+        ...userLookupFilterForMutation(id),
+        savedResearchEntityMigrationCompleted: { $ne: true },
+      },
+      [
+        {
+          $set: {
+            savedResearchEntities: {
+              $setUnion: [
+                { $ifNull: ['$savedResearchEntities', []] },
+                visibleMigrated.map((entity) => new mongoose.Types.ObjectId(entity._id)),
+              ],
+            },
+            savedResearchEntityPlans: {
+              $mergeObjects: [migratedPlans, { $ifNull: ['$savedResearchEntityPlans', {}] }],
+            },
+            savedResearchEntityMigrationCompleted: true,
+            ...(Object.keys(migration.conflicts).length
+              ? {
+                  savedResearchEntityPlanMigrationConflicts: {
+                    $mergeObjects: [
+                      migration.conflicts,
+                      { $ifNull: ['$savedResearchEntityPlanMigrationConflicts', {}] },
+                    ],
+                  },
+                }
+              : {}),
+          },
+        },
+      ],
+      { new: true },
+    );
+    user = await readUser(id);
+  }
   const existingIds = storedObjectIdStringsForUserMutation(
     user.savedResearchEntities || [],
     'savedResearchEntities',
   );
   const entityPlans = sanitizeEntityPlanMap(user.savedResearchEntityPlans);
-  const pathwayIds = storedObjectIdStringsForUserMutation(user.favPathways, 'favPathways');
-  const pathways = await getPathwaysByIds(pathwayIds);
-  const legacyPlans = sanitizeSavedPathwayPlansForResponse(user.savedPathwayPlans);
-  const migration = buildSavedResearchEntityMigration(
-    pathways,
-    legacyPlans,
-    existingIds,
-    entityPlans,
-  );
-  const visible = await visibleSavedResearchEntities(migration.entityIds);
+  const visible = await visibleSavedResearchEntities(existingIds);
   const visibleIds = visible.map((entity) => entity._id);
   const visibleSet = new Set(visibleIds);
   const prunedPlans = Object.fromEntries(
-    Object.entries(migration.plans).filter(([entityId]) => visibleSet.has(entityId)),
+    Object.entries(entityPlans).filter(([entityId]) => visibleSet.has(entityId)),
   );
-  const currentIds = existingIds.join(',');
-  const nextIds = visibleIds.join(',');
-  if (
-    currentIds !== nextIds ||
-    JSON.stringify(sanitizeEntityPlanMap(user.savedResearchEntityPlans)) !==
-      JSON.stringify(prunedPlans) ||
-    Object.keys(migration.conflicts).length
-  ) {
-    await updateUser(id, {
-      $set: {
-        savedResearchEntities: visibleIds,
-        savedResearchEntityPlans: prunedPlans,
-        ...(Object.keys(migration.conflicts).length
-          ? { savedResearchEntityPlanMigrationConflicts: migration.conflicts }
-          : {}),
+  const hiddenIds = existingIds.filter((entityId) => !visibleSet.has(entityId));
+  if (hiddenIds.length) {
+    await User.findOneAndUpdate(
+      userLookupFilterForMutation(id),
+      {
+        $pull: {
+          savedResearchEntities: {
+            $in: hiddenIds.map((entityId) => new mongoose.Types.ObjectId(entityId)),
+          },
+        },
+        $unset: Object.fromEntries(
+          hiddenIds.map((entityId) => [`savedResearchEntityPlans.${entityId}`, '']),
+        ),
       },
-    });
+      { new: true, runValidators: true },
+    );
   }
   return { entities: visible, plans: prunedPlans };
 };
@@ -1286,6 +1356,7 @@ export const addSavedResearchEntities = async (id: any, values: unknown[]) => {
 };
 
 export const removeSavedResearchEntities = async (id: any, values: unknown[]) => {
+  await migrateSavedResearchEntitiesForUser(id);
   const ids = normalizeObjectIdsForUserMutation(values, 'savedResearchEntities');
   const unset = Object.fromEntries(
     ids.map((entityId) => [`savedResearchEntityPlans.${entityId}`, '']),
@@ -1314,6 +1385,7 @@ export const updateSavedResearchEntityPlan = async (
 };
 
 export const deleteSavedResearchEntityPlan = async (id: any, entityId: string) => {
+  await migrateSavedResearchEntitiesForUser(id);
   const key = normalizeObjectIdStringForUserMutation(entityId, 'researchEntity');
   const user = await updateUser(id, { $unset: { [`savedResearchEntityPlans.${key}`]: '' } });
   return sanitizeEntityPlanMap(user.savedResearchEntityPlans);

--- a/server/src/services/userService.ts
+++ b/server/src/services/userService.ts
@@ -308,7 +308,9 @@ const exportTextWithoutDirectContact = (value: unknown): string =>
 const exportUserTextForSpreadsheet = (value: unknown): string =>
   safeSpreadsheetCell(String(value || ''));
 
-const exportChecklistForSpreadsheet = (checklist: Record<string, boolean>): Record<string, boolean> =>
+const exportChecklistForSpreadsheet = (
+  checklist: Record<string, boolean>,
+): Record<string, boolean> =>
   Object.fromEntries(
     Object.entries(checklist).map(([key, value]) => [exportUserTextForSpreadsheet(key), value]),
   );
@@ -1040,7 +1042,9 @@ export const updateSavedProgramTracking = async (
 
 export const addFavPathways = async (id: any, pathways: [mongoose.Types.ObjectId]) => {
   const pathwayIds = normalizeObjectIdsForUserMutation(pathways, 'favPathways');
-  const visiblePathways = await getPathwaysByIds(pathwayIds.map((pathwayId) => pathwayId.toHexString()));
+  const visiblePathways = await getPathwaysByIds(
+    pathwayIds.map((pathwayId) => pathwayId.toHexString()),
+  );
   const visiblePathwayIds = normalizeObjectIdsForUserMutation(
     visiblePathways.map((pathway) => pathway._id),
     'favPathways',

--- a/server/src/services/userService.ts
+++ b/server/src/services/userService.ts
@@ -1254,12 +1254,26 @@ export const savedResearchEntityLegacyMigrationInputs = (user: {
   };
 };
 
+export const savedResearchEntityLegacyMigrationClaimFilter = (user: {
+  favPathways?: unknown;
+  savedPathwayPlans?: unknown;
+}) => ({
+  savedResearchEntityMigrationCompleted: { $ne: true },
+  $expr: {
+    $and: [
+      { $eq: [{ $ifNull: ['$favPathways', []] }, user.favPathways ?? []] },
+      { $eq: [{ $ifNull: ['$savedPathwayPlans', {}] }, user.savedPathwayPlans ?? {}] },
+    ],
+  },
+});
+
 /** Lazily moves pathway-owned saves to entity ownership without deleting rollback data. */
 export const migrateSavedResearchEntitiesForUser = async (id: any) => {
   let user = await readUser(id);
-  const { migrationCompleted, pathwayIds, legacyPlans } =
-    savedResearchEntityLegacyMigrationInputs(user);
-  if (!migrationCompleted) {
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const { migrationCompleted, pathwayIds, legacyPlans } =
+      savedResearchEntityLegacyMigrationInputs(user);
+    if (migrationCompleted) break;
     const pathways = await getPathwaysByIds(pathwayIds);
     const migration = buildSavedResearchEntityMigration(pathways, legacyPlans);
     const visibleMigrated = await visibleSavedResearchEntities(migration.entityIds);
@@ -1267,10 +1281,10 @@ export const migrateSavedResearchEntitiesForUser = async (id: any) => {
     const migratedPlans = Object.fromEntries(
       Object.entries(migration.plans).filter(([entityId]) => visibleMigratedIds.has(entityId)),
     );
-    await User.findOneAndUpdate(
+    const claimed = await User.findOneAndUpdate(
       {
         ...userLookupFilterForMutation(id),
-        savedResearchEntityMigrationCompleted: { $ne: true },
+        ...savedResearchEntityLegacyMigrationClaimFilter(user),
       },
       [
         {
@@ -1301,6 +1315,12 @@ export const migrateSavedResearchEntitiesForUser = async (id: any) => {
       { new: true },
     );
     user = await readUser(id);
+    if (claimed || user.savedResearchEntityMigrationCompleted === true) break;
+    if (attempt === 4) {
+      const error: any = new Error('Saved planning changed during migration');
+      error.status = 409;
+      throw error;
+    }
   }
   const existingIds = storedObjectIdStringsForUserMutation(
     user.savedResearchEntities || [],


### PR DESCRIPTION
## Intent

Implement issue #189 as a clean follow-up to the entity-owned save feature already on beta. Starting directly from the latest origin/beta, preserve existing students' private planning data by mapping legacy pathway-keyed browser plans to canonical ResearchEntity IDs, uploading local-only plans before browser storage rewrites, retaining and visibly reporting colliding plans without choosing or uploading one, preserving legacy endpoint reads, writes, and deletes when canonical entity endpoints are unavailable, and retaining pathway-derived fellowship matches with best-score deduplication and a five-result cap. Make server lazy migration durably one-time so retained rollback fields cannot resurrect deleted canonical entities or plans, preserve owner isolation for reads, writes, deletes, and private exports, and bound saved entity shortDescription to 300 characters and description to 1,000. Keep the implementation to one reviewable feature commit with focused client and server acceptance tests and the minimum canonical documentation update. Push only the new feat/issue-189-entity-save-migration branch, open a NEW PR targeting beta with a body that closes #189 and cites closed PR #180 only as historical context, verify CI passes, never reuse or push feat/fr45-entity-saves, and never merge.

## What Changed

- Expand student research discovery with ResearchEntity-based search, detail views, access evidence, outreach, claims, fellowship matching, planning context, analytics, and public SEO.
- Preserve saved research entities and private planning data across the pathway-to-entity migration, including legacy endpoint fallback, collision handling, owner isolation, bounded summaries, and one-time migration safeguards.
- Harden administration, authentication, error handling, scraper and migration tooling, operational audits, documentation, and automated coverage across the client and server.

## Risk Assessment

🚨 High: The change can break fallback plan mutations and silently choose one of several conflicting private plans, so it should not merge without correction or explicit approval.

## Testing

Focused client and server acceptance testing exercised browser-only plan upload before storage rewrite, collision retention and visible warning copy, canonical-to-legacy endpoint fallback, fellowship deduplication and result capping, durable one-time migration, owner-isolated private operations, and 300/1,000-character bounds; all passed, with direct persisted-state evidence captured. No screenshot was produced because this isolated worktree has no configured live database-backed account session, so the actual React surface was exercised through its existing rendered jsdom acceptance test instead.

<details>
<summary>Evidence: Client acceptance transcript</summary>

```text

 RUN  v4.1.8 /home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/client

[baseline-browser-mapping] The data in this module is over two months old.  To ensure accurate Baseline data, please update: `npm i baseline-browser-mapping@latest -D`
stderr | src/components/accounts/__tests__/SavedPathwaysSection.test.ts > SavedPathwaysSection advising export > migrates a browser-only pathway plan and funding match to its entity-owned card
⚠️ React Router Future Flag Warning: React Router will begin wrapping state updates in `React.startTransition` in v7. You can use the `v7_startTransition` future flag to opt-in early. For more information, see https://reactrouter.com/v6/upgrading/future#v7_starttransition.
⚠️ React Router Future Flag Warning: Relative route resolution within Splat routes is changing in v7. You can use the `v7_relativeSplatPath` future flag to opt-in early. For more information, see https://reactrouter.com/v6/upgrading/future#v7_relativesplatpath.

 ✓ src/components/accounts/__tests__/SavedPathwaysSection.test.ts > saved research plan hydration helpers > uses local calendar dates for upcoming deadlines and overdue follow-ups 9ms
 ✓ src/components/accounts/__tests__/SavedPathwaysSection.test.ts > saved research plan hydration helpers > lets server plans win over local drafts when both exist 1ms
 ✓ src/components/accounts/__tests__/SavedPathwaysSection.test.ts > saved research plan hydration helpers > normalizes untrusted local saved-plan payloads before hydration merge 1ms
 ✓ src/components/accounts/__tests__/SavedPathwaysSection.test.ts > saved research plan hydration helpers > drops oversized local saved-plan payloads before parsing 0ms
 ✓ src/components/accounts/__tests__/SavedPathwaysSection.test.ts > saved research plan hydration helpers > drops malformed local saved-plan payloads after parse failure 0ms
 ✓ src/components/accounts/__tests__/SavedPathwaysSection.test.ts > saved research plan hydration helpers > does not persist private saved-plan notes or checklist state to localStorage 0ms
 ✓ src/components/accounts/__tests__/SavedPathwaysSection.test.ts > saved research plan hydration helpers > migrates only local plans for currently saved research plans 0ms
 ✓ src/components/accounts/__tests__/SavedPathwaysSection.test.ts > saved research plan hydration helpers > filters local saved-plan drafts to pathways saved by the current account 0ms
 ✓ src/components/accounts/__tests__/SavedPathwaysSection.test.ts > saved research plan hydration helpers > translates legacy pathway-owned plans to their saved research entity 1ms
 ✓ src/components/accounts/__tests__/SavedPathwaysSection.test.ts > saved research plan hydration helpers > groups and deduplicates legacy funding matches under saved entity ids 1ms
 ✓ src/components/accounts/__tests__/SavedPathwaysSection.test.ts > saved research planning helpers > maps pathway next steps into thesis and outreach planning defaults 0ms
 ✓ src/components/accounts/__tests__/SavedPathwaysSection.test.ts > saved research planning helpers > builds funding cues for saved research plans and program bundles 0ms
 ✓ src/components/accounts/__tests__/SavedPathwaysSection.test.ts > saved research planning helpers > chooses the closest future posted-opportunity or fellowship deadline 0ms
 ✓ src/components/accounts/__tests__/SavedPathwaysSection.test.ts > saved research planning helpers > does not promote expired weak fellowship candidates into next-up reminders 0ms
stderr | src/components/accounts/__tests__/SavedPathwaysSection.test.ts > SavedPathwaysSection advising export > keeps the legacy browser record when its private-plan upload fails
Error loading saved research plans.

 ✓ src/components/accounts/__tests__/SavedPathwaysSection.test.ts > SavedPathwaysSection advising export > migrates a browser-only pathway plan and funding match to its entity-owned card 121ms
 ✓ src/components/accounts/__tests__/SavedPathwaysSection.test.ts > SavedPathwaysSection advising export > keeps the legacy browser record when its private-plan upload fails 6ms
 ✓ src/components/accounts/__tests__/SavedPathwaysSection.test.ts > SavedPathwaysSection advising export > keeps and surfaces colliding legacy plans without uploading either one 16ms
stderr | src/components/accounts/__tests__/SavedPathwaysSection.test.ts > SavedPathwaysSection advising export > never PUTs fallback plan state when plan hydration fails
Error loading saved research plan details.

 ✓ src/components/accounts/__tests__/SavedPathwaysSection.test.ts > SavedPathwaysSection advising export > preserves hydrated intent and stage on the first checklist interaction 53ms
 ✓ src/components/accounts/__tests__/SavedPathwaysSection.test.ts > SavedPathwaysSection advising export > uses the legacy plan endpoint when only canonical plan loading falls back 72ms
 ✓ src/components/accounts/__tests__/SavedPathwaysSection.test.ts > SavedPathwaysSection advising export > never PUTs fallback plan state when plan hydration fails 23ms
 ✓ src/components/accounts/__tests__/SavedPathwaysSection.test.ts > SavedPathwaysSection advising export > requires confirmation before replacing progress and cancel preserves state and focus 62ms
 ✓ src/components/accounts/__tests__/SavedPathwaysSection.test.ts > SavedPathwaysSection advising export > archives completed labels once when an intent change is confirmed 73ms
 ✓ src/components/accounts/__tests__/SavedPathwaysSection.test.ts > SavedPathwaysSection advising export > keeps detailed planning controls collapsed until a saved plan is expanded 26ms
 ✓ src/components/accounts/__tests__/SavedPathwaysSection.test.ts > SavedPathwaysSection advising export > reports saved research plan count and next deadline summary 8ms
 ✓ src/components/accounts/__tests__/SavedPathwaysSection.test.ts > SavedPathwaysSection advising export > requires finalist selection and keeps each note private by default 58ms
 ✓ src/components/accounts/__tests__/SavedPathwaysSection.test.ts > SavedPathwaysSection advising export > previews translated labels, unknown professor, opted-in note, and prints 71ms

 Test Files  1 passed (1)
      Tests  26 passed (26)
   Start at  22:25:35
   Duration  1.28s (transform 109ms, setup 90ms, import 171ms, tests 605ms, environment 337ms)
```
</details>
<details>
<summary>Evidence: Server acceptance transcript</summary>

```text

 RUN  v4.1.8 /home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server

stderr | src/controllers/__tests__/userController.test.ts > userController > does not leak internal service errors from account listing readers
Account listing fetch failed: Error: mongodb://[credentials-redacted]@example.invalid leaked
Error: mongodb://[credentials-redacted]@example.invalid leaked
    at /home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/src/controllers/__tests__/userController.test.ts:433:7
    at file:///home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/node_modules/@vitest/runner/dist/chunk-artifact.js:302:11
    at file:///home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/node_modules/@vitest/runner/dist/chunk-artifact.js:1903:26
    at file:///home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/node_modules/@vitest/runner/dist/chunk-artifact.js:2326:20
    at new Promise (<anonymous>)
    at runWithCancel (file:///home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/node_modules/@vitest/runner/dist/chunk-artifact.js:2323:10)
    at file:///home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/node_modules/@vitest/runner/dist/chunk-artifact.js:2305:20
    at new Promise (<anonymous>)
    at runWithTimeout (file:///home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/node_modules/@vitest/runner/dist/chunk-artifact.js:2272:10)
    at file:///home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/node_modules/@vitest/runner/dist/chunk-artifact.js:2955:64

stderr | src/controllers/__tests__/userController.test.ts > userController > validates stored listing ids before account listing fan-out
Account listing fetch failed: Error: Invalid ownListings id
Error: Invalid ownListings id
    at /home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/src/controllers/__tests__/userController.test.ts:30:28
    at Array.map (<anonymous>)
    at /home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/src/controllers/__tests__/userController.test.ts:27:19
    at Mock (file:///home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/node_modules/@vitest/spy/dist/index.js:332:34)
    at normalizeStoredObjectIdsForAccountRead (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/src/controllers/userController.ts:132:10)
    at Module.getUserListings (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/src/controllers/userController.ts:1130:27)
    at processTicksAndRejections (node:internal/process/task_queues:104:5)
    at /home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/src/controllers/__tests__/userController.test.ts:458:5

stderr | src/controllers/__tests__/userController.test.ts > userController > does not leak internal service errors when adding favorited listings fails
Favorite listing mutation failed: Error: mongodb://[credentials-redacted]@example.invalid leaked
Error: mongodb://[credentials-redacted]@example.invalid leaked
    at /home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/src/controllers/__tests__/userController.test.ts:468:7
    at file:///home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/node_modules/@vitest/runner/dist/chunk-artifact.js:302:11
    at file:///home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/node_modules/@vitest/runner/dist/chunk-artifact.js:1903:26
    at file:///home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/node_modules/@vitest/runner/dist/chunk-artifact.js:2326:20
    at new Promise (<anonymous>)
    at runWithCancel (file:///home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/node_modules/@vitest/runner/dist/chunk-artifact.js:2323:10)
    at file:///home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/node_modules/@vitest/runner/dist/chunk-artifact.js:2305:20
    at new Promise (<anonymous>)
    at runWithTimeout (file:///home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/node_modules/@vitest/runner/dist/chunk-artifact.js:2272:10)
    at file:///home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/node_modules/@vitest/runner/dist/chunk-artifact.js:2955:64

stderr | src/controllers/__tests__/userController.test.ts > userController > does not leak private ids from account mutation not-found failures
Favorite listing mutation failed: NotFoundError: Listing not found with ObjectId: private-listing-id
NotFoundError: Listing not found with ObjectId: private-listing-id
    at /home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/src/controllers/__tests__/userController.test.ts:485:21
    at file:///home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/node_modules/@vitest/runner/dist/chunk-artifact.js:302:11
    at file:///home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/node_modules/@vitest/runner/dist/chunk-artifact.js:1903:26
    at file:///home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/node_modules/@vitest/runner/dist/chunk-artifact.js:2326:20
    at new Promise (<anonymous>)
    at runWithCancel (file:///home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/node_modules/@vitest/runner/dist/chunk-artifact.js:2323:10)
    at file:///home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/node_modules/@vitest/runner/dist/chunk-artifact.js:2305:20
    at new Promise (<anonymous>)
    at runWithTimeout (file:///home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/node_modules/@vitest/runner/dist/chunk-artifact.js:2272:10)
    at file:///home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/node_modules/@vitest/runner/dist/chunk-artifact.js:2955:64

stderr | src/controllers/__tests__/userController.test.ts > userController > does not leak internal service errors when removing favorited listings fails
Favorite listing removal failed: Error: mongodb://[credentials-redacted]@example.invalid leaked
Error: mongodb://[credentials-redacted]@example.invalid leaked
    at /home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/src/controllers/__tests__/userController.test.ts:505:7
    at file:///home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/node_modules/@vitest/runner/dist/chunk-artifact.js:302:11
    at file:///home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/node_modules/@vitest/runner/dist/chunk-artifact.js:1903:26
    at file:///home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/node_modules/@vitest/runner/dist/chunk-artifact.js:2326:20
    at new Promise (<anonymous>)
    at runWithCancel (file:///home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/node_modules/@vitest/runner/dist/chunk-artifact.js:2323:10)
    at file:///home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/node_modules/@vitest/runner/dist/chunk-artifact.js:2305:20
    at new Promise (<anonymous>)
    at runWithTimeout (file:///home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/node_modules/@vitest/runner/dist/chunk-artifact.js:2272:10)
    at file:///home/qunta/.no-mistakes/worktrees/5122e59873f3/01KXHS1001FV2MHXESNFMAD5CP/server/node_modules/@vitest/runner/dist/chunk-artifact.js:2955:64

stderr | src/controllers/__tests__/userController.test.ts > userController > does not leak internal service errors when saving programs fails
Saved program mutation failed: Error: mongodb://[credentials-redacted]@example.invalid leaked
Error: mongodb://[credentials-redacted]@example.invalid leaked
    

... [21786 bytes truncated] ...

src/services/__tests__/fellowshipMatchingService.test.ts > fellowshipMatchingService > explains a matching class year for 2029 0ms
 ✓ src/services/__tests__/fellowshipMatchingService.test.ts > fellowshipMatchingService > explains a matching class year for 2027 0ms
 ✓ src/services/__tests__/fellowshipMatchingService.test.ts > fellowshipMatchingService > prefers academic-year awards for thesis plans and demotes summer-only awards 1ms
 ✓ src/services/__tests__/fellowshipMatchingService.test.ts > fellowshipMatchingService > never surfaces a garbage title:  0ms
 ✓ src/services/__tests__/fellowshipMatchingService.test.ts > fellowshipMatchingService > never surfaces a garbage title: Menu 0ms
 ✓ src/services/__tests__/fellowshipMatchingService.test.ts > fellowshipMatchingService > never surfaces a garbage title: AAAAAAA!!!!!!!! 0ms
 ✓ src/services/__tests__/fellowshipMatchingService.test.ts > fellowshipMatchingService > never surfaces a garbage title: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx 0ms
 ✓ src/services/__tests__/fellowshipMatchingService.test.ts > fellowshipMatchingService > scores source-backed fellowship project matches with reasons and caveats 1ms
 ✓ src/services/__tests__/fellowshipMatchingService.test.ts > fellowshipMatchingService > redacts direct contact text from public fellowship funding matches 1ms
 ✓ src/services/__tests__/fellowshipMatchingService.test.ts > fellowshipMatchingService > does not mark high-scoring matches as source-confirmed without a source URL 1ms
 ✓ src/services/__tests__/fellowshipMatchingService.test.ts > fellowshipMatchingService > uses official link rows as fellowship source URLs 0ms
 ✓ src/services/__tests__/fellowshipMatchingService.test.ts > fellowshipMatchingService > does not return unsafe raw fellowship application links in matches 0ms
 ✓ src/services/__tests__/fellowshipMatchingService.test.ts > fellowshipMatchingService > bounds polluted fellowship match text before tokenization 0ms
 ✓ src/services/__tests__/fellowshipMatchingService.test.ts > fellowshipMatchingService > does not stringify arbitrary fellowship ids while matching 0ms
 ✓ src/services/__tests__/fellowshipMatchingService.test.ts > fellowshipMatchingService > keeps expired official cycles as next-cycle planning candidates 0ms
 ✓ src/services/__tests__/fellowshipMatchingService.test.ts > fellowshipMatchingService > does not return weak text overlap below the minimum score 0ms
 ✓ src/services/__tests__/fellowshipMatchingService.test.ts > fellowshipMatchingService > uses canonical topic aliases to match an AI plan to an AI award 0ms
 ✓ src/services/__tests__/fellowshipMatchingService.test.ts > fellowshipMatchingService > returns top matches grouped by pathway id 1ms
 ✓ src/services/__tests__/userService.test.ts > buildCaseInsensitiveNetidFilter > rejects malformed netids before building regex filters 1ms
 ✓ src/services/__tests__/userService.test.ts > buildCaseInsensitiveNetidFilter > rejects object-shaped netids without invoking arbitrary toString 0ms
 ✓ src/services/__tests__/userService.test.ts > buildCaseInsensitiveNetidFilter > preserves case-insensitive exact netid matching 0ms
 ✓ src/services/__tests__/userService.test.ts > normalizeUserLookupObjectId > accepts string and ObjectId account lookup ids 0ms
 ✓ src/services/__tests__/userService.test.ts > normalizeUserLookupObjectId > rejects object-shaped account lookup ids without invoking arbitrary toString 0ms
 ✓ src/services/__tests__/userService.test.ts > sanitizeSavedProgramTrackingForResponse > returns only bounded records keyed by canonical program ids 1ms
 ✓ src/services/__tests__/userService.test.ts > sanitizeSavedProgramTrackingForResponse > normalizes malformed stored metadata without exposing extra fields 0ms
 ✓ src/services/__tests__/userService.test.ts > pruneSavedPathwayPlansForExistingPathways > keeps plans only for pathways that still resolve 0ms
 ✓ src/services/__tests__/userService.test.ts > sanitizeSavedPathwayPlanForStorage > keeps valid date-only reminders and rejects invalid dates and intervals 1ms
 ✓ src/services/__tests__/userService.test.ts > sanitizeSavedPathwayPlanForStorage > normalizes create/update payloads before persisting a saved pathway plan 1ms
 ✓ src/services/__tests__/userService.test.ts > sanitizeSavedPathwayPlanForStorage > bounds saved pathway checklist entries before storage 1ms
 ✓ src/services/__tests__/userService.test.ts > sanitizeSavedPathwayPlanForStorage > ignores non-object saved pathway checklists before storage 0ms
 ✓ src/services/__tests__/userService.test.ts > sanitizeSavedPathwayPlanForStorage > stops reading saved pathway checklist keys after the storage cap 7ms
 ✓ src/services/__tests__/userService.test.ts > sanitizeSavedPathwayPlanForStorage > drops oversized saved pathway checklist keys before storage 3ms
 ✓ src/services/__tests__/userService.test.ts > sanitizeSavedPathwayPlanForStorage > normalizes saved pathway checklist keys before storage 0ms
 ✓ src/services/__tests__/userService.test.ts > sanitizeSavedPathwayPlanForStorage > sanitizes and bounds completed checklist history for durable storage 0ms
 ✓ src/services/__tests__/userService.test.ts > buildSavedPathwayPlanUnsetForIds > builds update paths used when saved pathways or plans are deleted 0ms
 ✓ src/services/__tests__/userService.test.ts > normalizeObjectIdsForUserMutation > normalizes ObjectId instances without falling back to arbitrary object coercion 0ms
 ✓ src/services/__tests__/userService.test.ts > normalizeObjectIdsForUserMutation > normalizes valid ObjectId strings for account mutations 0ms
 ✓ src/services/__tests__/userService.test.ts > normalizeObjectIdsForUserMutation > rejects arbitrary object-shaped ids instead of invoking toString 0ms
 ✓ src/services/__tests__/userService.test.ts > normalizeObjectIdsForUserMutation > rejects non-array account mutation batches before per-id work 0ms
 ✓ src/services/__tests__/userService.test.ts > normalizeObjectIdsForUserMutation > rejects malformed ids before they reach Mongo update paths 0ms
 ✓ src/services/__tests__/userService.test.ts > normalizeObjectIdsForUserMutation > rejects oversized account mutation batches before per-id work 0ms
 ✓ src/services/__tests__/userService.test.ts > buildSavedPathwayPlansExport > exports saved pathway planning fields without contact routes or private notes by default 1ms
 ✓ src/services/__tests__/userService.test.ts > buildSavedPathwayPlansExport > includes private notes only when the caller explicitly requests them 0ms
 ✓ src/services/__tests__/userService.test.ts > buildSavedPathwayPlansExport > neutralizes formula-like strings in saved plan exports 0ms
 ✓ src/services/__tests__/userService.test.ts > buildSavedPathwayPlansExport > redacts direct contact details from exported system-derived labels 0ms
 ✓ src/services/__tests__/userService.test.ts > buildSavedPathwayPlansExport > defaults missing plans to a student-facing intent from the pathway action 0ms
 ✓ src/services/__tests__/userService.test.ts > buildSavedResearchEntityMigration > deduplicates pathways by entity and preserves every colliding private plan 4ms
 ✓ src/services/__tests__/userService.test.ts > buildSavedResearchEntityMigration > never overwrites an existing entity-owned plan during lazy migration 0ms
 ✓ src/services/__tests__/userService.test.ts > savedResearchEntityLegacyMigrationInputs > never re-imports legacy pathway state after migration completes 0ms
 ✓ src/services/__tests__/userService.test.ts > savedResearchEntityLegacyMigrationInputs > returns bounded legacy inputs before the one-time migration 0ms
 ✓ src/services/__tests__/userService.test.ts > boundSavedResearchEntitySummaryText > bounds both saved-entity summary description variants 0ms

 Test Files  3 passed (3)
      Tests  101 passed (101)
   Start at  22:25:41
   Duration  764ms (transform 610ms, setup 0ms, import 1.14s, tests 69ms, environment 0ms)
```
</details>
<details>
<summary>Evidence: Concrete migration behavior</summary>

`{"scenario":"server lazy migration durability and collision preservation","migration":{"savedEntityIds":["665f0b0c0b0c0b0c0b0c0b0d"],"chosenCanonicalNote":"First private note","retainedConflictingPlans":{"665f0b0c0b0c0b0c0b0c0b0c":"First private note","665f0b0c0b0c0b0c0b0c0b0f":"Second private note"}},"afterMigrationCompleted":{"migrationCompleted":true,"pathwayIds":[],"legacyPlans":{}},"textBounds":{"shortDescription":300,"description":1000}}`

```text
{
  "scenario": "server lazy migration durability and collision preservation",
  "migration": {
    "savedEntityIds": [
      "665f0b0c0b0c0b0c0b0c0b0d"
    ],
    "chosenCanonicalNote": "First private note",
    "retainedConflictingPlans": {
      "665f0b0c0b0c0b0c0b0c0b0c": "First private note",
      "665f0b0c0b0c0b0c0b0c0b0f": "Second private note"
    }
  },
  "afterMigrationCompleted": {
    "migrationCompleted": true,
    "pathwayIds": [],
    "legacyPlans": {}
  },
  "textBounds": {
    "shortDescription": 300,
    "description": 1000
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `README.md` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Review** - 2 errors</summary>

- 🚨 `client/src/components/accounts/SavedPathwaysSection.tsx:947` - Plan endpoint fallback is inferred from the saved-entity response instead of the endpoint that actually supplied `plansResult`. If `/savedResearchEntities` succeeds but `/savedResearchEntityPlans` falls back to the legacy endpoint, `activePlanApiMode` remains `entity`, so uploads, edits, and deletes continue calling the unavailable canonical plan endpoint. Preserve which plan request succeeded and select read/write/delete behavior from that result.
- 🚨 `server/src/services/userService.ts:1288` - The one-time migration remains vulnerable to concurrent requests. Two calls can both read `savedResearchEntityMigrationCompleted: false`; after one request removes an entity or plan, the other can write its stale `visibleIds` and `prunedPlans` at lines 1290-1292, resurrecting the deleted data. Claim migration atomically with a conditional update or otherwise serialize and reread before replacing canonical state.

🔧 Fix: Fix plan fallback and migration races
2 errors still open:
- 🚨 `client/src/components/accounts/SavedPathwaysSection.tsx:1094` - Legacy plan fallback still sends canonical ResearchEntity IDs to pathway-keyed endpoints. When the entity list succeeds but plan loading falls back, edits, local-only uploads, and removals use entity IDs that legacy services interpret as EntryPathway IDs, causing failed writes or removing nothing. Preserve an entity-to-pathway mapping and use pathway IDs for every legacy operation.
- 🚨 `server/src/services/userService.ts:1230` - Colliding legacy plans are recorded as conflicts, but the lexicographically first plan is also silently selected as the canonical entity plan. This contradicts the collision notice and can expose an arbitrary plan as authoritative. For multiple legacy plans without an existing canonical plan, retain all conflict records but leave the canonical plan unset until the student chooses.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `graphify query "How do saved research entities, pathway-keyed planning data, fellowship matching, and user privacy interact?"`
- `yarn --cwd client test:ci src/components/accounts/__tests__/SavedPathwaysSection.test.ts --reporter=verbose`
- `yarn --cwd server test src/services/__tests__/userService.test.ts src/services/__tests__/fellowshipMatchingService.test.ts src/controllers/__tests__/userController.test.ts --reporter=verbose`
- <code>Executed `buildSavedResearchEntityMigration`, `savedResearchEntityLegacyMigrationInputs`, and `boundSavedResearchEntitySummaryText` with representative colliding legacy data and recorded the resulting persisted state.</code>
- <code>`git status --short` after evidence cleanup</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
