### PR TITLE
fix: consolidate principal investigator details

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -151,7 +151,9 @@ This rebuilds local Research and Pathways indexes from MongoDB. Use `--strategy=
 
 When a `/research` browse has no search query, results are ordered "best first" by a precomputed `browseRankScore` (completeness of the profile plus strength-weighted undergraduate access signals), falling back to recency. After importing or migrating data, populate the score with `yarn --cwd server research-homes:backfill-browse-rank --apply --confirm-browse-rank` (it runs in dry-run by default); ongoing scrape/materialize runs keep it fresh automatically.
 
-Organizational research homes (centers, institutes, initiatives, core facilities) have no single PI, so their scraped rosters list everyone as core faculty and the public "Principal Investigator" panel shows nothing. The `center-director-llm` scraper reads each home's official site and leadership pages, extracts the single named **director**, and the materializer resolves that name to a Yale user before promoting them to a director (lead) member. New scrape/materialize runs apply this automatically; to fill in the existing corpus run `yarn --cwd server research-homes:backfill-center-directors --apply --confirm-center-directors --limit <n>` (dry-run by default, lists eligible homes without calling the LLM; apply needs `OPENAI_API_KEY`).
+Organizational research homes (centers, institutes, initiatives, core facilities) have no single PI, so their scraped rosters list everyone as core faculty and the public leadership display has no lead to show.
+The `center-director-llm` scraper reads each home's official site and leadership pages, extracts the single named **director**, and the materializer resolves that name to a Yale user before promoting them to a director (lead) member.
+New scrape/materialize runs apply this automatically; to fill in the existing corpus run `yarn --cwd server research-homes:backfill-center-directors --apply --confirm-center-directors --limit <n>` (dry-run by default, lists eligible homes without calling the LLM; apply needs `OPENAI_API_KEY`).
 
 ### 6. Start dev servers
 

--- a/client/src/components/labs/LabMembersList.tsx
+++ b/client/src/components/labs/LabMembersList.tsx
@@ -9,6 +9,7 @@ import { EXTERNAL_IMAGE_REFERRER_POLICY, safeHttpUrl } from '../../utils/url';
 
 interface LabMembersListProps {
   members: LabMember[];
+  singleColumn?: boolean;
 }
 
 const ROLE_LABELS: Record<LabMemberRole, string> = {
@@ -42,7 +43,7 @@ const ROLE_ORDER: Record<LabMemberRole, number> = {
   alumni: 6,
 };
 
-const LabMembersList = ({ members }: LabMembersListProps) => {
+const LabMembersList = ({ members, singleColumn = false }: LabMembersListProps) => {
   if (!members || members.length === 0) {
     return (
       <div className="rounded-md border border-dashed border-[var(--yr-line)] bg-[var(--yr-panel)] px-4 py-6 text-center">
@@ -74,7 +75,9 @@ const LabMembersList = ({ members }: LabMembersListProps) => {
     .sort((a, b) => (ROLE_ORDER[a.role] ?? 99) - (ROLE_ORDER[b.role] ?? 99));
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+    <div
+      className={`grid grid-cols-1 gap-4 ${singleColumn ? '' : 'sm:grid-cols-2 lg:grid-cols-3'}`}
+    >
       {sorted.map(({ user, role }) => {
         const fullName = user.displayName || `${user.fname} ${user.lname}`.trim();
         const initials = `${user.fname?.charAt(0) || ''}${
@@ -89,29 +92,39 @@ const LabMembersList = ({ members }: LabMembersListProps) => {
                   src={profileImageHref}
                   alt={fullName}
                   referrerPolicy={EXTERNAL_IMAGE_REFERRER_POLICY}
-                  className="w-14 h-14 rounded-full object-cover"
+                  className={`${singleColumn ? 'h-11 w-11' : 'h-14 w-14'} rounded-full object-cover`}
                 />
               ) : (
-                <div className="w-14 h-14 rounded-full bg-gradient-to-br from-blue-100 to-blue-200 flex items-center justify-center text-blue-700 font-semibold">
+                <div
+                  className={`${singleColumn ? 'h-11 w-11 text-sm' : 'h-14 w-14'} flex items-center justify-center rounded-full bg-gradient-to-br from-blue-100 to-blue-200 font-semibold text-blue-700`}
+                >
                   {initials || fullName.charAt(0).toUpperCase() || '?'}
                 </div>
               )}
             </div>
             <div className="min-w-0 flex-1">
-              <p className="truncate text-sm font-semibold text-gray-900">
+              <p
+                className={`${singleColumn ? 'text-xs leading-snug' : 'truncate text-sm'} font-semibold text-gray-900`}
+              >
                 {fullName}
               </p>
               {user.title && (
-                <p className="text-xs text-gray-500 truncate">{user.title}</p>
+                <p
+                  className={`${singleColumn ? 'text-[11px] leading-snug' : 'truncate text-xs'} text-gray-500`}
+                >
+                  {user.title}
+                </p>
               )}
-              <div className="flex flex-wrap items-center gap-1.5 mt-1.5">
+              <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
                 <span
-                  className={`text-[10px] px-1.5 py-0.5 rounded-full font-medium ${ROLE_PILL_CLASSES[role]}`}
+                  className={`${singleColumn ? 'text-[9px]' : 'text-[10px]'} rounded-full px-1.5 py-0.5 font-medium ${ROLE_PILL_CLASSES[role]}`}
                 >
                   {ROLE_LABELS[role]}
                 </span>
                 {user.primary_department && (
-                  <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-[var(--yr-panel-muted)] text-gray-500 truncate max-w-[10rem]">
+                  <span
+                    className={`${singleColumn ? 'max-w-full whitespace-normal text-[9px] leading-snug' : 'max-w-[10rem] truncate text-[10px]'} rounded-full bg-[var(--yr-panel-muted)] px-1.5 py-0.5 text-gray-500`}
+                  >
                     {user.primary_department}
                   </span>
                 )}
@@ -120,7 +133,7 @@ const LabMembersList = ({ members }: LabMembersListProps) => {
           </>
         );
         const className =
-          'flex items-center gap-3 p-3 rounded-lg border border-[var(--yr-line)] bg-[var(--yr-panel)] transition';
+          `flex items-center rounded-lg border border-[var(--yr-line)] bg-[var(--yr-panel)] p-3 transition ${singleColumn ? 'gap-2' : 'gap-3'}`;
         const key = `${user.publicKey || fullName}-${role}`;
         // Lead-investigator cards are intentionally non-interactive: the
         // professor's official profile is reached via the decision-summary

--- a/client/src/components/labs/LabMembersList.tsx
+++ b/client/src/components/labs/LabMembersList.tsx
@@ -132,8 +132,7 @@ const LabMembersList = ({ members, singleColumn = false }: LabMembersListProps) 
             </div>
           </>
         );
-        const className =
-          `flex items-center rounded-lg border border-[var(--yr-line)] bg-[var(--yr-panel)] p-3 transition ${singleColumn ? 'gap-2' : 'gap-3'}`;
+        const className = `flex items-center rounded-lg border border-[var(--yr-line)] bg-[var(--yr-panel)] p-3 transition ${singleColumn ? 'gap-2' : 'gap-3'}`;
         const key = `${user.publicKey || fullName}-${role}`;
         // Lead-investigator cards are intentionally non-interactive: the
         // professor's official profile is reached via the decision-summary

--- a/client/src/pages/__tests__/labDetail.test.tsx
+++ b/client/src/pages/__tests__/labDetail.test.tsx
@@ -105,7 +105,9 @@ describe('LabDetail page', () => {
     await screen.findByText(DEFAULT_ENTITY_NAME);
 
     expect(
-      screen.getByText('Review the official profile first, then decide whether targeted outreach is appropriate.'),
+      screen.getByText(
+        'Review the official profile first, then decide whether targeted outreach is appropriate.',
+      ),
     ).toBeTruthy();
     expect(screen.getByRole('link', { name: 'Open official profile' }).getAttribute('href')).toBe(
       OFFICIAL_PROFILE_URL,
@@ -294,7 +296,9 @@ describe('LabDetail page', () => {
     await screen.findByText(DEFAULT_ENTITY_NAME);
 
     expect(
-      screen.getByText('Studies specific mechanisms of neurological disease in source-backed terms.'),
+      screen.getByText(
+        'Studies specific mechanisms of neurological disease in source-backed terms.',
+      ),
     ).toBeTruthy();
     expect(screen.getByText('Plan careful exploratory outreach.')).toBeTruthy();
     expect(
@@ -303,9 +307,15 @@ describe('LabDetail page', () => {
       ),
     ).toBeTruthy();
     expect(screen.getByText('Why')).toBeTruthy();
-    expect(screen.getByText('The access evidence points to an official profile route.')).toBeTruthy();
+    expect(
+      screen.getByText('The access evidence points to an official profile route.'),
+    ).toBeTruthy();
     expect(screen.getByText('What this page is')).toBeTruthy();
-    expect(screen.getByText('This page summarizes the research context and entry points, not a posted opening.')).toBeTruthy();
+    expect(
+      screen.getByText(
+        'This page summarizes the research context and entry points, not a posted opening.',
+      ),
+    ).toBeTruthy();
     expect(container.textContent?.indexOf('Studies specific mechanisms')).toBeLessThan(
       container.textContent?.indexOf('Plan careful exploratory outreach.'),
     );
@@ -353,8 +363,7 @@ describe('LabDetail page', () => {
   });
 
   it('keeps multiple PI cards together in a dedicated pluralized section', async () => {
-    const secondInvestigatorProfileUrl =
-      'https://medicine.yale.edu/profile/second-investigator/';
+    const secondInvestigatorProfileUrl = 'https://medicine.yale.edu/profile/second-investigator/';
     renderLabDetail({
       ...basePayload,
       group: {
@@ -577,7 +586,9 @@ describe('LabDetail page', () => {
 
     expect(screen.getByText('jordan.researcher@yale.edu')).toBeTruthy();
     expect(
-      screen.getByText(`Inquiry from a Yale undergraduate about research in ${DEFAULT_ENTITY_NAME}`),
+      screen.getByText(
+        `Inquiry from a Yale undergraduate about research in ${DEFAULT_ENTITY_NAME}`,
+      ),
     ).toBeTruthy();
   });
 
@@ -627,7 +638,9 @@ describe('LabDetail page', () => {
 
     await screen.findByText(DEFAULT_ENTITY_NAME);
 
-    expect(screen.getAllByText('Contact the program manager through the listed route.')).toHaveLength(1);
+    expect(
+      screen.getAllByText('Contact the program manager through the listed route.'),
+    ).toHaveLength(1);
     expect(screen.getByRole('link', { name: 'Open official route' }).getAttribute('href')).toBe(
       OFFICIAL_ROUTE_URL,
     );
@@ -644,11 +657,7 @@ describe('LabDetail page', () => {
         slug: 'example-field-lab',
         name: 'Example Field Lab',
         websiteUrl: RESEARCH_WEBSITE_URL,
-        sourceUrls: [
-          FACULTY_ROSTER_URL,
-          FACULTY_AFFILIATED_PROFILE_URL,
-          RESEARCH_WEBSITE_URL,
-        ],
+        sourceUrls: [FACULTY_ROSTER_URL, FACULTY_AFFILIATED_PROFILE_URL, RESEARCH_WEBSITE_URL],
       },
       entryPathways: [
         {
@@ -659,10 +668,7 @@ describe('LabDetail page', () => {
           studentFacingLabel: 'Explore the PI profile',
           explanation: 'An official Yale faculty profile is available.',
           bestNextStep: 'Review the PI profile and lab site first.',
-          sourceUrls: [
-            FACULTY_AFFILIATED_PROFILE_URL,
-            RESEARCH_WEBSITE_URL,
-          ],
+          sourceUrls: [FACULTY_AFFILIATED_PROFILE_URL, RESEARCH_WEBSITE_URL],
         },
       ],
       contactRoutes: [
@@ -705,11 +711,7 @@ describe('LabDetail page', () => {
         kind: 'lab',
         entityType: 'LAB',
         websiteUrl: RESEARCH_WEBSITE_URL,
-        sourceUrls: [
-          FACULTY_ROSTER_URL,
-          FACULTY_PROFILE_URL,
-          RESEARCH_WEBSITE_URL,
-        ],
+        sourceUrls: [FACULTY_ROSTER_URL, FACULTY_PROFILE_URL, RESEARCH_WEBSITE_URL],
       },
       contactRoutes: [
         {
@@ -833,10 +835,7 @@ describe('LabDetail page', () => {
         entityType: 'LAB',
         websiteUrl: RESEARCH_WEBSITE_URL,
         shortDescription: 'Co-Director of Graduate Studies',
-        sourceUrls: [
-          FACULTY_PROFILE_URL,
-          RESEARCH_WEBSITE_URL,
-        ],
+        sourceUrls: [FACULTY_PROFILE_URL, RESEARCH_WEBSITE_URL],
         departments: ['Statistics & Data Science'],
         researchAreas: ['Mathematical Statistics', 'Machine Learning'],
       },
@@ -850,10 +849,7 @@ describe('LabDetail page', () => {
           explanation: 'An official Yale faculty profile is available.',
           bestNextStep:
             'Review the PI profile and lab site first, then decide whether targeted exploratory outreach is appropriate.',
-          sourceUrls: [
-            FACULTY_PROFILE_URL,
-            RESEARCH_WEBSITE_URL,
-          ],
+          sourceUrls: [FACULTY_PROFILE_URL, RESEARCH_WEBSITE_URL],
         },
       ],
       contactRoutes: [
@@ -902,10 +898,7 @@ describe('LabDetail page', () => {
         kind: 'lab',
         entityType: 'LAB',
         websiteUrl: RESEARCH_WEBSITE_URL,
-        sourceUrls: [
-          FACULTY_PROFILE_URL,
-          RESEARCH_WEBSITE_URL,
-        ],
+        sourceUrls: [FACULTY_PROFILE_URL, RESEARCH_WEBSITE_URL],
         departments: ['Psychology'],
         researchAreas: ['Decision neuroscience'],
       },
@@ -950,10 +943,7 @@ describe('LabDetail page', () => {
         kind: 'lab',
         entityType: 'LAB',
         websiteUrl: RESEARCH_WEBSITE_URL,
-        sourceUrls: [
-          FACULTY_PROFILE_URL,
-          RESEARCH_WEBSITE_URL,
-        ],
+        sourceUrls: [FACULTY_PROFILE_URL, RESEARCH_WEBSITE_URL],
         departments: ['Biomedical Engineering'],
         researchAreas: ['Optical Microscopy'],
       },
@@ -989,10 +979,7 @@ describe('LabDetail page', () => {
         kind: 'lab',
         entityType: 'LAB',
         websiteUrl: JOIN_LAB_WEBSITE_URL,
-        sourceUrls: [
-          FACULTY_PROFILE_URL,
-          JOIN_LAB_WEBSITE_URL,
-        ],
+        sourceUrls: [FACULTY_PROFILE_URL, JOIN_LAB_WEBSITE_URL],
         departments: ['Psychology'],
         researchAreas: ['Social cognition'],
       },
@@ -1029,7 +1016,9 @@ describe('LabDetail page', () => {
     // already shown in the research summary.
     const officialRouteLinks = screen.getAllByRole('link', { name: 'Open official route' });
     expect(officialRouteLinks).toHaveLength(1);
-    expect(officialRouteLinks.every((link) => link.getAttribute('href') === JOIN_PAGE_URL)).toBe(true);
+    expect(officialRouteLinks.every((link) => link.getAttribute('href') === JOIN_PAGE_URL)).toBe(
+      true,
+    );
     expect(screen.queryByRole('link', { name: 'Open contact route' })).toBeNull();
     expect(screen.queryByRole('link', { name: 'Open official profile' })).toBeNull();
   });
@@ -1164,7 +1153,8 @@ describe('LabDetail page', () => {
         ...basePayload.group,
         slug: 'example-health-systems-profile',
         name: 'Example Health Systems Profile',
-        description: 'Studies emergency medicine, health disparities, data systems, and public health research.',
+        description:
+          'Studies emergency medicine, health disparities, data systems, and public health research.',
         departments: ['Fixture School of Medicine'],
         researchAreas: [
           'Emergency Medicine',
@@ -1215,10 +1205,7 @@ describe('LabDetail page', () => {
 
     await screen.findByText(DEFAULT_ENTITY_NAME);
     await waitFor(() => {
-      expect(mockedAxios.get).toHaveBeenCalledWith(
-        `/research/${DEFAULT_SLUG}`,
-        expect.any(Object),
-      );
+      expect(mockedAxios.get).toHaveBeenCalledWith(`/research/${DEFAULT_SLUG}`, expect.any(Object));
     });
 
     const text = container.textContent || '';
@@ -1288,9 +1275,11 @@ describe('LabDetail page', () => {
     await screen.findByText(DEFAULT_ENTITY_NAME);
 
     expect(
-      screen.getByRole('link', {
-        name: 'Biomass gasification tar removal using catalyst assisted Dielectric Barrier discharge reactor',
-      }).getAttribute('href'),
+      screen
+        .getByRole('link', {
+          name: 'Biomass gasification tar removal using catalyst assisted Dielectric Barrier discharge reactor',
+        })
+        .getAttribute('href'),
     ).toBe(EXAMPLE_MECHANISM_DOI);
     expect(document.body.textContent).not.toContain('<p><b><span>');
   });
@@ -1363,9 +1352,9 @@ describe('LabDetail page', () => {
 
     await screen.findByText(DEFAULT_ENTITY_NAME);
 
-    expect(
-      consoleError.mock.calls.some((call) => String(call[0]).includes('same key')),
-    ).toBe(false);
+    expect(consoleError.mock.calls.some((call) => String(call[0]).includes('same key'))).toBe(
+      false,
+    );
     consoleError.mockRestore();
   });
 
@@ -1448,10 +1437,7 @@ describe('LabDetail page', () => {
       researchEntity: {
         ...basePayload.group,
         researchAreas: [],
-        profileResearchAreas: [
-          'Fixture Delivery Systems',
-          'Synthetic Signal Transfer',
-        ],
+        profileResearchAreas: ['Fixture Delivery Systems', 'Synthetic Signal Transfer'],
         researchAreaSource: 'PI_PROFILE_FALLBACK',
       },
     } as unknown as LabDetailPayload);
@@ -1474,10 +1460,7 @@ describe('LabDetail page', () => {
         fullDescription: '',
         departments: ['Behavioral Studies'],
         researchAreas: [],
-        profileResearchAreas: [
-          'Fixture Care Pathway Design',
-          'Synthetic Adherence Workflow',
-        ],
+        profileResearchAreas: ['Fixture Care Pathway Design', 'Synthetic Adherence Workflow'],
         researchAreaSource: 'PI_PROFILE_FALLBACK',
       },
       entryPathways: [
@@ -1512,9 +1495,7 @@ describe('LabDetail page', () => {
     expect(text).not.toContain('PI research interests');
     expect(text).not.toContain('Fixture Care Pathway Design');
     expect(text).toContain('A Yale research profile with limited public description.');
-    expect(text).not.toContain(
-      'Research connected to Fixture Care Pathway Design',
-    );
+    expect(text).not.toContain('Research connected to Fixture Care Pathway Design');
     expect(text).not.toContain('Research connected to Behavioral Studies.');
     expect(screen.queryByText('Plan your next step')).toBeNull();
     expect(screen.queryByText('Ways to approach this lab')).toBeNull();
@@ -1533,10 +1514,7 @@ describe('LabDetail page', () => {
         fullDescription: '',
         departments: ['Statistics & Data Science'],
         researchAreas: [],
-        profileResearchAreas: [
-          'High-Dimensional Statistics',
-          'Probability Theory',
-        ],
+        profileResearchAreas: ['High-Dimensional Statistics', 'Probability Theory'],
         researchAreaSource: 'PI_PROFILE_FALLBACK',
         profileSynthesisDescription:
           'It appears to center on High-Dimensional Statistics and Probability Theory.',
@@ -1708,11 +1686,7 @@ describe('LabDetail page', () => {
         ...basePayload.group,
         name: 'Example Sparse Profile Lab',
         websiteUrl: DEPARTMENT_HOME_URL,
-        sourceUrls: [
-          DEPARTMENT_PEOPLE_URL,
-          FACULTY_PROFILE_URL,
-          DEPARTMENT_HOME_URL,
-        ],
+        sourceUrls: [DEPARTMENT_PEOPLE_URL, FACULTY_PROFILE_URL, DEPARTMENT_HOME_URL],
         departments: ['Public Policy'],
         researchAreas: [],
       },

--- a/client/src/pages/__tests__/labDetail.test.tsx
+++ b/client/src/pages/__tests__/labDetail.test.tsx
@@ -360,6 +360,7 @@ describe('LabDetail page', () => {
       group: {
         ...basePayload.group,
         websiteUrl: secondInvestigatorProfileUrl,
+        leadProfessorPublicKey: 'fixture-second-pi',
       },
       members: [
         {

--- a/client/src/pages/__tests__/labDetail.test.tsx
+++ b/client/src/pages/__tests__/labDetail.test.tsx
@@ -311,7 +311,7 @@ describe('LabDetail page', () => {
     );
   });
 
-  it('renders the lead professor name as non-clickable text in the student decision panel', async () => {
+  it('renders one full PI card in the student decision panel without a duplicate section', async () => {
     renderLabDetail({
       ...basePayload,
       members: [
@@ -338,17 +338,135 @@ describe('LabDetail page', () => {
       .getByRole('heading', { name: 'Principal Investigator' })
       .closest('section');
 
-    expect(screen.getByText('Lead professor')).toBeTruthy();
+    expect(screen.queryByText('Lead professor')).toBeNull();
     // The professor is reached via the action button(s); the name is not a link.
     expect(screen.queryAllByRole('link', { name: /Jordan Researcher/ })).toHaveLength(0);
-    expect(screen.getAllByText('Jordan Researcher').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Jordan Researcher')).toHaveLength(1);
     expect(
       within(principalInvestigatorSection as HTMLElement).queryByRole('link', {
         name: /Jordan Researcher/,
       }),
     ).toBeNull();
-    expect(screen.getByText('Professor of Example Studies · Example Studies')).toBeTruthy();
+    expect(screen.getByText('Professor of Example Studies')).toBeTruthy();
+    expect(screen.getByText('Example Studies')).toBeTruthy();
     expect(screen.getByText('Recommended next step')).toBeTruthy();
+  });
+
+  it('keeps multiple PI cards together in a dedicated pluralized section', async () => {
+    const secondInvestigatorProfileUrl =
+      'https://medicine.yale.edu/profile/second-investigator/';
+    renderLabDetail({
+      ...basePayload,
+      group: {
+        ...basePayload.group,
+        websiteUrl: secondInvestigatorProfileUrl,
+      },
+      members: [
+        {
+          role: 'pi',
+          user: {
+            publicKey: 'fixture-first-pi',
+            fname: 'First',
+            lname: 'Investigator',
+            displayName: 'First Investigator',
+            profileUrls: {
+              official: 'https://medicine.yale.edu/profile/first-investigator/',
+            },
+          },
+        },
+        {
+          role: 'co-pi',
+          user: {
+            publicKey: 'fixture-second-pi',
+            fname: 'Second',
+            lname: 'Investigator',
+            displayName: 'Second Investigator',
+            title: 'Professor of Example Studies',
+            primary_department: 'Example Studies',
+            profileUrls: {
+              official: secondInvestigatorProfileUrl,
+            },
+          },
+        },
+      ],
+    });
+
+    await screen.findByText(DEFAULT_ENTITY_NAME);
+
+    const section = screen
+      .getByRole('heading', { name: 'Principal Investigators' })
+      .closest('section');
+    expect(section).toBeTruthy();
+    expect(within(section as HTMLElement).getByText('First Investigator')).toBeTruthy();
+    expect(within(section as HTMLElement).getByText('Second Investigator')).toBeTruthy();
+    expect(screen.queryByRole('heading', { name: 'Principal Investigator' })).toBeNull();
+    expect(screen.getByRole('heading', { name: 'Lead professor' })).toBeTruthy();
+    expect(screen.getAllByText('First Investigator')).toHaveLength(1);
+    expect(screen.getAllByText('Second Investigator')).toHaveLength(2);
+    expect(screen.getAllByText('Professor of Example Studies')).toHaveLength(2);
+    expect(screen.getAllByText('Example Studies')).toHaveLength(2);
+  });
+
+  it('does not choose an arbitrary lead professor when no PI matches the official profile', async () => {
+    renderLabDetail({
+      ...basePayload,
+      members: [
+        {
+          role: 'pi',
+          user: {
+            publicKey: 'fixture-first-unmatched-pi',
+            fname: 'First',
+            lname: 'Unmatched',
+            profileUrls: {
+              official: 'https://medicine.yale.edu/profile/first-unmatched/',
+            },
+          },
+        },
+        {
+          role: 'co-pi',
+          user: {
+            publicKey: 'fixture-second-unmatched-pi',
+            fname: 'Second',
+            lname: 'Unmatched',
+            profileUrls: {
+              official: 'https://medicine.yale.edu/profile/second-unmatched/',
+            },
+          },
+        },
+      ],
+    });
+
+    await screen.findByText(DEFAULT_ENTITY_NAME);
+
+    expect(screen.getByRole('heading', { name: 'Principal Investigators' })).toBeTruthy();
+    expect(screen.queryByText('Lead professor')).toBeNull();
+  });
+
+  it('keeps the dedicated identity review state instead of showing a PI card', async () => {
+    renderLabDetail({
+      ...basePayload,
+      group: {
+        ...basePayload.group,
+        leadIdentityStatus: 'under_review',
+      },
+      members: [
+        {
+          role: 'pi',
+          user: {
+            publicKey: 'fixture-unverified-pi',
+            fname: 'Unverified',
+            lname: 'Investigator',
+            displayName: 'Unverified Investigator',
+          },
+        },
+      ],
+    });
+
+    await screen.findByText(DEFAULT_ENTITY_NAME);
+
+    expect(screen.getByRole('heading', { name: 'Principal Investigator' })).toBeTruthy();
+    expect(screen.getByText('Lead identity under review')).toBeTruthy();
+    expect(screen.queryByText('Unverified Investigator')).toBeNull();
   });
 
   it('does not link principal investigators to official faculty profiles from the detail page', async () => {

--- a/client/src/pages/labDetail.tsx
+++ b/client/src/pages/labDetail.tsx
@@ -68,7 +68,6 @@ import {
   sanitizeFacultyResearchCopy,
 } from '../utils/researchEntityCopy';
 import { getUniqueDepartmentLabels } from '../utils/departmentNames';
-import { principalInvestigatorLinkFromMemberUser } from '../utils/principalInvestigatorLinks';
 
 const FIRST_RESEARCH_PLAN_SAVE_KEY = 'yale-research.firstResearchPlanSave.v1';
 
@@ -1152,13 +1151,11 @@ const LabDetail = () => {
     !leadIdentityUnderReview && principalInvestigators.length === 1
       ? principalInvestigators[0]
       : undefined;
-  const normalizedDecisionProfileUrl = normalizeActionDestination(decisionProfileUrl);
   const officialProfileLeadProfessor =
-    !leadIdentityUnderReview && principalInvestigators.length > 1 && normalizedDecisionProfileUrl
-      ? principalInvestigators.find((member) => {
-          const memberProfile = principalInvestigatorLinkFromMemberUser(member.user);
-          return normalizeActionDestination(memberProfile?.href) === normalizedDecisionProfileUrl;
-        })
+    !leadIdentityUnderReview && principalInvestigators.length > 1 && group.leadProfessorPublicKey
+      ? principalInvestigators.find(
+          (member) => member.user.publicKey === group.leadProfessorPublicKey,
+        )
       : undefined;
   const showDedicatedPrincipalInvestigatorSection =
     leadIdentityUnderReview || principalInvestigators.length !== 1;

--- a/client/src/pages/labDetail.tsx
+++ b/client/src/pages/labDetail.tsx
@@ -16,10 +16,7 @@ import { useEffect, useReducer, useRef, useState } from 'react';
 import { isCancel } from 'axios';
 import { Link, useParams } from 'react-router-dom';
 import axios from '../utils/axios';
-import {
-  createInitialLabDetailState,
-  labDetailReducer,
-} from '../reducers/labDetailReducer';
+import { createInitialLabDetailState, labDetailReducer } from '../reducers/labDetailReducer';
 import LabHeader from '../components/labs/LabHeader';
 import LabMembersList from '../components/labs/LabMembersList';
 import LabPapersList from '../components/labs/LabPapersList';
@@ -52,11 +49,7 @@ import {
   getEvidenceSignalLabel,
   getEvidenceStrengthLabel,
 } from '../utils/researchDiscoveryAdapters';
-import {
-  computeAcceptanceVerdict,
-  EvidenceItem,
-  verdictLabel,
-} from '../utils/undergradAcceptance';
+import { computeAcceptanceVerdict, EvidenceItem, verdictLabel } from '../utils/undergradAcceptance';
 import { resolveLabOutreachContact } from '../utils/labOutreachContact';
 import {
   approachHeadingLabel,
@@ -72,9 +65,7 @@ import { getUniqueDepartmentLabels } from '../utils/departmentNames';
 const FIRST_RESEARCH_PLAN_SAVE_KEY = 'yale-research.firstResearchPlanSave.v1';
 
 const SectionHeading = ({ children }: { children: React.ReactNode }) => (
-  <h2 className="text-xs font-semibold text-gray-600 uppercase tracking-wider mb-3">
-    {children}
-  </h2>
+  <h2 className="text-xs font-semibold text-gray-600 uppercase tracking-wider mb-3">{children}</h2>
 );
 
 const formatEntityKindTag = (kind?: string | null): string | undefined =>
@@ -88,11 +79,11 @@ const RelatedResearchEntitiesSection = ({
   relatedResearchEntities: ResearchEntity[];
 }) => {
   const relationshipByEntityKey = new Map(
-    relationships
-      .flatMap((relationship) => [
-        relationship.relatedResearchEntitySlug,
-        relationship.relatedResearchEntityId,
-      ].filter(Boolean).map((key) => [key, relationship] as const)),
+    relationships.flatMap((relationship) =>
+      [relationship.relatedResearchEntitySlug, relationship.relatedResearchEntityId]
+        .filter(Boolean)
+        .map((key) => [key, relationship] as const),
+    ),
   );
 
   return (
@@ -152,19 +143,20 @@ const AffiliatedResearchEntitiesSection = ({
       {affiliatedResearchEntities.map((entity) => {
         const content = (
           <>
-          <div className="flex flex-wrap gap-2">
-            {uniqueCompact([formatEntityKindTag(entity.kind), ...compactDepartmentLabels(entity.departments)], 3).map(
-              (tag) => (
+            <div className="flex flex-wrap gap-2">
+              {uniqueCompact(
+                [formatEntityKindTag(entity.kind), ...compactDepartmentLabels(entity.departments)],
+                3,
+              ).map((tag) => (
                 <span
                   key={tag}
                   className="rounded-full bg-[var(--yr-panel-muted)] px-2 py-1 text-xs font-medium text-gray-700"
                 >
                   {tag}
                 </span>
-              ),
-            )}
-          </div>
-          <h3 className="mt-3 text-sm font-semibold text-gray-900">{entity.name}</h3>
+              ))}
+            </div>
+            <h3 className="mt-3 text-sm font-semibold text-gray-900">{entity.name}</h3>
           </>
         );
         const className =
@@ -249,12 +241,7 @@ const isGenericTopic = (value: string): boolean =>
   /^yale faculty\b/i.test(value);
 
 const detailTopics = (group: any, limit = 6): string[] =>
-  uniqueCompact(
-    [
-      ...(group.researchAreas || []),
-    ],
-    limit * 2,
-  )
+  uniqueCompact([...(group.researchAreas || [])], limit * 2)
     .filter((value) => !isGenericTopic(value))
     .slice(0, limit);
 
@@ -416,8 +403,7 @@ const dedupeLeadMembers = (members: LabMember[]): LabMember[] => {
     const current = byPerson.get(key);
     if (
       !current ||
-      (LEAD_ROLE_PRIORITY.get(member.role) ?? 99) <
-        (LEAD_ROLE_PRIORITY.get(current.role) ?? 99)
+      (LEAD_ROLE_PRIORITY.get(member.role) ?? 99) < (LEAD_ROLE_PRIORITY.get(current.role) ?? 99)
     ) {
       byPerson.set(key, member);
     }
@@ -587,10 +573,7 @@ const DecisionSummary = ({
               ? 'What this faculty research area covers'
               : decisionHeadingLabel(group)}
           </h2>
-          <LongText
-            text={description}
-            className="mt-2 text-base leading-relaxed text-gray-800"
-          />
+          <LongText text={description} className="mt-2 text-base leading-relaxed text-gray-800" />
           {studentDecisionExplanation && (
             <div className="mt-5 rounded-md border border-[var(--yr-line)] bg-[var(--yr-panel-muted)] p-4">
               <SectionHeading>Student decision</SectionHeading>
@@ -869,8 +852,12 @@ const OutreachSection = ({ group, onDraft }: { group: any; onDraft: () => void }
   const coursework = uniqueCompact(
     [
       ...compactDepartmentLabels(group.departments),
-      ...(topics.some((topic) => /comput|data|stat/i.test(topic)) ? ['Statistics and Computer Science'] : []),
-      ...(topics.some((topic) => /genetic|dna|biology/i.test(topic)) ? ['genetics or biology'] : []),
+      ...(topics.some((topic) => /comput|data|stat/i.test(topic))
+        ? ['Statistics and Computer Science']
+        : []),
+      ...(topics.some((topic) => /genetic|dna|biology/i.test(topic))
+        ? ['genetics or biology']
+        : []),
     ],
     4,
   );
@@ -990,7 +977,8 @@ const PUBLIC_LEAD_ROLES = new Set(['pi', 'co-pi', 'director', 'co-director']);
 
 const hasPublicPlanningRoute = (contactRoutes: LabContactRoute[]): boolean =>
   contactRoutes.some(
-    (route) => route.visibility === 'PUBLIC' && Boolean(route.url) && route.routeType !== 'FACULTY_PI',
+    (route) =>
+      route.visibility === 'PUBLIC' && Boolean(route.url) && route.routeType !== 'FACULTY_PI',
   );
 
 const hasSpecificWaysToApproach = (
@@ -1006,20 +994,16 @@ const hasSpecificWaysToApproach = (
 
 const LabDetail = () => {
   const { slug } = useParams<{ slug: string }>();
-  const [state, dispatch] = useReducer(
-    labDetailReducer,
-    undefined,
-    () => createInitialLabDetailState(),
+  const [state, dispatch] = useReducer(labDetailReducer, undefined, () =>
+    createInitialLabDetailState(),
   );
   const { payload, loading, error, isInquireModalOpen } = state;
   const requestIdRef = useRef(0);
   const fetchAbortRef = useRef<AbortController | null>(null);
   const [showResearchPlanSavedCallout, setShowResearchPlanSavedCallout] = useState(false);
-  const {
-    favIds: savedResearchPlanIds,
-    setFavorite: setSavedResearchPlanFavorite,
-  } = useFavorites('researchPlans');
-  const documentTitleGroup = payload ? payload.group ?? payload.researchEntity : null;
+  const { favIds: savedResearchPlanIds, setFavorite: setSavedResearchPlanFavorite } =
+    useFavorites('researchPlans');
+  const documentTitleGroup = payload ? (payload.group ?? payload.researchEntity) : null;
   useDocumentTitle(
     documentTitleGroup?.displayName || documentTitleGroup?.name || 'Research profile',
   );
@@ -1119,7 +1103,9 @@ const LabDetail = () => {
   );
   const hasActivePostedOpportunity = postedOpportunities.length > 0;
   const hasDirectRelatedResearch =
-    directRelatedResearchLinks.length > 0 || recentPapers.length > 0 || recentArxivPreprints.length > 0;
+    directRelatedResearchLinks.length > 0 ||
+    recentPapers.length > 0 ||
+    recentArxivPreprints.length > 0;
   const hasMemberRecentWork = memberRecentWorkLinks.length > 0;
   const hasResearchActivity = hasDirectRelatedResearch || hasMemberRecentWork;
   const hasWaysIn = entryPathways.length > 0 || postedOpportunities.length > 0;
@@ -1255,7 +1241,9 @@ const LabDetail = () => {
                     : [...recentPapers, ...recentArxivPreprints]
                 }
                 emptyText="No scholarly links are attached to this research profile yet."
-                showPreprintMeta={directRelatedResearchLinks.length === 0 && recentPapers.length === 0}
+                showPreprintMeta={
+                  directRelatedResearchLinks.length === 0 && recentPapers.length === 0
+                }
               />
             </section>
           )}

--- a/client/src/pages/labDetail.tsx
+++ b/client/src/pages/labDetail.tsx
@@ -68,6 +68,7 @@ import {
   sanitizeFacultyResearchCopy,
 } from '../utils/researchEntityCopy';
 import { getUniqueDepartmentLabels } from '../utils/departmentNames';
+import { principalInvestigatorLinkFromMemberUser } from '../utils/principalInvestigatorLinks';
 
 const FIRST_RESEARCH_PLAN_SAVE_KEY = 'yale-research.firstResearchPlanSave.v1';
 
@@ -544,6 +545,7 @@ const DecisionSummary = ({
   postedOpportunities,
   fallbackSourceUrl,
   hasActivePostedOpportunity,
+  principalInvestigator,
   leadProfessor,
 }: {
   group: any;
@@ -552,6 +554,7 @@ const DecisionSummary = ({
   postedOpportunities: LabPostedOpportunity[];
   fallbackSourceUrl?: string;
   hasActivePostedOpportunity: boolean;
+  principalInvestigator?: LabMember;
   leadProfessor?: LabMember;
 }) => {
   const topics = detailTopics(group, 5);
@@ -575,11 +578,6 @@ const DecisionSummary = ({
   const profileUrl = resolveDecisionProfileUrl(fallbackSourceUrl, contactRoutes, group);
   const officialRoute = resolveDecisionOfficialRoute(profileUrl, contactRoutes, group);
   const officialRouteUrl = safeHttpUrl(officialRoute?.url);
-  const leadProfessorName = leadProfessor ? memberDisplayName(leadProfessor) : '';
-  const leadProfessorMeta = uniqueCompact(
-    [leadProfessor?.user.title, leadProfessor?.user.primary_department],
-    2,
-  ).join(' · ');
   return (
     <section className="rounded-lg border border-blue-100 bg-[var(--yr-panel)] p-4 shadow-sm sm:p-5">
       <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_16rem] md:gap-5">
@@ -693,18 +691,19 @@ const DecisionSummary = ({
               )}
             </div>
           )}
+          {principalInvestigator && (
+            <div className="mt-4 border-t border-[var(--yr-line)] pt-4">
+              <SectionHeading>Principal Investigator</SectionHeading>
+              <div>
+                <LabMembersList members={[principalInvestigator]} singleColumn />
+              </div>
+            </div>
+          )}
           {leadProfessor && (
             <div className="mt-4 border-t border-[var(--yr-line)] pt-4">
-              <p className="text-xs font-semibold uppercase tracking-wider text-gray-600">
-                Lead professor
-              </p>
-              <div className="mt-2 rounded-md border border-[var(--yr-line)] bg-[var(--yr-panel)] px-3 py-2 text-sm">
-                <p className="font-semibold text-gray-900">{leadProfessorName}</p>
-                {leadProfessorMeta && (
-                  <p className="mt-0.5 text-xs leading-relaxed text-gray-600">
-                    {leadProfessorMeta}
-                  </p>
-                )}
+              <SectionHeading>Lead professor</SectionHeading>
+              <div>
+                <LabMembersList members={[leadProfessor]} singleColumn />
               </div>
             </div>
           )}
@@ -1148,6 +1147,21 @@ const LabDetail = () => {
     group,
   );
   const principalInvestigators = dedupeLeadMembers(members);
+  const leadIdentityUnderReview = group.leadIdentityStatus === 'under_review';
+  const singlePrincipalInvestigator =
+    !leadIdentityUnderReview && principalInvestigators.length === 1
+      ? principalInvestigators[0]
+      : undefined;
+  const normalizedDecisionProfileUrl = normalizeActionDestination(decisionProfileUrl);
+  const officialProfileLeadProfessor =
+    !leadIdentityUnderReview && principalInvestigators.length > 1 && normalizedDecisionProfileUrl
+      ? principalInvestigators.find((member) => {
+          const memberProfile = principalInvestigatorLinkFromMemberUser(member.user);
+          return normalizeActionDestination(memberProfile?.href) === normalizedDecisionProfileUrl;
+        })
+      : undefined;
+  const showDedicatedPrincipalInvestigatorSection =
+    leadIdentityUnderReview || principalInvestigators.length !== 1;
   const membersById = new Map(members.map((member) => [memberId(member), member]));
   const primaryRecentWorkMember =
     memberRecentWorkLinks
@@ -1206,13 +1220,33 @@ const LabDetail = () => {
             postedOpportunities={postedOpportunities}
             fallbackSourceUrl={fallbackSourceUrl}
             hasActivePostedOpportunity={hasActivePostedOpportunity}
-            leadProfessor={principalInvestigators[0]}
+            principalInvestigator={singlePrincipalInvestigator}
+            leadProfessor={officialProfileLeadProfessor}
           />
 
-          <section>
-            <SectionHeading>Principal Investigator</SectionHeading>
-            <LabMembersList members={principalInvestigators} />
-          </section>
+          {showDedicatedPrincipalInvestigatorSection && (
+            <section>
+              <SectionHeading>
+                {principalInvestigators.length > 1
+                  ? 'Principal Investigators'
+                  : 'Principal Investigator'}
+              </SectionHeading>
+              {leadIdentityUnderReview ? (
+                <div
+                  className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950"
+                  role="status"
+                >
+                  <p className="font-semibold">Lead identity under review</p>
+                  <p className="mt-1">
+                    The research information remains available, but this lead and profile link are
+                    not shown until their sources agree.
+                  </p>
+                </div>
+              ) : (
+                <LabMembersList members={principalInvestigators} />
+              )}
+            </section>
+          )}
 
           {hasDirectRelatedResearch && (
             <section>

--- a/client/src/types/researchEntity.ts
+++ b/client/src/types/researchEntity.ts
@@ -47,6 +47,8 @@ export type StudentVisibilityTier =
   | 'suppressed';
 
 export interface ResearchEntity extends ResearchEntityBacking {
+  leadIdentityStatus?: 'verified' | 'under_review';
+  leadProfessorPublicKey?: string;
   searchMatch?: ResearchEntitySearchMatch;
   waysIn?: PathwaySearchHit[];
   qualitySummary?: ResearchEntityQualitySummary;

--- a/client/src/types/researchEntity.ts
+++ b/client/src/types/researchEntity.ts
@@ -47,7 +47,9 @@ export type StudentVisibilityTier =
   | 'suppressed';
 
 export interface ResearchEntity extends ResearchEntityBacking {
+  /** Whether public lead identity evidence is safe to display or requires review. */
   leadIdentityStatus?: 'verified' | 'under_review';
+  /** Public member key for the unique lead matched by entity-owned official profile evidence. */
   leadProfessorPublicKey?: string;
   searchMatch?: ResearchEntitySearchMatch;
   waysIn?: PathwaySearchHit[];

--- a/client/src/types/researchEntity.ts
+++ b/client/src/types/researchEntity.ts
@@ -63,29 +63,35 @@ export interface ResearchEntity extends ResearchEntityBacking {
   studentVisibilityReviewNote?: string;
 }
 
-export interface ResearchEntitySearchResponse
-  extends Partial<Omit<ResearchGroupSearchResponse, 'hits' | 'researchEntities'>> {
+export interface ResearchEntitySearchResponse extends Partial<
+  Omit<ResearchGroupSearchResponse, 'hits' | 'researchEntities'>
+> {
   researchEntities?: ResearchEntity[];
   hits?: ResearchEntity[];
 }
 
-export interface NormalizedResearchEntitySearchResponse
-  extends Omit<ResearchGroupSearchResponse, 'hits' | 'researchEntities'> {
+export interface NormalizedResearchEntitySearchResponse extends Omit<
+  ResearchGroupSearchResponse,
+  'hits' | 'researchEntities'
+> {
   researchEntities: ResearchEntity[];
   hits: ResearchEntity[];
 }
 
-export interface ResearchEntityDetailPayload
-  extends Omit<LabDetailPayload, 'group' | 'researchEntity'> {
+export interface ResearchEntityDetailPayload extends Omit<
+  LabDetailPayload,
+  'group' | 'researchEntity'
+> {
   researchEntity: ResearchEntity;
   group?: ResearchEntity;
 }
 
-type MaybeResearchEntityDetailPayload =
-  Partial<Omit<LabDetailPayload, 'group' | 'researchEntity'>> & {
-    researchEntity?: ResearchEntity | null;
-    group?: ResearchEntity | null;
-  };
+type MaybeResearchEntityDetailPayload = Partial<
+  Omit<LabDetailPayload, 'group' | 'researchEntity'>
+> & {
+  researchEntity?: ResearchEntity | null;
+  group?: ResearchEntity | null;
+};
 
 const normalizeSearchMatch = (
   value: ResearchEntitySearchMatch | undefined,
@@ -111,7 +117,10 @@ const normalizeStudentDecisionExplanation = (
     headline: value.headline.trim(),
     explanation: value.explanation.trim(),
     why: Array.isArray(value.why)
-      ? value.why.map((item) => String(item).trim()).filter(Boolean).slice(0, 3)
+      ? value.why
+          .map((item) => String(item).trim())
+          .filter(Boolean)
+          .slice(0, 3)
       : [],
     sourceUrls: Array.isArray(value.sourceUrls)
       ? value.sourceUrls.map((item) => String(item).trim()).filter(Boolean)

--- a/docs/product-context.md
+++ b/docs/product-context.md
@@ -87,6 +87,11 @@ Each research entity page should answer:
 - How might the research relationship later be formalized?
 - What source verifies this?
 
+Leadership should be presented without redundant cards.
+A sole verified principal investigator appears once in the decision summary.
+When several principal investigators are attached, keep them together in a pluralized section and identify a separate Lead professor only from a unique match between the entity's official profile evidence and that member's official Yale faculty profile.
+If lead identity evidence conflicts, preserve an explicit review state instead of displaying the disputed person.
+
 ## CTA Vocabulary
 
 CTA options should depend on the access evidence, route, and current next step:

--- a/docs/research-data-pipeline.md
+++ b/docs/research-data-pipeline.md
@@ -32,6 +32,10 @@ Research-entity `sourceUrls` are durable home/profile/grant evidence pointers, n
 
 Research detail membership resolution must not display a `User` whose linked `facultyMemberId` conflicts with the membership row's `facultyMemberId`. In that case, the public detail payload falls back to the scraper-backed `FacultyMember` identity rather than showing the wrong Yale account. The student visibility gate treats `pi_identity_conflict` as a blocking reason routed to the PI identity repair lane, while a membership row with a trusted `facultyMemberId` but no `userId` still counts as attached lead evidence.
 
+The public research detail payload derives `leadIdentityStatus` from the raw membership links before replacing them with sanitized public member data.
+When canonical PI identities conflict, the payload reports `under_review` and the detail page withholds the disputed lead card and profile link.
+For verified entities with multiple lead members, `leadProfessorPublicKey` is emitted only when exactly one member's official Yale faculty profile matches an entity-owned official profile URL; no arbitrary lead fallback is selected.
+
 ## Read-Only Control Plane
 
 The first control-plane slice is the admin Operator Board. It remains read-only and does not replace CLI or cron execution. It should show:

--- a/docs/research-model.md
+++ b/docs/research-model.md
@@ -246,6 +246,11 @@ Current behavior:
 
 The same contact guardrail applies to public research detail payloads: unauthenticated/public detail responses should include only public route summaries and should not expose authenticated or admin-only scraped contact data.
 
+Public research detail entities also expose derived lead-display metadata.
+`leadIdentityStatus` is `verified` or `under_review`; an under-review identity suppresses the disputed lead card and profile link.
+`leadProfessorPublicKey` is present only when exactly one lead member's official Yale faculty profile matches an official person-profile URL owned by the entity.
+The detail page shows a sole verified lead once inside the decision summary, while multiple leads remain together in the dedicated Principal Investigators section and only the uniquely matched lead may also appear as Lead professor.
+
 Contact-route ordering should prefer official applications, program/department/fellowship/course routes, and lab-manager routes before faculty-direct routes. Public ways-in cards or detail sections may link to route URLs, but they should not expose raw scraped emails.
 
 Legacy active listings may still appear inside public research detail payloads for backwards compatibility, but those embedded listing summaries must be field allowlisted. Do not expose listing owner ids, creator ids, owner emails, collaborator emails, view counts, favorite counts, audit flags, or other authenticated/admin-oriented fields through `/api/research/:slug`.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
 # Graph Report - 01KXHSYGY3GN42EV0VQTHKNYWY  (2026-07-14)
 
 ## Corpus Check
-- 823 files · ~1,303,803 words
+- 823 files · ~1,303,991 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 11262 nodes · 21227 edges · 3266 communities (913 shown, 2353 thin omitted)
-- Extraction: 98% EXTRACTED · 2% INFERRED · 0% AMBIGUOUS · INFERRED: 452 edges (avg confidence: 0.62)
+- 11155 nodes · 21227 edges · 3161 communities (915 shown, 2246 thin omitted)
+- Extraction: 98% EXTRACTED · 2% INFERRED · 0% AMBIGUOUS · INFERRED: 451 edges (avg confidence: 0.62)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `eebbcfaa`
+- Built from commit: `358d7fc2`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -249,7 +249,6 @@
 - [[_COMMUNITY_normalizeAcceptedDecisionValidation|normalizeAcceptedDecisionValidation]]
 - [[_COMMUNITY_UIUX Direction|UI/UX Direction]]
 - [[_COMMUNITY_LEGACY_EXPLORATORY_CONTACT_PATHWAY_DERIVATION_KEYS|LEGACY_EXPLORATORY_CONTACT_PATHWAY_DERIVATION_KEYS]]
-- [[_COMMUNITY_profileService.test.ts|profileService.test.ts]]
 - [[_COMMUNITY_researchEntity.ts|researchEntity.ts]]
 - [[_COMMUNITY_fellowship.ts|fellowship.ts]]
 - [[_COMMUNITY_seed.ts|seed.ts]]
@@ -287,7 +286,6 @@
 - [[_COMMUNITY_redactDirectContactInfo|redactDirectContactInfo]]
 - [[_COMMUNITY_applyResearchEntityDedupeMergeGroup|applyResearchEntityDedupeMergeGroup]]
 - [[_COMMUNITY_researchAreasRoutes.test.ts|researchAreasRoutes.test.ts]]
-- [[_COMMUNITY_Codex Guide|Codex Guide]]
 - [[_COMMUNITY_visibilityRepairQueueService.test.ts|visibilityRepairQueueService.test.ts]]
 - [[_COMMUNITY_Codex Guide|Codex Guide]]
 - [[_COMMUNITY_dedupeSameNameLeadMembers|dedupeSameNameLeadMembers]]
@@ -309,7 +307,6 @@
 - [[_COMMUNITY_Yale Research Product Context|Yale Research Product Context]]
 - [[_COMMUNITY_10. P2 Fellowship, Course, And Contact Materialization|10. P2 Fellowship, Course, And Contact Materialization]]
 - [[_COMMUNITY_Research Data Pipeline|Research Data Pipeline]]
-- [[_COMMUNITY_API Routes|API Routes]]
 - [[_COMMUNITY_courseTableService.ts|courseTableService.ts]]
 - [[_COMMUNITY_1. M1.2 Client API-Boundary Vocabulary|1. M1.2 Client API-Boundary Vocabulary]]
 - [[_COMMUNITY_AdminListingsTable.tsx|AdminListingsTable.tsx]]
@@ -347,9 +344,6 @@
 - [[_COMMUNITY_check-no-secrets-core.mjs|check-no-secrets-core.mjs]]
 - [[_COMMUNITY_codebash (SCRAPER_ENV=beta yarn --cwd server betadata-quality --inclu)|code:bash (SCRAPER_ENV=beta yarn --cwd server beta:data-quality --inclu)]]
 - [[_COMMUNITY_1. Fresh machine setup|1. Fresh machine setup]]
-- [[_COMMUNITY_codebash (which node)|code:bash (which node)]]
-- [[_COMMUNITY_1. Fresh machine setup|1. Fresh machine setup]]
-- [[_COMMUNITY_CI|CI]]
 - [[_COMMUNITY_runStaleObservationConflictReview|runStaleObservationConflictReview]]
 - [[_COMMUNITY_Graphify repo memory|Graphify repo memory]]
 - [[_COMMUNITY_dataMigrationV4DeprecatedBackfills.test.ts|dataMigrationV4DeprecatedBackfills.test.ts]]
@@ -367,8 +361,6 @@
 - [[_COMMUNITY_checker.py|checker.py]]
 - [[_COMMUNITY_normalizeStaleObservationReviewDecision|normalizeStaleObservationReviewDecision]]
 - [[_COMMUNITY_3. Configure environment|3. Configure environment]]
-- [[_COMMUNITY_Architecture|Architecture]]
-- [[_COMMUNITY_Auth Middleware (`serversrcmiddlewareauth.ts`)|Auth Middleware (`server/src/middleware/auth.ts`)]]
 - [[_COMMUNITY_4. Start local Meilisearch|4. Start local Meilisearch]]
 - [[_COMMUNITY_{ hasExpectedEntityName }|{ hasExpectedEntityName }]]
 - [[_COMMUNITY_postcss.config.js|postcss.config.js]]
@@ -934,104 +926,62 @@
 - [[_COMMUNITY_2026-05-22 Student Experience MCP Fix Pass|2026-05-22 Student Experience MCP Fix Pass]]
 - [[_COMMUNITY_2) `pathways` debounced search can update from stale payload|2) `/pathways` debounced search can update from stale payload]]
 - [[_COMMUNITY_Commands|Commands]]
-- [[_COMMUNITY_Product Surfaces|Product Surfaces]]
 - [[_COMMUNITY_Sensitive Areas|Sensitive Areas]]
-- [[_COMMUNITY_`client.env`|`client/.env`]]
 - [[_COMMUNITY_codetypescript (const logListingEvent = (eventType AnalyticsEventType) = {)|code:typescript (const logListingEvent = (eventType: AnalyticsEventType) => {)]]
-- [[_COMMUNITY_Commands|Commands]]
 - [[_COMMUNITY_Error Handling|Error Handling]]
 - [[_COMMUNITY_External Integrations|External Integrations]]
 - [[_COMMUNITY_Modifying a Schema|Modifying a Schema]]
 - [[_COMMUNITY_Monorepo Structure|Monorepo Structure]]
 - [[_COMMUNITY_Naming Conventions|Naming Conventions]]
-- [[_COMMUNITY_Rate Limiting|Rate Limiting]]
 - [[_COMMUNITY_Routes|Routes]]
-- [[_COMMUNITY_6. Start dev servers|6. Start dev servers]]
 - [[_COMMUNITY_codebash (cd data-migration)|code:bash (cd data-migration)]]
 - [[_COMMUNITY_codebash (curl httplocalhost7700health)|code:bash (curl http://localhost:7700/health)]]
 - [[_COMMUNITY_codebash (cd client)|code:bash (cd client)]]
-- [[_COMMUNITY_codebash (curl -o- httpsraw.githubusercontent.comnvm-shnvmmaster)|code:bash (curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master)]]
 - [[_COMMUNITY_codebash (nvm install 20)|code:bash (nvm install 20)]]
 - [[_COMMUNITY_codebash (yarn installall)|code:bash (yarn install:all)]]
-- [[_COMMUNITY_codebash (cp server.env.example server.env)|code:bash (cp server/.env.example server/.env)]]
-- [[_COMMUNITY_codebash ( client.env)|code:bash (# client/.env)]]
 - [[_COMMUNITY_codebash (docker pull getmeilimeilisearchlatest)|code:bash (docker pull getmeili/meilisearch:latest)]]
 - [[_COMMUNITY_Environments|Environments]]
 - [[_COMMUNITY_Migration Scripts|Migration Scripts]]
 - [[_COMMUNITY_Modifying a Schema|Modifying a Schema]]
-- [[_COMMUNITY_codebash (yarn playwrightrun screenshot httpsexample.com tmpexam)|code:bash (yarn playwright:run screenshot https://example.com /tmp/exam)]]
-- [[_COMMUNITY_Quick Start|Quick Start]]
-- [[_COMMUNITY_Graphify Repo Memory|Graphify Repo Memory]]
 - [[_COMMUNITY_Product Surfaces|Product Surfaces]]
-- [[_COMMUNITY_Architecture|Architecture]]
-- [[_COMMUNITY_Auth Middleware|Auth Middleware]]
-- [[_COMMUNITY_codeblock1 (React (Vite) → Express (Passport.js) → MongoDB Atlas + Meili)|code:block1 (React (Vite) → Express (Passport.js) → MongoDB Atlas + Meili)]]
 - [[_COMMUNITY_Database|Database]]
-- [[_COMMUNITY_External Integrations|External Integrations]]
 - [[_COMMUNITY_Graphify Repo Memory|Graphify Repo Memory]]
-- [[_COMMUNITY_Routes|Routes]]
-- [[_COMMUNITY_`server.env`|`server/.env`]]
-- [[_COMMUNITY_Testing|Testing]]
 - [[_COMMUNITY_Validation Middleware|Validation Middleware]]
-- [[_COMMUNITY_2. Install dependencies|2. Install dependencies]]
-- [[_COMMUNITY_7. Verify setup|7. Verify setup]]
-- [[_COMMUNITY_Authentication|Authentication]]
 - [[_COMMUNITY_CI|CI]]
 - [[_COMMUNITY_codebash (curl httplocalhost7700health)|code:bash (curl http://localhost:7700/health)]]
 - [[_COMMUNITY_codebash (curl httplocalhost7700health)|code:bash (curl http://localhost:7700/health)]]
 - [[_COMMUNITY_codetxt (Usage Error Couldn't find the node_modules state file - run)|code:txt (Usage Error: Couldn't find the node_modules state file - run)]]
-- [[_COMMUNITY_codebash (nvm install 20)|code:bash (nvm install 20)]]
 - [[_COMMUNITY_codebash (sudo apt update)|code:bash (sudo apt update)]]
 - [[_COMMUNITY_codebash (nvm install 20)|code:bash (nvm install 20)]]
-- [[_COMMUNITY_codebash (yarn installall)|code:bash (yarn install:all)]]
 - [[_COMMUNITY_codebash (cp server.env.example server.env)|code:bash (cp server/.env.example server/.env)]]
-- [[_COMMUNITY_New API Endpoint|New API Endpoint]]
-- [[_COMMUNITY_Prerequisites|Prerequisites]]
 - [[_COMMUNITY_Running tests|Running tests]]
 - [[_COMMUNITY_Testing|Testing]]
-- [[_COMMUNITY_Commands|Commands]]
-- [[_COMMUNITY_Core Modeling Direction|Core Modeling Direction]]
 - [[_COMMUNITY_Done Criteria|Done Criteria]]
 - [[_COMMUNITY_Parallel Work|Parallel Work]]
 - [[_COMMUNITY_Authentication Flow|Authentication Flow]]
 - [[_COMMUNITY_CI|CI]]
 - [[_COMMUNITY_codeblock1 (React (Vite) → Express (Passport.js) → MongoDB Atlas + Meili)|code:block1 (React (Vite) → Express (Passport.js) → MongoDB Atlas + Meili)]]
-- [[_COMMUNITY_Graphify Repo Memory|Graphify Repo Memory]]
 - [[_COMMUNITY_Known Technical Debt|Known Technical Debt]]
 - [[_COMMUNITY_YLabs Codebase Reference|Y/Labs Codebase Reference]]
 - [[_COMMUNITY_6. Start dev servers|6. Start dev servers]]
 - [[_COMMUNITY_7. Verify setup|7. Verify setup]]
-- [[_COMMUNITY_codebash (yarn devclient     Vite on port 3000)|code:bash (yarn dev:client    # Vite on port 3000)]]
 - [[_COMMUNITY_codebash (nvm install 20)|code:bash (nvm install 20)]]
 - [[_COMMUNITY_codebash (yarn install)|code:bash (yarn install)]]
 - [[_COMMUNITY_codebash (npx ts-node --transpile-only script.ts)|code:bash (npx ts-node --transpile-only <script>.ts)]]
 - [[_COMMUNITY_codebash (nvm install 20)|code:bash (nvm install 20)]]
-- [[_COMMUNITY_Common Commands|Common Commands]]
 - [[_COMMUNITY_What Is This|What Is This?]]
-- [[_COMMUNITY_codebash (corepack enable)|code:bash (corepack enable)]]
-- [[_COMMUNITY_Tech Stack|Tech Stack]]
 - [[_COMMUNITY_YURA Research Database|YURA Research Database]]
-- [[_COMMUNITY_Adding a New Page|Adding a New Page]]
 - [[_COMMUNITY_Auth Middleware|Auth Middleware]]
-- [[_COMMUNITY_CI|CI]]
 - [[_COMMUNITY_Commands|Commands]]
 - [[_COMMUNITY_Rate Limiting|Rate Limiting]]
-- [[_COMMUNITY_Search|Search]]
 - [[_COMMUNITY_Sensitive Files|Sensitive Files]]
-- [[_COMMUNITY_Validation Middleware|Validation Middleware]]
 - [[_COMMUNITY_codebash (curl httplocalhost7700health)|code:bash (curl http://localhost:7700/health)]]
 - [[_COMMUNITY_codebash (nvm install 20)|code:bash (nvm install 20)]]
 - [[_COMMUNITY_codeblock19 (ylabs)|code:block19 (ylabs/)]]
-- [[_COMMUNITY_codebash (corepack enable)|code:bash (corepack enable)]]
-- [[_COMMUNITY_Environments|Environments]]
 - [[_COMMUNITY_Local Development Setup|Local Development Setup]]
-- [[_COMMUNITY_Migration Scripts|Migration Scripts]]
-- [[_COMMUNITY_Project Structure|Project Structure]]
-- [[_COMMUNITY_Running tests|Running tests]]
 - [[_COMMUNITY_Tech Stack|Tech Stack]]
 - [[_COMMUNITY_What is tested|What is tested]]
 - [[_COMMUNITY_Quick Start|Quick Start]]
-- [[_COMMUNITY_YURA Research Database|YURA Research Database]]
 - [[_COMMUNITY_Core Modeling Direction|Core Modeling Direction]]
 - [[_COMMUNITY_Current Stack|Current Stack]]
 - [[_COMMUNITY_Default Task Loop|Default Task Loop]]
@@ -1039,69 +989,40 @@
 - [[_COMMUNITY_Rule Evolution|Rule Evolution]]
 - [[_COMMUNITY_Architecture|Architecture]]
 - [[_COMMUNITY_codeblock2 (ylabs)|code:block2 (ylabs/)]]
-- [[_COMMUNITY_codetypescript (export const asyncHandler = (fn Function) = {)|code:typescript (export const asyncHandler = (fn: Function) => {)]]
 - [[_COMMUNITY_Environments|Environments]]
-- [[_COMMUNITY_Error Handling|Error Handling]]
-- [[_COMMUNITY_Known Technical Debt|Known Technical Debt]]
 - [[_COMMUNITY_Scrapers|Scrapers]]
-- [[_COMMUNITY_4. Start local Meilisearch|4. Start local Meilisearch]]
-- [[_COMMUNITY_5. Seed Meilisearch|5. Seed Meilisearch]]
 - [[_COMMUNITY_codeblock1 (React (Vite) → Express (Passport.js) → MongoDB Atlas + Meili)|code:block1 (React (Vite) → Express (Passport.js) → MongoDB Atlas + Meili)]]
 - [[_COMMUNITY_codebash (curl httplocalhost7700health)|code:bash (curl http://localhost:7700/health)]]
 - [[_COMMUNITY_codebash (yarn devclient     Vite on port 3000)|code:bash (yarn dev:client    # Vite on port 3000)]]
 - [[_COMMUNITY_codebash (nvm install 20)|code:bash (nvm install 20)]]
 - [[_COMMUNITY_codebash (corepack enable)|code:bash (corepack enable)]]
 - [[_COMMUNITY_codebash ( client.env)|code:bash (# client/.env)]]
-- [[_COMMUNITY_codebash (docker pull getmeilimeilisearchlatest)|code:bash (docker pull getmeili/meilisearch:latest)]]
 - [[_COMMUNITY_Common Commands|Common Commands]]
-- [[_COMMUNITY_Dev login bypass|Dev login bypass]]
 - [[_COMMUNITY_New Page|New Page]]
 - [[_COMMUNITY_Prerequisites|Prerequisites]]
-- [[_COMMUNITY_Search|Search]]
-- [[_COMMUNITY_What Is This|What Is This?]]
-- [[_COMMUNITY_YLabs — Developer Guide|Y/Labs — Developer Guide]]
 - [[_COMMUNITY_codebash (yarn playwrightrun screenshot httpsexample.com tmpexam)|code:bash (yarn playwright:run screenshot https://example.com /tmp/exam)]]
-- [[_COMMUNITY_Playwright environment fix (no root required)|Playwright environment fix (no root required)]]
 - [[_COMMUNITY_Tech Stack|Tech Stack]]
-- [[_COMMUNITY_Legacy CSV-to-JSON update script retired.  Department ground truth no longer com|Legacy CSV-to-JSON update script retired.  Department ground truth no longer com]]
-- [[_COMMUNITY_Current Stack|Current Stack]]
 - [[_COMMUNITY_Implementation Rules|Implementation Rules]]
-- [[_COMMUNITY_Parallel Work|Parallel Work]]
 - [[_COMMUNITY_Product North Star|Product North Star]]
 - [[_COMMUNITY_Adding a New Page|Adding a New Page]]
-- [[_COMMUNITY_Analytics Interception|Analytics Interception]]
 - [[_COMMUNITY_`client.env`|`client/.env`]]
-- [[_COMMUNITY_Database|Database]]
-- [[_COMMUNITY_Modifying a Schema|Modifying a Schema]]
 - [[_COMMUNITY_Product Model|Product Model]]
-- [[_COMMUNITY_TypeScript Configuration|TypeScript Configuration]]
 - [[_COMMUNITY_codebash (curl httplocalhost7700health)|code:bash (curl http://localhost:7700/health)]]
 - [[_COMMUNITY_codebash (nvm install 20)|code:bash (nvm install 20)]]
-- [[_COMMUNITY_codebash (yarn install)|code:bash (yarn install)]]
-- [[_COMMUNITY_codebash (sudo apt update)|code:bash (sudo apt update)]]
 - [[_COMMUNITY_codeblock20 (User → Yale CAS SSO → passport.ts findOrCreateUser)|code:block20 (User → Yale CAS SSO → passport.ts findOrCreateUser)]]
 - [[_COMMUNITY_codebash (curl -o- httpsraw.githubusercontent.comnvm-shnvmmaster)|code:bash (curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master)]]
 - [[_COMMUNITY_New API Endpoint|New API Endpoint]]
-- [[_COMMUNITY_Troubleshooting Yarn setup|Troubleshooting Yarn setup]]
 - [[_COMMUNITY_Documentation|Documentation]]
-- [[_COMMUNITY_Default Task Loop|Default Task Loop]]
-- [[_COMMUNITY_Documentation Maintenance|Documentation Maintenance]]
 - [[_COMMUNITY_Graphify Repo Memory|Graphify Repo Memory]]
-- [[_COMMUNITY_Product North Star|Product North Star]]
 - [[_COMMUNITY_Analytics Interception|Analytics Interception]]
 - [[_COMMUNITY_codeblock2 (yale-research)|code:block2 (yale-research/)]]
-- [[_COMMUNITY_codeblock5 (User → Yale CAS SSO → passport.ts findOrCreateUser)|code:block5 (User → Yale CAS SSO → passport.ts findOrCreateUser)]]
 - [[_COMMUNITY_Environment Variables|Environment Variables]]
 - [[_COMMUNITY_Key Services|Key Services]]
-- [[_COMMUNITY_Maintenance|Maintenance]]
-- [[_COMMUNITY_Monorepo Structure|Monorepo Structure]]
-- [[_COMMUNITY_Naming Conventions|Naming Conventions]]
 - [[_COMMUNITY_Security Middleware|Security Middleware]]
 - [[_COMMUNITY_`server.env`|`server/.env`]]
 - [[_COMMUNITY_Yale Research Codebase Reference|Yale Research Codebase Reference]]
 - [[_COMMUNITY_API Routes|API Routes]]
 - [[_COMMUNITY_Architecture|Architecture]]
-- [[_COMMUNITY_codebash (curl httplocalhost7700health)|code:bash (curl http://localhost:7700/health)]]
 - [[_COMMUNITY_codebash (curl httplocalhost7700health)|code:bash (curl http://localhost:7700/health)]]
 - [[_COMMUNITY_codebash (which node)|code:bash (which node)]]
 - [[_COMMUNITY_codeblock20 (yale-research)|code:block20 (yale-research/)]]
@@ -1109,11 +1030,8 @@
 - [[_COMMUNITY_Dev login bypass|Dev login bypass]]
 - [[_COMMUNITY_Operator board Gate Status — keeping it honest and current|Operator board Gate Status — keeping it honest and current]]
 - [[_COMMUNITY_YLabs — Developer Guide|Y/Labs — Developer Guide]]
-- [[_COMMUNITY_Acknowledgements|Acknowledgements]]
 - [[_COMMUNITY_codebash (corepack enable)|code:bash (corepack enable)]]
-- [[_COMMUNITY_codebash ( Terminal 1)|code:bash (# Terminal 1)]]
 - [[_COMMUNITY_codebash (codex mcp add playwright -- reposcriptswith-playwright-l)|code:bash (codex mcp add playwright -- <repo>/scripts/with-playwright-l)]]
-- [[_COMMUNITY_Documentation|Documentation]]
 - [[_COMMUNITY_Playwright environment fix (no root required)|Playwright environment fix (no root required)]]
 - [[_COMMUNITY_summary|summary]]
 - [[_COMMUNITY_acceptedInputsCoreSource|acceptedInputsCoreSource]]
@@ -2586,24 +2504,17 @@
 - [[_COMMUNITY_lab|lab]]
 - [[_COMMUNITY_sanitized|sanitized]]
 - [[_COMMUNITY_agents|agents]]
-- [[_COMMUNITY_Done Criteria|Done Criteria]]
-- [[_COMMUNITY_graphify|graphify]]
-- [[_COMMUNITY_Environment Variables|Environment Variables]]
-- [[_COMMUNITY_Environments|Environments]]
 - [[_COMMUNITY_Maintenance|Maintenance]]
 - [[_COMMUNITY_Tech Stack|Tech Stack]]
 - [[_COMMUNITY_Testing|Testing]]
 - [[_COMMUNITY_TypeScript Configuration|TypeScript Configuration]]
-- [[_COMMUNITY_YLabs Codebase Reference|Y/Labs Codebase Reference]]
 - [[_COMMUNITY_1. Install dependencies|1. Install dependencies]]
 - [[_COMMUNITY_2. Configure environment|2. Configure environment]]
 - [[_COMMUNITY_2. Install dependencies|2. Install dependencies]]
-- [[_COMMUNITY_3. Configure environment|3. Configure environment]]
 - [[_COMMUNITY_3. Start local Meilisearch|3. Start local Meilisearch]]
 - [[_COMMUNITY_4. Seed Meilisearch|4. Seed Meilisearch]]
 - [[_COMMUNITY_5. Seed Meilisearch|5. Seed Meilisearch]]
 - [[_COMMUNITY_5. Start dev servers|5. Start dev servers]]
-- [[_COMMUNITY_codeblock1 (React (Vite) → Express (Passport.js) → MongoDB Atlas + Meili)|code:block1 (React (Vite) → Express (Passport.js) → MongoDB Atlas + Meili)]]
 - [[_COMMUNITY_codebash (curl httplocalhost7700health)|code:bash (curl http://localhost:7700/health)]]
 - [[_COMMUNITY_codebash (yarn --cwd server meilirebuild-all --clear)|code:bash (yarn --cwd server meili:rebuild-all --clear)]]
 - [[_COMMUNITY_codebash (curl httplocalhost7700health)|code:bash (curl http://localhost:7700/health)]]
@@ -2611,36 +2522,20 @@
 - [[_COMMUNITY_codebash (yarn scrape help)|code:bash (yarn scrape help)]]
 - [[_COMMUNITY_codeblock21 (User → Yale CAS SSO → passport.ts findOrCreateUser)|code:block21 (User → Yale CAS SSO → passport.ts findOrCreateUser)]]
 - [[_COMMUNITY_codebash (yarn --cwd client test         watch mode — reruns on file )|code:bash (yarn --cwd client test        # watch mode — reruns on file )]]
-- [[_COMMUNITY_Local Development Setup|Local Development Setup]]
-- [[_COMMUNITY_Modifying a Schema|Modifying a Schema]]
-- [[_COMMUNITY_New Page|New Page]]
 - [[_COMMUNITY_Search|Search]]
-- [[_COMMUNITY_Tech Stack|Tech Stack]]
-- [[_COMMUNITY_Testing|Testing]]
 - [[_COMMUNITY_Troubleshooting|Troubleshooting]]
-- [[_COMMUNITY_What is tested|What is tested]]
 - [[_COMMUNITY_Yale Research — Developer Guide|Yale Research — Developer Guide]]
 - [[_COMMUNITY_Legacy CSV-to-JSON update script retired.  Department ground truth no longer com|Legacy CSV-to-JSON update script retired.  Department ground truth no longer com]]
 - [[_COMMUNITY_Documentation Maintenance|Documentation Maintenance]]
-- [[_COMMUNITY_Implementation Rules|Implementation Rules]]
-- [[_COMMUNITY_Rule Evolution|Rule Evolution]]
-- [[_COMMUNITY_Sensitive Areas|Sensitive Areas]]
 - [[_COMMUNITY_codetypescript (export const asyncHandler = (fn Function) = {)|code:typescript (export const asyncHandler = (fn: Function) => {)]]
-- [[_COMMUNITY_codetypescript (const logListingEvent = (eventType AnalyticsEventType) = {)|code:typescript (const logListingEvent = (eventType: AnalyticsEventType) => {)]]
 - [[_COMMUNITY_codeblock5 (User → Yale CAS SSO → passport.ts findOrCreateUser)|code:block5 (User → Yale CAS SSO → passport.ts findOrCreateUser)]]
-- [[_COMMUNITY_Product Model|Product Model]]
-- [[_COMMUNITY_Scrapers|Scrapers]]
 - [[_COMMUNITY_Search|Search]]
-- [[_COMMUNITY_Sensitive Files|Sensitive Files]]
-- [[_COMMUNITY_Tech Stack|Tech Stack]]
 - [[_COMMUNITY_Auth Middleware (`serversrcmiddlewareauth.ts`)|Auth Middleware (`server/src/middleware/auth.ts`)]]
 - [[_COMMUNITY_Authentication|Authentication]]
 - [[_COMMUNITY_codebash (curl httplocalhost7700health)|code:bash (curl http://localhost:7700/health)]]
-- [[_COMMUNITY_codetxt (Usage Error Couldn't find the node_modules state file - run)|code:txt (Usage Error: Couldn't find the node_modules state file - run)]]
 - [[_COMMUNITY_codebash (nvm install 20)|code:bash (nvm install 20)]]
 - [[_COMMUNITY_codebash (nvm install 20)|code:bash (nvm install 20)]]
 - [[_COMMUNITY_Project Structure|Project Structure]]
-- [[_COMMUNITY_Troubleshooting|Troubleshooting]]
 - [[_COMMUNITY_Troubleshooting Yarn setup|Troubleshooting Yarn setup]]
 - [[_COMMUNITY_codebash ( Terminal 1)|code:bash (# Terminal 1)]]
 
@@ -2671,7 +2566,7 @@
 ## Import Cycles
 - None detected.
 
-## Communities (3266 total, 2353 thin omitted)
+## Communities (3161 total, 2246 thin omitted)
 
 ### Community 0 - "Decisions"
 Cohesion: 0.11
@@ -2682,8 +2577,8 @@ Cohesion: 0.07
 Nodes (48): adminQualityNotes(), AffiliatedResearchEntitiesSection(), compactDepartmentLabels(), decisionNextStep(), DecisionSummary(), dedupeLeadMembers(), detailDescription(), detailTopics() (+40 more)
 
 ### Community 2 - "browsable.ts"
-Cohesion: 0.05
-Nodes (58): FellowshipModal(), FellowshipModalProps, RichText(), trackFellowshipApplyClick(), ArchivedBadge(), BrowseCard, BrowseCardProps, BrowseGrid() (+50 more)
+Cohesion: 0.06
+Nodes (47): ArchivedBadge(), BrowseCard, BrowseCardProps, BrowseGrid(), BrowseGridProps, BrowseListItem, BrowseListItemProps, FavoriteButton (+39 more)
 
 ### Community 3 - "security-preflight.test.mjs"
 Cohesion: 0.29
@@ -2698,8 +2593,8 @@ Cohesion: 0.08
 Nodes (32): LabInquireModal(), LabInquireModalProps, LabMembersList(), LabMembersListProps, ROLE_LABELS, ROLE_ORDER, ROLE_PILL_CLASSES, basePayload (+24 more)
 
 ### Community 6 - "App.tsx"
-Cohesion: 0.05
-Nodes (33): PlanningOverview(), PlanningOverviewProps, pluralize(), scrollPositions, ScrollToTop(), normalizeReturnPath(), SignInButton(), SignInButtonProps (+25 more)
+Cohesion: 0.04
+Nodes (34): PlanningOverview(), PlanningOverviewProps, pluralize(), scrollPositions, ScrollToTop(), normalizeReturnPath(), SignInButton(), SignInButtonProps (+26 more)
 
 ### Community 7 - "logSanitizer.ts"
 Cohesion: 0.06
@@ -2710,8 +2605,8 @@ Cohesion: 0.21
 Nodes (9): AdminFellowshipsTable(), AdminFellowshipsFilter, AdminFellowshipsSortField, AdminFellowshipsTableAction, adminFellowshipsTableReducer(), AdminFellowshipsTableState, createInitialAdminFellowshipsTableState(), createInitialAdminTableState() (+1 more)
 
 ### Community 9 - "cleanPublicProfileBio"
-Cohesion: 0.12
-Nodes (24): appointmentTitleCount(), cleanPublicProfileBio(), clipPublicProfileBio(), degreeTokenCount(), hasPublicProfileEmail(), hasResearchDescriptionVerb(), isAffiliationOnlyResearchSummary(), isAppointmentListOnlyProfileBio() (+16 more)
+Cohesion: 0.07
+Nodes (60): ADMIN_UPDATE_FIELDS, ALLOWED_SELF_UPDATE_FIELDS, appointmentTitleCount(), boundedProfileUrlKey(), boundedPublicationNumber(), boundedPublicationText(), boundedPublicProfileUrl(), capitalizeSentenceStart() (+52 more)
 
 ### Community 10 - "labMicrositeUndergradLLMExtractor.ts"
 Cohesion: 0.09
@@ -2738,8 +2633,8 @@ Cohesion: 0.08
 Nodes (55): AccessSignalConfidence, AccessSignalType, ContactPolicy, ContactRouteVisibility, accessArtifactCandidatesFromDerived(), AccessMaterializationResult, AccessObservation, bestObservation() (+47 more)
 
 ### Community 16 - "ConfigContext.ts"
-Cohesion: 0.18
-Nodes (16): baseProfile, ConfigContextType, defaultConfigContext, DepartmentConfig, FieldConfig, ResearchAreaConfig, colorKeyToTailwind, ConfigContextProvider() (+8 more)
+Cohesion: 0.09
+Nodes (26): baseProfile, ConfigContextType, defaultConfigContext, DepartmentConfig, FieldConfig, ResearchAreaConfig, __resetResearchPageSnapshotForTests(), departments (+18 more)
 
 ### Community 18 - "sanitizeLogValue"
 Cohesion: 0.10
@@ -2754,8 +2649,8 @@ Cohesion: 0.07
 Nodes (49): authConfig, authDebug(), AuthenticatedSessionUser, buildDirectoryUpdate(), casLogin(), DEV_LOGIN_PROFILES, ensureDevLoginUser(), findOrCreateUser() (+41 more)
 
 ### Community 21 - "Navbar.tsx"
-Cohesion: 0.05
-Nodes (32): AboutButton(), AnalyticsButton(), FeedbackButton(), getAcademicDisciplineColor(), getResearchAreaChipColor(), listingQuickFilters, Navbar(), NavbarSearchBar() (+24 more)
+Cohesion: 0.04
+Nodes (36): AboutButton(), AnalyticsButton(), FeedbackButton(), getAcademicDisciplineColor(), getResearchAreaChipColor(), listingQuickFilters, Navbar(), NavbarSearchBar() (+28 more)
 
 ### Community 22 - "undergradFellowshipRecipientScraper.ts"
 Cohesion: 0.10
@@ -2830,8 +2725,8 @@ Cohesion: 0.06
 Nodes (44): AdminDepartments(), CATEGORY_COLORS, DEPARTMENT_CATEGORIES, DepartmentAction, DepartmentDoc, DepartmentState, EditDraft, INITIAL_NEW_DRAFT (+36 more)
 
 ### Community 42 - "getUniqueDepartmentLabels"
-Cohesion: 0.07
-Nodes (42): DepartmentInput(), DepartmentInputProps, ProfileEditor(), ProfileEditorProps, orcidHref(), ProfileHeader(), ProfileHeaderProps, profileLinkDedupeKey() (+34 more)
+Cohesion: 0.08
+Nodes (37): DepartmentInput(), DepartmentInputProps, ProfileEditor(), ProfileEditorProps, AdminListing, AdminListingEditModal(), Props, orcidHref() (+29 more)
 
 ### Community 43 - "researchEntityCoverageAudit.ts"
 Cohesion: 0.13
@@ -2839,7 +2734,7 @@ Nodes (29): aggregateCountMap(), AuditEntityRecord, buildBulkAudit(), buildObser
 
 ### Community 44 - "axios.ts"
 Cohesion: 0.05
-Nodes (37): mockedAxios, AdminListing, AdminListingEditModal(), Props, mockedAxios, HttpStatusNotifier(), CourseTableCourse, CourseTableSection() (+29 more)
+Nodes (42): mockedAxios, mockedAxios, HttpStatusNotifier(), CourseTableCourse, CourseTableSection(), CourseTableSectionProps, formatSeason(), ProfileListingsProps (+34 more)
 
 ### Community 45 - "sourceHealth.ts"
 Cohesion: 0.06
@@ -2859,15 +2754,15 @@ Nodes (38): annotateEntitiesWithLeadUsers(), annotateEntitiesWithSourceObservati
 
 ### Community 49 - "listingService.ts"
 Cohesion: 0.10
-Nodes (48): deleteListingForCurrentUser(), getListingModel(), addFavorite(), addView(), archiveListing(), boundedListingDate(), boundedListingNetid(), boundedListingNetidArray() (+40 more)
+Nodes (47): getListingModel(), addFavorite(), addView(), archiveListing(), boundedListingDate(), boundedListingNetid(), boundedListingNetidArray(), boundedListingNumber() (+39 more)
 
 ### Community 50 - "fellowshipService.ts"
 Cohesion: 0.09
 Nodes (43): addFavorite(), addView(), adminFellowshipDate(), adminFellowshipLinks(), adminFellowshipNumber(), adminFellowshipStringArray(), adminFellowshipText(), archiveFellowship() (+35 more)
 
 ### Community 51 - "betaDataQualityCore.ts"
-Cohesion: 0.06
-Nodes (65): DuplicateEntityCluster, main(), BETA_CHECK_OPERATOR_METADATA, betaCommand(), BetaDataQualityCheck, BetaDataQualityDiagnostics, BetaDataQualityProgressEvent, BetaDataQualityScorecard (+57 more)
+Cohesion: 0.05
+Nodes (67): DuplicateEntityCluster, main(), BETA_CHECK_OPERATOR_METADATA, betaCommand(), BetaDataQualityCheck, BetaDataQualityDiagnostics, BetaDataQualityProgressEvent, BetaDataQualityScorecard (+59 more)
 
 ### Community 52 - "scripts"
 Cohesion: 0.03
@@ -2890,16 +2785,16 @@ Cohesion: 0.11
 Nodes (27): getOpportunityById(), normalizeOpportunityIdParam(), mocks, compactStrings(), evidenceExcerpt(), firstEvidenceText(), getOpportunityApplicationLabel(), getOpportunityApplicationState() (+19 more)
 
 ### Community 57 - "staleObservationConflictReview.ts"
-Cohesion: 0.07
-Nodes (29): ACCESS_EVIDENCE_CONFLICT_FIELDS, ADDITIVE_METADATA_CONFLICT_FIELDS, AggregatedObservationConflictGroup, ALL_KNOWN_CONFLICT_FIELDS, buildMongoFieldFilter(), CONTENT_CONFLICT_FIELDS, __filename, FUNDING_CONTEXT_CONFLICT_FIELDS (+21 more)
+Cohesion: 0.08
+Nodes (25): ACCESS_EVIDENCE_CONFLICT_FIELDS, ADDITIVE_METADATA_CONFLICT_FIELDS, AggregatedObservationConflictGroup, ALL_KNOWN_CONFLICT_FIELDS, CONTENT_CONFLICT_FIELDS, __filename, FUNDING_CONTEXT_CONFLICT_FIELDS, IDENTITY_OR_ROUTING_CONFLICT_FIELDS (+17 more)
 
 ### Community 58 - "researchEntityDescriptionQuality.ts"
 Cohesion: 0.13
 Nodes (47): activeAreasOfResearchSummary(), assessResearchEntityDescriptionQuality(), deriveShortDescriptionFromFullDescription(), DescriptionQualityFlag, FieldQuality, fullDescriptionQuality(), hasBrokenTemplate(), hasDuplicatedLongFragment() (+39 more)
 
 ### Community 59 - "betaDataQuality.ts"
-Cohesion: 0.09
-Nodes (50): ACTIVE_FILTER, asString(), asStringArray(), buildBetaDataQualityScorecard(), buildCollectionCounts(), buildDescriptionQuality(), buildDuplicateEntityNames(), buildLiveLinkCheck() (+42 more)
+Cohesion: 0.10
+Nodes (48): ACTIVE_FILTER, asString(), asStringArray(), buildBetaDataQualityScorecard(), buildCollectionCounts(), buildDescriptionQuality(), buildDuplicateEntityNames(), buildLiveLinkCheck() (+40 more)
 
 ### Community 60 - "studentVisibilityTier.ts"
 Cohesion: 0.12
@@ -2907,15 +2802,15 @@ Nodes (33): classifyProgramResearchRelevance(), ProgramResearchRelevanceInput, P
 
 ### Community 61 - "listingController.ts"
 Cohesion: 0.09
-Nodes (42): addViewToListing(), archiveListingForCurrentUser(), boundedListingSearchQuery(), buildRobustFilterMatch(), createListingForCurrentUser(), escapeMeiliFilterValue(), filterListingUpdate(), getListingById() (+34 more)
+Nodes (43): addViewToListing(), archiveListingForCurrentUser(), boundedListingSearchQuery(), buildRobustFilterMatch(), createListingForCurrentUser(), deleteListingForCurrentUser(), escapeMeiliFilterValue(), filterListingUpdate() (+35 more)
 
 ### Community 62 - "researchGroup.ts"
 Cohesion: 0.07
 Nodes (48): LabHeader(), LabHeaderProps, normalizeActionUrl(), baseGroup, baseGroup, WaysToApproachSection(), getResearchGroupStatus(), AccessSummary (+40 more)
 
 ### Community 63 - "analyticsService.ts"
-Cohesion: 0.07
-Nodes (62): AnalyticsEvent, ActionNeededAnalytics, ANALYTICS_EVENT_TYPES, ANALYTICS_NON_USER_NETIDS, ANALYTICS_RESEARCH_ENTITY_TYPES, AnalyticsUserDrilldownQuery, AnalyticsUserDrilldownResult, AnalyticsUsersQuery (+54 more)
+Cohesion: 0.05
+Nodes (70): AnalyticsEvent, ANALYTICS_SORT_DIRECTIONS, ANALYTICS_USER_SORTS, AnalyticsRequestError, parseAnalyticsSortDirection(), parseAnalyticsUserSort(), ActionNeededAnalytics, ANALYTICS_EVENT_TYPES (+62 more)
 
 ### Community 65 - "acceptedInputsCore.ts"
 Cohesion: 0.07
@@ -2958,8 +2853,8 @@ Cohesion: 0.12
 Nodes (25): addIfDefined(), getProfile(), getProfileCourses(), getProfileListings(), getPublications(), normalizePublicationPagination(), PUBLICATION_SORT_FIELDS, publicationSortValue() (+17 more)
 
 ### Community 75 - "analytics.ts"
-Cohesion: 0.05
-Nodes (45): analyticsEventSchema, AnalyticsEventType, RESEARCH_ENTITY_TYPES, ResearchEntityType, ANALYTICS_SORT_DIRECTIONS, ANALYTICS_USER_SORTS, AnalyticsRequestError, parseAnalyticsSortDirection() (+37 more)
+Cohesion: 0.09
+Nodes (33): analyticsEventSchema, AnalyticsEventType, RESEARCH_ENTITY_TYPES, ResearchEntityType, AnalyticsUserEvent, LogEventParams, AnalyticsUser, buildResearchEvent() (+25 more)
 
 ### Community 76 - "openAlexPaperScraper.ts"
 Cohesion: 0.13
@@ -2994,8 +2889,8 @@ Cohesion: 0.06
 Nodes (42): BetaRepairQueueGateArtifact, buildQueueSummaries(), buildReleaseQueueSummary(), buildSourceFreshness(), classifyOperatorQueueReason(), compactProgramSample(), compactResearchSample(), countByTier() (+34 more)
 
 ### Community 84 - "Listing"
-Cohesion: 0.13
-Nodes (17): ListingEditor(), ListingEditorProps, COLUMNS, KanbanBoardProps, createInitialListingFormState(), ListingFormAction, ListingFormErrors, listingFormReducer() (+9 more)
+Cohesion: 0.11
+Nodes (24): ListingEditor(), COLUMNS, KanbanBoardProps, SearchContextProvider(), SearchContextProviderProps, createInitialOwnListingsState(), OwnListingsAction, ownListingsReducer() (+16 more)
 
 ### Community 85 - "promoteAcceptedBetaCopy.ts"
 Cohesion: 0.11
@@ -3058,8 +2953,8 @@ Cohesion: 0.12
 Nodes (31): DuplicatePersonGroup, buildUserIdentityDedupePlan(), buildUserIdentityDedupeSummary(), canonicalScore(), chooseCanonicalUser(), clusterUsersByCompatibleName(), comparePlannedGroups(), compareStrings() (+23 more)
 
 ### Community 101 - "opportunityDetail.tsx"
-Cohesion: 0.09
-Nodes (22): PrivateRoute(), PrivateRouteProps, InfiniteScrollLoadingDots(), InfiniteScrollLoadingDotsProps, LoadingSpinner(), LoadingSpinnerProps, sizeMap, applicationStateTone() (+14 more)
+Cohesion: 0.20
+Nodes (17): assertBetaSeedAllowed(), BetaSeedEnvironmentCliOptions, BetaSeedPlan, BetaSeedPlanStep, BetaSeedRunResult, buildBetaSeedPlan(), __filename, main() (+9 more)
 
 ### Community 103 - "ScraperContext"
 Cohesion: 0.12
@@ -3085,17 +2980,21 @@ Nodes (53): allowedValues(), hasOversizedStringList(), isOversizedSearchRequest(
 Cohesion: 0.25
 Nodes (16): addResearchEntityDetailAlias(), addResearchEntitySearchAliases(), departmentDisplayLabel(), normalizedDepartmentLabel(), OPERATOR_PUBLIC_RESEARCH_ENTITY_FIELDS, OPTIONAL_PUBLIC_RESEARCH_ENTITY_FIELDS, publicDepartmentArray(), publicHttpUrl() (+8 more)
 
+### Community 109 - "Authentication Flow"
+Cohesion: 0.23
+Nodes (12): expandedResearchAreasPublicBio(), formatPublicBioList(), hasOfficialYaleProfileUrl(), officialProfileResearchInterestTermsBio(), publicProfileDisplayName(), supportedPublicProfileTopics(), cleanResearchTerm(), extractExplicitResearchInterestPhrases() (+4 more)
+
 ### Community 110 - "repairArchivedEntityArtifacts.ts"
 Cohesion: 0.15
 Nodes (24): applyRepairPlan(), archiveArtifact(), ARTIFACT_SPECS, ArtifactSpec, assertArchivedEntityArtifactRepairApplyAllowed(), buildRepairArchivedEntityArtifactsOutput(), collectionExists(), __filename (+16 more)
 
 ### Community 111 - "profileService.ts"
 Cohesion: 0.09
-Nodes (44): ADMIN_UPDATE_FIELDS, ALLOWED_SELF_UPDATE_FIELDS, boundedProfileUrlKey(), boundedPublicationNumber(), boundedPublicationText(), boundedPublicProfileUrl(), cleanPublicHttpUrl(), cleanPublicSourceLabel() (+36 more)
+Nodes (31): buildProfileResearchMembershipFilter(), cleanPublicSourceLabel(), cleanScholarlyTitle(), cleanUrl(), dateToIso(), hasInspectableOpenAlexDestination(), isDatasetLikeScholarlyLink(), isGeneratedOfficialProfilePublicationAnchor() (+23 more)
 
 ### Community 113 - "betaRepairQueue.ts"
-Cohesion: 0.09
-Nodes (36): StudentVisibilityTier, VisibilityReleaseQueueCollection, visibilityReleaseQueueCollections, visibilityReleaseQueueItemSchema, VisibilityReleaseQueueStatus, visibilityReleaseQueueStatuses, VisibilityRepairStage, visibilityRepairStages (+28 more)
+Cohesion: 0.22
+Nodes (17): arrayValue(), assertBetaRepairQueueApplyReviewedArtifact(), BetaRepairQueueApplyArtifactValidation, BetaRepairQueueCliOptions, blockedReasonsForAttempt(), buildApplyFromArtifactOptions(), buildBetaRepairQueueOutput(), main() (+9 more)
 
 ### Community 115 - "materializeEntity"
 Cohesion: 0.16
@@ -3117,6 +3016,10 @@ Nodes (21): ScrapeJobLock, scrapeJobLockSchema, Source, createCronOwnerId(), cre
 Cohesion: 0.18
 Nodes (19): absoluteUrl(), cleanText(), DEFAULT_YALE_RESEARCH_DIRECTORY_CONFIGS, entityFromRecord(), entityToObservations(), inferResearchYaleKind(), pageUrlForIndex(), parseDirectory() (+11 more)
 
+### Community 123 - "Adding a New Endpoint"
+Cohesion: 0.31
+Nodes (7): createInitialListingFormState(), ListingFormAction, ListingFormErrors, listingFormReducer(), ListingFormState, researchAreasFromListing(), resolve()
+
 ### Community 124 - "visibilityRepairQueueService.ts"
 Cohesion: 0.10
 Nodes (68): member(), actionReasons, archivedResearchEntityRepairBlock(), attemptProgramRepair(), attemptResearchActionEvidenceRepair(), attemptResearchRepair(), attemptVisibilityRepair(), buildResearchSourceDescriptionPatch() (+60 more)
@@ -3126,8 +3029,8 @@ Cohesion: 0.18
 Nodes (16): candidateProfileUrls(), defaultVerifier(), DESC_BLOCK_REASONS, __dirname, __filename, isTrustedYaleProfileUrl(), LEAD_ROLES, main() (+8 more)
 
 ### Community 126 - "fellowships.tsx"
-Cohesion: 0.07
-Nodes (30): ActiveFilterChip, ActiveFiltersProps, QuickFilterDef, sortOptions, copy, FirstSaveCallout(), FirstSaveCalloutProps, ViewModeToggle() (+22 more)
+Cohesion: 0.06
+Nodes (38): FellowshipModal(), FellowshipModalProps, RichText(), trackFellowshipApplyClick(), sortOptions, copy, FirstSaveCallout(), FirstSaveCalloutProps (+30 more)
 
 ### Community 127 - "researchEntityDescriptionText.ts"
 Cohesion: 0.18
@@ -3142,8 +3045,8 @@ Cohesion: 0.21
 Nodes (12): arxivEntryToObservations(), ArxivFetcher, buildAuthorSearchQuery(), normalizeArxivId(), normalizeArxivText(), parseArxivFeed(), ParsedArxivEntry, shouldProcessFaculty() (+4 more)
 
 ### Community 131 - "launchReviewExceptions.ts"
-Cohesion: 0.09
-Nodes (36): publicSafeStudentVisibilityTiers, publicStudentVisibilityTiers, studentVisibilityTiers, buildLaunchReviewExceptionCandidates(), buildLaunchReviewExceptionDecisionTemplate(), buildLaunchReviewExceptionOutput(), buildLaunchReviewExceptionPlan(), buildLaunchReviewExceptionReview() (+28 more)
+Cohesion: 0.06
+Nodes (55): publicSafeStudentVisibilityTiers, publicStudentVisibilityTiers, StudentVisibilityTier, studentVisibilityTiers, VisibilityReleaseQueueCollection, visibilityReleaseQueueCollections, visibilityReleaseQueueItemSchema, VisibilityReleaseQueueStatus (+47 more)
 
 ### Community 133 - "Session Notes"
 Cohesion: 0.10
@@ -3183,7 +3086,7 @@ Nodes (29): cleanOfficialProfileDisplayName(), cleanOfficialProfileTitle(), clip
 
 ### Community 143 - "assertScriptApplyAllowed"
 Cohesion: 0.06
-Nodes (58): assertDepartmentMigrationApplyAllowed(), buildDepartmentMigrationOutput(), ChangeLog, DepartmentDoc, DepartmentMigrationCliOptions, DepartmentMigrationResult, __dirname, __filename (+50 more)
+Nodes (49): assertDepartmentMigrationApplyAllowed(), buildDepartmentMigrationOutput(), ChangeLog, DepartmentDoc, DepartmentMigrationCliOptions, DepartmentMigrationResult, __dirname, __filename (+41 more)
 
 ### Community 144 - "centerDirectorLLMExtractor.ts"
 Cohesion: 0.15
@@ -3246,8 +3149,8 @@ Cohesion: 0.18
 Nodes (21): addPublicPaperField(), buildLeadPiOutreachContactRoute(), getResearchGroupDetail(), memberDisplayName(), PUBLIC_PAPER_STAGES, publicAccessSignalForResearchDetail(), publicContactRouteForResearchDetail(), publicEntryPathwayForResearchDetail() (+13 more)
 
 ### Community 163 - "normalizePublicProfile"
-Cohesion: 0.13
-Nodes (23): hasProfileDirectoryLabelContamination(), isLabOrResearchGroupUrl(), normalizePublicProfile(), parseProfileUrl(), PUBLIC_PROFILE_BASE_ARRAY_FIELDS, PUBLIC_PROFILE_BASE_TEXT_FIELDS, publicProfileBase(), publicProfileImageUrl() (+15 more)
+Cohesion: 0.18
+Nodes (19): cleanProfileUrlsForPerson(), cleanPublicHttpUrl(), hasProfileDirectoryLabelContamination(), normalizePublicProfile(), officialYaleProfileUrlForUser(), PUBLIC_PROFILE_BASE_ARRAY_FIELDS, PUBLIC_PROFILE_BASE_TEXT_FIELDS, publicProfileBase() (+11 more)
 
 ### Community 164 - "disambiguateSurnameLabNames.ts"
 Cohesion: 0.12
@@ -3290,8 +3193,8 @@ Cohesion: 0.17
 Nodes (18): BETA_ROLLOUT_ORDER, BetaReadinessGateCliOptions, buildBetaReadinessCommands(), buildBetaReadinessGateOutput(), collectionCount(), describeMongoTarget(), __dirname, EXPECTED_SOURCE_NAMES (+10 more)
 
 ### Community 178 - "updateOwnProfile"
-Cohesion: 0.22
-Nodes (13): ADMIN_PROFILE_USER_TYPES, adminUpdateProfile(), boundedAdminProfileEmail(), boundedAdminProfileNumber(), boundedAdminProfileText(), boundedProfileString(), boundedProfileStringArray(), isProfileUpdatePayload() (+5 more)
+Cohesion: 0.31
+Nodes (10): ADMIN_PROFILE_USER_TYPES, adminUpdateProfile(), boundedAdminProfileEmail(), boundedAdminProfileNumber(), boundedAdminProfileText(), boundedProfileString(), boundedProfileStringArray(), sanitizeAdminProfileScalarFields() (+2 more)
 
 ### Community 180 - "adminAccessReviewService.ts"
 Cohesion: 0.14
@@ -3346,20 +3249,20 @@ Cohesion: 0.25
 Nodes (8): assertStaleObservationConflictReviewApplyAllowed(), buildStaleObservationConflictReviewOutput(), buildStaleObservationDecisionTemplate(), main(), normalizeStaleObservationObjectId(), toObjectId(), writeStaleObservationConflictReviewOutput(), writeStaleObservationDecisionTemplate()
 
 ### Community 193 - "launchTrustContract.ts"
-Cohesion: 0.22
-Nodes (14): LaunchReviewExceptionCliOptions, buildLaunchTrustContractOutput(), CliOptions, __filename, main(), parseLaunchTrustContractArgs(), parsePositiveInteger(), parseRequiredValue() (+6 more)
+Cohesion: 0.33
+Nodes (4): router, invokeRouteHandler(), mocks, routeByPath()
 
 ### Community 194 - "EvidenceSourceRow.tsx"
 Cohesion: 0.39
 Nodes (7): EvidenceSourceRow(), EvidenceSourceRowProps, formatConfidence(), formatDate(), formatSourceType(), labelize(), EvidenceSourceRowData
 
 ### Community 195 - "UserContext.ts"
-Cohesion: 0.07
-Nodes (22): defaultUserContext, container, root, __resetResearchPageSnapshotForTests(), UserContextValue, departments, mockedAxios, mockEmptySearchResponses() (+14 more)
+Cohesion: 0.22
+Nodes (11): ListingEditorProps, container, root, UserContextProvider(), sampleUser, createInitialUserState(), UserAction, userReducer() (+3 more)
 
 ### Community 196 - "resolveSafeJsonReportOutputPath"
-Cohesion: 0.12
-Nodes (30): Fellowship, CliOptions, main(), parseArgs(), assertBackfillProgramClassificationsApplyAllowed(), BackfillProgramClassificationsCliOptions, buildBackfillProgramClassificationsOutput(), main() (+22 more)
+Cohesion: 0.10
+Nodes (36): Fellowship, CliOptions, main(), parseArgs(), BackfillEntry, CliOptions, DEFAULT_INPUT, isCommunityForcePortal() (+28 more)
 
 ### Community 197 - "dependencies"
 Cohesion: 0.12
@@ -3392,6 +3295,10 @@ Nodes (13): applyRepairs(), assertRepairListingResearchEntityProfilesApplyAllowe
 ### Community 204 - "researchGroupFilters.ts"
 Cohesion: 0.33
 Nodes (6): acceptanceLevelClauses(), AcceptanceLevelInput, buildResearchGroupFilterString(), escapeMeiliFilterValue(), orEqualsClause(), ResearchGroupFilterInput
+
+### Community 205 - "Adding Things"
+Cohesion: 0.29
+Nodes (7): applyStaleObservationSupersessions(), buildMongoFieldFilter(), defaultStaleObservationApplyDeps(), loadSameSourceConflictGroups(), mongoFieldFilterForCategory(), runStaleObservationConflictReview(), stringifyId()
 
 ### Community 206 - "AdminFacultyProfilesTable.tsx"
 Cohesion: 0.16
@@ -3478,8 +3385,8 @@ Cohesion: 0.11
 Nodes (18): compilerOptions, esModuleInterop, forceConsistentCasingInFileNames, lib, module, moduleResolution, noImplicitAny, outDir (+10 more)
 
 ### Community 233 - "trustedLeadResearchHomeBioFallback"
-Cohesion: 0.21
-Nodes (13): capitalizeSentenceStart(), cleanResearchHomeSummaryForBio(), dedupeProfileResearchEntities(), entityNameMatchesUser(), isIndividualResearchEntity(), isLeadRole(), isUsefulResearchHomeBioSummary(), looksLikePersonOnlyResearchHomeName() (+5 more)
+Cohesion: 0.40
+Nodes (6): hasPersonScopedYaleDirectoryPath(), isLabOrResearchGroupUrl(), isOfficialYaleProfileUrlForUser(), isYaleHost(), parseProfileUrl(), pathSegments()
 
 ### Community 234 - "cli.ts"
 Cohesion: 0.15
@@ -3504,10 +3411,6 @@ Nodes (6): copyFiniteNumber(), normalizeAcceptedDecisionValidation(), normalizeD
 ### Community 243 - "UI/UX Direction"
 Cohesion: 0.18
 Nodes (11): Canonical Product Frame, Current Interface Shape, Graphify Grounding, `/listings`, Near-Term UX Moves, Open UX Questions, `/research`, `/research/:slug` (+3 more)
-
-### Community 247 - "profileService.test.ts"
-Cohesion: 0.21
-Nodes (9): buildProfileResearchMembershipFilter(), isOfficialProfileScholarlyLink(), loadProfileResearchEntities(), loadProfileScholarlyLinks(), orderProfileScholarlyLinks(), paperToScholarlyLink(), profileDocumentId(), buildResearchActivityLinkPayload() (+1 more)
 
 ### Community 248 - "researchEntity.ts"
 Cohesion: 0.06
@@ -3566,8 +3469,8 @@ Cohesion: 0.18
 Nodes (11): CTA Vocabulary, Entity Page Questions, Explore Research, Navigation Shape, North Star, Primary Surfaces, Product Context, Product Premise (+3 more)
 
 ### Community 272 - "apiBaseUrl.ts"
-Cohesion: 0.22
-Nodes (13): AdminRoute(), AdminRouteProps, getLocalAdminDevLoginUrl(), getSafeLocalAdminRedirectTarget(), SignOutButton(), storeLogoutReturnPath(), buildApiUrl(), getApiBaseUrl() (+5 more)
+Cohesion: 0.12
+Nodes (20): AdminRoute(), AdminRouteProps, getLocalAdminDevLoginUrl(), getSafeLocalAdminRedirectTarget(), PrivateRoute(), PrivateRouteProps, InfiniteScrollLoadingDots(), InfiniteScrollLoadingDotsProps (+12 more)
 
 ### Community 273 - "resolutions"
 Cohesion: 0.12
@@ -3586,8 +3489,8 @@ Cohesion: 0.27
 Nodes (7): adminTableReducer(), createInitialPublicationsTableState(), PublicationsFilter, PublicationsTableAction, publicationsTableReducer(), PublicationsTableState, TestPublication
 
 ### Community 283 - "isLikelyPersonUrl"
-Cohesion: 0.14
-Nodes (27): initial(), allNameTokens(), allowsLastNameOnlyPersonUrl(), cleanProfileUrlsForPerson(), compoundLastNameMatchedTokens(), expandedResearchAreasPublicBio(), formatPublicBioList(), givenNameAliasMatches() (+19 more)
+Cohesion: 0.28
+Nodes (15): initial(), allNameTokens(), allowsLastNameOnlyPersonUrl(), compoundLastNameMatchedTokens(), givenNameAliasMatches(), hasPartialCompoundLastNameProfilePath(), hasSurnameOnlyProfilePath(), isAmbiguousInitialLastProfileUrl() (+7 more)
 
 ### Community 284 - "sanitizeMongo.ts"
 Cohesion: 0.40
@@ -3738,8 +3641,8 @@ Cohesion: 0.43
 Nodes (5): findSecretFindings(), isAllowedPlaceholder(), lineNumberForIndex(), PLACEHOLDER_PATTERNS, SECRET_RULES
 
 ### Community 408 - "runStaleObservationConflictReview"
-Cohesion: 0.29
-Nodes (7): applyStaleObservationSupersessions(), defaultStaleObservationApplyDeps(), runStaleObservationConflictReview(), sameStringSet(), StaleObservationConflictObservation, validateStaleObservationReviewDecision(), validateStaleObservationReviewDecisions()
+Cohesion: 0.50
+Nodes (4): sameStringSet(), StaleObservationConflictObservation, validateStaleObservationReviewDecision(), validateStaleObservationReviewDecisions()
 
 ### Community 409 - "Graphify repo memory"
 Cohesion: 0.15
@@ -3774,24 +3677,24 @@ Cohesion: 0.09
 Nodes (33): AccessSignal, accessSignalSchema, ContactRoute, contactRouteSchema, EntryPathway, entryPathwaySchema, grantSchema, fieldProvenanceSchema (+25 more)
 
 ## Knowledge Gaps
-- **4483 isolated node(s):** `name`, `version`, `private`, `node`, `@emotion/react` (+4478 more)
+- **4377 isolated node(s):** `name`, `version`, `private`, `node`, `@emotion/react` (+4372 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **2353 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **2246 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `sanitizeLogValue()` connect `sanitizeLogValue` to `departmentRosterScraper.ts`, `logSanitizer.ts`, `labMicrositeUndergradLLMExtractor.ts`, `entityMaterializer.ts`, `labMicrositeDescriptionLLMExtractor.ts`, `passport.ts`, `undergradFellowshipRecipientScraper.ts`, `duplicateEntityNameReview.ts`, `dedupeResearchEntitiesByPi.ts`, `admin.ts`, `profileDataQualityAudit.ts`, `centersInstitutesScraper.ts`, `nihReporterScraper.ts`, `User`, `userService.ts`, `serializedDocumentId`, `researchEntityCoverageAudit.ts`, `sourceHealth.ts`, `repairOfficialProfilePublicationPointers.ts`, `officialProfilePiBackfillScraper.test.ts`, `listingService.ts`, `runReport.ts`, `opportunityDetailService.ts`, `staleObservationConflictReview.ts`, `betaDataQuality.ts`, `listingController.ts`, `analyticsService.ts`, `entryPathwayService.ts`, `yaleCollegeFellowshipsOfficeScraper.ts`, `nsfAwardScraper.ts`, `scholarlyLinkSuppressionAudit.ts`, `postedOpportunityService.ts`, `profileController.ts`, `analytics.ts`, `openAlexPaperScraper.ts`, `types.ts`, `ResearchGroupMember`, `promoteAcceptedBetaCopy.ts`, `paperAuthorshipAudit.ts`, `Observation`, `assertPublicHttpUrl`, `studentDecisionLLMExtractor.ts`, `backfillProfileBiosFromOfficialUrls.ts`, `rebuildPathwaySearchIndex.ts`, `claimGate.ts`, `ScraperContext`, `officialProfilePiBackfillScraper.ts`, `repairArchivedEntityArtifacts.ts`, `betaRepairQueue.ts`, `materializeEntity`, `pathwayQualityAudit.ts`, `cronRunner.ts`, `backfillResearchHomeOfficialUrls.ts`, `arxivPreprintScraper.ts`, `launchReviewExceptions.ts`, `acceptedInputs.ts`, `dedupeUsersByIdentity.ts`, `fellowshipController.ts`, `applicationRoutePathwayBackfillCore.ts`, `assertScriptApplyAllowed`, `centerDirectorLLMExtractor.ts`, `crossSourceObservationConflictReview.ts`, `migrateResearchEntities.ts`, `researchQualitySearchReview.ts`, `migrateResearchEntityCollections.ts`, `researchGroupController.ts`, `disambiguateSurnameLabNames.ts`, `repairDuplicateAccessSignals.ts`, `profileBioCoverageAudit.ts`, `programController.ts`, `repairMismatchedPersonEmailsCore.ts`, `betaReadinessGate.ts`, `studentVisibilityRepairTargets.ts`, `cleanupLegacyMongoCollections.ts`, `seedSources.ts`, `configService.ts`, `backfillCenterDirectors.ts`, `migrateMongoNaming.ts`, `launchTrustContract.ts`, `resolveSafeJsonReportOutputPath`, `userEmailHygiene.ts`, `orcidWorksScraper.ts`, `repairListingResearchEntityProfiles.ts`, `meiliSyncService.ts`, `index.ts`, `repairProfileDescriptionBackfillConflicts.ts`, `clearBetaStudentAnalytics.ts`, `scraperIntegrityDuplicateReview.ts`, `auditResearchEntityRename.ts`, `backfillPostedOpportunitiesFromListings.ts`, `paperQualityService.ts`, `pathwayRelevanceReview.ts`, `scraperIntegrityGate.ts`, `programs.ts`, `cli.ts`, `listings.ts`, `researchEntity.ts`, `seed.ts`, `users.ts`, `launchAcquisitionReport.ts`, `index.ts`, `refreshGateScorecards.ts`, `dedupeExploratoryContactPathways.ts`, `materializePaperObservationsFromRun`, `courseTableService.ts`, `errorHandler.ts`?**
-  _High betweenness centrality (0.082) - this node is a cross-community bridge._
+- **Why does `sanitizeLogValue()` connect `sanitizeLogValue` to `departmentRosterScraper.ts`, `logSanitizer.ts`, `labMicrositeUndergradLLMExtractor.ts`, `entityMaterializer.ts`, `labMicrositeDescriptionLLMExtractor.ts`, `passport.ts`, `undergradFellowshipRecipientScraper.ts`, `duplicateEntityNameReview.ts`, `dedupeResearchEntitiesByPi.ts`, `admin.ts`, `profileDataQualityAudit.ts`, `centersInstitutesScraper.ts`, `nihReporterScraper.ts`, `User`, `userService.ts`, `serializedDocumentId`, `researchEntityCoverageAudit.ts`, `sourceHealth.ts`, `repairOfficialProfilePublicationPointers.ts`, `officialProfilePiBackfillScraper.test.ts`, `listingService.ts`, `runReport.ts`, `opportunityDetailService.ts`, `staleObservationConflictReview.ts`, `betaDataQuality.ts`, `listingController.ts`, `analyticsService.ts`, `entryPathwayService.ts`, `yaleCollegeFellowshipsOfficeScraper.ts`, `nsfAwardScraper.ts`, `scholarlyLinkSuppressionAudit.ts`, `postedOpportunityService.ts`, `profileController.ts`, `openAlexPaperScraper.ts`, `types.ts`, `ResearchGroupMember`, `promoteAcceptedBetaCopy.ts`, `paperAuthorshipAudit.ts`, `Observation`, `assertPublicHttpUrl`, `studentDecisionLLMExtractor.ts`, `backfillProfileBiosFromOfficialUrls.ts`, `rebuildPathwaySearchIndex.ts`, `claimGate.ts`, `opportunityDetail.tsx`, `ScraperContext`, `officialProfilePiBackfillScraper.ts`, `repairArchivedEntityArtifacts.ts`, `betaRepairQueue.ts`, `materializeEntity`, `pathwayQualityAudit.ts`, `cronRunner.ts`, `backfillResearchHomeOfficialUrls.ts`, `arxivPreprintScraper.ts`, `launchReviewExceptions.ts`, `acceptedInputs.ts`, `dedupeUsersByIdentity.ts`, `fellowshipController.ts`, `applicationRoutePathwayBackfillCore.ts`, `assertScriptApplyAllowed`, `centerDirectorLLMExtractor.ts`, `crossSourceObservationConflictReview.ts`, `migrateResearchEntities.ts`, `researchQualitySearchReview.ts`, `migrateResearchEntityCollections.ts`, `researchGroupController.ts`, `disambiguateSurnameLabNames.ts`, `repairDuplicateAccessSignals.ts`, `profileBioCoverageAudit.ts`, `programController.ts`, `repairMismatchedPersonEmailsCore.ts`, `betaReadinessGate.ts`, `studentVisibilityRepairTargets.ts`, `cleanupLegacyMongoCollections.ts`, `seedSources.ts`, `configService.ts`, `backfillCenterDirectors.ts`, `migrateMongoNaming.ts`, `resolveSafeJsonReportOutputPath`, `userEmailHygiene.ts`, `orcidWorksScraper.ts`, `repairListingResearchEntityProfiles.ts`, `meiliSyncService.ts`, `index.ts`, `repairProfileDescriptionBackfillConflicts.ts`, `clearBetaStudentAnalytics.ts`, `scraperIntegrityDuplicateReview.ts`, `auditResearchEntityRename.ts`, `backfillPostedOpportunitiesFromListings.ts`, `paperQualityService.ts`, `pathwayRelevanceReview.ts`, `scraperIntegrityGate.ts`, `programs.ts`, `cli.ts`, `listings.ts`, `researchEntity.ts`, `seed.ts`, `users.ts`, `launchAcquisitionReport.ts`, `index.ts`, `refreshGateScorecards.ts`, `dedupeExploratoryContactPathways.ts`, `materializePaperObservationsFromRun`, `courseTableService.ts`, `errorHandler.ts`?**
+  _High betweenness centrality (0.085) - this node is a cross-community bridge._
 - **Why does `field()` connect `dedupeUsersByIdentity.ts` to `arxivPreprintScraper.ts`, `logSanitizer.ts`, `adminFellowshipsTableReducer.ts`, `ImportRootDataFiles.ts`, `safeHttpUrl`, `labMicrositeUndergradLLMExtractor.ts`, `textValue`, `integrityGate.ts`, `crossSourceObservationConflictReview.ts`, `index.ts`, `normalizePublicProfile`, `User`, `sourceHealth.ts`, `fellowshipService.ts`, `runReport.ts`, `betaDataQuality.ts`, `analyticsService.ts`, `acceptedInputsCore.ts`, `entryPathwayService.ts`, `workPlanner.ts`, `orcidWorksScraper.ts`, `AdminListingsTable.tsx`, `openAlexPaperScraper.ts`, `AdminFacultyProfilesTable.tsx`, `scraperIntegrityDuplicateReview.ts`, `promoteAcceptedBetaCopy.ts`, `ScraperContext`, `confidenceResolver.ts`, `materializeEntity`, `buildStaleObservationConflictSummary`, `visibilityRepairQueueService.ts`?**
-  _High betweenness centrality (0.045) - this node is a cross-community bridge._
+  _High betweenness centrality (0.047) - this node is a cross-community bridge._
 - **Why does `ResearchGroup` connect `researchGroup.ts` to `labDetailReducer.test.ts`, `browsable.ts`, `labDetail.ts`, `ImportRootDataFiles.ts`, `BackfillV4FacultyMembers.ts`?**
-  _High betweenness centrality (0.034) - this node is a cross-community bridge._
+  _High betweenness centrality (0.036) - this node is a cross-community bridge._
 - **What connects `name`, `version`, `private` to the rest of the system?**
-  _4487 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _4380 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Decisions` be split into smaller, more focused modules?**
   _Cohesion score 0.10526315789473684 - nodes in this community are weakly interconnected._
 - **Should `labDetail.tsx` be split into smaller, more focused modules?**
   _Cohesion score 0.0734006734006734 - nodes in this community are weakly interconnected._
 - **Should `browsable.ts` be split into smaller, more focused modules?**
-  _Cohesion score 0.0531883632089333 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.05985915492957746 - nodes in this community are weakly interconnected._

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
-# Graph Report - ylabs  (2026-07-04)
+# Graph Report - 01KXHSYGY3GN42EV0VQTHKNYWY  (2026-07-14)
 
 ## Corpus Check
-- 806 files · ~1,289,316 words
+- 823 files · ~1,303,803 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 11253 nodes · 20904 edges · 3372 communities (913 shown, 2459 thin omitted)
-- Extraction: 98% EXTRACTED · 2% INFERRED · 0% AMBIGUOUS · INFERRED: 447 edges (avg confidence: 0.62)
+- 11262 nodes · 21227 edges · 3266 communities (913 shown, 2353 thin omitted)
+- Extraction: 98% EXTRACTED · 2% INFERRED · 0% AMBIGUOUS · INFERRED: 452 edges (avg confidence: 0.62)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `1e2b889b`
+- Built from commit: `eebbcfaa`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -20,18 +20,18 @@
 - [[_COMMUNITY_browsable.ts|browsable.ts]]
 - [[_COMMUNITY_security-preflight.test.mjs|security-preflight.test.mjs]]
 - [[_COMMUNITY_departmentRosterScraper.ts|departmentRosterScraper.ts]]
-- [[_COMMUNITY_index.ts|index.ts]]
+- [[_COMMUNITY_labDetail.ts|labDetail.ts]]
 - [[_COMMUNITY_App.tsx|App.tsx]]
-- [[_COMMUNITY_assertScriptApplyAllowed|assertScriptApplyAllowed]]
-- [[_COMMUNITY_adminListingsTableReducer.ts|adminListingsTableReducer.ts]]
-- [[_COMMUNITY_profileService.ts|profileService.ts]]
+- [[_COMMUNITY_logSanitizer.ts|logSanitizer.ts]]
+- [[_COMMUNITY_adminFellowshipsTableReducer.ts|adminFellowshipsTableReducer.ts]]
+- [[_COMMUNITY_cleanPublicProfileBio|cleanPublicProfileBio]]
 - [[_COMMUNITY_labMicrositeUndergradLLMExtractor.ts|labMicrositeUndergradLLMExtractor.ts]]
 - [[_COMMUNITY_safeHttpUrl|safeHttpUrl]]
 - [[_COMMUNITY_entityMaterializer.ts|entityMaterializer.ts]]
 - [[_COMMUNITY_researchGroupService.ts|researchGroupService.ts]]
 - [[_COMMUNITY_labMicrositeDescriptionLLMExtractor.ts|labMicrositeDescriptionLLMExtractor.ts]]
 - [[_COMMUNITY_accessMaterializer.ts|accessMaterializer.ts]]
-- [[_COMMUNITY_research.test.tsx|research.test.tsx]]
+- [[_COMMUNITY_ConfigContext.ts|ConfigContext.ts]]
 - [[_COMMUNITY_sanitizeLogValue|sanitizeLogValue]]
 - [[_COMMUNITY_integrityGate.ts|integrityGate.ts]]
 - [[_COMMUNITY_passport.ts|passport.ts]]
@@ -41,7 +41,7 @@
 - [[_COMMUNITY_app.ts|app.ts]]
 - [[_COMMUNITY_dedupeResearchEntitiesByPi.ts|dedupeResearchEntitiesByPi.ts]]
 - [[_COMMUNITY_admin.ts|admin.ts]]
-- [[_COMMUNITY_BackfillV4ResearchGroupMembers.ts|BackfillV4ResearchGroupMembers.ts]]
+- [[_COMMUNITY_researchEntityEvidenceCoverage.ts|researchEntityEvidenceCoverage.ts]]
 - [[_COMMUNITY_researchDiscoveryAdapters.ts|researchDiscoveryAdapters.ts]]
 - [[_COMMUNITY_ysmAtoZScraper.ts|ysmAtoZScraper.ts]]
 - [[_COMMUNITY_advisees|advisees]]
@@ -51,31 +51,31 @@
 - [[_COMMUNITY_types.tsx|types.tsx]]
 - [[_COMMUNITY_nihReporterScraper.ts|nihReporterScraper.ts]]
 - [[_COMMUNITY_studentVisibilityGateService.ts|studentVisibilityGateService.ts]]
-- [[_COMMUNITY_ScraperContext|ScraperContext]]
+- [[_COMMUNITY_User|User]]
 - [[_COMMUNITY_userService.ts|userService.ts]]
 - [[_COMMUNITY_serializedDocumentId|serializedDocumentId]]
 - [[_COMMUNITY_AdminDepartments.tsx|AdminDepartments.tsx]]
-- [[_COMMUNITY_profile.tsx|profile.tsx]]
+- [[_COMMUNITY_getUniqueDepartmentLabels|getUniqueDepartmentLabels]]
 - [[_COMMUNITY_researchEntityCoverageAudit.ts|researchEntityCoverageAudit.ts]]
-- [[_COMMUNITY_LabHeader.tsx|LabHeader.tsx]]
+- [[_COMMUNITY_axios.ts|axios.ts]]
 - [[_COMMUNITY_sourceHealth.ts|sourceHealth.ts]]
-- [[_COMMUNITY_research.tsx|research.tsx]]
-- [[_COMMUNITY_entityMaterializer.test.ts|entityMaterializer.test.ts]]
-- [[_COMMUNITY_ScrapeRun|ScrapeRun]]
+- [[_COMMUNITY_repairOfficialProfilePublicationPointers.ts|repairOfficialProfilePublicationPointers.ts]]
+- [[_COMMUNITY_textValue|textValue]]
+- [[_COMMUNITY_officialProfilePiBackfillScraper.test.ts|officialProfilePiBackfillScraper.test.ts]]
 - [[_COMMUNITY_listingService.ts|listingService.ts]]
 - [[_COMMUNITY_fellowshipService.ts|fellowshipService.ts]]
 - [[_COMMUNITY_betaDataQualityCore.ts|betaDataQualityCore.ts]]
 - [[_COMMUNITY_scripts|scripts]]
 - [[_COMMUNITY_productionPromotionSmoke.mjs|productionPromotionSmoke.mjs]]
-- [[_COMMUNITY_researchEntity.ts|researchEntity.ts]]
+- [[_COMMUNITY_research.tsx|research.tsx]]
 - [[_COMMUNITY_runReport.ts|runReport.ts]]
-- [[_COMMUNITY_redactDirectContactInfo|redactDirectContactInfo]]
+- [[_COMMUNITY_opportunityDetailService.ts|opportunityDetailService.ts]]
 - [[_COMMUNITY_staleObservationConflictReview.ts|staleObservationConflictReview.ts]]
 - [[_COMMUNITY_researchEntityDescriptionQuality.ts|researchEntityDescriptionQuality.ts]]
 - [[_COMMUNITY_betaDataQuality.ts|betaDataQuality.ts]]
 - [[_COMMUNITY_studentVisibilityTier.ts|studentVisibilityTier.ts]]
 - [[_COMMUNITY_listingController.ts|listingController.ts]]
-- [[_COMMUNITY_researchEntityBrowseRankService.ts|researchEntityBrowseRankService.ts]]
+- [[_COMMUNITY_researchGroup.ts|researchGroup.ts]]
 - [[_COMMUNITY_analyticsService.ts|analyticsService.ts]]
 - [[_COMMUNITY_BOOLEAN_FLAGS|BOOLEAN_FLAGS]]
 - [[_COMMUNITY_acceptedInputsCore.ts|acceptedInputsCore.ts]]
@@ -83,212 +83,216 @@
 - [[_COMMUNITY_yaleCollegeFellowshipsOfficeScraper.ts|yaleCollegeFellowshipsOfficeScraper.ts]]
 - [[_COMMUNITY_fellowshipMatchingService.ts|fellowshipMatchingService.ts]]
 - [[_COMMUNITY_AdminOperatorBoard.tsx|AdminOperatorBoard.tsx]]
-- [[_COMMUNITY_repairOfficialProfilePublicationPointers.ts|repairOfficialProfilePublicationPointers.ts]]
+- [[_COMMUNITY_nsfAwardScraper.ts|nsfAwardScraper.ts]]
 - [[_COMMUNITY_fellowshipInputs.ts|fellowshipInputs.ts]]
-- [[_COMMUNITY_OfficialProfilePublicationValue|OfficialProfilePublicationValue]]
+- [[_COMMUNITY_scholarlyLinkSuppressionAudit.ts|scholarlyLinkSuppressionAudit.ts]]
 - [[_COMMUNITY_postedOpportunityService.ts|postedOpportunityService.ts]]
 - [[_COMMUNITY_profileController.ts|profileController.ts]]
 - [[_COMMUNITY_analytics.ts|analytics.ts]]
 - [[_COMMUNITY_openAlexPaperScraper.ts|openAlexPaperScraper.ts]]
-- [[_COMMUNITY_errorHandler.ts|errorHandler.ts]]
-- [[_COMMUNITY_researchEntityMemberReferenceAudit.ts|researchEntityMemberReferenceAudit.ts]]
+- [[_COMMUNITY_types.ts|types.ts]]
+- [[_COMMUNITY_ResearchGroupMember|ResearchGroupMember]]
 - [[_COMMUNITY_SavedPathwaysSection.tsx|SavedPathwaysSection.tsx]]
-- [[_COMMUNITY_getUniqueDepartmentLabels|getUniqueDepartmentLabels]]
+- [[_COMMUNITY_departmentUndergradResearchScraper.ts|departmentUndergradResearchScraper.ts]]
 - [[_COMMUNITY_pathwaySearchIndexService.ts|pathwaySearchIndexService.ts]]
-- [[_COMMUNITY_2. Install dependencies|2. Install dependencies]]
+- [[_COMMUNITY_researchEntity.ts|researchEntity.ts]]
 - [[_COMMUNITY_adminOperatorBoardService.ts|adminOperatorBoardService.ts]]
 - [[_COMMUNITY_Listing|Listing]]
 - [[_COMMUNITY_promoteAcceptedBetaCopy.ts|promoteAcceptedBetaCopy.ts]]
-- [[_COMMUNITY_Yale Research — Developer Guide|Yale Research — Developer Guide]]
+- [[_COMMUNITY_Yale Research - Developer Guide|Yale Research - Developer Guide]]
 - [[_COMMUNITY_paperAuthorshipAudit.ts|paperAuthorshipAudit.ts]]
 - [[_COMMUNITY_Observation|Observation]]
 - [[_COMMUNITY_Environment Progression|Environment Progression]]
 - [[_COMMUNITY_devDependencies|devDependencies]]
 - [[_COMMUNITY_Per-Source Audit Playbooks|Per-Source Audit Playbooks]]
-- [[_COMMUNITY_dependencies|dependencies]]
+- [[_COMMUNITY_assertPublicHttpUrl|assertPublicHttpUrl]]
 - [[_COMMUNITY_studentDecisionLLMExtractor.ts|studentDecisionLLMExtractor.ts]]
 - [[_COMMUNITY_AdminFellowshipsTable.tsx|AdminFellowshipsTable.tsx]]
-- [[_COMMUNITY_yaleResearchOfficialScraper.ts|yaleResearchOfficialScraper.ts]]
+- [[_COMMUNITY_profile.tsx|profile.tsx]]
 - [[_COMMUNITY_backfillProfileBiosFromOfficialUrls.ts|backfillProfileBiosFromOfficialUrls.ts]]
-- [[_COMMUNITY_resolveSafeJsonReportOutputPath|resolveSafeJsonReportOutputPath]]
-- [[_COMMUNITY_accessClaims.ts|accessClaims.ts]]
-- [[_COMMUNITY_Beta Repair Lanes Audit Implementation Plan|Beta Repair Lanes Audit Implementation Plan]]
-- [[_COMMUNITY_axios.ts|axios.ts]]
+- [[_COMMUNITY_rebuildPathwaySearchIndex.ts|rebuildPathwaySearchIndex.ts]]
+- [[_COMMUNITY_claimGate.ts|claimGate.ts]]
+- [[_COMMUNITY_dedupeUsersByIdentityCore.ts|dedupeUsersByIdentityCore.ts]]
+- [[_COMMUNITY_opportunityDetail.tsx|opportunityDetail.tsx]]
 - [[_COMMUNITY_attempt|attempt]]
-- [[_COMMUNITY_assertPublicHttpUrl|assertPublicHttpUrl]]
-- [[_COMMUNITY_labDetail.ts|labDetail.ts]]
+- [[_COMMUNITY_ScraperContext|ScraperContext]]
+- [[_COMMUNITY_buildAdminOperatorBoard|buildAdminOperatorBoard]]
 - [[_COMMUNITY_analytics.tsx|analytics.tsx]]
 - [[_COMMUNITY_officialProfilePiBackfillScraper.ts|officialProfilePiBackfillScraper.ts]]
 - [[_COMMUNITY_pathwaySearchService.ts|pathwaySearchService.ts]]
 - [[_COMMUNITY_researchEntityDto.ts|researchEntityDto.ts]]
 - [[_COMMUNITY_Authentication Flow|Authentication Flow]]
 - [[_COMMUNITY_repairArchivedEntityArtifacts.ts|repairArchivedEntityArtifacts.ts]]
-- [[_COMMUNITY_Adding a New Page|Adding a New Page]]
+- [[_COMMUNITY_profileService.ts|profileService.ts]]
 - [[_COMMUNITY_brianFeed|brianFeed]]
-- [[_COMMUNITY_smartTitle.ts|smartTitle.ts]]
+- [[_COMMUNITY_betaRepairQueue.ts|betaRepairQueue.ts]]
 - [[_COMMUNITY_assessment|assessment]]
-- [[_COMMUNITY_centerDirectorLLMExtractor.ts|centerDirectorLLMExtractor.ts]]
+- [[_COMMUNITY_materializeEntity|materializeEntity]]
 - [[_COMMUNITY_scripts|scripts]]
 - [[_COMMUNITY_pathwayQualityAudit.ts|pathwayQualityAudit.ts]]
 - [[_COMMUNITY_base|base]]
 - [[_COMMUNITY_Adding a New Endpoint|Adding a New Endpoint]]
+- [[_COMMUNITY_cronRunner.ts|cronRunner.ts]]
+- [[_COMMUNITY_yaleResearchOfficialScraper.ts|yaleResearchOfficialScraper.ts]]
+- [[_COMMUNITY_Adding a New Endpoint|Adding a New Endpoint]]
+- [[_COMMUNITY_visibilityRepairQueueService.ts|visibilityRepairQueueService.ts]]
+- [[_COMMUNITY_backfillResearchHomeOfficialUrls.ts|backfillResearchHomeOfficialUrls.ts]]
+- [[_COMMUNITY_fellowships.tsx|fellowships.tsx]]
+- [[_COMMUNITY_researchEntityDescriptionText.ts|researchEntityDescriptionText.ts]]
 - [[_COMMUNITY_researchEntitySearchIndexService.ts|researchEntitySearchIndexService.ts]]
-- [[_COMMUNITY_Adding a New Endpoint|Adding a New Endpoint]]
-- [[_COMMUNITY_Adding a New Endpoint|Adding a New Endpoint]]
-- [[_COMMUNITY_Adding a New Endpoint|Adding a New Endpoint]]
-- [[_COMMUNITY_Adding a New Endpoint|Adding a New Endpoint]]
-- [[_COMMUNITY_Adding a New Endpoint|Adding a New Endpoint]]
-- [[_COMMUNITY_Adding a New Endpoint|Adding a New Endpoint]]
-- [[_COMMUNITY_Adding a New Endpoint|Adding a New Endpoint]]
-- [[_COMMUNITY_buildAdminOperatorBoard|buildAdminOperatorBoard]]
+- [[_COMMUNITY_arxivPreprintScraper.ts|arxivPreprintScraper.ts]]
 - [[_COMMUNITY_dir|dir]]
 - [[_COMMUNITY_launchReviewExceptions.ts|launchReviewExceptions.ts]]
 - [[_COMMUNITY_adminRender|adminRender]]
 - [[_COMMUNITY_Session Notes|Session Notes]]
-- [[_COMMUNITY_Current Execution Plan|Current Execution Plan]]
-- [[_COMMUNITY_File Structure|File Structure]]
+- [[_COMMUNITY_acceptedInputs.ts|acceptedInputs.ts]]
+- [[_COMMUNITY_safeRouteSegment|safeRouteSegment]]
 - [[_COMMUNITY_research-detail-professor-audit.mjs|research-detail-professor-audit.mjs]]
 - [[_COMMUNITY_dedupeUsersByIdentity.ts|dedupeUsersByIdentity.ts]]
 - [[_COMMUNITY_ImportRootDataFiles.ts|ImportRootDataFiles.ts]]
-- [[_COMMUNITY_officialProfilePiBackfillScraper.test.ts|officialProfilePiBackfillScraper.test.ts]]
-- [[_COMMUNITY_applicationRoutePathwayBackfillCore.ts|applicationRoutePathwayBackfillCore.ts]]
-- [[_COMMUNITY_launchTrustContractService.ts|launchTrustContractService.ts]]
 - [[_COMMUNITY_fellowshipController.ts|fellowshipController.ts]]
-- [[_COMMUNITY_department.ts|department.ts]]
+- [[_COMMUNITY_applicationRoutePathwayBackfillCore.ts|applicationRoutePathwayBackfillCore.ts]]
+- [[_COMMUNITY_textValue|textValue]]
+- [[_COMMUNITY_assertScriptApplyAllowed|assertScriptApplyAllowed]]
+- [[_COMMUNITY_centerDirectorLLMExtractor.ts|centerDirectorLLMExtractor.ts]]
 - [[_COMMUNITY_FavoritesManager.tsx|FavoritesManager.tsx]]
 - [[_COMMUNITY_departmentGroundTruth.ts|departmentGroundTruth.ts]]
-- [[_COMMUNITY_profileBioCoverageAudit.ts|profileBioCoverageAudit.ts]]
+- [[_COMMUNITY_profileBioCoverageAuditCore.ts|profileBioCoverageAuditCore.ts]]
 - [[_COMMUNITY_Research Model|Research Model]]
-- [[_COMMUNITY_useFavorites.ts|useFavorites.ts]]
-- [[_COMMUNITY_Beta SourcePIAction Audit Implementation Plan|Beta Source/PI/Action Audit Implementation Plan]]
-- [[_COMMUNITY_cli.ts|cli.ts]]
+- [[_COMMUNITY_AdminAccessReview.tsx|AdminAccessReview.tsx]]
+- [[_COMMUNITY_ObservationInput|ObservationInput]]
+- [[_COMMUNITY_studentDecisionExplanationService.ts|studentDecisionExplanationService.ts]]
 - [[_COMMUNITY_crossSourceObservationConflictReview.ts|crossSourceObservationConflictReview.ts]]
 - [[_COMMUNITY_migrateResearchEntities.ts|migrateResearchEntities.ts]]
-- [[_COMMUNITY_visibilityRepairQueueService.ts|visibilityRepairQueueService.ts]]
+- [[_COMMUNITY_researchEntityQuality.ts|researchEntityQuality.ts]]
 - [[_COMMUNITY_abstractBios|abstractBios]]
 - [[_COMMUNITY_researchQualitySearchReview.ts|researchQualitySearchReview.ts]]
 - [[_COMMUNITY_{ container }|{ container }]]
 - [[_COMMUNITY_migrateResearchEntityCollections.ts|migrateResearchEntityCollections.ts]]
 - [[_COMMUNITY_researchGroupController.ts|researchGroupController.ts]]
-- [[_COMMUNITY_GStack Production Promotion Iteration Implementation Plan|GStack Production Promotion Iteration Implementation Plan]]
+- [[_COMMUNITY_getResearchGroupDetail|getResearchGroupDetail]]
 - [[_COMMUNITY_externalIdsSchema|externalIdsSchema]]
-- [[_COMMUNITY_sanitizeProfileResearchTerms|sanitizeProfileResearchTerms]]
+- [[_COMMUNITY_normalizePublicProfile|normalizePublicProfile]]
 - [[_COMMUNITY_disambiguateSurnameLabNames.ts|disambiguateSurnameLabNames.ts]]
 - [[_COMMUNITY_repairDuplicateAccessSignals.ts|repairDuplicateAccessSignals.ts]]
-- [[_COMMUNITY_ResearchHomeCard.tsx|ResearchHomeCard.tsx]]
+- [[_COMMUNITY_smartTitle.ts|smartTitle.ts]]
 - [[_COMMUNITY_LIVE|LIVE]]
-- [[_COMMUNITY_clientErrorMessage|clientErrorMessage]]
-- [[_COMMUNITY_dedupeUsersByIdentityCore.ts|dedupeUsersByIdentityCore.ts]]
-- [[_COMMUNITY_logSanitizer.ts|logSanitizer.ts]]
+- [[_COMMUNITY_dependencies|dependencies]]
+- [[_COMMUNITY_normalizeOfficialProfileUrl|normalizeOfficialProfileUrl]]
+- [[_COMMUNITY_profileBioCoverageAudit.ts|profileBioCoverageAudit.ts]]
 - [[_COMMUNITY_programController.ts|programController.ts]]
 - [[_COMMUNITY_seedDepartments.ts|seedDepartments.ts]]
 - [[_COMMUNITY_Active Detail Docs|Active Detail Docs]]
 - [[_COMMUNITY_repairMismatchedPersonEmailsCore.ts|repairMismatchedPersonEmailsCore.ts]]
 - [[_COMMUNITY_betaReadinessGate.ts|betaReadinessGate.ts]]
-- [[_COMMUNITY_pathwayController.ts|pathwayController.ts]]
+- [[_COMMUNITY_updateOwnProfile|updateOwnProfile]]
 - [[_COMMUNITY_callLLM|callLLM]]
 - [[_COMMUNITY_adminAccessReviewService.ts|adminAccessReviewService.ts]]
 - [[_COMMUNITY_studentVisibilityRepairTargets.ts|studentVisibilityRepairTargets.ts]]
 - [[_COMMUNITY_scripts|scripts]]
-- [[_COMMUNITY_v4MigrationUtils.ts|v4MigrationUtils.ts]]
-- [[_COMMUNITY_scholarlyLinkSuppressionAudit.ts|scholarlyLinkSuppressionAudit.ts]]
+- [[_COMMUNITY_BackfillV4FacultyMembers.ts|BackfillV4FacultyMembers.ts]]
+- [[_COMMUNITY_generateKeywords.ts|generateKeywords.ts]]
 - [[_COMMUNITY_cleanupLegacyMongoCollections.ts|cleanupLegacyMongoCollections.ts]]
 - [[_COMMUNITY_seedSources.ts|seedSources.ts]]
-- [[_COMMUNITY_auditProgramResearchRelevance.ts|auditProgramResearchRelevance.ts]]
-- [[_COMMUNITY_researchAreas.ts|researchAreas.ts]]
-- [[_COMMUNITY_BackfillV4StudentProfiles.ts|BackfillV4StudentProfiles.ts]]
+- [[_COMMUNITY_migrateSmartTitles.ts|migrateSmartTitles.ts]]
+- [[_COMMUNITY_configService.ts|configService.ts]]
+- [[_COMMUNITY_backfillCenterDirectors.ts|backfillCenterDirectors.ts]]
 - [[_COMMUNITY_migrateMongoNaming.ts|migrateMongoNaming.ts]]
 - [[_COMMUNITY_researchEntityPiDedupeCore.ts|researchEntityPiDedupeCore.ts]]
 - [[_COMMUNITY_staleObservationConflictReview.test.ts|staleObservationConflictReview.test.ts]]
-- [[_COMMUNITY_listings.ts|listings.ts]]
+- [[_COMMUNITY_launchTrustContract.ts|launchTrustContract.ts]]
 - [[_COMMUNITY_EvidenceSourceRow.tsx|EvidenceSourceRow.tsx]]
-- [[_COMMUNITY_1. Fresh machine setup|1. Fresh machine setup]]
-- [[_COMMUNITY_3. Configure environment|3. Configure environment]]
-- [[_COMMUNITY_1. Fresh machine setup|1. Fresh machine setup]]
-- [[_COMMUNITY_1. Fresh machine setup|1. Fresh machine setup]]
+- [[_COMMUNITY_UserContext.ts|UserContext.ts]]
+- [[_COMMUNITY_resolveSafeJsonReportOutputPath|resolveSafeJsonReportOutputPath]]
+- [[_COMMUNITY_dependencies|dependencies]]
+- [[_COMMUNITY_workPlanner.ts|workPlanner.ts]]
 - [[_COMMUNITY_unified-research-search-audit.mjs|unified-research-search-audit.mjs]]
-- [[_COMMUNITY_Technical Due Diligence Review — Yale Research (yalelabs)|Technical Due Diligence Review — Yale Research (yalelabs)]]
+- [[_COMMUNITY_departmentResolver.ts|departmentResolver.ts]]
 - [[_COMMUNITY_userEmailHygiene.ts|userEmailHygiene.ts]]
-- [[_COMMUNITY_departmentUndergradResearchScraper.ts|departmentUndergradResearchScraper.ts]]
+- [[_COMMUNITY_orcidWorksScraper.ts|orcidWorksScraper.ts]]
+- [[_COMMUNITY_repairListingResearchEntityProfiles.ts|repairListingResearchEntityProfiles.ts]]
+- [[_COMMUNITY_researchGroupFilters.ts|researchGroupFilters.ts]]
 - [[_COMMUNITY_Adding Things|Adding Things]]
-- [[_COMMUNITY_Adding Things|Adding Things]]
-- [[_COMMUNITY_Adding Things|Adding Things]]
-- [[_COMMUNITY_Adding Things|Adding Things]]
+- [[_COMMUNITY_AdminFacultyProfilesTable.tsx|AdminFacultyProfilesTable.tsx]]
 - [[_COMMUNITY_meiliSyncService.ts|meiliSyncService.ts]]
-- [[_COMMUNITY_acceptedInputs.ts|acceptedInputs.ts]]
-- [[_COMMUNITY_textValue|textValue]]
+- [[_COMMUNITY_AdminOperatorBoard|AdminOperatorBoard]]
+- [[_COMMUNITY_index.ts|index.ts]]
 - [[_COMMUNITY_accessSummaryService.ts|accessSummaryService.ts]]
 - [[_COMMUNITY_repairProfileDescriptionBackfillConflicts.ts|repairProfileDescriptionBackfillConflicts.ts]]
 - [[_COMMUNITY_clearBetaStudentAnalytics.ts|clearBetaStudentAnalytics.ts]]
 - [[_COMMUNITY_scraperIntegrityDuplicateReview.ts|scraperIntegrityDuplicateReview.ts]]
-- [[_COMMUNITY_runStaleObservationConflictReview|runStaleObservationConflictReview]]
+- [[_COMMUNITY_researchGroupService.test.ts|researchGroupService.test.ts]]
 - [[_COMMUNITY_departmentLeadRepairPlanCore.ts|departmentLeadRepairPlanCore.ts]]
 - [[_COMMUNITY_auditResearchEntityRename.ts|auditResearchEntityRename.ts]]
-- [[_COMMUNITY_betaRepairQueue.ts|betaRepairQueue.ts]]
+- [[_COMMUNITY_longText.ts|longText.ts]]
 - [[_COMMUNITY_authorshipEvidence|authorshipEvidence]]
 - [[_COMMUNITY_actor|actor]]
 - [[_COMMUNITY_compilerOptions|compilerOptions]]
-- [[_COMMUNITY_1. Fresh machine setup|1. Fresh machine setup]]
+- [[_COMMUNITY_backfillPostedOpportunitiesFromListings.ts|backfillPostedOpportunitiesFromListings.ts]]
 - [[_COMMUNITY_acronymExpansion|acronymExpansion]]
 - [[_COMMUNITY_paperQualityService.ts|paperQualityService.ts]]
 - [[_COMMUNITY_importFellowships.ts|importFellowships.ts]]
 - [[_COMMUNITY_actionabilityMatch|actionabilityMatch]]
 - [[_COMMUNITY_pathwayRelevanceReview.ts|pathwayRelevanceReview.ts]]
-- [[_COMMUNITY_profileImageQualityAudit.ts|profileImageQualityAudit.ts]]
-- [[_COMMUNITY_fellowships.tsx|fellowships.tsx]]
+- [[_COMMUNITY_profileImageQualityAuditCore.ts|profileImageQualityAuditCore.ts]]
+- [[_COMMUNITY_scraperIntegrityGate.ts|scraperIntegrityGate.ts]]
 - [[_COMMUNITY_programs.ts|programs.ts]]
 - [[_COMMUNITY_bare|bare]]
 - [[_COMMUNITY_compilerOptions|compilerOptions]]
-- [[_COMMUNITY_AdminFacultyProfilesTable.tsx|AdminFacultyProfilesTable.tsx]]
-- [[_COMMUNITY_scriptWriteGuards.ts|scriptWriteGuards.ts]]
+- [[_COMMUNITY_trustedLeadResearchHomeBioFallback|trustedLeadResearchHomeBioFallback]]
+- [[_COMMUNITY_cli.ts|cli.ts]]
 - [[_COMMUNITY_sourceHealthService.ts|sourceHealthService.ts]]
-- [[_COMMUNITY_adminTableReducer.test.ts|adminTableReducer.test.ts]]
+- [[_COMMUNITY_listings.ts|listings.ts]]
 - [[_COMMUNITY_confidenceResolver.ts|confidenceResolver.ts]]
 - [[_COMMUNITY_facultyResearch|facultyResearch]]
 - [[_COMMUNITY_authenticatedRouteDoc|authenticatedRouteDoc]]
-- [[_COMMUNITY_normalizePublicProfile|normalizePublicProfile]]
+- [[_COMMUNITY_normalizeAcceptedDecisionValidation|normalizeAcceptedDecisionValidation]]
 - [[_COMMUNITY_UIUX Direction|UI/UX Direction]]
 - [[_COMMUNITY_LEGACY_EXPLORATORY_CONTACT_PATHWAY_DERIVATION_KEYS|LEGACY_EXPLORATORY_CONTACT_PATHWAY_DERIVATION_KEYS]]
-- [[_COMMUNITY_Product Model|Product Model]]
-- [[_COMMUNITY_backfillResearchHomeOfficialUrls.ts|backfillResearchHomeOfficialUrls.ts]]
+- [[_COMMUNITY_profileService.test.ts|profileService.test.ts]]
+- [[_COMMUNITY_researchEntity.ts|researchEntity.ts]]
 - [[_COMMUNITY_fellowship.ts|fellowship.ts]]
 - [[_COMMUNITY_seed.ts|seed.ts]]
 - [[_COMMUNITY_adminGrantService.ts|adminGrantService.ts]]
 - [[_COMMUNITY_seedResearchAreas.ts|seedResearchAreas.ts]]
-- [[_COMMUNITY_scraperIntegrityGate.ts|scraperIntegrityGate.ts]]
-- [[_COMMUNITY_claimGate.ts|claimGate.ts]]
+- [[_COMMUNITY_searchResearchGroupsViaMeili|searchResearchGroupsViaMeili]]
+- [[_COMMUNITY_adminTableReducer.test.ts|adminTableReducer.test.ts]]
 - [[_COMMUNITY_dir|dir]]
 - [[_COMMUNITY_environment.ts|environment.ts]]
-- [[_COMMUNITY_useConfig|useConfig]]
+- [[_COMMUNITY_labDetailReducer.test.ts|labDetailReducer.test.ts]]
 - [[_COMMUNITY_dependencies|dependencies]]
 - [[_COMMUNITY_users.ts|users.ts]]
 - [[_COMMUNITY_departmentGroundTruth.test.ts|departmentGroundTruth.test.ts]]
 - [[_COMMUNITY_csv|csv]]
 - [[_COMMUNITY_dir|dir]]
-- [[_COMMUNITY_repairListingResearchEntityProfiles.ts|repairListingResearchEntityProfiles.ts]]
+- [[_COMMUNITY_isPublicHttpUrl|isPublicHttpUrl]]
 - [[_COMMUNITY_CanonicalDepartmentListResult|CanonicalDepartmentListResult]]
-- [[_COMMUNITY_AdminFellowshipEditModal.tsx|AdminFellowshipEditModal.tsx]]
+- [[_COMMUNITY_ArtifactFreshnessStrip|ArtifactFreshnessStrip]]
 - [[_COMMUNITY_MockBroadcastChannel|MockBroadcastChannel]]
 - [[_COMMUNITY_Product Context|Product Context]]
 - [[_COMMUNITY_1. Admin And Search Gates|1. Admin And Search Gates]]
-- [[_COMMUNITY_dependencies|dependencies]]
+- [[_COMMUNITY_apiBaseUrl.ts|apiBaseUrl.ts]]
 - [[_COMMUNITY_resolutions|resolutions]]
-- [[_COMMUNITY_BackfillV4FacultyMembers.ts|BackfillV4FacultyMembers.ts]]
+- [[_COMMUNITY_sourceReviewDecisionValidationLines|sourceReviewDecisionValidationLines]]
 - [[_COMMUNITY_summary|summary]]
-- [[_COMMUNITY_resolutions|resolutions]]
-- [[_COMMUNITY_BackfillV4Grants.ts|BackfillV4Grants.ts]]
-- [[_COMMUNITY_paragraphs|paragraphs]]
-- [[_COMMUNITY_corsOrigin.ts|corsOrigin.ts]]
+- [[_COMMUNITY_launchAcquisitionReport.ts|launchAcquisitionReport.ts]]
 - [[_COMMUNITY_README|README.md]]
+- [[_COMMUNITY_paragraphs|paragraphs]]
+- [[_COMMUNITY_adminListingsTableReducer.ts|adminListingsTableReducer.ts]]
+- [[_COMMUNITY_README|README.md]]
+- [[_COMMUNITY_publicationsTableReducer.ts|publicationsTableReducer.ts]]
 - [[_COMMUNITY_isLikelyPersonUrl|isLikelyPersonUrl]]
 - [[_COMMUNITY_sanitizeMongo.ts|sanitizeMongo.ts]]
 - [[_COMMUNITY_index.ts|index.ts]]
-- [[_COMMUNITY_listingFormReducer.ts|listingFormReducer.ts]]
+- [[_COMMUNITY_redactDirectContactInfo|redactDirectContactInfo]]
+- [[_COMMUNITY_applyResearchEntityDedupeMergeGroup|applyResearchEntityDedupeMergeGroup]]
+- [[_COMMUNITY_researchAreasRoutes.test.ts|researchAreasRoutes.test.ts]]
 - [[_COMMUNITY_Codex Guide|Codex Guide]]
+- [[_COMMUNITY_visibilityRepairQueueService.test.ts|visibilityRepairQueueService.test.ts]]
 - [[_COMMUNITY_Codex Guide|Codex Guide]]
-- [[_COMMUNITY_Codex Guide|Codex Guide]]
-- [[_COMMUNITY_csrfOriginGuard.ts|csrfOriginGuard.ts]]
+- [[_COMMUNITY_dedupeSameNameLeadMembers|dedupeSameNameLeadMembers]]
 - [[_COMMUNITY_refreshGateScorecards.ts|refreshGateScorecards.ts]]
+- [[_COMMUNITY_profileAreaDuplicateRisk.ts|profileAreaDuplicateRisk.ts]]
 - [[_COMMUNITY_dedupeExploratoryContactPathways.ts|dedupeExploratoryContactPathways.ts]]
 - [[_COMMUNITY_args|args]]
 - [[_COMMUNITY_compilerOptions|compilerOptions]]
@@ -296,27 +300,21 @@
 - [[_COMMUNITY_CliOptions|CliOptions]]
 - [[_COMMUNITY_testFixturePrivacy.test.ts|testFixturePrivacy.test.ts]]
 - [[_COMMUNITY_{ ctx }|{ ctx }]]
-- [[_COMMUNITY_main|main]]
-- [[_COMMUNITY_officialProfileObservationMatchesUser|officialProfileObservationMatchesUser]]
-- [[_COMMUNITY_corsOrigin.ts|corsOrigin.ts]]
+- [[_COMMUNITY_sourceReviewDecisionHandoffs|sourceReviewDecisionHandoffs]]
+- [[_COMMUNITY_sourceReviewDecisionValidationProbeCommands|sourceReviewDecisionValidationProbeCommands]]
 - [[_COMMUNITY_astronomyConfig|astronomyConfig]]
-- [[_COMMUNITY_securityHeaders.ts|securityHeaders.ts]]
 - [[_COMMUNITY_materializePaperObservationsFromRun|materializePaperObservationsFromRun]]
 - [[_COMMUNITY_ensure-server-build-fresh.mjs|ensure-server-build-fresh.mjs]]
 - [[_COMMUNITY_createRoutes|createRoutes]]
 - [[_COMMUNITY_Yale Research Product Context|Yale Research Product Context]]
 - [[_COMMUNITY_10. P2 Fellowship, Course, And Contact Materialization|10. P2 Fellowship, Course, And Contact Materialization]]
-- [[_COMMUNITY_Priority Roadmap|Priority Roadmap]]
-- [[_COMMUNITY_2. Install dependencies|2. Install dependencies]]
+- [[_COMMUNITY_Research Data Pipeline|Research Data Pipeline]]
 - [[_COMMUNITY_API Routes|API Routes]]
-- [[_COMMUNITY_API Routes|API Routes]]
-- [[_COMMUNITY_Legacy CSV-to-JSON update script retired.  Department ground truth no longer com|Legacy CSV-to-JSON update script retired.  Department ground truth no longer com]]
-- [[_COMMUNITY_adminFellowshipsTableReducer.ts|adminFellowshipsTableReducer.ts]]
-- [[_COMMUNITY_importFaculty.ts|importFaculty.ts]]
+- [[_COMMUNITY_courseTableService.ts|courseTableService.ts]]
 - [[_COMMUNITY_1. M1.2 Client API-Boundary Vocabulary|1. M1.2 Client API-Boundary Vocabulary]]
 - [[_COMMUNITY_AdminListingsTable.tsx|AdminListingsTable.tsx]]
 - [[_COMMUNITY_devDependencies|devDependencies]]
-- [[_COMMUNITY_refreshGateScorecards.ts|refreshGateScorecards.ts]]
+- [[_COMMUNITY_errorHandler.ts|errorHandler.ts]]
 - [[_COMMUNITY_next|next]]
 - [[_COMMUNITY_appSecurityRuntime.test.ts|appSecurityRuntime.test.ts]]
 - [[_COMMUNITY_dir|dir]]
@@ -324,24 +322,21 @@
 - [[_COMMUNITY_chain|chain]]
 - [[_COMMUNITY_codetxt (Source metadata)|code:txt (Source metadata)]]
 - [[_COMMUNITY_Acknowledgements|Acknowledgements]]
-- [[_COMMUNITY_Acknowledgements|Acknowledgements]]
 - [[_COMMUNITY_Available Scripts|Available Scripts]]
 - [[_COMMUNITY_Auth and Security|Auth and Security]]
-- [[_COMMUNITY_ResearchGroupMember|ResearchGroupMember]]
+- [[_COMMUNITY_Local Development Setup|Local Development Setup]]
 - [[_COMMUNITY_Architecture|Architecture]]
-- [[_COMMUNITY_backfillProgramOfficialSources.ts|backfillProgramOfficialSources.ts]]
+- [[_COMMUNITY_Scraper Deployment Runbook|Scraper Deployment Runbook]]
 - [[_COMMUNITY_researchAreaResolver.ts|researchAreaResolver.ts]]
-- [[_COMMUNITY_Yale Research - Agent Guide|Yale Research - Agent Guide]]
+- [[_COMMUNITY_Yale Research|Yale Research]]
 - [[_COMMUNITY_resolutions|resolutions]]
-- [[_COMMUNITY_copyBetaToProd.ts|copyBetaToProd.ts]]
 - [[_COMMUNITY_parseStaleObservationConflictReviewArgs|parseStaleObservationConflictReviewArgs]]
 - [[_COMMUNITY_package.json|package.json]]
 - [[_COMMUNITY_buildCandidateSample|buildCandidateSample]]
 - [[_COMMUNITY_buildStaleObservationConflictSummary|buildStaleObservationConflictSummary]]
 - [[_COMMUNITY_manifest.json|manifest.json]]
 - [[_COMMUNITY_package.json|package.json]]
-- [[_COMMUNITY_itemOperations.ts|itemOperations.ts]]
-- [[_COMMUNITY_Finishing work|Finishing work]]
+- [[_COMMUNITY_agent-workflow|agent-workflow.md]]
 - [[_COMMUNITY_dataMigrationV4GrantBackfill.test.ts|dataMigrationV4GrantBackfill.test.ts]]
 - [[_COMMUNITY_dataMigrationPackageScripts.test.ts|dataMigrationPackageScripts.test.ts]]
 - [[_COMMUNITY_userMigrationCliSafety.test.ts|userMigrationCliSafety.test.ts]]
@@ -353,7 +348,6 @@
 - [[_COMMUNITY_codebash (SCRAPER_ENV=beta yarn --cwd server betadata-quality --inclu)|code:bash (SCRAPER_ENV=beta yarn --cwd server beta:data-quality --inclu)]]
 - [[_COMMUNITY_1. Fresh machine setup|1. Fresh machine setup]]
 - [[_COMMUNITY_codebash (which node)|code:bash (which node)]]
-- [[_COMMUNITY_1. Fresh machine setup|1. Fresh machine setup]]
 - [[_COMMUNITY_1. Fresh machine setup|1. Fresh machine setup]]
 - [[_COMMUNITY_CI|CI]]
 - [[_COMMUNITY_runStaleObservationConflictReview|runStaleObservationConflictReview]]
@@ -372,16 +366,14 @@
 - [[_COMMUNITY_15. M10 Final Migration Rollout And Cleanup|15. M10 Final Migration Rollout And Cleanup]]
 - [[_COMMUNITY_checker.py|checker.py]]
 - [[_COMMUNITY_normalizeStaleObservationReviewDecision|normalizeStaleObservationReviewDecision]]
-- [[_COMMUNITY_Product Model|Product Model]]
 - [[_COMMUNITY_3. Configure environment|3. Configure environment]]
-- [[_COMMUNITY_Architecture|Architecture]]
 - [[_COMMUNITY_Architecture|Architecture]]
 - [[_COMMUNITY_Auth Middleware (`serversrcmiddlewareauth.ts`)|Auth Middleware (`server/src/middleware/auth.ts`)]]
 - [[_COMMUNITY_4. Start local Meilisearch|4. Start local Meilisearch]]
 - [[_COMMUNITY_{ hasExpectedEntityName }|{ hasExpectedEntityName }]]
 - [[_COMMUNITY_postcss.config.js|postcss.config.js]]
 - [[_COMMUNITY_with-playwright-libs.sh|with-playwright-libs.sh]]
-- [[_COMMUNITY_researchEntityRelationship.ts|researchEntityRelationship.ts]]
+- [[_COMMUNITY_researchAccessTypes.ts|researchAccessTypes.ts]]
 - [[_COMMUNITY_diffDepartmentRows|diffDepartmentRows]]
 - [[_COMMUNITY_update_rdb.py|update_rdb.py]]
 - [[_COMMUNITY_apiBase|apiBase]]
@@ -942,27 +934,21 @@
 - [[_COMMUNITY_2026-05-22 Student Experience MCP Fix Pass|2026-05-22 Student Experience MCP Fix Pass]]
 - [[_COMMUNITY_2) `pathways` debounced search can update from stale payload|2) `/pathways` debounced search can update from stale payload]]
 - [[_COMMUNITY_Commands|Commands]]
-- [[_COMMUNITY_Graphify Repo Memory|Graphify Repo Memory]]
-- [[_COMMUNITY_Parallel Work|Parallel Work]]
 - [[_COMMUNITY_Product Surfaces|Product Surfaces]]
 - [[_COMMUNITY_Sensitive Areas|Sensitive Areas]]
-- [[_COMMUNITY_CI|CI]]
 - [[_COMMUNITY_`client.env`|`client/.env`]]
 - [[_COMMUNITY_codetypescript (const logListingEvent = (eventType AnalyticsEventType) = {)|code:typescript (const logListingEvent = (eventType: AnalyticsEventType) => {)]]
 - [[_COMMUNITY_Commands|Commands]]
 - [[_COMMUNITY_Error Handling|Error Handling]]
 - [[_COMMUNITY_External Integrations|External Integrations]]
-- [[_COMMUNITY_Maintenance|Maintenance]]
 - [[_COMMUNITY_Modifying a Schema|Modifying a Schema]]
 - [[_COMMUNITY_Monorepo Structure|Monorepo Structure]]
 - [[_COMMUNITY_Naming Conventions|Naming Conventions]]
 - [[_COMMUNITY_Rate Limiting|Rate Limiting]]
 - [[_COMMUNITY_Routes|Routes]]
-- [[_COMMUNITY_Scrapers|Scrapers]]
 - [[_COMMUNITY_6. Start dev servers|6. Start dev servers]]
 - [[_COMMUNITY_codebash (cd data-migration)|code:bash (cd data-migration)]]
 - [[_COMMUNITY_codebash (curl httplocalhost7700health)|code:bash (curl http://localhost:7700/health)]]
-- [[_COMMUNITY_codebash (yarn install)|code:bash (yarn install)]]
 - [[_COMMUNITY_codebash (cd client)|code:bash (cd client)]]
 - [[_COMMUNITY_codebash (curl -o- httpsraw.githubusercontent.comnvm-shnvmmaster)|code:bash (curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master)]]
 - [[_COMMUNITY_codebash (nvm install 20)|code:bash (nvm install 20)]]
@@ -970,16 +956,11 @@
 - [[_COMMUNITY_codebash (cp server.env.example server.env)|code:bash (cp server/.env.example server/.env)]]
 - [[_COMMUNITY_codebash ( client.env)|code:bash (# client/.env)]]
 - [[_COMMUNITY_codebash (docker pull getmeilimeilisearchlatest)|code:bash (docker pull getmeili/meilisearch:latest)]]
-- [[_COMMUNITY_Dev login bypass|Dev login bypass]]
 - [[_COMMUNITY_Environments|Environments]]
 - [[_COMMUNITY_Migration Scripts|Migration Scripts]]
 - [[_COMMUNITY_Modifying a Schema|Modifying a Schema]]
-- [[_COMMUNITY_What is tested|What is tested]]
 - [[_COMMUNITY_codebash (yarn playwrightrun screenshot httpsexample.com tmpexam)|code:bash (yarn playwright:run screenshot https://example.com /tmp/exam)]]
 - [[_COMMUNITY_Quick Start|Quick Start]]
-- [[_COMMUNITY_Tech Stack|Tech Stack]]
-- [[_COMMUNITY_Current Stack|Current Stack]]
-- [[_COMMUNITY_graphify|graphify]]
 - [[_COMMUNITY_Graphify Repo Memory|Graphify Repo Memory]]
 - [[_COMMUNITY_Product Surfaces|Product Surfaces]]
 - [[_COMMUNITY_Architecture|Architecture]]
@@ -997,7 +978,6 @@
 - [[_COMMUNITY_Authentication|Authentication]]
 - [[_COMMUNITY_CI|CI]]
 - [[_COMMUNITY_codebash (curl httplocalhost7700health)|code:bash (curl http://localhost:7700/health)]]
-- [[_COMMUNITY_codebash (yarn devclient     Vite on port 3000)|code:bash (yarn dev:client    # Vite on port 3000)]]
 - [[_COMMUNITY_codebash (curl httplocalhost7700health)|code:bash (curl http://localhost:7700/health)]]
 - [[_COMMUNITY_codetxt (Usage Error Couldn't find the node_modules state file - run)|code:txt (Usage Error: Couldn't find the node_modules state file - run)]]
 - [[_COMMUNITY_codebash (nvm install 20)|code:bash (nvm install 20)]]
@@ -1009,7 +989,6 @@
 - [[_COMMUNITY_Prerequisites|Prerequisites]]
 - [[_COMMUNITY_Running tests|Running tests]]
 - [[_COMMUNITY_Testing|Testing]]
-- [[_COMMUNITY_Troubleshooting Yarn setup|Troubleshooting Yarn setup]]
 - [[_COMMUNITY_Commands|Commands]]
 - [[_COMMUNITY_Core Modeling Direction|Core Modeling Direction]]
 - [[_COMMUNITY_Done Criteria|Done Criteria]]
@@ -1017,54 +996,32 @@
 - [[_COMMUNITY_Authentication Flow|Authentication Flow]]
 - [[_COMMUNITY_CI|CI]]
 - [[_COMMUNITY_codeblock1 (React (Vite) → Express (Passport.js) → MongoDB Atlas + Meili)|code:block1 (React (Vite) → Express (Passport.js) → MongoDB Atlas + Meili)]]
-- [[_COMMUNITY_External Integrations|External Integrations]]
 - [[_COMMUNITY_Graphify Repo Memory|Graphify Repo Memory]]
 - [[_COMMUNITY_Known Technical Debt|Known Technical Debt]]
-- [[_COMMUNITY_Routes|Routes]]
 - [[_COMMUNITY_YLabs Codebase Reference|Y/Labs Codebase Reference]]
 - [[_COMMUNITY_6. Start dev servers|6. Start dev servers]]
 - [[_COMMUNITY_7. Verify setup|7. Verify setup]]
-- [[_COMMUNITY_Auth Middleware (`serversrcmiddlewareauth.ts`)|Auth Middleware (`server/src/middleware/auth.ts`)]]
 - [[_COMMUNITY_codebash (yarn devclient     Vite on port 3000)|code:bash (yarn dev:client    # Vite on port 3000)]]
-- [[_COMMUNITY_codebash (curl httplocalhost7700health)|code:bash (curl http://localhost:7700/health)]]
 - [[_COMMUNITY_codebash (nvm install 20)|code:bash (nvm install 20)]]
 - [[_COMMUNITY_codebash (yarn install)|code:bash (yarn install)]]
 - [[_COMMUNITY_codebash (npx ts-node --transpile-only script.ts)|code:bash (npx ts-node --transpile-only <script>.ts)]]
 - [[_COMMUNITY_codebash (nvm install 20)|code:bash (nvm install 20)]]
 - [[_COMMUNITY_Common Commands|Common Commands]]
-- [[_COMMUNITY_New API Endpoint|New API Endpoint]]
-- [[_COMMUNITY_New Page|New Page]]
-- [[_COMMUNITY_Testing|Testing]]
 - [[_COMMUNITY_What Is This|What Is This?]]
 - [[_COMMUNITY_codebash (corepack enable)|code:bash (corepack enable)]]
-- [[_COMMUNITY_codebash (yarn playwrightrun screenshot httpsexample.com tmpexam)|code:bash (yarn playwright:run screenshot https://example.com /tmp/exam)]]
-- [[_COMMUNITY_Playwright environment fix (no root required)|Playwright environment fix (no root required)]]
 - [[_COMMUNITY_Tech Stack|Tech Stack]]
 - [[_COMMUNITY_YURA Research Database|YURA Research Database]]
-- [[_COMMUNITY_Commands|Commands]]
-- [[_COMMUNITY_Core Modeling Direction|Core Modeling Direction]]
-- [[_COMMUNITY_Default Task Loop|Default Task Loop]]
-- [[_COMMUNITY_Documentation Maintenance|Documentation Maintenance]]
-- [[_COMMUNITY_Implementation Rules|Implementation Rules]]
-- [[_COMMUNITY_Product North Star|Product North Star]]
 - [[_COMMUNITY_Adding a New Page|Adding a New Page]]
 - [[_COMMUNITY_Auth Middleware|Auth Middleware]]
 - [[_COMMUNITY_CI|CI]]
-- [[_COMMUNITY_`client.env`|`client/.env`]]
 - [[_COMMUNITY_Commands|Commands]]
-- [[_COMMUNITY_Environment Variables|Environment Variables]]
-- [[_COMMUNITY_Modifying a Schema|Modifying a Schema]]
-- [[_COMMUNITY_Monorepo Structure|Monorepo Structure]]
-- [[_COMMUNITY_Product Model|Product Model]]
 - [[_COMMUNITY_Rate Limiting|Rate Limiting]]
 - [[_COMMUNITY_Search|Search]]
 - [[_COMMUNITY_Sensitive Files|Sensitive Files]]
 - [[_COMMUNITY_Validation Middleware|Validation Middleware]]
-- [[_COMMUNITY_codeblock1 (React (Vite) → Express (Passport.js) → MongoDB Atlas + Meili)|code:block1 (React (Vite) → Express (Passport.js) → MongoDB Atlas + Meili)]]
 - [[_COMMUNITY_codebash (curl httplocalhost7700health)|code:bash (curl http://localhost:7700/health)]]
 - [[_COMMUNITY_codebash (nvm install 20)|code:bash (nvm install 20)]]
 - [[_COMMUNITY_codeblock19 (ylabs)|code:block19 (ylabs/)]]
-- [[_COMMUNITY_codebash (curl -o- httpsraw.githubusercontent.comnvm-shnvmmaster)|code:bash (curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master)]]
 - [[_COMMUNITY_codebash (corepack enable)|code:bash (corepack enable)]]
 - [[_COMMUNITY_Environments|Environments]]
 - [[_COMMUNITY_Local Development Setup|Local Development Setup]]
@@ -1072,9 +1029,7 @@
 - [[_COMMUNITY_Project Structure|Project Structure]]
 - [[_COMMUNITY_Running tests|Running tests]]
 - [[_COMMUNITY_Tech Stack|Tech Stack]]
-- [[_COMMUNITY_Troubleshooting|Troubleshooting]]
 - [[_COMMUNITY_What is tested|What is tested]]
-- [[_COMMUNITY_codebash ( Terminal 1)|code:bash (# Terminal 1)]]
 - [[_COMMUNITY_Quick Start|Quick Start]]
 - [[_COMMUNITY_YURA Research Database|YURA Research Database]]
 - [[_COMMUNITY_Core Modeling Direction|Core Modeling Direction]]
@@ -1082,20 +1037,15 @@
 - [[_COMMUNITY_Default Task Loop|Default Task Loop]]
 - [[_COMMUNITY_graphify|graphify]]
 - [[_COMMUNITY_Rule Evolution|Rule Evolution]]
-- [[_COMMUNITY_Sensitive Areas|Sensitive Areas]]
 - [[_COMMUNITY_Architecture|Architecture]]
 - [[_COMMUNITY_codeblock2 (ylabs)|code:block2 (ylabs/)]]
 - [[_COMMUNITY_codetypescript (export const asyncHandler = (fn Function) = {)|code:typescript (export const asyncHandler = (fn: Function) => {)]]
-- [[_COMMUNITY_codetypescript (const logListingEvent = (eventType AnalyticsEventType) = {)|code:typescript (const logListingEvent = (eventType: AnalyticsEventType) => {)]]
 - [[_COMMUNITY_Environments|Environments]]
 - [[_COMMUNITY_Error Handling|Error Handling]]
 - [[_COMMUNITY_Known Technical Debt|Known Technical Debt]]
 - [[_COMMUNITY_Scrapers|Scrapers]]
-- [[_COMMUNITY_Search|Search]]
-- [[_COMMUNITY_TypeScript Configuration|TypeScript Configuration]]
 - [[_COMMUNITY_4. Start local Meilisearch|4. Start local Meilisearch]]
 - [[_COMMUNITY_5. Seed Meilisearch|5. Seed Meilisearch]]
-- [[_COMMUNITY_CI|CI]]
 - [[_COMMUNITY_codeblock1 (React (Vite) → Express (Passport.js) → MongoDB Atlas + Meili)|code:block1 (React (Vite) → Express (Passport.js) → MongoDB Atlas + Meili)]]
 - [[_COMMUNITY_codebash (curl httplocalhost7700health)|code:bash (curl http://localhost:7700/health)]]
 - [[_COMMUNITY_codebash (yarn devclient     Vite on port 3000)|code:bash (yarn dev:client    # Vite on port 3000)]]
@@ -1108,10 +1058,8 @@
 - [[_COMMUNITY_New Page|New Page]]
 - [[_COMMUNITY_Prerequisites|Prerequisites]]
 - [[_COMMUNITY_Search|Search]]
-- [[_COMMUNITY_Tech Stack|Tech Stack]]
 - [[_COMMUNITY_What Is This|What Is This?]]
 - [[_COMMUNITY_YLabs — Developer Guide|Y/Labs — Developer Guide]]
-- [[_COMMUNITY_codebash (corepack enable)|code:bash (corepack enable)]]
 - [[_COMMUNITY_codebash (yarn playwrightrun screenshot httpsexample.com tmpexam)|code:bash (yarn playwright:run screenshot https://example.com /tmp/exam)]]
 - [[_COMMUNITY_Playwright environment fix (no root required)|Playwright environment fix (no root required)]]
 - [[_COMMUNITY_Tech Stack|Tech Stack]]
@@ -1122,40 +1070,22 @@
 - [[_COMMUNITY_Product North Star|Product North Star]]
 - [[_COMMUNITY_Adding a New Page|Adding a New Page]]
 - [[_COMMUNITY_Analytics Interception|Analytics Interception]]
-- [[_COMMUNITY_Architecture|Architecture]]
-- [[_COMMUNITY_Auth Middleware|Auth Middleware]]
-- [[_COMMUNITY_Authentication Flow|Authentication Flow]]
 - [[_COMMUNITY_`client.env`|`client/.env`]]
-- [[_COMMUNITY_codetypescript (export const asyncHandler = (fn Function) = {)|code:typescript (export const asyncHandler = (fn: Function) => {)]]
 - [[_COMMUNITY_Database|Database]]
-- [[_COMMUNITY_Environments|Environments]]
-- [[_COMMUNITY_Known Technical Debt|Known Technical Debt]]
 - [[_COMMUNITY_Modifying a Schema|Modifying a Schema]]
-- [[_COMMUNITY_Naming Conventions|Naming Conventions]]
 - [[_COMMUNITY_Product Model|Product Model]]
-- [[_COMMUNITY_Rate Limiting|Rate Limiting]]
-- [[_COMMUNITY_`server.env`|`server/.env`]]
-- [[_COMMUNITY_Tech Stack|Tech Stack]]
 - [[_COMMUNITY_TypeScript Configuration|TypeScript Configuration]]
-- [[_COMMUNITY_Validation Middleware|Validation Middleware]]
-- [[_COMMUNITY_7. Verify setup|7. Verify setup]]
 - [[_COMMUNITY_codebash (curl httplocalhost7700health)|code:bash (curl http://localhost:7700/health)]]
 - [[_COMMUNITY_codebash (nvm install 20)|code:bash (nvm install 20)]]
 - [[_COMMUNITY_codebash (yarn install)|code:bash (yarn install)]]
 - [[_COMMUNITY_codebash (sudo apt update)|code:bash (sudo apt update)]]
 - [[_COMMUNITY_codeblock20 (User → Yale CAS SSO → passport.ts findOrCreateUser)|code:block20 (User → Yale CAS SSO → passport.ts findOrCreateUser)]]
 - [[_COMMUNITY_codebash (curl -o- httpsraw.githubusercontent.comnvm-shnvmmaster)|code:bash (curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master)]]
-- [[_COMMUNITY_codebash (docker pull getmeilimeilisearchlatest)|code:bash (docker pull getmeili/meilisearch:latest)]]
-- [[_COMMUNITY_Local Development Setup|Local Development Setup]]
 - [[_COMMUNITY_New API Endpoint|New API Endpoint]]
-- [[_COMMUNITY_Running tests|Running tests]]
-- [[_COMMUNITY_Search|Search]]
 - [[_COMMUNITY_Troubleshooting Yarn setup|Troubleshooting Yarn setup]]
 - [[_COMMUNITY_Documentation|Documentation]]
-- [[_COMMUNITY_YURA Research Database|YURA Research Database]]
 - [[_COMMUNITY_Default Task Loop|Default Task Loop]]
 - [[_COMMUNITY_Documentation Maintenance|Documentation Maintenance]]
-- [[_COMMUNITY_Done Criteria|Done Criteria]]
 - [[_COMMUNITY_Graphify Repo Memory|Graphify Repo Memory]]
 - [[_COMMUNITY_Product North Star|Product North Star]]
 - [[_COMMUNITY_Analytics Interception|Analytics Interception]]
@@ -1169,22 +1099,15 @@
 - [[_COMMUNITY_Security Middleware|Security Middleware]]
 - [[_COMMUNITY_`server.env`|`server/.env`]]
 - [[_COMMUNITY_Yale Research Codebase Reference|Yale Research Codebase Reference]]
-- [[_COMMUNITY_3. Configure environment|3. Configure environment]]
 - [[_COMMUNITY_API Routes|API Routes]]
 - [[_COMMUNITY_Architecture|Architecture]]
-- [[_COMMUNITY_Authentication|Authentication]]
 - [[_COMMUNITY_codebash (curl httplocalhost7700health)|code:bash (curl http://localhost:7700/health)]]
 - [[_COMMUNITY_codebash (curl httplocalhost7700health)|code:bash (curl http://localhost:7700/health)]]
 - [[_COMMUNITY_codebash (which node)|code:bash (which node)]]
 - [[_COMMUNITY_codeblock20 (yale-research)|code:block20 (yale-research/)]]
 - [[_COMMUNITY_codebash (nvm install 20)|code:bash (nvm install 20)]]
-- [[_COMMUNITY_Common Commands|Common Commands]]
 - [[_COMMUNITY_Dev login bypass|Dev login bypass]]
-- [[_COMMUNITY_Migration Scripts|Migration Scripts]]
-- [[_COMMUNITY_Modifying a Schema|Modifying a Schema]]
 - [[_COMMUNITY_Operator board Gate Status — keeping it honest and current|Operator board Gate Status — keeping it honest and current]]
-- [[_COMMUNITY_Project Structure|Project Structure]]
-- [[_COMMUNITY_What Is This|What Is This?]]
 - [[_COMMUNITY_YLabs — Developer Guide|Y/Labs — Developer Guide]]
 - [[_COMMUNITY_Acknowledgements|Acknowledgements]]
 - [[_COMMUNITY_codebash (corepack enable)|code:bash (corepack enable)]]
@@ -2665,16 +2588,9 @@
 - [[_COMMUNITY_agents|agents]]
 - [[_COMMUNITY_Done Criteria|Done Criteria]]
 - [[_COMMUNITY_graphify|graphify]]
-- [[_COMMUNITY_Product Surfaces|Product Surfaces]]
-- [[_COMMUNITY_Rule Evolution|Rule Evolution]]
-- [[_COMMUNITY_Adding a New Page|Adding a New Page]]
-- [[_COMMUNITY_Analytics Interception|Analytics Interception]]
-- [[_COMMUNITY_codeblock5 (User → Yale CAS SSO → passport.ts findOrCreateUser)|code:block5 (User → Yale CAS SSO → passport.ts findOrCreateUser)]]
 - [[_COMMUNITY_Environment Variables|Environment Variables]]
 - [[_COMMUNITY_Environments|Environments]]
-- [[_COMMUNITY_Graphify Repo Memory|Graphify Repo Memory]]
 - [[_COMMUNITY_Maintenance|Maintenance]]
-- [[_COMMUNITY_Sensitive Files|Sensitive Files]]
 - [[_COMMUNITY_Tech Stack|Tech Stack]]
 - [[_COMMUNITY_Testing|Testing]]
 - [[_COMMUNITY_TypeScript Configuration|TypeScript Configuration]]
@@ -2685,71 +2601,48 @@
 - [[_COMMUNITY_3. Configure environment|3. Configure environment]]
 - [[_COMMUNITY_3. Start local Meilisearch|3. Start local Meilisearch]]
 - [[_COMMUNITY_4. Seed Meilisearch|4. Seed Meilisearch]]
-- [[_COMMUNITY_4. Start local Meilisearch|4. Start local Meilisearch]]
 - [[_COMMUNITY_5. Seed Meilisearch|5. Seed Meilisearch]]
 - [[_COMMUNITY_5. Start dev servers|5. Start dev servers]]
-- [[_COMMUNITY_6. Start dev servers|6. Start dev servers]]
-- [[_COMMUNITY_Adding Things|Adding Things]]
 - [[_COMMUNITY_codeblock1 (React (Vite) → Express (Passport.js) → MongoDB Atlas + Meili)|code:block1 (React (Vite) → Express (Passport.js) → MongoDB Atlas + Meili)]]
 - [[_COMMUNITY_codebash (curl httplocalhost7700health)|code:bash (curl http://localhost:7700/health)]]
 - [[_COMMUNITY_codebash (yarn --cwd server meilirebuild-all --clear)|code:bash (yarn --cwd server meili:rebuild-all --clear)]]
 - [[_COMMUNITY_codebash (curl httplocalhost7700health)|code:bash (curl http://localhost:7700/health)]]
-- [[_COMMUNITY_codetxt (Usage Error Couldn't find the node_modules state file - run)|code:txt (Usage Error: Couldn't find the node_modules state file - run)]]
 - [[_COMMUNITY_codebash (LOCAL_AUTH_BYPASS_NETID=devadmin)|code:bash (LOCAL_AUTH_BYPASS_NETID=devadmin)]]
 - [[_COMMUNITY_codebash (yarn scrape help)|code:bash (yarn scrape help)]]
-- [[_COMMUNITY_codebash (sudo apt update)|code:bash (sudo apt update)]]
 - [[_COMMUNITY_codeblock21 (User → Yale CAS SSO → passport.ts findOrCreateUser)|code:block21 (User → Yale CAS SSO → passport.ts findOrCreateUser)]]
 - [[_COMMUNITY_codebash (yarn --cwd client test         watch mode — reruns on file )|code:bash (yarn --cwd client test        # watch mode — reruns on file )]]
-- [[_COMMUNITY_codebash (nvm install 20)|code:bash (nvm install 20)]]
-- [[_COMMUNITY_codebash (corepack enable)|code:bash (corepack enable)]]
-- [[_COMMUNITY_codebash ( client.env)|code:bash (# client/.env)]]
-- [[_COMMUNITY_Environments|Environments]]
 - [[_COMMUNITY_Local Development Setup|Local Development Setup]]
 - [[_COMMUNITY_Modifying a Schema|Modifying a Schema]]
 - [[_COMMUNITY_New Page|New Page]]
-- [[_COMMUNITY_Prerequisites|Prerequisites]]
 - [[_COMMUNITY_Search|Search]]
 - [[_COMMUNITY_Tech Stack|Tech Stack]]
 - [[_COMMUNITY_Testing|Testing]]
 - [[_COMMUNITY_Troubleshooting|Troubleshooting]]
 - [[_COMMUNITY_What is tested|What is tested]]
 - [[_COMMUNITY_Yale Research — Developer Guide|Yale Research — Developer Guide]]
-- [[_COMMUNITY_Documentation|Documentation]]
 - [[_COMMUNITY_Legacy CSV-to-JSON update script retired.  Department ground truth no longer com|Legacy CSV-to-JSON update script retired.  Department ground truth no longer com]]
 - [[_COMMUNITY_Documentation Maintenance|Documentation Maintenance]]
 - [[_COMMUNITY_Implementation Rules|Implementation Rules]]
 - [[_COMMUNITY_Rule Evolution|Rule Evolution]]
 - [[_COMMUNITY_Sensitive Areas|Sensitive Areas]]
-- [[_COMMUNITY_codeblock1 (React (Vite) → Express (Passport.js) → MongoDB Atlas + Meili)|code:block1 (React (Vite) → Express (Passport.js) → MongoDB Atlas + Meili)]]
 - [[_COMMUNITY_codetypescript (export const asyncHandler = (fn Function) = {)|code:typescript (export const asyncHandler = (fn: Function) => {)]]
 - [[_COMMUNITY_codetypescript (const logListingEvent = (eventType AnalyticsEventType) = {)|code:typescript (const logListingEvent = (eventType: AnalyticsEventType) => {)]]
 - [[_COMMUNITY_codeblock5 (User → Yale CAS SSO → passport.ts findOrCreateUser)|code:block5 (User → Yale CAS SSO → passport.ts findOrCreateUser)]]
-- [[_COMMUNITY_Commands|Commands]]
-- [[_COMMUNITY_Database|Database]]
-- [[_COMMUNITY_Error Handling|Error Handling]]
 - [[_COMMUNITY_Product Model|Product Model]]
 - [[_COMMUNITY_Scrapers|Scrapers]]
 - [[_COMMUNITY_Search|Search]]
 - [[_COMMUNITY_Sensitive Files|Sensitive Files]]
 - [[_COMMUNITY_Tech Stack|Tech Stack]]
-- [[_COMMUNITY_Testing|Testing]]
-- [[_COMMUNITY_YLabs Codebase Reference|Y/Labs Codebase Reference]]
-- [[_COMMUNITY_5. Seed Meilisearch|5. Seed Meilisearch]]
 - [[_COMMUNITY_Auth Middleware (`serversrcmiddlewareauth.ts`)|Auth Middleware (`server/src/middleware/auth.ts`)]]
 - [[_COMMUNITY_Authentication|Authentication]]
 - [[_COMMUNITY_codebash (curl httplocalhost7700health)|code:bash (curl http://localhost:7700/health)]]
 - [[_COMMUNITY_codetxt (Usage Error Couldn't find the node_modules state file - run)|code:txt (Usage Error: Couldn't find the node_modules state file - run)]]
-- [[_COMMUNITY_codebash (which node)|code:bash (which node)]]
 - [[_COMMUNITY_codebash (nvm install 20)|code:bash (nvm install 20)]]
 - [[_COMMUNITY_codebash (nvm install 20)|code:bash (nvm install 20)]]
-- [[_COMMUNITY_codebash (yarn installall)|code:bash (yarn install:all)]]
-- [[_COMMUNITY_codebash (cp server.env.example server.env)|code:bash (cp server/.env.example server/.env)]]
 - [[_COMMUNITY_Project Structure|Project Structure]]
 - [[_COMMUNITY_Troubleshooting|Troubleshooting]]
 - [[_COMMUNITY_Troubleshooting Yarn setup|Troubleshooting Yarn setup]]
-- [[_COMMUNITY_YLabs — Developer Guide|Y/Labs — Developer Guide]]
 - [[_COMMUNITY_codebash ( Terminal 1)|code:bash (# Terminal 1)]]
-- [[_COMMUNITY_Quick Start|Quick Start]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `sanitizeLogValue()` - 249 edges
@@ -2761,7 +2654,7 @@
 7. `ResearchGroupMember` - 77 edges
 8. `scripts` - 75 edges
 9. `ScraperContext` - 69 edges
-10. `User` - 58 edges
+10. `User` - 59 edges
 
 ## Surprising Connections (you probably didn't know these)
 - `checkLiveLink()` --calls--> `request()`  [INFERRED]
@@ -2778,19 +2671,19 @@
 ## Import Cycles
 - None detected.
 
-## Communities (3372 total, 2459 thin omitted)
+## Communities (3266 total, 2353 thin omitted)
 
 ### Community 0 - "Decisions"
 Cohesion: 0.11
 Nodes (19): 2026-05-07: Evolve Legacy ResearchGroup Conservatively, 2026-05-07: North Star Is Research Navigation, 2026-05-07: Replace Binary Acceptance With Access Signals, 2026-05-07: Separate EntryPathway From PostedOpportunity, 2026-05-07: Use Two Main Product Surfaces, 2026-05-11: Use Pathways As The Student Action Layer, 2026-05-14: Student-Facing Routes Should Not Use URL Versioning, 2026-05-25: Beta Operator Review Is An Automatic Repair State (+11 more)
 
 ### Community 1 - "labDetail.tsx"
-Cohesion: 0.06
-Nodes (68): copy, FirstSaveCallout(), FirstSaveCalloutProps, adminQualityNotes(), AffiliatedResearchEntitiesSection(), compactDepartmentLabels(), decisionNextStep(), DecisionSummary() (+60 more)
+Cohesion: 0.07
+Nodes (48): adminQualityNotes(), AffiliatedResearchEntitiesSection(), compactDepartmentLabels(), decisionNextStep(), DecisionSummary(), dedupeLeadMembers(), detailDescription(), detailTopics() (+40 more)
 
 ### Community 2 - "browsable.ts"
-Cohesion: 0.06
-Nodes (55): FellowshipModal(), ArchivedBadge(), BrowseCard, BrowseCardProps, BrowseGrid(), BrowseGridProps, BrowseListItem, BrowseListItemProps (+47 more)
+Cohesion: 0.05
+Nodes (58): FellowshipModal(), FellowshipModalProps, RichText(), trackFellowshipApplyClick(), ArchivedBadge(), BrowseCard, BrowseCardProps, BrowseGrid() (+50 more)
 
 ### Community 3 - "security-preflight.test.mjs"
 Cohesion: 0.29
@@ -2798,183 +2691,183 @@ Nodes (6): ciWorkflow, keepAliveWorkflow, packageJson, productionSecuritySmokeWo
 
 ### Community 4 - "departmentRosterScraper.ts"
 Cohesion: 0.09
-Nodes (61): absolutize(), canonicalProfileUrlFromHtml(), cleanProfileSectionText(), cleanText(), csFacultyDataExtractor(), csJsRenderedStub(), csRenderedExtractor(), decodeHtmlEntities() (+53 more)
+Nodes (60): absolutize(), canonicalProfileUrlFromHtml(), cleanProfileSectionText(), cleanText(), csFacultyDataExtractor(), csJsRenderedStub(), csRenderedExtractor(), decodeHtmlEntities() (+52 more)
 
-### Community 5 - "index.ts"
+### Community 5 - "labDetail.ts"
 Cohesion: 0.08
-Nodes (32): LabMembersList(), LabMembersListProps, ROLE_LABELS, ROLE_ORDER, ROLE_PILL_CLASSES, decodeHtmlEntities(), decodeNumericEntity(), isScholarlyLink() (+24 more)
+Nodes (32): LabInquireModal(), LabInquireModalProps, LabMembersList(), LabMembersListProps, ROLE_LABELS, ROLE_ORDER, ROLE_PILL_CLASSES, basePayload (+24 more)
 
 ### Community 6 - "App.tsx"
+Cohesion: 0.05
+Nodes (33): PlanningOverview(), PlanningOverviewProps, pluralize(), scrollPositions, ScrollToTop(), normalizeReturnPath(), SignInButton(), SignInButtonProps (+25 more)
+
+### Community 7 - "logSanitizer.ts"
 Cohesion: 0.06
-Nodes (23): scrollPositions, ScrollToTop(), normalizeReturnPath(), SignInButton(), SignInButtonProps, UnprivateRoute(), UnprivateRouteProps, formatDocumentTitle() (+15 more)
+Nodes (45): ApiMode, getApiMode(), initializeConnections(), mongoOptions, startApp(), CliOptions, FILTER, main() (+37 more)
 
-### Community 7 - "assertScriptApplyAllowed"
-Cohesion: 0.08
-Nodes (29): ApiMode, getApiMode(), initializeConnections(), mongoOptions, startApp(), listingSchema, __filenameLocal, gateRefreshIntervalMs() (+21 more)
+### Community 8 - "adminFellowshipsTableReducer.ts"
+Cohesion: 0.21
+Nodes (9): AdminFellowshipsTable(), AdminFellowshipsFilter, AdminFellowshipsSortField, AdminFellowshipsTableAction, adminFellowshipsTableReducer(), AdminFellowshipsTableState, createInitialAdminFellowshipsTableState(), createInitialAdminTableState() (+1 more)
 
-### Community 8 - "adminListingsTableReducer.ts"
-Cohesion: 0.09
-Nodes (26): AdminFellowshipsTable(), AdminFacultyProfilesFilter, AdminFacultyProfilesSortField, AdminFacultyProfilesTableAction, adminFacultyProfilesTableReducer(), AdminFacultyProfilesTableState, createInitialAdminFacultyProfilesTableState(), AdminFellowshipsFilter (+18 more)
-
-### Community 9 - "profileService.ts"
-Cohesion: 0.09
-Nodes (34): appointmentTitleCount(), capitalizeSentenceStart(), cleanPublicProfileBio(), cleanResearchHomeSummaryForBio(), clipPublicProfileBio(), degreeTokenCount(), hasPublicProfileEmail(), hasResearchDescriptionVerb() (+26 more)
+### Community 9 - "cleanPublicProfileBio"
+Cohesion: 0.12
+Nodes (24): appointmentTitleCount(), cleanPublicProfileBio(), clipPublicProfileBio(), degreeTokenCount(), hasPublicProfileEmail(), hasResearchDescriptionVerb(), isAffiliationOnlyResearchSummary(), isAppointmentListOnlyProfileBio() (+16 more)
 
 ### Community 10 - "labMicrositeUndergradLLMExtractor.ts"
-Cohesion: 0.08
+Cohesion: 0.09
 Nodes (41): RenderedFetcher, summarizeFetchMetrics, buildLLMPrompt(), CallLLMFn, candidateCrawlUrls(), CandidateLab, candidateLabFromResearchEntityDoc(), candidateSubPageUrls() (+33 more)
 
 ### Community 11 - "safeHttpUrl"
-Cohesion: 0.06
-Nodes (54): AccessReviewCounts, AccessReviewDetail, AccessReviewEntitySummary, AccessSignal, AdminAccessReview(), ContactRoute, EntryPathway, evidenceIds() (+46 more)
+Cohesion: 0.10
+Nodes (37): DeveloperCard(), DeveloperCardProps, decodeHtmlEntities(), decodeNumericEntity(), isScholarlyLink(), LabPapersList(), LabPapersListProps, normalizeResearchActivityTitle() (+29 more)
 
 ### Community 12 - "entityMaterializer.ts"
-Cohesion: 0.10
-Nodes (32): ResolvedField, buildOfficialProfileScholarlyLinkUpserts(), cleanScholarlyHttpUrl(), cleanScholarlyText(), compactPersonName(), comparableObservationValue(), deptUserNameFilters(), escapeRegex() (+24 more)
+Cohesion: 0.08
+Nodes (58): ResolvedField, addPostMaterializationMetrics(), buildInferredPiMemberUpsert(), buildOfficialProfileScholarlyLinkUpserts(), cleanScholarlyHttpUrl(), cleanScholarlyText(), compactPersonName(), comparableObservationValue() (+50 more)
 
 ### Community 13 - "researchGroupService.ts"
-Cohesion: 0.05
-Nodes (98): PublicResearchEntityDto, addPublicMemberField(), addPublicMemberInternalProfilePath(), addPublicMemberProfileUrls(), addPublicPaperField(), boundedResearchFilterValues(), boundedResearchSearchQuery(), buildLeadPiOutreachContactRoute() (+90 more)
+Cohesion: 0.08
+Nodes (46): defaultOwnerToGroupSlug(), PublicResearchEntityDto, addPublicMemberField(), addPublicMemberInternalProfilePath(), addPublicMemberProfileUrls(), boundedResearchFilterValues(), contactRouteDedupeKey(), contactRouteRank() (+38 more)
 
 ### Community 14 - "labMicrositeDescriptionLLMExtractor.ts"
 Cohesion: 0.10
-Nodes (37): CallDescriptionLLMFn, CandidateDescriptionLab, CandidateDescriptionLabDoc, candidateDescriptionLabsFromDocs(), candidateKeyMatches(), candidateUrlsForDoc(), defaultCallLLM(), defaultLabFinder() (+29 more)
+Nodes (39): CallDescriptionLLMFn, CandidateDescriptionLab, CandidateDescriptionLabDoc, candidateDescriptionLabsFromDocs(), candidateKeyMatches(), candidateUrlsForDoc(), defaultCallLLM(), defaultLabFinder() (+31 more)
 
 ### Community 15 - "accessMaterializer.ts"
-Cohesion: 0.09
-Nodes (51): AccessSignalConfidence, AccessSignalType, accessArtifactCandidatesFromDerived(), AccessMaterializationResult, AccessObservation, bestObservation(), confidenceLabel(), contactSignalExcerpt() (+43 more)
+Cohesion: 0.08
+Nodes (55): AccessSignalConfidence, AccessSignalType, ContactPolicy, ContactRouteVisibility, accessArtifactCandidatesFromDerived(), AccessMaterializationResult, AccessObservation, bestObservation() (+47 more)
 
-### Community 16 - "research.test.tsx"
-Cohesion: 0.09
-Nodes (23): baseProfile, ResizeObserverMock, ConfigContextType, defaultConfigContext, DepartmentConfig, FieldConfig, ResearchAreaConfig, defaultSearchContext (+15 more)
+### Community 16 - "ConfigContext.ts"
+Cohesion: 0.18
+Nodes (16): baseProfile, ConfigContextType, defaultConfigContext, DepartmentConfig, FieldConfig, ResearchAreaConfig, colorKeyToTailwind, ConfigContextProvider() (+8 more)
 
 ### Community 18 - "sanitizeLogValue"
 Cohesion: 0.10
-Nodes (58): mocks, privateProgram, addFavFellowships(), addFavListings(), addFavPathways(), addSavedPrograms(), addSavedResearchPlans(), ALLOWED_SELF_USER_TYPES (+50 more)
+Nodes (67): mocks, privateProgram, addFavFellowships(), addFavListings(), addFavPathways(), addSavedPrograms(), addSavedResearchPlans(), ALLOWED_SELF_USER_TYPES (+59 more)
 
 ### Community 19 - "integrityGate.ts"
-Cohesion: 0.06
-Nodes (52): ResearchGroupMember, ResolvedRelationshipMaterializationDeps, ActiveArtifactOnArchivedEntity, buildDuplicateAccessSignalGroupsFromRows(), buildDuplicateResearchPaperGroupsFromRows(), BuildPostMaterializationIntegrityInput, buildPostMaterializationIntegritySummary(), buildSamePiNameDuplicateGroupsFromDedupeRows() (+44 more)
+Cohesion: 0.09
+Nodes (36): ActiveArtifactOnArchivedEntity, buildDuplicateResearchPaperGroupsFromRows(), BuildPostMaterializationIntegrityInput, buildPostMaterializationIntegritySummary(), buildSamePiNameDuplicateGroupsFromDedupeRows(), CurrentMemberOnArchivedEntity, DuplicateCurrentMemberGroup, DuplicateExploratoryContactPathwayGroup (+28 more)
 
 ### Community 20 - "passport.ts"
 Cohesion: 0.07
-Nodes (50): authConfig, authDebug(), AuthenticatedSessionUser, buildAuthenticatedSessionUser(), buildDirectoryUpdate(), casLogin(), DEV_LOGIN_PROFILES, ensureDevLoginUser() (+42 more)
+Nodes (49): authConfig, authDebug(), AuthenticatedSessionUser, buildDirectoryUpdate(), casLogin(), DEV_LOGIN_PROFILES, ensureDevLoginUser(), findOrCreateUser() (+41 more)
 
 ### Community 21 - "Navbar.tsx"
-Cohesion: 0.07
-Nodes (21): AboutButton(), AnalyticsButton(), FeedbackButton(), getAcademicDisciplineColor(), getResearchAreaChipColor(), listingQuickFilters, Navbar(), NavbarSearchBar() (+13 more)
+Cohesion: 0.05
+Nodes (32): AboutButton(), AnalyticsButton(), FeedbackButton(), getAcademicDisciplineColor(), getResearchAreaChipColor(), listingQuickFilters, Navbar(), NavbarSearchBar() (+24 more)
 
 ### Community 22 - "undergradFellowshipRecipientScraper.ts"
 Cohesion: 0.10
-Nodes (32): extractOrcid(), AdvisorAggregateRow, buildObservationsForAdvisor(), DEFAULT_ACCEPTED_FELLOWSHIP_RECIPIENT_PDF_DIR, DEFAULT_PROGRAM_CONFIGS, defaultOwnerToGroupSlug(), escapeRegex(), ExtractorCtx (+24 more)
+Nodes (33): htmlCandidateRows(), AdvisorAggregateRow, buildObservationsForAdvisor(), DEFAULT_ACCEPTED_FELLOWSHIP_RECIPIENT_PDF_DIR, DEFAULT_PROGRAM_CONFIGS, drupalRecipientRowExtractor(), escapeRegex(), ExtractorCtx (+25 more)
 
 ### Community 23 - "duplicateEntityNameReview.ts"
 Cohesion: 0.06
 Nodes (67): DuplicateEntityReviewCategory, DuplicateEntityReviewEntity, DuplicateEntityReviewSummary, applyResearchEntityDedupeGroupsSequentially, ResearchEntityDedupeMergeGroup, ACTIVE_FILTER, assertDuplicateEntityNameReviewApplyAllowed(), asString() (+59 more)
 
 ### Community 24 - "app.ts"
-Cohesion: 0.09
-Nodes (18): allowList, apiLimiter, app, bypassRuntimeSecurity, corsOptions, deployedBrowserOrigins, __dirname, getRateLimitKey() (+10 more)
+Cohesion: 0.07
+Nodes (28): allowList, apiLimiter, app, bypassRuntimeSecurity, corsOptions, deployedBrowserOrigins, __dirname, getRateLimitKey() (+20 more)
 
 ### Community 25 - "dedupeResearchEntitiesByPi.ts"
 Cohesion: 0.08
-Nodes (59): applyDeleteModeArtifactPlan(), applyResearchEntityDedupeMergeGroup(), applyResearchEntityPiDedupeGroupsSequentially(), archiveOrDeleteDuplicateDocument(), ARRAY_REFERENCE_SPECS, ARTIFACT_SPECS, assertResearchEntityPiDedupeApplyAllowed(), assertResearchEntityPiDedupeApplyBounded() (+51 more)
+Nodes (50): applyResearchEntityPiDedupeGroupsSequentially(), archiveOrDeleteDuplicateDocument(), ARRAY_REFERENCE_SPECS, ARTIFACT_SPECS, assertResearchEntityPiDedupeApplyAllowed(), assertResearchEntityPiDedupeApplyBounded(), betaCommand(), buildArchivedDocumentArchiveSet() (+42 more)
 
 ### Community 26 - "admin.ts"
-Cohesion: 0.06
-Nodes (54): ACCESS_REVIEW_RECORD_TYPES, ADMIN_FELLOWSHIP_SORT_FIELDS, ADMIN_LISTING_SORT_FIELDS, ADMIN_PROFILE_SORT_FIELDS, ADMIN_SEARCH_ERROR_MESSAGES, ADMIN_URL_CHECK_ALLOWED_PORTS, adminAccessReviewLockedFields(), adminAccessReviewRecordUpdateDto() (+46 more)
+Cohesion: 0.07
+Nodes (45): ACCESS_REVIEW_RECORD_TYPES, ADMIN_FELLOWSHIP_SORT_FIELDS, ADMIN_LISTING_SORT_FIELDS, ADMIN_PROFILE_SORT_FIELDS, ADMIN_SEARCH_ERROR_MESSAGES, ADMIN_URL_CHECK_ALLOWED_PORTS, adminAccessReviewLockedFields(), adminAccessReviewRecordUpdateDto() (+37 more)
 
-### Community 27 - "BackfillV4ResearchGroupMembers.ts"
+### Community 27 - "researchEntityEvidenceCoverage.ts"
 Cohesion: 0.11
-Nodes (32): assessResearchEntityEvidenceCoverage(), buildEvidenceCoverageImpact(), buildEvidenceCoverageImpactReportForObservations(), descriptionObservationSources(), descriptionState(), entityIdentifierKey(), EvidenceClaimState, EvidenceCoverageAssessment (+24 more)
+Nodes (34): candidateToObservations(), observation(), assessResearchEntityEvidenceCoverage(), buildEvidenceCoverageImpact(), buildEvidenceCoverageImpactReportForObservations(), descriptionObservationSources(), descriptionState(), entityIdentifierKey() (+26 more)
 
 ### Community 28 - "researchDiscoveryAdapters.ts"
-Cohesion: 0.08
-Nodes (48): formatDate(), PathwayActionCard(), buildCompleteContextSummary(), buildIdentityConfidenceRecords(), buildPathwayEvidenceRows(), buildProfileDiscoveryClusters(), buildResearchHomeContextLine(), buildResearchHomeContextSummary() (+40 more)
+Cohesion: 0.06
+Nodes (63): formatDate(), PathwayActionCard(), PathwayActionCardProps, emptyGroupedResults(), PathwayActionability, PathwayBestNextStepCategory, PathwayContactRouteSummary, PathwayEvidenceSummary (+55 more)
 
 ### Community 29 - "ysmAtoZScraper.ts"
 Cohesion: 0.12
-Nodes (31): absoluteUrl(), cleanDescription(), cleanProfileTitle(), clippedDescription(), decodeHtmlEntities(), escapeRegex(), extractLabHomepageDescription(), extractProfileContactWidgetProfile() (+23 more)
+Nodes (30): absoluteUrl(), cleanDescription(), cleanProfileTitle(), clippedDescription(), decodeHtmlEntities(), escapeRegex(), extractLabHomepageDescription(), extractProfileContactWidgetProfile() (+22 more)
 
 ### Community 31 - "launchAcquisitionReportService.ts"
-Cohesion: 0.08
-Nodes (61): buildLaunchAcquisitionReportOutput(), LaunchAcquisitionReportCliOptions, main(), parseLaunchAcquisitionReportArgs(), parsePositiveInteger(), writeLaunchAcquisitionReportOutput(), AccessRecordCounts, ActionEvidenceGroups (+53 more)
+Cohesion: 0.09
+Nodes (53): AccessRecordCounts, ActionEvidenceGroups, addGroup(), buildActionGroups(), buildActionManifestRow(), buildLaunchAcquisitionReport(), buildManifestRow(), buildPiGroups() (+45 more)
 
 ### Community 32 - "profileDataQualityAudit.ts"
 Cohesion: 0.10
 Nodes (58): auditProfileRecord(), candidateOfficialProfileUrls(), candidateProfileFactsMatchUser(), classifyStoredBioIssue(), classifyStoredTitleIssue(), collectObjects(), compareOfficialProfileFacts(), corpusForProfile() (+50 more)
 
 ### Community 33 - "centersInstitutesScraper.ts"
-Cohesion: 0.07
-Nodes (45): affiliationExtractionToObservations(), CallCenterAffiliationLLMFn, CandidateCenter, CenterAffiliationExtraction, CenterAffiliationLLMExtractor, CenterAffiliationLLMExtractorDeps, CenterAffiliationPerson, CenterFinderFn (+37 more)
+Cohesion: 0.06
+Nodes (52): affiliationExtractionToObservations(), CallCenterAffiliationLLMFn, CandidateCenter, CenterAffiliationExtraction, CenterAffiliationLLMExtractorDeps, CenterAffiliationPerson, CenterFinderFn, defaultCallLLM() (+44 more)
 
 ### Community 34 - "types.tsx"
-Cohesion: 0.08
-Nodes (29): AdminFellowshipEditModal(), Props, FellowshipModalProps, fellowship, defaultFellowshipSearchContext, FellowshipSearchContextType, mockedAxios, ResizeObserverMock (+21 more)
+Cohesion: 0.07
+Nodes (28): AdminFellowshipEditModal(), Props, fellowship, defaultFellowshipSearchContext, FellowshipSearchContextType, mockedAxios, ResizeObserverMock, FELLOWSHIP_SORTABLE_KEYS (+20 more)
 
 ### Community 35 - "nihReporterScraper.ts"
 Cohesion: 0.11
-Nodes (30): canonicalPiName(), DEFAULT_FISCAL_YEARS, escapeRegex(), fetchPage(), FetchPageOpts, findUserForPi(), grantToRecord(), groupGrantsByPi() (+22 more)
+Nodes (28): canonicalPiName(), DEFAULT_FISCAL_YEARS, escapeRegex(), fetchPage(), FetchPageOpts, findUserForPi(), grantToRecord(), groupGrantsByPi() (+20 more)
 
 ### Community 36 - "studentVisibilityGateService.ts"
 Cohesion: 0.07
 Nodes (51): actionRepairReasons, applyStudentVisibilityGatePlans(), buildNameOnlyVisibilityDedupeRows(), buildSamePiVisibilityDedupeRows(), countByEntityId(), defaultGateDeps, entityDuplicateUrls(), evidenceReasons (+43 more)
 
-### Community 38 - "ScraperContext"
-Cohesion: 0.06
-Nodes (35): normalizeUserType(), publicationSchema, User, userSchema, ProfileBackedFacultyResearchAreaMemberDeps, arxivEntryToObservations(), ArxivFetcher, ArxivPreprintScraper (+27 more)
+### Community 38 - "User"
+Cohesion: 0.05
+Nodes (43): normalizeUserType(), publicationSchema, User, userSchema, ProfileBackedFacultyResearchAreaMemberDeps, ScraperOrchestrator, ArxivPreprintScraper, ArxivPreprintScraperOptions (+35 more)
 
 ### Community 39 - "userService.ts"
-Cohesion: 0.07
-Nodes (69): readFellowships(), confirmListing(), unconfirmListing(), addDepartments(), addFavFellowships(), addFavListings(), addFavoriteObjectIdIfMissing(), addFavPathways() (+61 more)
+Cohesion: 0.08
+Nodes (52): addDepartments(), assertSafeUserUpdateDocument(), badRequestError(), buildCaseInsensitiveNetidFilter(), buildSavedPathwayPlansExport(), buildSavedPathwayPlanUnsetForIds(), clearDepartments(), clearFavFellowships() (+44 more)
 
 ### Community 40 - "serializedDocumentId"
-Cohesion: 0.13
-Nodes (33): StudentVisibilityTier, applyProgramUpdates(), applyResearchUpdates(), assertStudentVisibilityBackfillApplyAllowed(), buildNameOnlyVisibilityDedupeRows(), buildSamePiVisibilityDedupeRows(), buildStudentVisibilityBackfillOutput(), countByEntityId() (+25 more)
+Cohesion: 0.12
+Nodes (33): applyProgramUpdates(), applyResearchUpdates(), assertStudentVisibilityBackfillApplyAllowed(), buildNameOnlyVisibilityDedupeRows(), buildSamePiVisibilityDedupeRows(), buildStudentVisibilityBackfillOutput(), countByEntityId(), FORMALIZATION_ONLY_ENTRY_PATHWAY_TYPES (+25 more)
 
 ### Community 41 - "AdminDepartments.tsx"
-Cohesion: 0.09
-Nodes (30): AdminDepartments(), CATEGORY_COLORS, DEPARTMENT_CATEGORIES, DepartmentAction, DepartmentDoc, DepartmentState, EditDraft, INITIAL_NEW_DRAFT (+22 more)
+Cohesion: 0.06
+Nodes (44): AdminDepartments(), CATEGORY_COLORS, DEPARTMENT_CATEGORIES, DepartmentAction, DepartmentDoc, DepartmentState, EditDraft, INITIAL_NEW_DRAFT (+36 more)
 
-### Community 42 - "profile.tsx"
-Cohesion: 0.11
-Nodes (24): DepartmentInput(), DepartmentInputProps, ProfileEditor(), ProfileEditorProps, ProfileHeaderProps, useConfig(), createInitialDepartmentInputState(), DepartmentInputAction (+16 more)
+### Community 42 - "getUniqueDepartmentLabels"
+Cohesion: 0.07
+Nodes (42): DepartmentInput(), DepartmentInputProps, ProfileEditor(), ProfileEditorProps, orcidHref(), ProfileHeader(), ProfileHeaderProps, profileLinkDedupeKey() (+34 more)
 
 ### Community 43 - "researchEntityCoverageAudit.ts"
 Cohesion: 0.13
 Nodes (29): aggregateCountMap(), AuditEntityRecord, buildBulkAudit(), buildObservationFlags(), buildResearchEntityCoverageAuditOutput(), buildSlugAudit(), countMap(), __dirname (+21 more)
 
-### Community 44 - "LabHeader.tsx"
-Cohesion: 0.24
-Nodes (10): AdminListing, AdminListingEditModal(), Props, AdminListingEditAction, adminListingEditReducer(), AdminListingEditState, AdminListingShape, createInitialAdminListingEditState() (+2 more)
+### Community 44 - "axios.ts"
+Cohesion: 0.05
+Nodes (37): mockedAxios, AdminListing, AdminListingEditModal(), Props, mockedAxios, HttpStatusNotifier(), CourseTableCourse, CourseTableSection() (+29 more)
 
 ### Community 45 - "sourceHealth.ts"
-Cohesion: 0.07
-Nodes (55): AcceptedDecisionValidationCommandInput, attachAcceptedDecisionValidationSummary(), attachReviewArtifactSummary(), buildCrossSourceObservationReviewCommand(), buildReviewArtifactRollups(), buildReviewArtifactStatus(), buildReviewDecisionValidationStatus(), buildReviewQueues() (+47 more)
+Cohesion: 0.06
+Nodes (57): buildSourceHealthSummary(), classifySourceWarning(), AcceptedDecisionValidationCommandInput, attachAcceptedDecisionValidationSummary(), attachReviewArtifactSummary(), buildCrossSourceObservationReviewCommand(), buildReviewArtifactRollups(), buildReviewArtifactStatus() (+49 more)
 
-### Community 46 - "research.tsx"
+### Community 46 - "repairOfficialProfilePublicationPointers.ts"
 Cohesion: 0.15
 Nodes (37): absolutize(), archivePointerRow(), assertOfficialProfilePublicationPointerRepairApplyAllowed(), candidateRepairUrls(), cleanText(), crawlFeaturedPublications(), createRepairPageReader(), ExtractedFeaturedPublication (+29 more)
 
-### Community 47 - "entityMaterializer.test.ts"
+### Community 47 - "textValue"
 Cohesion: 0.15
-Nodes (24): buildResearchGroupMemberUpsert(), centerRelationshipTypeForResolvedTarget(), findExistingResearchEntityByFacultyResearchAreaIdentity(), findUniqueUserForResearchGroupMember(), findUniqueUserIdByPersonName(), idValue(), isFacultyResearchAreaKey(), isInitialOnlyNameValue() (+16 more)
+Nodes (24): buildResearchGroupMemberUpsert(), centerRelationshipTypeForResolvedTarget(), findExistingResearchEntityByFacultyResearchAreaIdentity(), findUniqueUserForResearchGroupMember(), findUniqueUserIdByPersonName(), idValue(), isFacultyResearchAreaKey(), latestObservationDate() (+16 more)
 
-### Community 48 - "ScrapeRun"
+### Community 48 - "officialProfilePiBackfillScraper.test.ts"
 Cohesion: 0.12
-Nodes (39): annotateEntitiesWithLeadUsers(), annotateEntitiesWithSourceObservationUrls(), annotateProfileDescriptionPreferredSourceEvidence(), entityLeadDirectWebsiteToObservations(), entityResearchHomeToObservations(), firstNonDuplicateLeadDirectWebsiteUrl(), identityToResearchEntityDescriptionObservations(), identityToResearchEntityPiKeyObservations() (+31 more)
+Nodes (38): annotateEntitiesWithLeadUsers(), annotateEntitiesWithSourceObservationUrls(), annotateProfileDescriptionPreferredSourceEvidence(), entityLeadDirectWebsiteToObservations(), entityResearchHomeToObservations(), firstNonDuplicateLeadDirectWebsiteUrl(), identityToResearchEntityDescriptionObservations(), identityToResearchEntityPiKeyObservations() (+30 more)
 
 ### Community 49 - "listingService.ts"
-Cohesion: 0.13
-Nodes (37): deleteListingForCurrentUser(), getListingModel(), addFavorite(), archiveListing(), boundedListingDate(), boundedListingNetid(), boundedListingNetidArray(), boundedListingNumber() (+29 more)
+Cohesion: 0.10
+Nodes (48): deleteListingForCurrentUser(), getListingModel(), addFavorite(), addView(), archiveListing(), boundedListingDate(), boundedListingNetid(), boundedListingNetidArray() (+40 more)
 
 ### Community 50 - "fellowshipService.ts"
-Cohesion: 0.10
-Nodes (42): isStudentVisibilityTier(), addFavorite(), addView(), adminFellowshipDate(), adminFellowshipLinks(), adminFellowshipNumber(), adminFellowshipStringArray(), adminFellowshipText() (+34 more)
+Cohesion: 0.09
+Nodes (43): addFavorite(), addView(), adminFellowshipDate(), adminFellowshipLinks(), adminFellowshipNumber(), adminFellowshipStringArray(), adminFellowshipText(), archiveFellowship() (+35 more)
 
 ### Community 51 - "betaDataQualityCore.ts"
 Cohesion: 0.06
-Nodes (52): DuplicateEntityCluster, BETA_CHECK_OPERATOR_METADATA, betaCommand(), BetaDataQualityCheck, BetaDataQualityDiagnostics, BetaDataQualityProgressEvent, BetaDataQualitySeverity, BetaDataQualitySummary (+44 more)
+Nodes (65): DuplicateEntityCluster, main(), BETA_CHECK_OPERATOR_METADATA, betaCommand(), BetaDataQualityCheck, BetaDataQualityDiagnostics, BetaDataQualityProgressEvent, BetaDataQualityScorecard (+57 more)
 
 ### Community 52 - "scripts"
 Cohesion: 0.03
@@ -2984,15 +2877,15 @@ Nodes (75): scripts, accepted-inputs, access-signals:repair-duplicates, applicat
 Cohesion: 0.13
 Nodes (37): addCheck(), checkOpportunityDetail(), checkProgramApis(), config, discoverResearch(), failOnInternalLabels(), installRoutes(), main() (+29 more)
 
-### Community 54 - "researchEntity.ts"
-Cohesion: 0.06
-Nodes (38): PathwayActionCardProps, ActiveResearchSearchRequest, buildDepartmentSearchTargets(), DepartmentResearchHomeConfig, DepartmentSearchTarget, emptyGroupedResults(), hasStructuredFilters(), isResearchEntitySearchExhausted() (+30 more)
+### Community 54 - "research.tsx"
+Cohesion: 0.10
+Nodes (25): ActiveResearchSearchRequest, buildDepartmentSearchTargets(), DepartmentResearchHomeConfig, DepartmentSearchTarget, hasStructuredFilters(), isResearchEntitySearchExhausted(), pluralize(), QUALITY_FILTER_OPTIONS (+17 more)
 
 ### Community 55 - "runReport.ts"
 Cohesion: 0.07
 Nodes (47): ACCESS_ARTIFACT_TYPES, ACCESS_EVIDENCE_CONFLICT_FIELDS, ADDITIVE_METADATA_CONFLICT_FIELDS, buildCoverageFetchSummary(), buildCoverageSourceSummary(), buildMaterializationConflictEntityClauses(), buildMaterializationConflictReview(), buildPostMaterializationSummary() (+39 more)
 
-### Community 56 - "redactDirectContactInfo"
+### Community 56 - "opportunityDetailService.ts"
 Cohesion: 0.11
 Nodes (27): getOpportunityById(), normalizeOpportunityIdParam(), mocks, compactStrings(), evidenceExcerpt(), firstEvidenceText(), getOpportunityApplicationLabel(), getOpportunityApplicationState() (+19 more)
 
@@ -3006,35 +2899,35 @@ Nodes (47): activeAreasOfResearchSummary(), assessResearchEntityDescriptionQuali
 
 ### Community 59 - "betaDataQuality.ts"
 Cohesion: 0.09
-Nodes (53): ACTIVE_FILTER, asString(), asStringArray(), buildBetaDataQualityScorecard(), buildCollectionCounts(), buildDescriptionQuality(), buildDuplicateEntityNames(), buildEmailHygiene() (+45 more)
+Nodes (50): ACTIVE_FILTER, asString(), asStringArray(), buildBetaDataQualityScorecard(), buildCollectionCounts(), buildDescriptionQuality(), buildDuplicateEntityNames(), buildLiveLinkCheck() (+42 more)
 
 ### Community 60 - "studentVisibilityTier.ts"
-Cohesion: 0.09
-Nodes (41): classifyProgramResearchRelevance(), ProgramResearchRelevanceInput, ProgramResearchRelevanceResult, RESEARCH_PROGRAM_KINDS, RESEARCH_PURPOSES, text(), computeProgramStudentVisibility(), computeResearchEntityStudentVisibility() (+33 more)
+Cohesion: 0.12
+Nodes (33): classifyProgramResearchRelevance(), ProgramResearchRelevanceInput, ProgramResearchRelevanceResult, RESEARCH_PROGRAM_KINDS, RESEARCH_PURPOSES, text(), computeProgramStudentVisibility(), computeResearchEntityStudentVisibility() (+25 more)
 
 ### Community 61 - "listingController.ts"
 Cohesion: 0.09
-Nodes (44): addViewToListing(), archiveListingForCurrentUser(), boundedListingSearchQuery(), buildRobustFilterMatch(), createListingForCurrentUser(), escapeMeiliFilterValue(), filterListingUpdate(), getListingById() (+36 more)
+Nodes (42): addViewToListing(), archiveListingForCurrentUser(), boundedListingSearchQuery(), buildRobustFilterMatch(), createListingForCurrentUser(), escapeMeiliFilterValue(), filterListingUpdate(), getListingById() (+34 more)
 
-### Community 62 - "researchEntityBrowseRankService.ts"
+### Community 62 - "researchGroup.ts"
 Cohesion: 0.07
-Nodes (43): LabHeader(), LabHeaderProps, normalizeActionUrl(), LabInquireModal(), LabInquireModalProps, baseGroup, baseGroup, getResearchGroupStatus() (+35 more)
+Nodes (48): LabHeader(), LabHeaderProps, normalizeActionUrl(), baseGroup, baseGroup, WaysToApproachSection(), getResearchGroupStatus(), AccessSummary (+40 more)
 
 ### Community 63 - "analyticsService.ts"
-Cohesion: 0.05
-Nodes (71): AnalyticsEvent, analyticsEventSchema, AnalyticsEventType, ANALYTICS_SORT_DIRECTIONS, ANALYTICS_USER_SORTS, AnalyticsRequestError, parseAnalyticsSortDirection(), parseAnalyticsUserSort() (+63 more)
+Cohesion: 0.07
+Nodes (62): AnalyticsEvent, ActionNeededAnalytics, ANALYTICS_EVENT_TYPES, ANALYTICS_NON_USER_NETIDS, ANALYTICS_RESEARCH_ENTITY_TYPES, AnalyticsUserDrilldownQuery, AnalyticsUserDrilldownResult, AnalyticsUsersQuery (+54 more)
 
 ### Community 65 - "acceptedInputsCore.ts"
 Cohesion: 0.07
-Nodes (58): AcceptedInputIssue, AcceptedInputUser, applyOrcidCrosswalkCsv(), applyScholarAcceptedCsv(), ArxivResolvedTarget, ArxivValidationResult, asString(), asStringArray() (+50 more)
+Nodes (62): AcceptedInputIssue, AcceptedInputUser, applyOrcidCrosswalkCsv(), applyScholarAcceptedCsv(), ArxivResolvedTarget, ArxivValidationResult, asString(), asStringArray() (+54 more)
 
 ### Community 66 - "entryPathwayService.ts"
-Cohesion: 0.10
-Nodes (28): ContactPolicy, ContactRouteVisibility, DerivedContactRoute, isHttpUrl(), compactObject(), ContactRouteServiceDeps, ContactRouteUpsertResult, getContactRouteModel() (+20 more)
+Cohesion: 0.11
+Nodes (34): AccessSignalServiceDeps, AccessSignalUpsertResult, compactObject(), getAccessSignalModel(), toStoredId(), toStoredObjectId(), upsertAccessSignal(), compactObject() (+26 more)
 
 ### Community 67 - "yaleCollegeFellowshipsOfficeScraper.ts"
-Cohesion: 0.08
-Nodes (52): ProgramCategory, ProgramEntryMode, ProgramKind, absoluteUrl(), bestDeadlineText(), candidateFromDetailPage(), candidateFromLink(), candidateToObservations() (+44 more)
+Cohesion: 0.11
+Nodes (40): absoluteUrl(), bestDeadlineText(), candidateFromDetailPage(), candidateFromLink(), compactTitleIdentity(), DEFAULT_PAGE_URLS, existingKeyForCandidate(), extractEmail() (+32 more)
 
 ### Community 68 - "fellowshipMatchingService.ts"
 Cohesion: 0.14
@@ -3044,81 +2937,81 @@ Nodes (24): buildFellowshipApplicationCycleEvidence(), cleanHttpUrl(), cleanStri
 Cohesion: 0.05
 Nodes (33): DataQualityDuplicateNamePreflight, DataQualitySamePiDedupeReview, DataQualitySuspiciousUserEmailCopy, decisionLaneCopy, evidenceReasons, GATE_LABELS, GateArtifactFreshness, LaunchReviewExceptionDecisionValidation (+25 more)
 
-### Community 70 - "repairOfficialProfilePublicationPointers.ts"
-Cohesion: 0.13
-Nodes (26): awardToRecord(), buildCoPiObservations(), buildPiUserObservations(), buildResearchGroupObservations(), defaultDateStart(), fetchPage(), findUserForPi(), groupAwardsByPi() (+18 more)
+### Community 70 - "nsfAwardScraper.ts"
+Cohesion: 0.09
+Nodes (42): escapeRegex(), findUserByName(), memberObservationsForEntityKey(), entryToUserObservations(), awardToRecord(), buildCoPiObservations(), buildPiUserObservations(), buildResearchGroupObservations() (+34 more)
 
 ### Community 71 - "fellowshipInputs.ts"
-Cohesion: 0.08
-Nodes (42): ACCEPTED_INPUT_FILE_EXTENSIONS, acceptedPath(), AdvisorResolution, AdvisorResolver, assertAcceptedInputPathRoot(), candidateRowsFromText(), coerceReviewRow(), defaultFetchUrl() (+34 more)
+Cohesion: 0.10
+Nodes (36): ACCEPTED_INPUT_FILE_EXTENSIONS, acceptedPath(), AdvisorResolution, AdvisorResolver, assertAcceptedInputPathRoot(), candidateRowsFromText(), coerceReviewRow(), escapeCsvCell() (+28 more)
 
-### Community 72 - "OfficialProfilePublicationValue"
+### Community 72 - "scholarlyLinkSuppressionAudit.ts"
 Cohesion: 0.08
-Nodes (40): researchScholarlyAttributionSchema, researchScholarlyLinkSchema, assertScholarlyLinkProvenanceAuditApplyAllowed(), buildScholarlyLinkProvenanceAuditOutput(), __filename, main(), nullTargetAttributionFilter, orphanAttributionIds() (+32 more)
+Nodes (39): researchScholarlyAttributionSchema, assertScholarlyLinkProvenanceAuditApplyAllowed(), buildScholarlyLinkProvenanceAuditOutput(), __filename, main(), nullTargetAttributionFilter, orphanAttributionIds(), ownerlessLinkFilter (+31 more)
 
 ### Community 73 - "postedOpportunityService.ts"
-Cohesion: 0.08
-Nodes (47): AccessSignalServiceDeps, AccessSignalUpsertResult, compactObject(), getAccessSignalModel(), toStoredId(), toStoredObjectId(), upsertAccessSignal(), compactObject() (+39 more)
+Cohesion: 0.13
+Nodes (30): CompensationType, PostedOpportunityStatus, activeListingBackfillFilter(), backfillPostedOpportunitiesFromListings(), BackfillPostedOpportunitiesFromListingsOptions, BackfillPostedOpportunitiesFromListingsResult, compactObject(), firstUrl() (+22 more)
 
 ### Community 74 - "profileController.ts"
-Cohesion: 0.13
-Nodes (24): addIfDefined(), getProfile(), getProfileCourses(), getProfileListings(), getPublications(), normalizePublicationPagination(), PUBLICATION_SORT_FIELDS, publicationSortValue() (+16 more)
+Cohesion: 0.12
+Nodes (25): addIfDefined(), getProfile(), getProfileCourses(), getProfileListings(), getPublications(), normalizePublicationPagination(), PUBLICATION_SORT_FIELDS, publicationSortValue() (+17 more)
 
 ### Community 75 - "analytics.ts"
-Cohesion: 0.33
-Nodes (4): router, invokeRouteHandler(), mocks, routeByPath()
+Cohesion: 0.05
+Nodes (45): analyticsEventSchema, AnalyticsEventType, RESEARCH_ENTITY_TYPES, ResearchEntityType, ANALYTICS_SORT_DIRECTIONS, ANALYTICS_USER_SORTS, AnalyticsRequestError, parseAnalyticsSortDirection() (+37 more)
 
 ### Community 76 - "openAlexPaperScraper.ts"
-Cohesion: 0.12
-Nodes (30): arxivIdFromUrl(), buildExternalIds(), buildOpenAlexAuthorshipEvidence(), extractArxivId(), FacultyRecord, fetchPage(), HttpFetcher, isExactNameMatch() (+22 more)
+Cohesion: 0.13
+Nodes (29): arxivIdFromUrl(), buildExternalIds(), buildOpenAlexAuthorshipEvidence(), extractArxivId(), FacultyRecord, fetchPage(), HttpFetcher, isExactNameMatch() (+21 more)
 
-### Community 77 - "errorHandler.ts"
-Cohesion: 0.10
-Nodes (29): average(), boundedRenderedFetchTimeout(), buildFetchAttemptMetrics(), createScraplingRenderedFetcher(), currentMemoryBytes(), DEFAULT_BRIDGE_PATH, defaultRenderedSeedRedirectCheck(), execFileAsync (+21 more)
+### Community 77 - "types.ts"
+Cohesion: 0.08
+Nodes (34): average(), boundedRenderedFetchTimeout(), buildFetchAttemptMetrics(), createScraplingRenderedFetcher(), currentMemoryBytes(), DEFAULT_BRIDGE_PATH, defaultRenderedSeedRedirectCheck(), execFileAsync (+26 more)
 
-### Community 78 - "researchEntityMemberReferenceAudit.ts"
-Cohesion: 0.12
-Nodes (38): applyMemberReferenceRepairs(), buildCurrentMemberOnArchivedEntityPipeline(), buildExistingMemberMatchQuery(), buildOrphanMemberUserReferencePipeline(), CURRENT_MEMBER_ON_ARCHIVED_ENTITY_STAGES, escapeRegExp(), exactCaseInsensitive(), loadCandidateUsers() (+30 more)
+### Community 78 - "ResearchGroupMember"
+Cohesion: 0.11
+Nodes (42): ResearchGroupMember, researchGroupMemberSchema, ResolvedRelationshipMaterializationDeps, defaultCenterFinder(), applyMemberReferenceRepairs(), buildCurrentMemberOnArchivedEntityPipeline(), buildExistingMemberMatchQuery(), buildOrphanMemberUserReferencePipeline() (+34 more)
 
 ### Community 79 - "SavedPathwaysSection.tsx"
 Cohesion: 0.09
 Nodes (40): CHECKLIST_TEMPLATES, daysUntil(), DeadlineReminder, deadlineReminderForPathway(), defaultIntentForPathway(), FellowshipFundingMatch, filterStoredPlansForSavedPathways(), formatDeadline() (+32 more)
 
-### Community 80 - "getUniqueDepartmentLabels"
-Cohesion: 0.14
-Nodes (31): ResearchGroupKind, absoluteUrl(), bestApplicationUrl(), conciseText(), DEFAULT_DEPARTMENT_UNDERGRAD_RESEARCH_PAGES, departmentEntityKey(), departmentGuidanceDescription(), DepartmentUndergradResearchPageConfig (+23 more)
+### Community 80 - "departmentUndergradResearchScraper.ts"
+Cohesion: 0.16
+Nodes (28): absoluteUrl(), bestApplicationUrl(), conciseText(), DEFAULT_DEPARTMENT_UNDERGRAD_RESEARCH_PAGES, departmentEntityKey(), departmentGuidanceDescription(), DepartmentUndergradResearchPageConfig, DepartmentUndergradResearchParser (+20 more)
 
 ### Community 81 - "pathwaySearchIndexService.ts"
 Cohesion: 0.10
-Nodes (41): anyFilter(), boundedFilterValues(), boundedSearchQuery(), buildPathwayMeiliFilter(), buildPathwayMeiliSort(), buildPathwaySearchIndexDocument(), buildPathwaySearchIndexDocuments(), configurePathwaySearchIndex() (+33 more)
+Nodes (42): anyFilter(), boundedFilterValues(), boundedSearchQuery(), buildPathwayMeiliFilter(), buildPathwayMeiliSort(), buildPathwaySearchIndexDocument(), buildPathwaySearchIndexDocuments(), configurePathwaySearchIndex() (+34 more)
 
-### Community 82 - "2. Install dependencies"
-Cohesion: 0.09
-Nodes (38): createInitialLabDetailState(), LabDetailAction, labDetailReducer(), LabDetailState, otherPayload, sampleGroup, sampleListing, samplePayload (+30 more)
+### Community 82 - "researchEntity.ts"
+Cohesion: 0.11
+Nodes (30): MaybeResearchEntityDetailPayload, NormalizedResearchEntitySearchResponse, normalizeResearchEntity(), normalizeResearchEntityDetailPayload(), normalizeSearchMatch(), normalizeStudentDecisionExplanation(), ResearchEntityDescriptionState, ResearchEntityLeadState (+22 more)
 
 ### Community 83 - "adminOperatorBoardService.ts"
 Cohesion: 0.06
 Nodes (42): BetaRepairQueueGateArtifact, buildQueueSummaries(), buildReleaseQueueSummary(), buildSourceFreshness(), classifyOperatorQueueReason(), compactProgramSample(), compactResearchSample(), countByTier() (+34 more)
 
 ### Community 84 - "Listing"
-Cohesion: 0.11
-Nodes (22): VennDiagramToggle(), VennDiagramToggleProps, CombinedFilterDropdown(), CombinedFilterDropdownProps, FilterTabConfig, COLUMNS, KanbanBoardProps, FilterMode (+14 more)
+Cohesion: 0.13
+Nodes (17): ListingEditor(), ListingEditorProps, COLUMNS, KanbanBoardProps, createInitialListingFormState(), ListingFormAction, ListingFormErrors, listingFormReducer() (+9 more)
 
 ### Community 85 - "promoteAcceptedBetaCopy.ts"
 Cohesion: 0.11
 Nodes (30): applyCopy(), assertPromotionSummaryCanApply(), assertSafeOptions(), buildApplyBlockers(), buildPlan(), buildPromotionSummary(), COLLECTION_CATEGORY_ORDER, CollectionCategorySummary (+22 more)
 
-### Community 86 - "Yale Research — Developer Guide"
+### Community 86 - "Yale Research - Developer Guide"
 Cohesion: 0.09
-Nodes (22): Adding Things, API Routes, Architecture, Auth Middleware (`server/src/middleware/auth.ts`), Authentication, CI, Common Commands, Environments (+14 more)
+Nodes (23): Adding Things, Analytics, API Routes, Architecture, Auth Middleware (`server/src/middleware/auth.ts`), Authentication, CI, Common Commands (+15 more)
 
 ### Community 87 - "paperAuthorshipAudit.ts"
-Cohesion: 0.12
-Nodes (40): Paper, PaperAuthor, applyCleanup(), applyIntegrityCleanup(), assertPaperAuthorshipAuditApplyAllowed(), AUTHORSHIP_METHODS, AUTHORSHIP_SOURCES, backfillOpenAlexPaperAuthors() (+32 more)
+Cohesion: 0.10
+Nodes (42): Paper, paperSchema, PaperAuthor, paperAuthorSchema, applyCleanup(), applyIntegrityCleanup(), assertPaperAuthorshipAuditApplyAllowed(), AUTHORSHIP_METHODS (+34 more)
 
 ### Community 88 - "Observation"
-Cohesion: 0.11
-Nodes (26): argValue(), run(), stripCustomFlags(), Observation, observationSchema, ScrapeRun, scrapeRunSchema, Source (+18 more)
+Cohesion: 0.12
+Nodes (26): entityKeyFor(), GroupRow, LATEST_WINS, Result, run(), Observation, observationSchema, ScrapeRun (+18 more)
 
 ### Community 89 - "Environment Progression"
 Cohesion: 0.14
@@ -3132,9 +3025,9 @@ Nodes (41): browserslist, development, production, devDependencies, agentation, 
 Cohesion: 0.11
 Nodes (18): Audit Checklist, `department-undergrad-research`, `dept-faculty-roster`, Entity Discovery Sources, Funding And Publication Enrichment, `lab-microsite-description-llm`, `lab-microsite-undergrad-llm`, Mental Model (+10 more)
 
-### Community 92 - "dependencies"
-Cohesion: 0.23
-Nodes (21): setCached(), defaultFetchPage(), defaultFetchPage(), fetchHtml(), fetchDeptData(), fetchHtml(), defaultFetchHtml(), defaultFetchPage() (+13 more)
+### Community 92 - "assertPublicHttpUrl"
+Cohesion: 0.14
+Nodes (32): defaultFetchUrl(), setCached(), defaultFetchPage(), defaultFetchPage(), fetchHtml(), fetchDeptData(), fetchHtml(), defaultFetchHtml() (+24 more)
 
 ### Community 93 - "studentDecisionLLMExtractor.ts"
 Cohesion: 0.09
@@ -3144,35 +3037,35 @@ Nodes (35): ScrapeSnapshot, scrapeSnapshotSchema, getCached(), invalidateCache()
 Cohesion: 0.16
 Nodes (14): AdminFellowship, FellowshipEditModal(), FellowshipLink, PAGE_SIZES, SortField, TABLE_COLUMNS, AdminFellowshipFormAction, adminFellowshipFormReducer() (+6 more)
 
-### Community 95 - "yaleResearchOfficialScraper.ts"
-Cohesion: 0.07
-Nodes (40): cleanResearchInterest(), ResearchInterests(), ResearchInterestsProps, SOURCE_CHROME_PATTERNS, splitCleanResearchInterest(), adminQualityLabels(), contextLabelClass(), countLabel() (+32 more)
+### Community 95 - "profile.tsx"
+Cohesion: 0.09
+Nodes (26): cleanResearchInterest(), ResearchInterests(), ResearchInterestsProps, SOURCE_CHROME_PATTERNS, splitCleanResearchInterest(), adminQualityLabels(), contextLabelClass(), countLabel() (+18 more)
 
 ### Community 97 - "backfillProfileBiosFromOfficialUrls.ts"
 Cohesion: 0.12
-Nodes (35): articleForFacultyTitle(), BioBackfillCandidate, BioBackfillDecision, buildCandidates(), composeTitleLedBio(), decideBioBackfill(), defaultFetcher(), detectFieldMismatch() (+27 more)
+Nodes (36): articleForFacultyTitle(), BioBackfillCandidate, BioBackfillDecision, buildCandidates(), composeTitleLedBio(), decideBioBackfill(), defaultFetcher(), defaultRewriter() (+28 more)
 
-### Community 98 - "resolveSafeJsonReportOutputPath"
-Cohesion: 0.20
-Nodes (18): assertRebuildPathwaySearchIndexAllowed(), buildRebuildPathwaySearchIndexOutput(), main(), parsePositiveInteger(), parseRebuildPathwaySearchIndexArgs(), parseRequiredOutputPath(), RebuildPathwaySearchIndexCliOptions, writeRebuildPathwaySearchIndexOutput() (+10 more)
+### Community 98 - "rebuildPathwaySearchIndex.ts"
+Cohesion: 0.22
+Nodes (16): assertRebuildPathwaySearchIndexAllowed(), buildRebuildPathwaySearchIndexOutput(), main(), parsePositiveInteger(), parseRebuildPathwaySearchIndexArgs(), parseRequiredOutputPath(), RebuildPathwaySearchIndexCliOptions, writeRebuildPathwaySearchIndexOutput() (+8 more)
 
-### Community 99 - "accessClaims.ts"
-Cohesion: 0.15
-Nodes (19): PostedOpportunityStatus, AccessArtifactCandidate, AccessArtifactType, buildClaimGateReport(), ClaimGateReport, ClaimGateStatus, ClaimValidationBundleResult, ClaimValidationResult (+11 more)
-
-### Community 100 - "Beta Repair Lanes Audit Implementation Plan"
-Cohesion: 0.11
-Nodes (32): DuplicatePersonGroup, buildUserIdentityDedupePlan(), buildUserIdentityDedupeSummary(), canonicalScore(), chooseCanonicalUser(), clusterUsersByCompatibleName(), comparePlannedGroups(), compareStrings() (+24 more)
-
-### Community 101 - "axios.ts"
+### Community 99 - "claimGate.ts"
 Cohesion: 0.10
-Nodes (26): LongText(), LongTextProps, applicationStateTone(), deadlineStateLabel(), formatDate(), labelize(), OpportunityDetail(), uniq() (+18 more)
+Nodes (32): buildClaimGateOutput(), ClaimGateCliOptions, ClaimGateCollection, consumeValue(), __dirname, __filename, loadResearchAccessArtifacts(), main() (+24 more)
 
-### Community 103 - "assertPublicHttpUrl"
-Cohesion: 0.13
-Nodes (19): ScraperOrchestrator, ReportScrapeRun, ScrapeRunReport, classifyUserType(), FACULTY_KEYWORDS, fetchYaliesPage(), isFacultyPerson(), isFacultyTitle() (+11 more)
+### Community 100 - "dedupeUsersByIdentityCore.ts"
+Cohesion: 0.12
+Nodes (31): DuplicatePersonGroup, buildUserIdentityDedupePlan(), buildUserIdentityDedupeSummary(), canonicalScore(), chooseCanonicalUser(), clusterUsersByCompatibleName(), comparePlannedGroups(), compareStrings() (+23 more)
 
-### Community 104 - "labDetail.ts"
+### Community 101 - "opportunityDetail.tsx"
+Cohesion: 0.09
+Nodes (22): PrivateRoute(), PrivateRouteProps, InfiniteScrollLoadingDots(), InfiniteScrollLoadingDotsProps, LoadingSpinner(), LoadingSpinnerProps, sizeMap, applicationStateTone() (+14 more)
+
+### Community 103 - "ScraperContext"
+Cohesion: 0.12
+Nodes (21): CrossrefFetcher, CrossrefMessage, crossrefMessageToObservations(), CrossrefPaperScraper, CrossrefPaperScraperOptions, dateFromParts(), normalizeDoi(), classifyUserType() (+13 more)
+
+### Community 104 - "buildAdminOperatorBoard"
 Cohesion: 0.16
 Nodes (27): betaTargetCommand(), buildAdminOperatorBoard(), buildGateArtifactFreshness(), buildRecommendedNextActions(), deriveDataQualityGate(), deriveLaunchAcquisitionGate(), deriveLaunchTrustGate(), derivePromotionCopyGate() (+19 more)
 
@@ -3181,32 +3074,32 @@ Cohesion: 0.09
 Nodes (32): Analytics(), analyticsRanges, defaultAdminAccess, defaultUserActivity, SortOrder, UserActivitySort, analyticsData, mockedAxios (+24 more)
 
 ### Community 106 - "officialProfilePiBackfillScraper.ts"
-Cohesion: 0.07
-Nodes (73): absolutize(), affiliationValuesFromProfiles(), canonicalLegacyResearchHomeUrl(), canonicalResearchHomeName(), canonicalUrlFromHtml(), classifyResearchHome(), cleanInterestForBio(), cleanOfficialProfileDisplayName() (+65 more)
+Cohesion: 0.09
+Nodes (46): absolutize(), affiliationValuesFromProfiles(), canonicalLegacyResearchHomeUrl(), canonicalResearchHomeName(), canonicalUrlFromHtml(), classifyResearchHome(), cleanInterestForBio(), cleanProfileCardLabWebsiteLabel() (+38 more)
 
 ### Community 107 - "pathwaySearchService.ts"
-Cohesion: 0.09
-Nodes (39): CompensationType, EntryPathwayStatus, EntryPathwayType, EvidenceStrength, DerivedEntryPathway, RouteClassification, UpsertEntryPathwayInput, BestNextStepSnapshot (+31 more)
+Cohesion: 0.06
+Nodes (53): allowedValues(), hasOversizedStringList(), isOversizedSearchRequest(), parseFilters(), parseSearchInput(), parseSort(), publicPathwayResearchEntity(), publicPathwaySearchResult() (+45 more)
 
 ### Community 108 - "researchEntityDto.ts"
-Cohesion: 0.23
-Nodes (17): mapResearchGroupKindToEntityType(), addResearchEntityDetailAlias(), addResearchEntitySearchAliases(), departmentDisplayLabel(), normalizedDepartmentLabel(), OPERATOR_PUBLIC_RESEARCH_ENTITY_FIELDS, OPTIONAL_PUBLIC_RESEARCH_ENTITY_FIELDS, publicDepartmentArray() (+9 more)
+Cohesion: 0.25
+Nodes (16): addResearchEntityDetailAlias(), addResearchEntitySearchAliases(), departmentDisplayLabel(), normalizedDepartmentLabel(), OPERATOR_PUBLIC_RESEARCH_ENTITY_FIELDS, OPTIONAL_PUBLIC_RESEARCH_ENTITY_FIELDS, publicDepartmentArray(), publicHttpUrl() (+8 more)
 
 ### Community 110 - "repairArchivedEntityArtifacts.ts"
 Cohesion: 0.15
 Nodes (24): applyRepairPlan(), archiveArtifact(), ARTIFACT_SPECS, ArtifactSpec, assertArchivedEntityArtifactRepairApplyAllowed(), buildRepairArchivedEntityArtifactsOutput(), collectionExists(), __filename (+16 more)
 
-### Community 111 - "Adding a New Page"
-Cohesion: 0.08
-Nodes (46): ADMIN_UPDATE_FIELDS, ALLOWED_SELF_UPDATE_FIELDS, buildProfileResearchMembershipFilter(), cleanPublicSourceLabel(), cleanScholarlyTitle(), cleanUrl(), dateToIso(), dedupeProfileResearchEntities() (+38 more)
+### Community 111 - "profileService.ts"
+Cohesion: 0.09
+Nodes (44): ADMIN_UPDATE_FIELDS, ALLOWED_SELF_UPDATE_FIELDS, boundedProfileUrlKey(), boundedPublicationNumber(), boundedPublicationText(), boundedPublicProfileUrl(), cleanPublicHttpUrl(), cleanPublicSourceLabel() (+36 more)
 
-### Community 113 - "smartTitle.ts"
-Cohesion: 0.15
-Nodes (19): VisibilityReleaseQueueCollection, visibilityReleaseQueueCollections, visibilityReleaseQueueItemSchema, VisibilityReleaseQueueStatus, visibilityReleaseQueueStatuses, VisibilityRepairStage, visibilityRepairStages, VisibilityRepairStatus (+11 more)
+### Community 113 - "betaRepairQueue.ts"
+Cohesion: 0.09
+Nodes (36): StudentVisibilityTier, VisibilityReleaseQueueCollection, visibilityReleaseQueueCollections, visibilityReleaseQueueItemSchema, VisibilityReleaseQueueStatus, visibilityReleaseQueueStatuses, VisibilityRepairStage, visibilityRepairStages (+28 more)
 
-### Community 115 - "centerDirectorLLMExtractor.ts"
-Cohesion: 0.17
-Nodes (19): addUniqueValuesToSet(), buildPaperUpdateFromObservations(), DISCOVERY_ONLY_ACCESS_FIELD_SOURCES, entityModelFor(), hasRequiredFieldsForCreate(), isOfficialProfileBioChromeObservation(), isResearchEntityObservationType(), materializedFieldValue() (+11 more)
+### Community 115 - "materializeEntity"
+Cohesion: 0.16
+Nodes (20): addUniqueValuesToSet(), authorshipEvidenceFromPaperObservations(), buildPaperUpdateFromObservations(), DISCOVERY_ONLY_ACCESS_FIELD_SOURCES, entityModelFor(), hasRequiredFieldsForCreate(), isOfficialProfileBioChromeObservation(), isResearchEntityObservationType() (+12 more)
 
 ### Community 116 - "scripts"
 Cohesion: 0.06
@@ -3216,49 +3109,53 @@ Nodes (36): scripts, audit:research-detail-professors, audit:unified-research, b
 Cohesion: 0.13
 Nodes (28): activeListingFilter(), aggregateCountMap(), buildEntityContexts(), buildPathwayQualityAuditOutput(), countMap(), __dirname, __filename, main() (+20 more)
 
-### Community 120 - "researchEntitySearchIndexService.ts"
-Cohesion: 0.14
-Nodes (24): ScrapeJobLock, scrapeJobLockSchema, createCronOwnerId(), createCronRunnerDependencies(), CronRunnerDependencies, loadCronSource(), runScraperCron(), RunScraperCronInput (+16 more)
+### Community 120 - "cronRunner.ts"
+Cohesion: 0.17
+Nodes (21): ScrapeJobLock, scrapeJobLockSchema, Source, createCronOwnerId(), createCronRunnerDependencies(), CronRunnerDependencies, loadCronSource(), runScraperCron() (+13 more)
 
-### Community 122 - "Adding a New Endpoint"
-Cohesion: 0.15
-Nodes (22): ResearchEntityType, absoluteUrl(), cleanText(), DEFAULT_YALE_RESEARCH_DIRECTORY_CONFIGS, entityFromRecord(), entityToObservations(), inferResearchYaleKind(), pageUrlForIndex() (+14 more)
+### Community 122 - "yaleResearchOfficialScraper.ts"
+Cohesion: 0.18
+Nodes (19): absoluteUrl(), cleanText(), DEFAULT_YALE_RESEARCH_DIRECTORY_CONFIGS, entityFromRecord(), entityToObservations(), inferResearchYaleKind(), pageUrlForIndex(), parseDirectory() (+11 more)
 
-### Community 124 - "Adding a New Endpoint"
-Cohesion: 0.06
-Nodes (96): member(), buildRepairQueueSummary(), ACCESS_SIGNAL_POINTS, accessPoints(), computeResearchEntityBrowseRank(), descriptionPoints(), leadPoints(), ResearchEntityBrowseRankInput (+88 more)
+### Community 124 - "visibilityRepairQueueService.ts"
+Cohesion: 0.10
+Nodes (68): member(), actionReasons, archivedResearchEntityRepairBlock(), attemptProgramRepair(), attemptResearchActionEvidenceRepair(), attemptResearchRepair(), attemptVisibilityRepair(), buildResearchSourceDescriptionPatch() (+60 more)
 
-### Community 125 - "Adding a New Endpoint"
+### Community 125 - "backfillResearchHomeOfficialUrls.ts"
 Cohesion: 0.18
 Nodes (16): candidateProfileUrls(), defaultVerifier(), DESC_BLOCK_REASONS, __dirname, __filename, isTrustedYaleProfileUrl(), LEAD_ROLES, main() (+8 more)
 
-### Community 126 - "Adding a New Endpoint"
+### Community 126 - "fellowships.tsx"
 Cohesion: 0.07
-Nodes (31): sortOptions, ViewModeToggle(), MockIntersectionObserver, TestScroller(), useInfiniteScroll(), UseInfiniteScrollOptions, dateValue(), fellowshipQuickFilters (+23 more)
+Nodes (30): ActiveFilterChip, ActiveFiltersProps, QuickFilterDef, sortOptions, copy, FirstSaveCallout(), FirstSaveCalloutProps, ViewModeToggle() (+22 more)
 
-### Community 127 - "Adding a New Endpoint"
+### Community 127 - "researchEntityDescriptionText.ts"
 Cohesion: 0.18
 Nodes (24): compactText(), DESCRIPTION_AND_SYNTHESIS_FIELDS, DESCRIPTION_FIELDS, facultyResearchLabelBase(), FacultyResearchTextEntity, isAcademicAppointmentDescription(), isBrokenResearchEntityDescriptionFragment(), isContactRouteDescriptionSnippet() (+16 more)
 
-### Community 129 - "buildAdminOperatorBoard"
-Cohesion: 0.11
-Nodes (17): CrossrefFetcher, CrossrefMessage, crossrefMessageToObservations(), CrossrefPaperScraper, CrossrefPaperScraperOptions, dateFromParts(), normalizeDoi(), obs() (+9 more)
+### Community 128 - "researchEntitySearchIndexService.ts"
+Cohesion: 0.12
+Nodes (29): buildResearchEntitySearchIndexDocument(), buildResearchEntitySearchIndexDocuments(), buildResearchEntitySearchIndexDocumentsWithMemberNames(), cleanPersonName(), emptyMemberNameFields(), facultyDisplayName(), fetchResearchEntitySearchMemberNames(), getResearchEntitySearchIndexSettings() (+21 more)
+
+### Community 129 - "arxivPreprintScraper.ts"
+Cohesion: 0.21
+Nodes (12): arxivEntryToObservations(), ArxivFetcher, buildAuthorSearchQuery(), normalizeArxivId(), normalizeArxivText(), parseArxivFeed(), ParsedArxivEntry, shouldProcessFaculty() (+4 more)
 
 ### Community 131 - "launchReviewExceptions.ts"
-Cohesion: 0.15
-Nodes (21): buildLaunchReviewExceptionCandidates(), buildLaunchReviewExceptionDecisionTemplate(), buildLaunchReviewExceptionOutput(), buildLaunchReviewExceptionPlan(), buildLaunchReviewExceptionReview(), __filename, isStudentReadyLaunchViolation(), LAUNCH_REVIEW_EXCEPTION_DECISION_VALUES (+13 more)
+Cohesion: 0.09
+Nodes (36): publicSafeStudentVisibilityTiers, publicStudentVisibilityTiers, studentVisibilityTiers, buildLaunchReviewExceptionCandidates(), buildLaunchReviewExceptionDecisionTemplate(), buildLaunchReviewExceptionOutput(), buildLaunchReviewExceptionPlan(), buildLaunchReviewExceptionReview() (+28 more)
 
 ### Community 133 - "Session Notes"
 Cohesion: 0.10
 Nodes (19): 10) `/research` cluster profile links should avoid broken routes on malformed data, 11) Playwright interaction pass for research flows could not run in this environment, 12) `/research` was blocked by an unrelated Listings error modal, 13) `/research/:slug` repeated the same official source link across pathways, evidence, and CTAs, 14) Listings load failure used a blocking modal instead of inline recovery, 15) `/research` showed duplicate Neuroscience concepts and undersized touch targets, 16) `/research` hierarchy exposed clusters before student decisions, 1) `/research` search request ordering and cancellation (+11 more)
 
-### Community 134 - "Current Execution Plan"
-Cohesion: 0.19
-Nodes (20): assertSafeAcceptedInputPathText(), defaultAdvisorResolver(), resolveSafeAcceptedInputPath(), resolveSafeAcceptedInputRoot(), assertAcceptedInputsApplyAllowed(), buildAcceptedInputsOutput(), CliOptions, COMMANDS_REQUIRING_DB (+12 more)
+### Community 134 - "acceptedInputs.ts"
+Cohesion: 0.21
+Nodes (19): assertSafeAcceptedInputPathText(), defaultAdvisorResolver(), resolveSafeAcceptedInputPath(), resolveSafeAcceptedInputRoot(), assertAcceptedInputsApplyAllowed(), buildAcceptedInputsOutput(), CliOptions, COMMANDS_REQUIRING_DB (+11 more)
 
-### Community 135 - "File Structure"
-Cohesion: 0.15
-Nodes (18): assertUserMigrationApplyAllowed(), assertUserMigrationReplacementAllowed(), buildUserMigrationOutput(), __dirname, __filename, migrateUsers(), UserMigrationCliOptions, UserMigrationResult (+10 more)
+### Community 135 - "safeRouteSegment"
+Cohesion: 0.12
+Nodes (24): ListingDetailModal(), ListingDetailModalProps, storeLogoutReturnPath(), UserButton(), filterByInstitution(), getInstitutionAffiliation(), getInstitutionLabel(), InstitutionCode (+16 more)
 
 ### Community 136 - "research-detail-professor-audit.mjs"
 Cohesion: 0.11
@@ -3266,71 +3163,71 @@ Nodes (27): absoluteApiUrl(), absoluteClientUrl(), addFinding(), artifacts, audi
 
 ### Community 137 - "dedupeUsersByIdentity.ts"
 Cohesion: 0.13
-Nodes (29): field(), applyUserIdentityDedupeGroups(), archiveDuplicateUniqueUserReferences(), assertDedupeUsersByIdentityApplyAllowed(), buildDedupeUsersByIdentityOutput(), buildUserIdentityCollisionPipeline(), IDENTITY_FIELDS, isMissing() (+21 more)
+Nodes (30): field(), applyUserIdentityDedupeGroups(), archiveDuplicateUniqueUserReferences(), assertDedupeUsersByIdentityApplyAllowed(), buildDedupeUsersByIdentityOutput(), buildUserIdentityCollisionPipeline(), IDENTITY_FIELDS, isMissing() (+22 more)
 
 ### Community 138 - "ImportRootDataFiles.ts"
-Cohesion: 0.05
-Nodes (75): asPlainObject(), assertRootDataImportApplyAllowed(), buildDepartmentMap(), buildRootDataImportOutput(), cleanText(), confidenceFor(), countCsvRows(), DEFAULT_OPTIONS (+67 more)
+Cohesion: 0.09
+Nodes (47): asPlainObject(), assertRootDataImportApplyAllowed(), buildDepartmentMap(), buildRootDataImportOutput(), cleanText(), confidenceFor(), countCsvRows(), DEFAULT_OPTIONS (+39 more)
 
-### Community 140 - "officialProfilePiBackfillScraper.test.ts"
-Cohesion: 0.17
-Nodes (18): addFavoriteToFellowship(), addViewToFellowship(), boundedSearchQuery(), getFellowshipFilterOptions(), numericSearchParam(), parseFilter(), PUBLIC_FELLOWSHIP_SORT_FIELDS, publicFellowshipPage() (+10 more)
+### Community 140 - "fellowshipController.ts"
+Cohesion: 0.18
+Nodes (17): addFavoriteToFellowship(), addViewToFellowship(), boundedSearchQuery(), getFellowshipFilterOptions(), numericSearchParam(), parseFilter(), PUBLIC_FELLOWSHIP_SORT_FIELDS, publicFellowshipPage() (+9 more)
 
 ### Community 141 - "applicationRoutePathwayBackfillCore.ts"
 Cohesion: 0.12
 Nodes (37): ContactRouteType, applicationRouteBackfillDerivationKey(), ApplicationRoutePathwayBackfillDeps, ApplicationRoutePathwayBackfillEntity, ApplicationRoutePathwayBackfillOptions, ApplicationRoutePathwayBackfillResult, ApplicationRoutePathwayBackfillRoute, backfillApplicationRoutePathways() (+29 more)
 
-### Community 142 - "launchTrustContractService.ts"
-Cohesion: 0.16
-Nodes (17): allowedValues(), hasOversizedStringList(), isOversizedSearchRequest(), parseFilters(), parseSearchInput(), parseSort(), publicPathwayResearchEntity(), publicPathwaySearchResult() (+9 more)
+### Community 142 - "textValue"
+Cohesion: 0.12
+Nodes (29): cleanOfficialProfileDisplayName(), cleanOfficialProfileTitle(), clipOfficialProfileBio(), extractBio(), extractDepartments(), extractEmail(), extractImageUrl(), extractOfficialProfileIdentity() (+21 more)
 
-### Community 143 - "fellowshipController.ts"
-Cohesion: 0.21
-Nodes (16): BetaSeedEnvironmentCliOptions, BetaSeedPlan, BetaSeedPlanStep, BetaSeedRunResult, buildBetaSeedPlan(), __filename, main(), parseBetaSeedEnvironmentArgs() (+8 more)
+### Community 143 - "assertScriptApplyAllowed"
+Cohesion: 0.06
+Nodes (58): assertDepartmentMigrationApplyAllowed(), buildDepartmentMigrationOutput(), ChangeLog, DepartmentDoc, DepartmentMigrationCliOptions, DepartmentMigrationResult, __dirname, __filename (+50 more)
 
-### Community 144 - "department.ts"
-Cohesion: 0.14
-Nodes (19): CallCenterDirectorLLMFn, CandidateCenter, CenterDirector, CenterDirectorExtraction, CenterDirectorLLMExtractor, CenterDirectorLLMExtractorDeps, CenterFinderFn, defaultCallLLM() (+11 more)
+### Community 144 - "centerDirectorLLMExtractor.ts"
+Cohesion: 0.15
+Nodes (18): CallCenterDirectorLLMFn, CandidateCenter, CenterDirector, CenterDirectorExtraction, CenterDirectorLLMExtractor, CenterDirectorLLMExtractorDeps, CenterFinderFn, defaultCallLLM() (+10 more)
 
 ### Community 145 - "FavoritesManager.tsx"
-Cohesion: 0.06
-Nodes (58): csvCell(), dateFormatter, deadlineEndOfUtcDay(), FavoritesManager(), FavoritesManagerProps, fellowshipToBrowsable(), savedProgramDeadlineSummary(), validDeadlineDate() (+50 more)
+Cohesion: 0.07
+Nodes (56): csvCell(), dateFormatter, deadlineEndOfUtcDay(), FavoritesManager(), FavoritesManagerProps, fellowshipToBrowsable(), savedProgramDeadlineSummary(), validDeadlineDate() (+48 more)
 
 ### Community 146 - "departmentGroundTruth.ts"
 Cohesion: 0.14
 Nodes (29): addSourceRecord(), buildDepartmentGroundTruth(), buildResolverKeys(), buildRowsFromSources(), categoryColorKeys, chooseCodeSystem(), CuratedDepartment, curatedDepartments (+21 more)
 
-### Community 147 - "profileBioCoverageAudit.ts"
-Cohesion: 0.10
-Nodes (40): buildProfessorBioCoverageAuditOutput(), buildProfessorBioCoverageInputs(), idValue(), main(), parseInteger(), parseProfessorBioCoverageAuditArgs(), parseRequiredOutputPath(), ProfessorBioCoverageAuditCliOptions (+32 more)
+### Community 147 - "profileBioCoverageAuditCore.ts"
+Cohesion: 0.17
+Nodes (25): buildProfessorBioCoverageAudit(), emptySourceBuckets(), hasUsefulResearchSummary(), homeFallbackBucketForProfile(), isIndividualResearchHome(), isLeadRole(), isOrcidUrl(), isTrustedResearchHomeWebsite() (+17 more)
 
 ### Community 148 - "Research Model"
 Cohesion: 0.11
 Nodes (19): 2026-05-13 External Yale Validation, 2026-05-13 Model Audit, AccessSignal, Admin Review, ContactRoute, Current Implementation Context, EntryPathway, Migration Guidance (+11 more)
 
-### Community 149 - "useFavorites.ts"
-Cohesion: 0.22
-Nodes (12): assertPublicationMigrationApplyAllowed(), buildPublicationMigrationOutput(), dedupeKey(), __dirname, EmbeddedPub, __filename, migratePublicationsToPapers(), parsePositiveInteger() (+4 more)
+### Community 149 - "AdminAccessReview.tsx"
+Cohesion: 0.10
+Nodes (24): AccessReviewCounts, AccessReviewDetail, AccessReviewEntitySummary, AccessSignal, AdminAccessReview(), ContactRoute, EntryPathway, evidenceIds() (+16 more)
 
-### Community 150 - "Beta Source/PI/Action Audit Implementation Plan"
+### Community 150 - "ObservationInput"
 Cohesion: 0.22
 Nodes (17): ACCESS_DETAIL_CONFIGS, accessObservationsForEntity(), cleanName(), entityToObservations(), inferKind(), normalizeUrl(), pageText(), parseCenters() (+9 more)
 
-### Community 151 - "cli.ts"
+### Community 151 - "studentDecisionExplanationService.ts"
 Cohesion: 0.23
 Nodes (17): actionSet, cleanHttpUrl(), cleanText(), containsDirectEmail(), hasActivePostedOpportunity(), hasPublicOfficialApplicationRoute(), hasPublicRoute(), hasUndergraduateAccessEvidence() (+9 more)
 
 ### Community 152 - "crossSourceObservationConflictReview.ts"
 Cohesion: 0.05
-Nodes (71): observation(), ACCESS_EVIDENCE_CONFLICT_FIELDS, ADDITIVE_METADATA_CONFLICT_FIELDS, AggregatedCrossSourceObservationConflictGroup, asString(), asStringArray(), buildCandidateSample(), buildCategoryCounts() (+63 more)
+Nodes (70): ACCESS_EVIDENCE_CONFLICT_FIELDS, ADDITIVE_METADATA_CONFLICT_FIELDS, AggregatedCrossSourceObservationConflictGroup, asString(), asStringArray(), buildCandidateSample(), buildCategoryCounts(), buildConflictPlan() (+62 more)
 
 ### Community 153 - "migrateResearchEntities.ts"
-Cohesion: 0.13
-Nodes (29): assertResearchEntityMigrationWriteAllowed(), BACKFILL_ARRAY_FIELD_PAIRS, BACKFILL_FIELD_PAIRS, backfillReferences(), buildResearchEntityMigrationOutput(), buildResearchEntityMigrationReferenceMatch(), collectionExists(), copyResearchEntities() (+21 more)
+Cohesion: 0.12
+Nodes (31): mapResearchGroupKindToEntityType(), assertResearchEntityMigrationWriteAllowed(), BACKFILL_ARRAY_FIELD_PAIRS, BACKFILL_FIELD_PAIRS, backfillReferences(), buildResearchEntityMigrationOutput(), buildResearchEntityMigrationReferenceMatch(), collectionExists() (+23 more)
 
-### Community 154 - "visibilityRepairQueueService.ts"
-Cohesion: 0.17
-Nodes (16): buildReferenceAuditSample(), buildReferenceAuditSamples(), main(), BetaDataQualityScorecard, buildArrayRefOrphanSamplePipeline(), buildBetaDataQualityOutput(), buildMissingRequiredRefSamplePipeline(), buildScalarRefOrphanSamplePipeline() (+8 more)
+### Community 154 - "researchEntityQuality.ts"
+Cohesion: 0.14
+Nodes (21): ACCESS_SIGNAL_POINTS, accessPoints(), computeResearchEntityBrowseRank(), descriptionPoints(), leadPoints(), ResearchEntityBrowseRankInput, __testing, buildResearchEntityQualitySummary() (+13 more)
 
 ### Community 157 - "researchQualitySearchReview.ts"
 Cohesion: 0.07
@@ -3344,13 +3241,13 @@ Nodes (30): assertResearchEntityCollectionMigrationWriteAllowed(), buildCollecti
 Cohesion: 0.19
 Nodes (16): getResearchGroupBySlug(), hasOversizedStringList(), isOversizedSearchRequest(), OPERATOR_ALLOWED_SORT_FIELDS, parseFilters(), parsePositiveIntegerParam(), parseQualityFilters(), parseStudentVisibilityTiers() (+8 more)
 
-### Community 161 - "GStack Production Promotion Iteration Implementation Plan"
-Cohesion: 0.22
-Nodes (15): buildClaimGateOutput(), ClaimGateCliOptions, ClaimGateCollection, consumeValue(), __dirname, __filename, loadResearchAccessArtifacts(), main() (+7 more)
+### Community 161 - "getResearchGroupDetail"
+Cohesion: 0.18
+Nodes (21): addPublicPaperField(), buildLeadPiOutreachContactRoute(), getResearchGroupDetail(), memberDisplayName(), PUBLIC_PAPER_STAGES, publicAccessSignalForResearchDetail(), publicContactRouteForResearchDetail(), publicEntryPathwayForResearchDetail() (+13 more)
 
-### Community 163 - "sanitizeProfileResearchTerms"
+### Community 163 - "normalizePublicProfile"
 Cohesion: 0.13
-Nodes (23): cleanPublicHttpUrl(), hasPersonScopedYaleDirectoryPath(), hasProfileDirectoryLabelContamination(), isLabOrResearchGroupUrl(), isOfficialYaleProfileUrlForUser(), isYaleHost(), normalizePublicProfile(), officialYaleProfileUrlForUser() (+15 more)
+Nodes (23): hasProfileDirectoryLabelContamination(), isLabOrResearchGroupUrl(), normalizePublicProfile(), parseProfileUrl(), PUBLIC_PROFILE_BASE_ARRAY_FIELDS, PUBLIC_PROFILE_BASE_TEXT_FIELDS, publicProfileBase(), publicProfileImageUrl() (+15 more)
 
 ### Community 164 - "disambiguateSurnameLabNames.ts"
 Cohesion: 0.12
@@ -3360,25 +3257,25 @@ Nodes (27): ACTIVE_FILTER, applyPlans(), ApplyResult, assertDisambiguateSurnameL
 Cohesion: 0.14
 Nodes (27): applyPlans(), assertDuplicateAccessSignalRepairApplyAllowed(), BlockedDuplicateAccessSignalRepairGroup, buildDuplicateAccessSignalRepairPlans(), __dirname, DuplicateAccessSignalPathwayContext, DuplicateAccessSignalRecord, DuplicateAccessSignalRepairPlanResult (+19 more)
 
-### Community 166 - "ResearchHomeCard.tsx"
-Cohesion: 0.18
-Nodes (16): DepartmentCategory, ARTS_DEPARTMENT_ABBRS, buildDepartmentLookup(), CATEGORY_PRIORITY, CATEGORY_SUFFIXES, DepartmentDoc, determineSuffix(), escapeRegex() (+8 more)
+### Community 166 - "smartTitle.ts"
+Cohesion: 0.17
+Nodes (14): DepartmentCategory, ARTS_DEPARTMENT_ABBRS, buildDepartmentLookup(), CATEGORY_PRIORITY, CATEGORY_SUFFIXES, DepartmentDoc, determineSuffix(), escapeRegex() (+6 more)
 
-### Community 169 - "clientErrorMessage"
-Cohesion: 0.08
-Nodes (29): dependencies, @emotion/react, @emotion/styled, @mui/material, react, react-dom, react-is, react-router-dom (+21 more)
+### Community 169 - "dependencies"
+Cohesion: 0.07
+Nodes (30): dependencies, axios, @emotion/react, @emotion/styled, @mui/material, react, react-dom, react-is (+22 more)
 
-### Community 170 - "dedupeUsersByIdentityCore.ts"
+### Community 170 - "normalizeOfficialProfileUrl"
 Cohesion: 0.22
 Nodes (16): entityExpectedPeople(), isOfficialYalePersonPageUrl(), isOfficialYaleProfileUrl(), isPotentialDirectYalePersonPageUrl(), normalizeOfficialProfileUrl(), officialPersonUrlMatchesEntity(), officialProfileUrlsForUser(), profileSlug() (+8 more)
 
-### Community 171 - "logSanitizer.ts"
-Cohesion: 0.29
-Nodes (14): memberObservationsForEntityKey(), entryToUserObservations(), entityNameAsUser(), generatedOfficialProfileUrlCandidatesForPerson(), nameMatchesEntity(), officialProfileSlugMatchesGivenNameVariant(), personPageUrlMatchesUser(), resolveExistingUserForIdentity() (+6 more)
+### Community 171 - "profileBioCoverageAudit.ts"
+Cohesion: 0.21
+Nodes (15): buildProfessorBioCoverageAuditOutput(), buildProfessorBioCoverageInputs(), idValue(), main(), parseInteger(), parseProfessorBioCoverageAuditArgs(), parseRequiredOutputPath(), ProfessorBioCoverageAuditCliOptions (+7 more)
 
 ### Community 172 - "programController.ts"
-Cohesion: 0.12
-Nodes (29): getFellowshipById(), addFavoriteToProgram(), addViewToProgram(), boundedSearchQuery(), getProgramById(), numericSearchParam(), OPERATOR_PROGRAM_SORT_FIELDS, parseFilter() (+21 more)
+Cohesion: 0.13
+Nodes (27): getFellowshipById(), addFavoriteToProgram(), addViewToProgram(), boundedSearchQuery(), getProgramById(), numericSearchParam(), OPERATOR_PROGRAM_SORT_FIELDS, parseFilter() (+19 more)
 
 ### Community 173 - "seedDepartments.ts"
 Cohesion: 0.12
@@ -3389,16 +3286,16 @@ Cohesion: 0.15
 Nodes (25): applyRepairs(), assertRepairMismatchedPersonEmailsApplyAllowed(), loadUsers(), main(), runRepairMismatchedPersonEmails(), writeOutput(), buildMismatchedExternalIdentityRepairs(), buildMismatchedPersonEmailRepairPlan() (+17 more)
 
 ### Community 176 - "betaReadinessGate.ts"
-Cohesion: 0.15
-Nodes (21): buildAcceptedInputsStatus(), loadAcceptedInputUsers(), readFileIfExists(), BETA_ROLLOUT_ORDER, BetaReadinessGateCliOptions, buildBetaReadinessCommands(), buildBetaReadinessGateOutput(), collectionCount() (+13 more)
+Cohesion: 0.17
+Nodes (18): BETA_ROLLOUT_ORDER, BetaReadinessGateCliOptions, buildBetaReadinessCommands(), buildBetaReadinessGateOutput(), collectionCount(), describeMongoTarget(), __dirname, EXPECTED_SOURCE_NAMES (+10 more)
 
-### Community 178 - "pathwayController.ts"
-Cohesion: 0.15
-Nodes (19): ADMIN_PROFILE_USER_TYPES, adminUpdateProfile(), boundedAdminProfileEmail(), boundedAdminProfileNumber(), boundedAdminProfileText(), boundedProfileString(), boundedProfileStringArray(), boundedProfileUrlKey() (+11 more)
+### Community 178 - "updateOwnProfile"
+Cohesion: 0.22
+Nodes (13): ADMIN_PROFILE_USER_TYPES, adminUpdateProfile(), boundedAdminProfileEmail(), boundedAdminProfileNumber(), boundedAdminProfileText(), boundedProfileString(), boundedProfileStringArray(), isProfileUpdatePayload() (+5 more)
 
 ### Community 180 - "adminAccessReviewService.ts"
-Cohesion: 0.11
-Nodes (31): recordReviewStatuses, AccessReviewCountSummary, accessReviewDocumentId(), AccessReviewEntitySummary, AccessReviewListInput, AccessReviewRecordType, attachEvidenceItems(), buildReviewSummary() (+23 more)
+Cohesion: 0.14
+Nodes (26): AccessReviewCountSummary, accessReviewDocumentId(), AccessReviewEntitySummary, AccessReviewListInput, AccessReviewRecordType, attachEvidenceItems(), buildReviewSummary(), countByEntity() (+18 more)
 
 ### Community 181 - "studentVisibilityRepairTargets.ts"
 Cohesion: 0.12
@@ -3408,13 +3305,13 @@ Nodes (31): buildBucket(), buildStudentVisibilityRepairTargetReport(), compactSa
 Cohesion: 0.07
 Nodes (28): dependencies, csv-parse, dotenv, meilisearch, mongoose, openai, description, devDependencies (+20 more)
 
-### Community 183 - "v4MigrationUtils.ts"
+### Community 183 - "BackfillV4FacultyMembers.ts"
 Cohesion: 0.08
-Nodes (51): backfillV4FacultyMembers(), buildDepartmentMap(), compact(), departmentIdsFor(), __filename, isFacultyTitle(), norm(), slugify() (+43 more)
+Nodes (50): backfillV4FacultyMembers(), buildDepartmentMap(), compact(), departmentIdsFor(), __filename, isFacultyTitle(), norm(), slugify() (+42 more)
 
-### Community 184 - "scholarlyLinkSuppressionAudit.ts"
-Cohesion: 0.25
-Nodes (12): AdminProfile, AdminProfileEditModal(), AdminProfileEditModalProps, AdminProfileEditAction, adminProfileEditReducer(), AdminProfileEditState, AdminProfileShape, createInitialAdminProfileEditState() (+4 more)
+### Community 184 - "generateKeywords.ts"
+Cohesion: 0.17
+Nodes (16): ALIAS_MAP, args, buildSystemPrompt(), buildUserPrompt(), callOpenAI(), classifyExistingAreas(), classifyNovelAreas(), classifyOnly (+8 more)
 
 ### Community 185 - "cleanupLegacyMongoCollections.ts"
 Cohesion: 0.17
@@ -3424,93 +3321,93 @@ Nodes (23): assertLegacyCleanupWriteAllowed(), buildLegacyCleanupOutput(), colle
 Cohesion: 0.08
 Nodes (31): sourceSchema, SourceCoverageArtifactType, sourceCoverageArtifactTypes, sourceCoverageEvidenceCategories, SourceCoverageEvidenceCategory, SourceCoverageMetadata, SourceCoverageTier, sourceCoverageTiers (+23 more)
 
-### Community 187 - "auditProgramResearchRelevance.ts"
-Cohesion: 0.24
-Nodes (10): container, root, UserContextProvider(), sampleUser, createInitialUserState(), UserAction, userReducer(), UserState (+2 more)
+### Community 187 - "migrateSmartTitles.ts"
+Cohesion: 0.16
+Nodes (16): args, ARTS_DEPARTMENT_ABBRS, CATEGORY_PRIORITY, CATEGORY_SUFFIXES, DepartmentCategory, DepartmentDoc, determineSuffix(), escapeRegex() (+8 more)
 
-### Community 188 - "researchAreas.ts"
-Cohesion: 0.09
-Nodes (25): fieldColorKeys, ResearchArea, researchAreaSchema, ResearchField, router, hasDirectContactInfo(), router, routeHandlerNames() (+17 more)
+### Community 188 - "configService.ts"
+Cohesion: 0.10
+Nodes (25): fieldColorKeys, ResearchArea, researchAreaSchema, ResearchField, router, hasDirectContactInfo(), routeHandlerNames(), routesByPath() (+17 more)
 
-### Community 189 - "BackfillV4StudentProfiles.ts"
+### Community 189 - "backfillCenterDirectors.ts"
 Cohesion: 0.18
-Nodes (12): assertDepartmentMigrationApplyAllowed(), buildDepartmentMigrationOutput(), ChangeLog, DepartmentDoc, DepartmentMigrationCliOptions, DepartmentMigrationResult, __dirname, __filename (+4 more)
+Nodes (15): MaterializerObservationLike, CenterDirectorsBackfillCliOptions, CenterDirectorsBackfillResult, __dirname, __filename, findCenterDirectorCandidates(), LEAD_ROLES, main() (+7 more)
 
 ### Community 190 - "migrateMongoNaming.ts"
-Cohesion: 0.15
-Nodes (21): assertMongoNamingMigrationWriteAllowed(), buildMongoNamingMigrationOutput(), buildUserFieldSetStage(), COLLECTION_RENAMES, collectionExists(), CollectionRenameResult, main(), migrateMongoNaming() (+13 more)
+Cohesion: 0.16
+Nodes (20): assertMongoNamingMigrationWriteAllowed(), buildMongoNamingMigrationOutput(), buildUserFieldSetStage(), COLLECTION_RENAMES, collectionExists(), CollectionRenameResult, main(), migrateMongoNaming() (+12 more)
 
 ### Community 191 - "researchEntityPiDedupeCore.ts"
-Cohesion: 0.16
-Nodes (28): buildFundingGroupFromCluster(), buildGroupFromCluster(), buildOfficialLabUrlResearchEntityDedupePlan(), buildProfileAreaShellDuplicateGroup(), buildResearchEntityPiDedupePlan(), canonicalScore(), cleanMergedResearchAreas(), comparablePiLabName() (+20 more)
+Cohesion: 0.17
+Nodes (28): buildFundingGroupFromCluster(), buildFundingResearchEntityDedupePlan(), buildGroupFromCluster(), buildOfficialLabUrlResearchEntityDedupePlan(), buildProfileAreaShellDuplicateGroup(), buildResearchEntityPiDedupePlan(), canonicalScore(), cleanMergedResearchAreas() (+20 more)
 
 ### Community 192 - "staleObservationConflictReview.test.ts"
 Cohesion: 0.25
 Nodes (8): assertStaleObservationConflictReviewApplyAllowed(), buildStaleObservationConflictReviewOutput(), buildStaleObservationDecisionTemplate(), main(), normalizeStaleObservationObjectId(), toObjectId(), writeStaleObservationConflictReviewOutput(), writeStaleObservationDecisionTemplate()
 
-### Community 193 - "listings.ts"
-Cohesion: 0.13
-Nodes (24): LaunchReviewExceptionCliOptions, buildLaunchTrustContractOutput(), CliOptions, __filename, main(), parseLaunchTrustContractArgs(), parsePositiveInteger(), parseRequiredValue() (+16 more)
+### Community 193 - "launchTrustContract.ts"
+Cohesion: 0.22
+Nodes (14): LaunchReviewExceptionCliOptions, buildLaunchTrustContractOutput(), CliOptions, __filename, main(), parseLaunchTrustContractArgs(), parsePositiveInteger(), parseRequiredValue() (+6 more)
 
 ### Community 194 - "EvidenceSourceRow.tsx"
 Cohesion: 0.39
 Nodes (7): EvidenceSourceRow(), EvidenceSourceRowProps, formatConfidence(), formatDate(), formatSourceType(), labelize(), EvidenceSourceRowData
 
-### Community 195 - "1. Fresh machine setup"
-Cohesion: 0.06
-Nodes (25): PlanningOverview(), PlanningOverviewProps, pluralize(), fellowship, item, defaultUserContext, Account(), nextPlanningCue() (+17 more)
+### Community 195 - "UserContext.ts"
+Cohesion: 0.07
+Nodes (22): defaultUserContext, container, root, __resetResearchPageSnapshotForTests(), UserContextValue, departments, mockedAxios, mockEmptySearchResponses() (+14 more)
 
-### Community 196 - "3. Configure environment"
-Cohesion: 0.11
-Nodes (33): CliOptions, FILTER, main(), parseArgs(), CliOptions, main(), parseArgs(), BackfillEntry (+25 more)
+### Community 196 - "resolveSafeJsonReportOutputPath"
+Cohesion: 0.12
+Nodes (30): Fellowship, CliOptions, main(), parseArgs(), assertBackfillProgramClassificationsApplyAllowed(), BackfillProgramClassificationsCliOptions, buildBackfillProgramClassificationsOutput(), main() (+22 more)
 
-### Community 197 - "1. Fresh machine setup"
-Cohesion: 0.13
-Nodes (15): dependencies, cheerio, cookie-session, cors, cross-env, dotenv, express, express-rate-limit (+7 more)
+### Community 197 - "dependencies"
+Cohesion: 0.12
+Nodes (16): dependencies, axios, cheerio, cookie-session, cors, cross-env, dotenv, express (+8 more)
 
-### Community 198 - "1. Fresh machine setup"
-Cohesion: 0.21
-Nodes (13): ObservedEntityType, NOW, buildEntityWorkPlan(), BuildEntityWorkPlanOptions, BuildFieldPlanOptions, EntityWorkPlan, FieldPlan, latestObservedAt() (+5 more)
+### Community 198 - "workPlanner.ts"
+Cohesion: 0.26
+Nodes (11): ObservedEntityType, buildEntityWorkPlan(), BuildEntityWorkPlanOptions, BuildFieldPlanOptions, EntityWorkPlan, FieldPlan, latestObservedAt(), LoadEntityWorkPlanOptions (+3 more)
 
 ### Community 199 - "unified-research-search-audit.mjs"
 Cohesion: 0.12
 Nodes (22): artifacts, assert(), assertTextExcludes(), assertTextIncludes(), assertTextMatches(), audit(), bodyText(), clientBase (+14 more)
 
-### Community 200 - "Technical Due Diligence Review — Yale Research (yalelabs)"
+### Community 200 - "departmentResolver.ts"
 Cohesion: 0.31
 Nodes (8): cache, canonicalizeDepartment(), CanonicalizeResult, DepartmentRow, loadCache(), normalize(), registerDepartmentAlias(), tokenJaccard()
 
 ### Community 201 - "userEmailHygiene.ts"
-Cohesion: 0.21
-Nodes (19): assertUserEmailHygieneApplyAllowed(), buildSuspiciousUserEmailFilter(), buildUserEmailHygieneOutput(), loadSuspiciousUsers(), main(), runUserEmailHygiene(), writeUserEmailHygieneOutput(), buildUserEmailHygieneSummary() (+11 more)
+Cohesion: 0.18
+Nodes (23): buildEmailHygiene(), buildSuspiciousUserEmailScorecardSummary(), isInvalidOptionalEmail(), assertUserEmailHygieneApplyAllowed(), buildSuspiciousUserEmailFilter(), buildUserEmailHygieneOutput(), loadSuspiciousUsers(), main() (+15 more)
 
-### Community 202 - "departmentUndergradResearchScraper.ts"
-Cohesion: 0.13
-Nodes (20): closeAll(), DEFAULT_EXCLUDED, flush(), main(), parseList(), entityKeyForWork(), normalizeArxivId(), normalizeDoi() (+12 more)
+### Community 202 - "orcidWorksScraper.ts"
+Cohesion: 0.10
+Nodes (28): closeAll(), DEFAULT_EXCLUDED, flush(), main(), parseList(), isPaperAuthorshipEvidence(), isPaperAuthorshipSource(), isPaperMetadataOnlySource() (+20 more)
 
-### Community 203 - "Adding Things"
-Cohesion: 0.17
-Nodes (16): defaultRewriter(), DESC_BLOCK_REASONS, DescriptionRewriter, __dirname, entityHttpUrls(), fetchGrantAbstract(), __filename, groundingScore() (+8 more)
+### Community 203 - "repairListingResearchEntityProfiles.ts"
+Cohesion: 0.30
+Nodes (13): applyRepairs(), assertRepairListingResearchEntityProfilesApplyAllowed(), buildRepairListingResearchEntityProfilesOutput(), main(), normalizeListingProfileRepairObjectId(), normalizeListingProfileRepairObjectIdString(), parsePositiveInteger(), parseRepairListingResearchEntityProfilesArgs() (+5 more)
 
-### Community 204 - "Adding Things"
+### Community 204 - "researchGroupFilters.ts"
 Cohesion: 0.33
 Nodes (6): acceptanceLevelClauses(), AcceptanceLevelInput, buildResearchGroupFilterString(), escapeMeiliFilterValue(), orEqualsClause(), ResearchGroupFilterInput
 
-### Community 206 - "Adding Things"
-Cohesion: 0.18
-Nodes (9): AdminFacultyProfilesTable(), AdminProfile, getHIndex(), getPrimaryDepartment(), PAGE_SIZES, SortField, TABLE_COLUMNS, Tab (+1 more)
+### Community 206 - "AdminFacultyProfilesTable.tsx"
+Cohesion: 0.16
+Nodes (14): AdminFacultyProfilesTable(), AdminProfile, getHIndex(), getPrimaryDepartment(), PAGE_SIZES, SortField, TABLE_COLUMNS, AdminFacultyProfilesFilter (+6 more)
 
 ### Community 207 - "meiliSyncService.ts"
+Cohesion: 0.22
+Nodes (14): deleteFromIndex(), ENTITY_REGISTRY, EntityIndexConfig, getConfig(), isSyncableEntityType(), MaybePromise, stripInternalFields(), SyncableEntityType (+6 more)
+
+### Community 208 - "AdminOperatorBoard"
 Cohesion: 0.20
-Nodes (15): deleteFromIndex(), ENTITY_REGISTRY, EntityIndexConfig, getConfig(), isSyncableEntityType(), MaybePromise, stripInternalFields(), SyncableEntityType (+7 more)
+Nodes (12): AdminOperatorBoard(), classifyReason(), formatCountList(), formatDate(), queueDecisionPrompt(), sourceConflictScopeText(), sourceReviewArtifactRollupLines(), sourceReviewCategoryText() (+4 more)
 
-### Community 208 - "acceptedInputs.ts"
-Cohesion: 0.17
-Nodes (13): AdminOperatorBoard(), formatCountList(), formatDate(), queueDecisionPrompt(), sourceConflictScopeText(), sourceDecisionValidationStatusText(), sourceReviewArtifactRollupLines(), sourceReviewCategoryText() (+5 more)
-
-### Community 209 - "textValue"
-Cohesion: 0.27
-Nodes (11): backfillV4StudentProfiles(), buildDepartmentMap(), compact(), departmentIdsFor(), __filename, graduationYear(), norm(), V4StudentProfileBackfillResult (+3 more)
+### Community 209 - "index.ts"
+Cohesion: 0.07
+Nodes (31): backfillV4StudentProfiles(), buildDepartmentMap(), compact(), departmentIdsFor(), __filename, graduationYear(), norm(), V4StudentProfileBackfillResult (+23 more)
 
 ### Community 210 - "accessSummaryService.ts"
 Cohesion: 0.21
@@ -3525,52 +3422,52 @@ Cohesion: 0.24
 Nodes (17): assertClearBetaStudentAnalyticsApplyAllowed(), buildBetaStudentAnalyticsEventFilter(), buildClearBetaStudentAnalyticsOutput(), loadCandidateSummary(), main(), runClearBetaStudentAnalytics(), writeClearBetaStudentAnalyticsOutput(), BETA_STUDENT_ANALYTICS_USER_TYPES (+9 more)
 
 ### Community 213 - "scraperIntegrityDuplicateReview.ts"
-Cohesion: 0.17
-Nodes (18): DuplicateAccessSignalGroup, DuplicateResearchPaperGroup, DuplicateAccessSignalRepairPlan, buildScraperIntegrityDuplicateReviewReport(), consumeValue(), __dirname, __filename, loadDuplicateAccessSignalReviewGroups() (+10 more)
+Cohesion: 0.15
+Nodes (21): buildDuplicateAccessSignalGroupsFromRows(), DuplicateAccessSignalGroup, DuplicateResearchPaperGroup, loadDuplicateAccessSignalGroups(), DuplicateAccessSignalRepairPlan, loadDuplicateAccessSignalGroups(), buildScraperIntegrityDuplicateReviewReport(), consumeValue() (+13 more)
 
-### Community 214 - "runStaleObservationConflictReview"
-Cohesion: 0.26
-Nodes (11): expandedResearchAreasPublicBio(), formatPublicBioList(), hasOfficialYaleProfileUrl(), officialProfileResearchInterestTermsBio(), publicProfileDisplayName(), cleanResearchTerm(), extractExplicitResearchInterestPhrases(), isProseResearchBlurb() (+3 more)
+### Community 214 - "researchGroupService.test.ts"
+Cohesion: 0.20
+Nodes (14): currentResearchEntityMemberFilter(), getResearchGroupById(), idEquals(), listMembersOfGroup(), listResearchEntityRelationshipPayload(), normalizeResearchGroupObjectId(), publicRelationshipForResearchDetail(), leanResult() (+6 more)
 
 ### Community 215 - "departmentLeadRepairPlanCore.ts"
-Cohesion: 0.11
-Nodes (32): escapeRegExp(), main(), normalizeEmail(), parseDepartmentLeadRepairPlanArgs(), valuesForArg(), buildDepartmentLeadRepairApplyOperations(), buildDepartmentLeadRepairPlan(), compareDepartmentLeadRepairPlans() (+24 more)
+Cohesion: 0.14
+Nodes (26): buildDepartmentLeadRepairApplyOperations(), buildDepartmentLeadRepairPlan(), compareDepartmentLeadRepairPlans(), currentLeadMember(), DepartmentLeadRepairApplyOperation, DepartmentLeadRepairEntity, DepartmentLeadRepairExistingMember, DepartmentLeadRepairObservation (+18 more)
 
 ### Community 216 - "auditResearchEntityRename.ts"
 Cohesion: 0.18
 Nodes (19): buildLegacyResidueSummary(), buildResearchEntityRenameAuditOutput(), collectionExists(), countCollection(), countDanglingReferences(), countLegacyResidue(), LEGACY_RESIDUE_CHECKS, LegacyResidueCheck (+11 more)
 
-### Community 217 - "betaRepairQueue.ts"
-Cohesion: 0.26
-Nodes (15): arrayValue(), assertBetaRepairQueueApplyReviewedArtifact(), BetaRepairQueueApplyArtifactValidation, blockedReasonsForAttempt(), buildApplyFromArtifactOptions(), buildBetaRepairQueueOutput(), main(), objectValue() (+7 more)
+### Community 217 - "longText.ts"
+Cohesion: 0.30
+Nodes (11): LongText(), LongTextProps, LongTextOptions, longTextParagraphs(), normalizeCommonAcademicAbbreviations(), normalizeInlineWhitespace(), protectDots(), protectSentenceAbbreviations() (+3 more)
 
 ### Community 220 - "compilerOptions"
 Cohesion: 0.11
 Nodes (18): compilerOptions, allowJs, allowSyntheticDefaultImports, esModuleInterop, forceConsistentCasingInFileNames, isolatedModules, jsx, lib (+10 more)
 
-### Community 221 - "1. Fresh machine setup"
+### Community 221 - "backfillPostedOpportunitiesFromListings.ts"
 Cohesion: 0.18
 Nodes (18): assertPostedOpportunityBackfillApplyAllowed(), buildPostedOpportunityBackfillOutput(), __dirname, __filename, main(), parsePositiveInteger(), parsePostedOpportunityBackfillArgs(), PostedOpportunityBackfillCliOptions (+10 more)
 
 ### Community 223 - "paperQualityService.ts"
-Cohesion: 0.14
-Nodes (22): buildPaperQualityAuditOutput(), __filename, main(), PaperQualityAuditCliOptions, parseNonNegativeInteger(), parsePaperQualityAuditArgs(), writePaperQualityAuditOutput(), activeScholarlyLinkFilter (+14 more)
+Cohesion: 0.13
+Nodes (23): researchScholarlyLinkSchema, buildPaperQualityAuditOutput(), __filename, main(), PaperQualityAuditCliOptions, parseNonNegativeInteger(), parsePaperQualityAuditArgs(), writePaperQualityAuditOutput() (+15 more)
 
 ### Community 224 - "importFellowships.ts"
-Cohesion: 0.15
-Nodes (21): assertFellowshipImportApplyAllowed(), buildFellowshipImportOutput(), cleanEmail(), cleanText(), __dirname, FellowshipCSVRow, FellowshipImportCliOptions, FellowshipImportResult (+13 more)
+Cohesion: 0.16
+Nodes (20): assertFellowshipImportApplyAllowed(), buildFellowshipImportOutput(), cleanEmail(), cleanText(), __dirname, FellowshipCSVRow, FellowshipImportCliOptions, FellowshipImportResult (+12 more)
 
 ### Community 226 - "pathwayRelevanceReview.ts"
 Cohesion: 0.21
 Nodes (15): buildPathwayRelevanceReviewOutput(), DEFAULT_REVIEW_CASES, __dirname, errorMessage(), __filename, main(), overlap(), parsePathwayRelevanceReviewArgs() (+7 more)
 
-### Community 227 - "profileImageQualityAudit.ts"
+### Community 227 - "profileImageQualityAuditCore.ts"
 Cohesion: 0.26
 Nodes (17): buildProfileImageQualitySummary(), DuplicateProfileImageFinding, isLikelyPublicProfileImageUrl(), isNonPersonProfileImageUrl(), isSharedProfileImageAcrossDifferentNames(), isTrustedPublicProfileImageHost(), normalizedIdentityKey(), normalizedName() (+9 more)
 
-### Community 228 - "fellowships.tsx"
-Cohesion: 0.33
-Nodes (6): Core Rules, Default Task Loop, Implementation Rules, On-Demand Skills, Parallel Work, Yale Research - Agent Guide
+### Community 228 - "scraperIntegrityGate.ts"
+Cohesion: 0.27
+Nodes (11): isIntegrityGateFailure(), PostMaterializationIntegritySummary, buildScraperIntegrityGateOutput(), consumeValue(), __dirname, __filename, main(), parseScraperIntegrityGateArgs() (+3 more)
 
 ### Community 229 - "programs.ts"
 Cohesion: 0.22
@@ -3580,19 +3477,19 @@ Nodes (9): buildProgramSearchFilters(), getStringParam(), hasProgramSearchFilter
 Cohesion: 0.11
 Nodes (18): compilerOptions, esModuleInterop, forceConsistentCasingInFileNames, lib, module, moduleResolution, noImplicitAny, outDir (+10 more)
 
-### Community 233 - "AdminFacultyProfilesTable.tsx"
-Cohesion: 0.43
-Nodes (7): accessSignalTypesByEntityId(), browseRankDocumentId(), LEAD_ROLES, leadMembersByEntityId(), recomputeBrowseRankForEntities(), RecomputeBrowseRankOptions, RecomputeBrowseRankResult
+### Community 233 - "trustedLeadResearchHomeBioFallback"
+Cohesion: 0.21
+Nodes (13): capitalizeSentenceStart(), cleanResearchHomeSummaryForBio(), dedupeProfileResearchEntities(), entityNameMatchesUser(), isIndividualResearchEntity(), isLeadRole(), isUsefulResearchHomeBioSummary(), looksLikePersonOnlyResearchHomeName() (+5 more)
 
-### Community 234 - "scriptWriteGuards.ts"
+### Community 234 - "cli.ts"
 Cohesion: 0.15
-Nodes (27): __dirname, __filename, main(), BOOLEAN_FLAGS, buildCronOutputPayload(), buildMaterializeOutputPayload(), buildScraperCliOutputPayload(), buildScraperCliPreflight() (+19 more)
+Nodes (23): __dirname, __filename, main(), BOOLEAN_FLAGS, buildCronOutputPayload(), buildMaterializeOutputPayload(), buildScraperCliOutputPayload(), buildScraperCliPreflight() (+15 more)
 
 ### Community 235 - "sourceHealthService.ts"
 Cohesion: 0.24
 Nodes (15): betaCommand(), buildSourceHealthRows(), commandArg(), iso(), noRecentRunCommand(), reportCommand(), reportOutputPath(), reviewArtifactForRun() (+7 more)
 
-### Community 236 - "adminTableReducer.test.ts"
+### Community 236 - "listings.ts"
 Cohesion: 0.24
 Nodes (8): buildListingSearchFilters(), getStringParam(), hasListingSearchFilters(), logListingCreateEvent(), logListingEvent(), logSearchEvent(), parseFilterParam(), router
 
@@ -3600,7 +3497,7 @@ Nodes (8): buildListingSearchFilters(), getStringParam(), hasListingSearchFilter
 Cohesion: 0.27
 Nodes (10): applyProseCompletenessBonus(), DEFAULTS, normalizedProse(), PROSE_COMPLETENESS_FIELDS, recencyDecay(), resolveAllFields(), resolveField(), ResolverOptions (+2 more)
 
-### Community 241 - "normalizePublicProfile"
+### Community 241 - "normalizeAcceptedDecisionValidation"
 Cohesion: 0.53
 Nodes (6): copyFiniteNumber(), normalizeAcceptedDecisionValidation(), normalizeDecisionHandoff(), normalizeDuplicateNamePreflight(), normalizeSamePiDedupeReview(), normalizeSamePiDedupeReviewBreakdown()
 
@@ -3608,45 +3505,45 @@ Nodes (6): copyFiniteNumber(), normalizeAcceptedDecisionValidation(), normalizeD
 Cohesion: 0.18
 Nodes (11): Canonical Product Frame, Current Interface Shape, Graphify Grounding, `/listings`, Near-Term UX Moves, Open UX Questions, `/research`, `/research/:slug` (+3 more)
 
-### Community 247 - "Product Model"
-Cohesion: 0.40
-Nodes (4): Canonical runtime model, Modeling rules, Product Model, Student-facing surfaces
+### Community 247 - "profileService.test.ts"
+Cohesion: 0.21
+Nodes (9): buildProfileResearchMembershipFilter(), isOfficialProfileScholarlyLink(), loadProfileResearchEntities(), loadProfileScholarlyLinks(), orderProfileScholarlyLinks(), paperToScholarlyLink(), profileDocumentId(), buildResearchActivityLinkPayload() (+1 more)
 
-### Community 248 - "backfillResearchHomeOfficialUrls.ts"
-Cohesion: 0.07
-Nodes (38): MaterializerObservationLike, BrowseRankBackfillCliOptions, BrowseRankBackfillResult, __dirname, __filename, main(), parseBrowseRankBackfillArgs(), parsePositiveInt() (+30 more)
+### Community 248 - "researchEntity.ts"
+Cohesion: 0.06
+Nodes (47): researchGroupSchema, BrowseRankBackfillCliOptions, BrowseRankBackfillResult, __dirname, __filename, main(), parseBrowseRankBackfillArgs(), parsePositiveInt() (+39 more)
 
 ### Community 249 - "fellowship.ts"
-Cohesion: 0.25
-Nodes (7): programCategories, programEntryModes, programKinds, publicSafeStudentVisibilityTiers, publicStudentVisibilityTiers, studentVisibilityFields, studentVisibilityTiers
+Cohesion: 0.18
+Nodes (16): fellowshipSchema, programCategories, ProgramCategory, ProgramEntryMode, programEntryModes, ProgramKind, programKinds, studentVisibilityFields (+8 more)
 
 ### Community 250 - "seed.ts"
-Cohesion: 0.14
-Nodes (9): normalizeSeedNetid(), requireLocalSeedRuntime(), requireSeedToken(), router, SEED_USER_FIELDS, seedListingSummary(), seedUserPayload(), seedUserSummary() (+1 more)
+Cohesion: 0.11
+Nodes (14): normalizeSeedNetid(), requireLocalSeedRuntime(), requireSeedToken(), router, SEED_USER_FIELDS, seedListingSummary(), seedUserPayload(), seedUserSummary() (+6 more)
 
 ### Community 251 - "adminGrantService.ts"
-Cohesion: 0.15
-Nodes (26): AuthenticatedUser, canCreateListing(), hasAdminAuthority(), hasAuthenticatedPrincipal(), isAdmin(), isAuthenticated(), isConfirmed(), isProfessor() (+18 more)
+Cohesion: 0.14
+Nodes (28): AuthenticatedUser, canCreateListing(), hasAdminAuthority(), hasAuthenticatedPrincipal(), isAdmin(), isAuthenticated(), isConfirmed(), isProfessor() (+20 more)
 
 ### Community 252 - "seedResearchAreas.ts"
 Cohesion: 0.14
 Nodes (18): assertResearchAreaSeedApplyAllowed(), buildResearchAreaSeedOutput(), buildResearchAreaSeedRows(), defaultResearchAreas, __dirname, fieldColorKeys, __filename, main() (+10 more)
 
-### Community 253 - "scraperIntegrityGate.ts"
-Cohesion: 0.38
-Nodes (5): mockedAxios, mockedSwal, Endpoints, FavoritesKind, useFavorites()
+### Community 253 - "searchResearchGroupsViaMeili"
+Cohesion: 0.26
+Nodes (12): boundedResearchSearchQuery(), isMissingMeiliEmbedderError(), isUnsortableAttributeError(), leadMembersForEntities(), matchesQualityFilters(), mongoFilterFromResearchFilters(), mongoVisibilityFilter(), researchGroupDocumentId() (+4 more)
 
-### Community 254 - "claimGate.ts"
+### Community 254 - "adminTableReducer.test.ts"
 Cohesion: 0.33
 Nodes (4): Filter, makeState(), Row, Sort
 
 ### Community 257 - "environment.ts"
-Cohesion: 0.31
-Nodes (13): allowsNonProductionSecurityBypass(), isCI(), isDevelopment(), isLocalDevelopmentRuntime(), isLocalHostValue(), isProduction(), isTest(), LOCAL_DEV_HOSTS (+5 more)
+Cohesion: 0.11
+Nodes (30): csrfOriginGuard(), isTrustedUnsafeRequestOrigin(), originFromUrl(), SAFE_METHODS, buildContentSecurityPolicy(), CONNECT_SRC_ORIGINS, connectSrcDirective(), CONTENT_SECURITY_POLICY (+22 more)
 
-### Community 258 - "useConfig"
-Cohesion: 0.67
-Nodes (3): classifyReason(), splitReasons(), uniqueReasons()
+### Community 258 - "labDetailReducer.test.ts"
+Cohesion: 0.25
+Nodes (9): createInitialLabDetailState(), LabDetailAction, labDetailReducer(), LabDetailState, otherPayload, sampleGroup, sampleListing, samplePayload (+1 more)
 
 ### Community 259 - "dependencies"
 Cohesion: 0.12
@@ -3660,29 +3557,37 @@ Nodes (8): getFavoriteIds(), logFavoriteEvent(), logProfileUpdateEvent(), normal
 Cohesion: 0.32
 Nodes (6): DepartmentCategory, DepartmentCodeSystem, departmentSourceUrls, validateDepartmentRows(), __dirname, fixtureByUrl
 
-### Community 266 - "repairListingResearchEntityProfiles.ts"
+### Community 266 - "isPublicHttpUrl"
 Cohesion: 0.15
-Nodes (27): applyRepairs(), assertRepairListingResearchEntityProfilesApplyAllowed(), buildRepairListingResearchEntityProfilesOutput(), main(), normalizeListingProfileRepairObjectId(), normalizeListingProfileRepairObjectIdString(), parsePositiveInteger(), parseRepairListingResearchEntityProfilesArgs() (+19 more)
+Nodes (23): isHttpUrl(), buildListingResearchEntityProfilePatch(), hasText(), isHttpUrl(), ListingResearchEntityProfileInput, looksLikeOwnerTitle(), looksLikePublicationBlurb(), missingArray() (+15 more)
 
 ### Community 270 - "Product Context"
 Cohesion: 0.18
 Nodes (11): CTA Vocabulary, Entity Page Questions, Explore Research, Navigation Shape, North Star, Primary Surfaces, Product Context, Product Premise (+3 more)
 
-### Community 272 - "dependencies"
-Cohesion: 0.07
-Nodes (31): axios, AdminRoute(), AdminRouteProps, getLocalAdminDevLoginUrl(), getSafeLocalAdminRedirectTarget(), PrivateRoute(), PrivateRouteProps, CourseTableCourse (+23 more)
+### Community 272 - "apiBaseUrl.ts"
+Cohesion: 0.22
+Nodes (13): AdminRoute(), AdminRouteProps, getLocalAdminDevLoginUrl(), getSafeLocalAdminRedirectTarget(), SignOutButton(), storeLogoutReturnPath(), buildApiUrl(), getApiBaseUrl() (+5 more)
 
 ### Community 273 - "resolutions"
 Cohesion: 0.12
 Nodes (16): resolutions, axios, brace-expansion, braces, encoding-sniffer, form-data, glob, ip-address (+8 more)
 
-### Community 280 - "corsOrigin.ts"
-Cohesion: 0.29
-Nodes (8): CorsOriginCallback, CorsOriginError, createCorsOriginHandler(), isAllowedCorsOrigin(), normalizeCorsOrigin(), allowedOrigins, HandlerResult, runOriginHandler()
+### Community 277 - "launchAcquisitionReport.ts"
+Cohesion: 0.33
+Nodes (8): buildLaunchAcquisitionReportOutput(), LaunchAcquisitionReportCliOptions, main(), parseLaunchAcquisitionReportArgs(), parsePositiveInteger(), writeLaunchAcquisitionReportOutput(), LaunchAcquisitionReport, LaunchAcquisitionReportOptions
+
+### Community 280 - "adminListingsTableReducer.ts"
+Cohesion: 0.27
+Nodes (8): AdminListingsFilter, AdminListingsSortField, AdminListingsTableAction, AdminListingsTableState, UrlCheckResult, AdminTableAction, AdminTableDefaults, AdminTableState
+
+### Community 282 - "publicationsTableReducer.ts"
+Cohesion: 0.27
+Nodes (7): adminTableReducer(), createInitialPublicationsTableState(), PublicationsFilter, PublicationsTableAction, publicationsTableReducer(), PublicationsTableState, TestPublication
 
 ### Community 283 - "isLikelyPersonUrl"
-Cohesion: 0.22
-Nodes (18): initial(), allNameTokens(), allowsLastNameOnlyPersonUrl(), cleanProfileUrlsForPerson(), compoundLastNameMatchedTokens(), entityNameMatchesUser(), givenNameAliasMatches(), hasPartialCompoundLastNameProfilePath() (+10 more)
+Cohesion: 0.14
+Nodes (27): initial(), allNameTokens(), allowsLastNameOnlyPersonUrl(), cleanProfileUrlsForPerson(), compoundLastNameMatchedTokens(), expandedResearchAreasPublicBio(), formatPublicBioList(), givenNameAliasMatches() (+19 more)
 
 ### Community 284 - "sanitizeMongo.ts"
 Cohesion: 0.40
@@ -3690,19 +3595,35 @@ Nodes (9): hasUnsafeMongoShape(), isPlainObject(), isUnsafeMongoKey(), PROTOTYPE
 
 ### Community 285 - "index.ts"
 Cohesion: 0.08
-Nodes (21): asyncHandler(), compactPositiveInteger(), requireBody(), requireFields(), validateNetid(), validateObjectId(), validatePagination(), validateQuery() (+13 more)
+Nodes (20): asyncHandler(), compactPositiveInteger(), requireBody(), requireFields(), validateNetid(), validateObjectId(), validatePagination(), validateQuery() (+12 more)
 
-### Community 288 - "listingFormReducer.ts"
-Cohesion: 0.31
-Nodes (7): createInitialListingFormState(), ListingFormAction, ListingFormErrors, listingFormReducer(), ListingFormState, researchAreasFromListing(), resolve()
+### Community 286 - "redactDirectContactInfo"
+Cohesion: 0.40
+Nodes (8): publicProgramLinks(), publicProgramText(), publicProgramTextArray(), boundedPublicText(), publicFellowshipField(), publicFellowshipLinks(), redactDirectContactInfo(), publicHttpUrl()
 
-### Community 292 - "csrfOriginGuard.ts"
+### Community 287 - "applyResearchEntityDedupeMergeGroup"
 Cohesion: 0.31
-Nodes (6): csrfOriginGuard(), isTrustedUnsafeRequestOrigin(), originFromUrl(), SAFE_METHODS, allowedOrigins, ORIGINAL_ENV
+Nodes (10): applyDeleteModeArtifactPlan(), applyResearchEntityDedupeMergeGroup(), buildResearchEntityDedupeReferenceFilter(), chooseResearchEntityPiDedupeConflictAction(), collectionExists(), countRemainingDuplicateReferences(), loadArtifactsForDeleteMode(), relinkArrayReferences() (+2 more)
+
+### Community 288 - "researchAreasRoutes.test.ts"
+Cohesion: 0.29
+Nodes (4): router, invokeRouteHandler(), mocks, routesByPath()
+
+### Community 290 - "visibilityRepairQueueService.test.ts"
+Cohesion: 0.39
+Nodes (6): buildRepairQueueSummary(), buildVisibilityRepairPiMemberUpsert(), buildVisibilityRepairPlan(), buildVisibilityRepairPlans(), repairActionForStage(), runVisibilityRepairQueue()
+
+### Community 292 - "dedupeSameNameLeadMembers"
+Cohesion: 0.32
+Nodes (8): dedupeSameNameLeadMembers(), departmentMatchScore(), memberEvidenceScore(), normalizedMemberName(), normalizedWordsForMatch(), SAME_PERSON_LEAD_ROLE_PRIORITY, samePersonLeadRoleKey(), shouldCollapseSamePersonLeadRoles()
 
 ### Community 293 - "refreshGateScorecards.ts"
 Cohesion: 0.28
 Nodes (8): argValue(), Feeder, FeederResult, FEEDERS, __filenameLocal, runFeeder(), runGateRefresh(), SERVER_ROOT
+
+### Community 294 - "profileAreaDuplicateRisk.ts"
+Cohesion: 0.33
+Nodes (6): concreteEntityTypes, concreteKinds, individualEntityTypes, normalizedProfileAreaWords(), ProfileAreaDuplicateEntity, profileAreaShellNameMatchesPerson()
 
 ### Community 295 - "dedupeExploratoryContactPathways.ts"
 Cohesion: 0.30
@@ -3720,22 +3641,6 @@ Nodes (14): devDependencies, nodemon, ts-node, tsup, tsx, @types/cookie-session,
 Cohesion: 0.31
 Nodes (8): localPartIsSynthetic(), REAL_FIXTURE_PATTERNS, ROOT, SELF, SOURCE_ROOTS, SYNTHETIC_YALE_TOKENS, testFiles(), walk()
 
-### Community 303 - "main"
-Cohesion: 0.60
-Nodes (5): status(), blocked_reason(), fail(), is_blocked(), main()
-
-### Community 305 - "officialProfileObservationMatchesUser"
-Cohesion: 0.25
-Nodes (14): DEPARTMENT_IDENTITY_STOPWORDS, departmentIdentityTokens(), findUserDocByOfficialProfileObservations(), identityTokens(), isLikelyYaleEmailLocalPart(), normalizeIdentityText(), observationValueForField(), observedUserDepartmentLabels() (+6 more)
-
-### Community 307 - "corsOrigin.ts"
-Cohesion: 0.27
-Nodes (12): addPostMaterializationMetrics(), buildInferredPiMemberUpsert(), countListingBackedPostedOpportunitiesForRun(), departmentValuesForInferredPiLookup(), emptyPostMaterializationMetrics(), materializeFromRun(), materializeInferredPiMembership(), normalizeMaterializerObjectId() (+4 more)
-
-### Community 311 - "securityHeaders.ts"
-Cohesion: 0.27
-Nodes (11): buildContentSecurityPolicy(), CONNECT_SRC_ORIGINS, connectSrcDirective(), CONTENT_SECURITY_POLICY, IMG_SRC_ORIGINS, imgSrcDirective(), PERMISSIONS_POLICY, securityHeaders() (+3 more)
-
 ### Community 313 - "materializePaperObservationsFromRun"
 Cohesion: 0.35
 Nodes (13): findEntityDocByIdentifier(), findPaperForObservationGroup(), isArxivPaperKey(), isDoiPaperKey(), mapExistingPapers(), materializePaperAuthorEvidenceFromGroups(), materializePaperObservationsFromRun(), normalizeDoiForMaterialization() (+5 more)
@@ -3748,27 +3653,23 @@ Nodes (8): buildDir, buildEntrypoint, forbiddenBuildArtifacts, freshnessInputs, 
 Cohesion: 0.18
 Nodes (10): Author-Disambiguation Rules, Core Flows, Data-Quality Caveats, Not Optimizing For, Primary User Jobs, Product Thesis, Target User, Trust Constraints (+2 more)
 
-### Community 319 - "Priority Roadmap"
-Cohesion: 0.29
-Nodes (7): Active Priority Queue, Current Focus, How To Use, Operating Baseline, Priority Roadmap, Priority Scale, Verification Commands
+### Community 319 - "Research Data Pipeline"
+Cohesion: 0.13
+Nodes (14): Canonical Collections, Pipeline Shape, Promotion Invariants, Read-Only Control Plane, Research Data Pipeline, Retention Posture, Rollback Drill Expectations, Active Priority Queue (+6 more)
 
-### Community 327 - "adminFellowshipsTableReducer.ts"
-Cohesion: 0.20
-Nodes (16): publicProgramLinks(), publicProgramText(), publicProgramTextArray(), defaultRewriter(), cache, CourseTableCourse, fetchAllSeasonCourses(), fetchCourseTableData() (+8 more)
-
-### Community 328 - "importFaculty.ts"
-Cohesion: 0.31
-Nodes (9): cleanPrimaryDepartment(), cleanSecondaryDepartments(), hasPathPrefix(), importFaculty(), KNOWN_DEPARTMENTS, RawFacultyEntry, resolveSafeFacultyImportJsonPath(), SORTED_KNOWN_DEPTS (+1 more)
+### Community 327 - "courseTableService.ts"
+Cohesion: 0.32
+Nodes (11): cache, CourseTableCourse, fetchAllSeasonCourses(), fetchCourseTableData(), getRecentSeasonCodes(), normalizeCourseTableProfessorName(), normalizeCourseTableSeason(), publicCourseTableCourse() (+3 more)
 
 ### Community 331 - "AdminListingsTable.tsx"
-Cohesion: 0.14
-Nodes (14): AdminListing, AdminListingsTable(), PAGE_SIZES, SORT_OPTIONS, SortField, TABLE_COLUMNS, AdminListingsFilter, AdminListingsSortField (+6 more)
+Cohesion: 0.20
+Nodes (9): AdminListing, AdminListingsTable(), PAGE_SIZES, SORT_OPTIONS, SortField, TABLE_COLUMNS, adminListingsTableReducer(), createInitialAdminListingsTableState() (+1 more)
 
 ### Community 333 - "devDependencies"
 Cohesion: 0.17
 Nodes (12): devDependencies, eslint, eslint-config-prettier, eslint-plugin-react, eslint-plugin-react-hooks, globals, playwright, prettier (+4 more)
 
-### Community 334 - "refreshGateScorecards.ts"
+### Community 334 - "errorHandler.ts"
 Cohesion: 0.14
 Nodes (16): triggerReconnect(), AsyncRequestHandler, clientErrorStatus(), errorHandler(), notFoundHandler(), publicClientErrorMessage(), ORIGINAL_ENV, addFavorite() (+8 more)
 
@@ -3780,7 +3681,7 @@ Nodes (7): Available Scripts, Getting Started with Create React App, Learn More,
 Cohesion: 0.17
 Nodes (11): Auth and Security, Auth middleware, Authentication flow, Client, Environment variables, Error handling, Rate limits, Security middleware (+3 more)
 
-### Community 359 - "ResearchGroupMember"
+### Community 359 - "Local Development Setup"
 Cohesion: 0.18
 Nodes (11): 1. Fresh machine setup, 2. Install dependencies, 3. Configure environment, 4. Start local Meilisearch, 5. Seed Meilisearch, 6. Start dev servers, 7. Verify setup, Dev login bypass (+3 more)
 
@@ -3788,7 +3689,7 @@ Nodes (11): 1. Fresh machine setup, 2. Install dependencies, 3. Configure enviro
 Cohesion: 0.18
 Nodes (10): Architecture, Commands, Environments, External integrations, Key services, Naming conventions, Repo map, Routes (+2 more)
 
-### Community 365 - "backfillProgramOfficialSources.ts"
+### Community 365 - "Scraper Deployment Runbook"
 Cohesion: 0.20
 Nodes (10): Compact Observation Retention, Cost Controls, Data Flow, Goal, Operating Model, Recurring Refresh, Report Checklist, Rollback (+2 more)
 
@@ -3796,17 +3697,13 @@ Nodes (10): Compact Observation Retention, Cost Controls, Data Flow, Goal, Opera
 Cohesion: 0.31
 Nodes (8): cache, canonicalizeResearchArea(), CanonicalizeResult, loadCache(), normalize(), registerResearchAreaAlias(), ResearchAreaRow, tokenJaccard()
 
-### Community 367 - "Yale Research - Agent Guide"
-Cohesion: 0.25
-Nodes (8): Acknowledgements, Documentation, Playwright environment fix (no root required), Product Surfaces, Quick Start, Release Posture, Tech Stack, Yale Research
+### Community 367 - "Yale Research"
+Cohesion: 0.11
+Nodes (15): Core Rules, Default Task Loop, Implementation Rules, On-Demand Skills, Parallel Work, Yale Research - Agent Guide, Yale Research, Acknowledgements (+7 more)
 
 ### Community 368 - "resolutions"
-Cohesion: 0.22
-Nodes (9): resolutions, axios, form-data, path-to-regexp, shell-quote, underscore, undici, uuid (+1 more)
-
-### Community 369 - "copyBetaToProd.ts"
-Cohesion: 0.27
-Nodes (10): authorshipEvidenceFromPaperObservations(), isPaperAuthorshipEvidence(), isPaperAuthorshipSource(), isPaperMetadataOnlySource(), normalizePaperAuthorshipEvidence(), PAPER_AUTHORSHIP_METHODS, PAPER_AUTHORSHIP_SOURCE_NAMES, PAPER_METADATA_ONLY_SOURCE_NAMES (+2 more)
+Cohesion: 0.20
+Nodes (10): resolutions, axios, brace-expansion, form-data, path-to-regexp, shell-quote, underscore, undici (+2 more)
 
 ### Community 370 - "parseStaleObservationConflictReviewArgs"
 Cohesion: 0.47
@@ -3832,13 +3729,9 @@ Nodes (7): background_color, display, icons, name, short_name, start_url, theme_
 Cohesion: 0.25
 Nodes (7): author, license, main, name, packageManager, repository, version
 
-### Community 383 - "itemOperations.ts"
-Cohesion: 0.29
-Nodes (7): Canonical Collections, Pipeline Shape, Promotion Invariants, Read-Only Control Plane, Research Data Pipeline, Retention Posture, Rollback Drill Expectations
-
-### Community 384 - "Finishing work"
-Cohesion: 0.25
-Nodes (7): Finishing work, Fold durable changes into docs, Refresh Graphify, Review the final diff, Rule evolution, Task roadmap, Verify
+### Community 384 - "agent-workflow.md"
+Cohesion: 0.10
+Nodes (15): Agent Workflow, Durable Notes, Read Order, Skill Index, Finishing work, Fold durable changes into docs, Refresh Graphify, Review the final diff (+7 more)
 
 ### Community 393 - "check-no-secrets-core.mjs"
 Cohesion: 0.43
@@ -3872,37 +3765,33 @@ Nodes (4): load_env(), main(), normalize(), Lowercase, strip whitespace and punc
 Cohesion: 0.50
 Nodes (5): asString(), asStringArray(), normalizeStaleObservationReviewDecision(), optionalString(), readStaleObservationReviewDecisions()
 
-### Community 430 - "Product Model"
-Cohesion: 0.17
-Nodes (5): Yale Research, Agent Workflow, Durable Notes, Read Order, Skill Index
-
 ### Community 445 - "with-playwright-libs.sh"
 Cohesion: 0.67
 Nodes (3): install_libs(), LD_LIBRARY_PATH, with-playwright-libs.sh script
 
-### Community 446 - "researchEntityRelationship.ts"
-Cohesion: 0.06
-Nodes (51): AccessSignal, accessSignalSchema, ContactRoute, contactRouteSchema, categoryColorKeys, Department, DepartmentCodeSystem, departmentSchema (+43 more)
+### Community 446 - "researchAccessTypes.ts"
+Cohesion: 0.09
+Nodes (33): AccessSignal, accessSignalSchema, ContactRoute, contactRouteSchema, EntryPathway, entryPathwaySchema, grantSchema, fieldProvenanceSchema (+25 more)
 
 ## Knowledge Gaps
-- **4549 isolated node(s):** `name`, `version`, `private`, `node`, `@emotion/react` (+4544 more)
+- **4483 isolated node(s):** `name`, `version`, `private`, `node`, `@emotion/react` (+4478 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **2459 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **2353 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `sanitizeLogValue()` connect `sanitizeLogValue` to `departmentRosterScraper.ts`, `assertScriptApplyAllowed`, `labMicrositeUndergradLLMExtractor.ts`, `entityMaterializer.ts`, `labMicrositeDescriptionLLMExtractor.ts`, `integrityGate.ts`, `passport.ts`, `undergradFellowshipRecipientScraper.ts`, `duplicateEntityNameReview.ts`, `dedupeResearchEntitiesByPi.ts`, `admin.ts`, `launchAcquisitionReportService.ts`, `profileDataQualityAudit.ts`, `centersInstitutesScraper.ts`, `nihReporterScraper.ts`, `ScraperContext`, `userService.ts`, `serializedDocumentId`, `researchEntityCoverageAudit.ts`, `sourceHealth.ts`, `research.tsx`, `ScrapeRun`, `listingService.ts`, `runReport.ts`, `redactDirectContactInfo`, `staleObservationConflictReview.ts`, `betaDataQuality.ts`, `listingController.ts`, `analyticsService.ts`, `entryPathwayService.ts`, `yaleCollegeFellowshipsOfficeScraper.ts`, `repairOfficialProfilePublicationPointers.ts`, `OfficialProfilePublicationValue`, `postedOpportunityService.ts`, `profileController.ts`, `openAlexPaperScraper.ts`, `errorHandler.ts`, `researchEntityMemberReferenceAudit.ts`, `promoteAcceptedBetaCopy.ts`, `paperAuthorshipAudit.ts`, `Observation`, `dependencies`, `studentDecisionLLMExtractor.ts`, `backfillProfileBiosFromOfficialUrls.ts`, `resolveSafeJsonReportOutputPath`, `assertPublicHttpUrl`, `officialProfilePiBackfillScraper.ts`, `repairArchivedEntityArtifacts.ts`, `centerDirectorLLMExtractor.ts`, `pathwayQualityAudit.ts`, `researchEntitySearchIndexService.ts`, `Adding a New Endpoint`, `buildAdminOperatorBoard`, `launchReviewExceptions.ts`, `Current Execution Plan`, `File Structure`, `dedupeUsersByIdentity.ts`, `officialProfilePiBackfillScraper.test.ts`, `applicationRoutePathwayBackfillCore.ts`, `fellowshipController.ts`, `department.ts`, `profileBioCoverageAudit.ts`, `crossSourceObservationConflictReview.ts`, `migrateResearchEntities.ts`, `researchQualitySearchReview.ts`, `migrateResearchEntityCollections.ts`, `researchGroupController.ts`, `GStack Production Promotion Iteration Implementation Plan`, `disambiguateSurnameLabNames.ts`, `repairDuplicateAccessSignals.ts`, `programController.ts`, `repairMismatchedPersonEmailsCore.ts`, `betaReadinessGate.ts`, `studentVisibilityRepairTargets.ts`, `cleanupLegacyMongoCollections.ts`, `seedSources.ts`, `researchAreas.ts`, `migrateMongoNaming.ts`, `listings.ts`, `3. Configure environment`, `userEmailHygiene.ts`, `departmentUndergradResearchScraper.ts`, `Adding Things`, `meiliSyncService.ts`, `repairProfileDescriptionBackfillConflicts.ts`, `clearBetaStudentAnalytics.ts`, `scraperIntegrityDuplicateReview.ts`, `departmentLeadRepairPlanCore.ts`, `auditResearchEntityRename.ts`, `betaRepairQueue.ts`, `1. Fresh machine setup`, `paperQualityService.ts`, `pathwayRelevanceReview.ts`, `programs.ts`, `scriptWriteGuards.ts`, `adminTableReducer.test.ts`, `backfillResearchHomeOfficialUrls.ts`, `seed.ts`, `users.ts`, `repairListingResearchEntityProfiles.ts`, `index.ts`, `refreshGateScorecards.ts`, `dedupeExploratoryContactPathways.ts`, `corsOrigin.ts`, `materializePaperObservationsFromRun`, `adminFellowshipsTableReducer.ts`, `importFaculty.ts`, `refreshGateScorecards.ts`?**
-  _High betweenness centrality (0.067) - this node is a cross-community bridge._
-- **Why does `ResearchGroup` connect `researchEntityBrowseRankService.ts` to `browsable.ts`, `index.ts`, `ImportRootDataFiles.ts`, `2. Install dependencies`, `v4MigrationUtils.ts`?**
-  _High betweenness centrality (0.051) - this node is a cross-community bridge._
-- **Why does `member()` connect `Adding a New Endpoint` to `labDetail.tsx`, `centersInstitutesScraper.ts`, `departmentRosterScraper.ts`, `index.ts`, `disambiguateSurnameLabNames.ts`, `research-detail-professor-audit.mjs`, `AdminFacultyProfilesTable.tsx`, `ImportRootDataFiles.ts`, `researchGroupService.ts`, `profileBioCoverageAudit.ts`, `v4MigrationUtils.ts`, `studentVisibilityTier.ts`, `researchQualitySearchReview.ts`?**
-  _High betweenness centrality (0.038) - this node is a cross-community bridge._
+- **Why does `sanitizeLogValue()` connect `sanitizeLogValue` to `departmentRosterScraper.ts`, `logSanitizer.ts`, `labMicrositeUndergradLLMExtractor.ts`, `entityMaterializer.ts`, `labMicrositeDescriptionLLMExtractor.ts`, `passport.ts`, `undergradFellowshipRecipientScraper.ts`, `duplicateEntityNameReview.ts`, `dedupeResearchEntitiesByPi.ts`, `admin.ts`, `profileDataQualityAudit.ts`, `centersInstitutesScraper.ts`, `nihReporterScraper.ts`, `User`, `userService.ts`, `serializedDocumentId`, `researchEntityCoverageAudit.ts`, `sourceHealth.ts`, `repairOfficialProfilePublicationPointers.ts`, `officialProfilePiBackfillScraper.test.ts`, `listingService.ts`, `runReport.ts`, `opportunityDetailService.ts`, `staleObservationConflictReview.ts`, `betaDataQuality.ts`, `listingController.ts`, `analyticsService.ts`, `entryPathwayService.ts`, `yaleCollegeFellowshipsOfficeScraper.ts`, `nsfAwardScraper.ts`, `scholarlyLinkSuppressionAudit.ts`, `postedOpportunityService.ts`, `profileController.ts`, `analytics.ts`, `openAlexPaperScraper.ts`, `types.ts`, `ResearchGroupMember`, `promoteAcceptedBetaCopy.ts`, `paperAuthorshipAudit.ts`, `Observation`, `assertPublicHttpUrl`, `studentDecisionLLMExtractor.ts`, `backfillProfileBiosFromOfficialUrls.ts`, `rebuildPathwaySearchIndex.ts`, `claimGate.ts`, `ScraperContext`, `officialProfilePiBackfillScraper.ts`, `repairArchivedEntityArtifacts.ts`, `betaRepairQueue.ts`, `materializeEntity`, `pathwayQualityAudit.ts`, `cronRunner.ts`, `backfillResearchHomeOfficialUrls.ts`, `arxivPreprintScraper.ts`, `launchReviewExceptions.ts`, `acceptedInputs.ts`, `dedupeUsersByIdentity.ts`, `fellowshipController.ts`, `applicationRoutePathwayBackfillCore.ts`, `assertScriptApplyAllowed`, `centerDirectorLLMExtractor.ts`, `crossSourceObservationConflictReview.ts`, `migrateResearchEntities.ts`, `researchQualitySearchReview.ts`, `migrateResearchEntityCollections.ts`, `researchGroupController.ts`, `disambiguateSurnameLabNames.ts`, `repairDuplicateAccessSignals.ts`, `profileBioCoverageAudit.ts`, `programController.ts`, `repairMismatchedPersonEmailsCore.ts`, `betaReadinessGate.ts`, `studentVisibilityRepairTargets.ts`, `cleanupLegacyMongoCollections.ts`, `seedSources.ts`, `configService.ts`, `backfillCenterDirectors.ts`, `migrateMongoNaming.ts`, `launchTrustContract.ts`, `resolveSafeJsonReportOutputPath`, `userEmailHygiene.ts`, `orcidWorksScraper.ts`, `repairListingResearchEntityProfiles.ts`, `meiliSyncService.ts`, `index.ts`, `repairProfileDescriptionBackfillConflicts.ts`, `clearBetaStudentAnalytics.ts`, `scraperIntegrityDuplicateReview.ts`, `auditResearchEntityRename.ts`, `backfillPostedOpportunitiesFromListings.ts`, `paperQualityService.ts`, `pathwayRelevanceReview.ts`, `scraperIntegrityGate.ts`, `programs.ts`, `cli.ts`, `listings.ts`, `researchEntity.ts`, `seed.ts`, `users.ts`, `launchAcquisitionReport.ts`, `index.ts`, `refreshGateScorecards.ts`, `dedupeExploratoryContactPathways.ts`, `materializePaperObservationsFromRun`, `courseTableService.ts`, `errorHandler.ts`?**
+  _High betweenness centrality (0.082) - this node is a cross-community bridge._
+- **Why does `field()` connect `dedupeUsersByIdentity.ts` to `arxivPreprintScraper.ts`, `logSanitizer.ts`, `adminFellowshipsTableReducer.ts`, `ImportRootDataFiles.ts`, `safeHttpUrl`, `labMicrositeUndergradLLMExtractor.ts`, `textValue`, `integrityGate.ts`, `crossSourceObservationConflictReview.ts`, `index.ts`, `normalizePublicProfile`, `User`, `sourceHealth.ts`, `fellowshipService.ts`, `runReport.ts`, `betaDataQuality.ts`, `analyticsService.ts`, `acceptedInputsCore.ts`, `entryPathwayService.ts`, `workPlanner.ts`, `orcidWorksScraper.ts`, `AdminListingsTable.tsx`, `openAlexPaperScraper.ts`, `AdminFacultyProfilesTable.tsx`, `scraperIntegrityDuplicateReview.ts`, `promoteAcceptedBetaCopy.ts`, `ScraperContext`, `confidenceResolver.ts`, `materializeEntity`, `buildStaleObservationConflictSummary`, `visibilityRepairQueueService.ts`?**
+  _High betweenness centrality (0.045) - this node is a cross-community bridge._
+- **Why does `ResearchGroup` connect `researchGroup.ts` to `labDetailReducer.test.ts`, `browsable.ts`, `labDetail.ts`, `ImportRootDataFiles.ts`, `BackfillV4FacultyMembers.ts`?**
+  _High betweenness centrality (0.034) - this node is a cross-community bridge._
 - **What connects `name`, `version`, `private` to the rest of the system?**
-  _4554 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _4487 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Decisions` be split into smaller, more focused modules?**
   _Cohesion score 0.10526315789473684 - nodes in this community are weakly interconnected._
 - **Should `labDetail.tsx` be split into smaller, more focused modules?**
-  _Cohesion score 0.05927405927405927 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.0734006734006734 - nodes in this community are weakly interconnected._
 - **Should `browsable.ts` be split into smaller, more focused modules?**
-  _Cohesion score 0.058747160012982795 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.0531883632089333 - nodes in this community are weakly interconnected._

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
 # Graph Report - 01KXHSYGY3GN42EV0VQTHKNYWY  (2026-07-14)
 
 ## Corpus Check
-- 823 files · ~1,303,991 words
+- 823 files · ~1,304,249 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 11155 nodes · 21227 edges · 3161 communities (915 shown, 2246 thin omitted)
+- 11114 nodes · 21227 edges · 3119 communities (914 shown, 2205 thin omitted)
 - Extraction: 98% EXTRACTED · 2% INFERRED · 0% AMBIGUOUS · INFERRED: 451 edges (avg confidence: 0.62)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `358d7fc2`
+- Built from commit: `7181d031`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -212,7 +212,6 @@
 - [[_COMMUNITY_orcidWorksScraper.ts|orcidWorksScraper.ts]]
 - [[_COMMUNITY_repairListingResearchEntityProfiles.ts|repairListingResearchEntityProfiles.ts]]
 - [[_COMMUNITY_researchGroupFilters.ts|researchGroupFilters.ts]]
-- [[_COMMUNITY_Adding Things|Adding Things]]
 - [[_COMMUNITY_AdminFacultyProfilesTable.tsx|AdminFacultyProfilesTable.tsx]]
 - [[_COMMUNITY_meiliSyncService.ts|meiliSyncService.ts]]
 - [[_COMMUNITY_AdminOperatorBoard|AdminOperatorBoard]]
@@ -318,7 +317,6 @@
 - [[_COMMUNITY_searchRoute|searchRoute]]
 - [[_COMMUNITY_chain|chain]]
 - [[_COMMUNITY_codetxt (Source metadata)|code:txt (Source metadata)]]
-- [[_COMMUNITY_Acknowledgements|Acknowledgements]]
 - [[_COMMUNITY_Available Scripts|Available Scripts]]
 - [[_COMMUNITY_Auth and Security|Auth and Security]]
 - [[_COMMUNITY_Local Development Setup|Local Development Setup]]
@@ -343,7 +341,6 @@
 - [[_COMMUNITY_useDebouncedLocalStorage.test.tsx|useDebouncedLocalStorage.test.tsx]]
 - [[_COMMUNITY_check-no-secrets-core.mjs|check-no-secrets-core.mjs]]
 - [[_COMMUNITY_codebash (SCRAPER_ENV=beta yarn --cwd server betadata-quality --inclu)|code:bash (SCRAPER_ENV=beta yarn --cwd server beta:data-quality --inclu)]]
-- [[_COMMUNITY_1. Fresh machine setup|1. Fresh machine setup]]
 - [[_COMMUNITY_runStaleObservationConflictReview|runStaleObservationConflictReview]]
 - [[_COMMUNITY_Graphify repo memory|Graphify repo memory]]
 - [[_COMMUNITY_dataMigrationV4DeprecatedBackfills.test.ts|dataMigrationV4DeprecatedBackfills.test.ts]]
@@ -351,7 +348,6 @@
 - [[_COMMUNITY_yaliesService.test.ts|yaliesService.test.ts]]
 - [[_COMMUNITY_vite-env.d.ts|vite-env.d.ts]]
 - [[_COMMUNITY_Contributing endpoints, pages, schema|Contributing: endpoints, pages, schema]]
-- [[_COMMUNITY_Adding Things|Adding Things]]
 - [[_COMMUNITY_Scrapers|Scrapers]]
 - [[_COMMUNITY_Search and Data|Search and Data]]
 - [[_COMMUNITY_dataMigrationV4IdentityBackfills.test.ts|dataMigrationV4IdentityBackfills.test.ts]]
@@ -360,8 +356,6 @@
 - [[_COMMUNITY_15. M10 Final Migration Rollout And Cleanup|15. M10 Final Migration Rollout And Cleanup]]
 - [[_COMMUNITY_checker.py|checker.py]]
 - [[_COMMUNITY_normalizeStaleObservationReviewDecision|normalizeStaleObservationReviewDecision]]
-- [[_COMMUNITY_3. Configure environment|3. Configure environment]]
-- [[_COMMUNITY_4. Start local Meilisearch|4. Start local Meilisearch]]
 - [[_COMMUNITY_{ hasExpectedEntityName }|{ hasExpectedEntityName }]]
 - [[_COMMUNITY_postcss.config.js|postcss.config.js]]
 - [[_COMMUNITY_with-playwright-libs.sh|with-playwright-libs.sh]]
@@ -940,51 +934,36 @@
 - [[_COMMUNITY_codebash (nvm install 20)|code:bash (nvm install 20)]]
 - [[_COMMUNITY_codebash (yarn installall)|code:bash (yarn install:all)]]
 - [[_COMMUNITY_codebash (docker pull getmeilimeilisearchlatest)|code:bash (docker pull getmeili/meilisearch:latest)]]
-- [[_COMMUNITY_Environments|Environments]]
 - [[_COMMUNITY_Migration Scripts|Migration Scripts]]
-- [[_COMMUNITY_Modifying a Schema|Modifying a Schema]]
 - [[_COMMUNITY_Product Surfaces|Product Surfaces]]
 - [[_COMMUNITY_Database|Database]]
 - [[_COMMUNITY_Graphify Repo Memory|Graphify Repo Memory]]
 - [[_COMMUNITY_Validation Middleware|Validation Middleware]]
-- [[_COMMUNITY_CI|CI]]
 - [[_COMMUNITY_codebash (curl httplocalhost7700health)|code:bash (curl http://localhost:7700/health)]]
 - [[_COMMUNITY_codebash (curl httplocalhost7700health)|code:bash (curl http://localhost:7700/health)]]
 - [[_COMMUNITY_codetxt (Usage Error Couldn't find the node_modules state file - run)|code:txt (Usage Error: Couldn't find the node_modules state file - run)]]
 - [[_COMMUNITY_codebash (sudo apt update)|code:bash (sudo apt update)]]
 - [[_COMMUNITY_codebash (nvm install 20)|code:bash (nvm install 20)]]
 - [[_COMMUNITY_codebash (cp server.env.example server.env)|code:bash (cp server/.env.example server/.env)]]
-- [[_COMMUNITY_Running tests|Running tests]]
-- [[_COMMUNITY_Testing|Testing]]
 - [[_COMMUNITY_Done Criteria|Done Criteria]]
-- [[_COMMUNITY_Parallel Work|Parallel Work]]
 - [[_COMMUNITY_Authentication Flow|Authentication Flow]]
 - [[_COMMUNITY_CI|CI]]
 - [[_COMMUNITY_codeblock1 (React (Vite) → Express (Passport.js) → MongoDB Atlas + Meili)|code:block1 (React (Vite) → Express (Passport.js) → MongoDB Atlas + Meili)]]
 - [[_COMMUNITY_Known Technical Debt|Known Technical Debt]]
 - [[_COMMUNITY_YLabs Codebase Reference|Y/Labs Codebase Reference]]
-- [[_COMMUNITY_6. Start dev servers|6. Start dev servers]]
-- [[_COMMUNITY_7. Verify setup|7. Verify setup]]
 - [[_COMMUNITY_codebash (nvm install 20)|code:bash (nvm install 20)]]
 - [[_COMMUNITY_codebash (yarn install)|code:bash (yarn install)]]
 - [[_COMMUNITY_codebash (npx ts-node --transpile-only script.ts)|code:bash (npx ts-node --transpile-only <script>.ts)]]
 - [[_COMMUNITY_codebash (nvm install 20)|code:bash (nvm install 20)]]
-- [[_COMMUNITY_What Is This|What Is This?]]
 - [[_COMMUNITY_YURA Research Database|YURA Research Database]]
 - [[_COMMUNITY_Auth Middleware|Auth Middleware]]
 - [[_COMMUNITY_Commands|Commands]]
 - [[_COMMUNITY_Rate Limiting|Rate Limiting]]
 - [[_COMMUNITY_Sensitive Files|Sensitive Files]]
-- [[_COMMUNITY_codebash (curl httplocalhost7700health)|code:bash (curl http://localhost:7700/health)]]
 - [[_COMMUNITY_codebash (nvm install 20)|code:bash (nvm install 20)]]
 - [[_COMMUNITY_codeblock19 (ylabs)|code:block19 (ylabs/)]]
-- [[_COMMUNITY_Local Development Setup|Local Development Setup]]
-- [[_COMMUNITY_Tech Stack|Tech Stack]]
-- [[_COMMUNITY_What is tested|What is tested]]
-- [[_COMMUNITY_Quick Start|Quick Start]]
 - [[_COMMUNITY_Core Modeling Direction|Core Modeling Direction]]
 - [[_COMMUNITY_Current Stack|Current Stack]]
-- [[_COMMUNITY_Default Task Loop|Default Task Loop]]
 - [[_COMMUNITY_graphify|graphify]]
 - [[_COMMUNITY_Rule Evolution|Rule Evolution]]
 - [[_COMMUNITY_Architecture|Architecture]]
@@ -997,12 +976,7 @@
 - [[_COMMUNITY_codebash (nvm install 20)|code:bash (nvm install 20)]]
 - [[_COMMUNITY_codebash (corepack enable)|code:bash (corepack enable)]]
 - [[_COMMUNITY_codebash ( client.env)|code:bash (# client/.env)]]
-- [[_COMMUNITY_Common Commands|Common Commands]]
-- [[_COMMUNITY_New Page|New Page]]
-- [[_COMMUNITY_Prerequisites|Prerequisites]]
 - [[_COMMUNITY_codebash (yarn playwrightrun screenshot httpsexample.com tmpexam)|code:bash (yarn playwright:run screenshot https://example.com /tmp/exam)]]
-- [[_COMMUNITY_Tech Stack|Tech Stack]]
-- [[_COMMUNITY_Implementation Rules|Implementation Rules]]
 - [[_COMMUNITY_Product North Star|Product North Star]]
 - [[_COMMUNITY_Adding a New Page|Adding a New Page]]
 - [[_COMMUNITY_`client.env`|`client/.env`]]
@@ -1011,8 +985,6 @@
 - [[_COMMUNITY_codebash (nvm install 20)|code:bash (nvm install 20)]]
 - [[_COMMUNITY_codeblock20 (User → Yale CAS SSO → passport.ts findOrCreateUser)|code:block20 (User → Yale CAS SSO → passport.ts findOrCreateUser)]]
 - [[_COMMUNITY_codebash (curl -o- httpsraw.githubusercontent.comnvm-shnvmmaster)|code:bash (curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master)]]
-- [[_COMMUNITY_New API Endpoint|New API Endpoint]]
-- [[_COMMUNITY_Documentation|Documentation]]
 - [[_COMMUNITY_Graphify Repo Memory|Graphify Repo Memory]]
 - [[_COMMUNITY_Analytics Interception|Analytics Interception]]
 - [[_COMMUNITY_codeblock2 (yale-research)|code:block2 (yale-research/)]]
@@ -1021,18 +993,13 @@
 - [[_COMMUNITY_Security Middleware|Security Middleware]]
 - [[_COMMUNITY_`server.env`|`server/.env`]]
 - [[_COMMUNITY_Yale Research Codebase Reference|Yale Research Codebase Reference]]
-- [[_COMMUNITY_API Routes|API Routes]]
-- [[_COMMUNITY_Architecture|Architecture]]
 - [[_COMMUNITY_codebash (curl httplocalhost7700health)|code:bash (curl http://localhost:7700/health)]]
 - [[_COMMUNITY_codebash (which node)|code:bash (which node)]]
 - [[_COMMUNITY_codeblock20 (yale-research)|code:block20 (yale-research/)]]
-- [[_COMMUNITY_codebash (nvm install 20)|code:bash (nvm install 20)]]
-- [[_COMMUNITY_Dev login bypass|Dev login bypass]]
 - [[_COMMUNITY_Operator board Gate Status — keeping it honest and current|Operator board Gate Status — keeping it honest and current]]
 - [[_COMMUNITY_YLabs — Developer Guide|Y/Labs — Developer Guide]]
 - [[_COMMUNITY_codebash (corepack enable)|code:bash (corepack enable)]]
 - [[_COMMUNITY_codebash (codex mcp add playwright -- reposcriptswith-playwright-l)|code:bash (codex mcp add playwright -- <repo>/scripts/with-playwright-l)]]
-- [[_COMMUNITY_Playwright environment fix (no root required)|Playwright environment fix (no root required)]]
 - [[_COMMUNITY_summary|summary]]
 - [[_COMMUNITY_acceptedInputsCoreSource|acceptedInputsCoreSource]]
 - [[_COMMUNITY_acceptedInputsSource|acceptedInputsSource]]
@@ -2510,10 +2477,8 @@
 - [[_COMMUNITY_TypeScript Configuration|TypeScript Configuration]]
 - [[_COMMUNITY_1. Install dependencies|1. Install dependencies]]
 - [[_COMMUNITY_2. Configure environment|2. Configure environment]]
-- [[_COMMUNITY_2. Install dependencies|2. Install dependencies]]
 - [[_COMMUNITY_3. Start local Meilisearch|3. Start local Meilisearch]]
 - [[_COMMUNITY_4. Seed Meilisearch|4. Seed Meilisearch]]
-- [[_COMMUNITY_5. Seed Meilisearch|5. Seed Meilisearch]]
 - [[_COMMUNITY_5. Start dev servers|5. Start dev servers]]
 - [[_COMMUNITY_codebash (curl httplocalhost7700health)|code:bash (curl http://localhost:7700/health)]]
 - [[_COMMUNITY_codebash (yarn --cwd server meilirebuild-all --clear)|code:bash (yarn --cwd server meili:rebuild-all --clear)]]
@@ -2522,21 +2487,14 @@
 - [[_COMMUNITY_codebash (yarn scrape help)|code:bash (yarn scrape help)]]
 - [[_COMMUNITY_codeblock21 (User → Yale CAS SSO → passport.ts findOrCreateUser)|code:block21 (User → Yale CAS SSO → passport.ts findOrCreateUser)]]
 - [[_COMMUNITY_codebash (yarn --cwd client test         watch mode — reruns on file )|code:bash (yarn --cwd client test        # watch mode — reruns on file )]]
-- [[_COMMUNITY_Search|Search]]
-- [[_COMMUNITY_Troubleshooting|Troubleshooting]]
 - [[_COMMUNITY_Yale Research — Developer Guide|Yale Research — Developer Guide]]
-- [[_COMMUNITY_Legacy CSV-to-JSON update script retired.  Department ground truth no longer com|Legacy CSV-to-JSON update script retired.  Department ground truth no longer com]]
 - [[_COMMUNITY_Documentation Maintenance|Documentation Maintenance]]
 - [[_COMMUNITY_codetypescript (export const asyncHandler = (fn Function) = {)|code:typescript (export const asyncHandler = (fn: Function) => {)]]
 - [[_COMMUNITY_codeblock5 (User → Yale CAS SSO → passport.ts findOrCreateUser)|code:block5 (User → Yale CAS SSO → passport.ts findOrCreateUser)]]
 - [[_COMMUNITY_Search|Search]]
-- [[_COMMUNITY_Auth Middleware (`serversrcmiddlewareauth.ts`)|Auth Middleware (`server/src/middleware/auth.ts`)]]
-- [[_COMMUNITY_Authentication|Authentication]]
 - [[_COMMUNITY_codebash (curl httplocalhost7700health)|code:bash (curl http://localhost:7700/health)]]
 - [[_COMMUNITY_codebash (nvm install 20)|code:bash (nvm install 20)]]
 - [[_COMMUNITY_codebash (nvm install 20)|code:bash (nvm install 20)]]
-- [[_COMMUNITY_Project Structure|Project Structure]]
-- [[_COMMUNITY_Troubleshooting Yarn setup|Troubleshooting Yarn setup]]
 - [[_COMMUNITY_codebash ( Terminal 1)|code:bash (# Terminal 1)]]
 
 ## God Nodes (most connected - your core abstractions)
@@ -2566,7 +2524,7 @@
 ## Import Cycles
 - None detected.
 
-## Communities (3161 total, 2246 thin omitted)
+## Communities (3119 total, 2205 thin omitted)
 
 ### Community 0 - "Decisions"
 Cohesion: 0.11
@@ -2577,8 +2535,8 @@ Cohesion: 0.07
 Nodes (48): adminQualityNotes(), AffiliatedResearchEntitiesSection(), compactDepartmentLabels(), decisionNextStep(), DecisionSummary(), dedupeLeadMembers(), detailDescription(), detailTopics() (+40 more)
 
 ### Community 2 - "browsable.ts"
-Cohesion: 0.06
-Nodes (47): ArchivedBadge(), BrowseCard, BrowseCardProps, BrowseGrid(), BrowseGridProps, BrowseListItem, BrowseListItemProps, FavoriteButton (+39 more)
+Cohesion: 0.05
+Nodes (59): FellowshipModal(), FellowshipModalProps, RichText(), trackFellowshipApplyClick(), ArchivedBadge(), BrowseCard, BrowseCardProps, BrowseGrid() (+51 more)
 
 ### Community 3 - "security-preflight.test.mjs"
 Cohesion: 0.29
@@ -2605,8 +2563,8 @@ Cohesion: 0.21
 Nodes (9): AdminFellowshipsTable(), AdminFellowshipsFilter, AdminFellowshipsSortField, AdminFellowshipsTableAction, adminFellowshipsTableReducer(), AdminFellowshipsTableState, createInitialAdminFellowshipsTableState(), createInitialAdminTableState() (+1 more)
 
 ### Community 9 - "cleanPublicProfileBio"
-Cohesion: 0.07
-Nodes (60): ADMIN_UPDATE_FIELDS, ALLOWED_SELF_UPDATE_FIELDS, appointmentTitleCount(), boundedProfileUrlKey(), boundedPublicationNumber(), boundedPublicationText(), boundedPublicProfileUrl(), capitalizeSentenceStart() (+52 more)
+Cohesion: 0.12
+Nodes (24): appointmentTitleCount(), cleanPublicProfileBio(), clipPublicProfileBio(), degreeTokenCount(), hasPublicProfileEmail(), hasResearchDescriptionVerb(), isAffiliationOnlyResearchSummary(), isAppointmentListOnlyProfileBio() (+16 more)
 
 ### Community 10 - "labMicrositeUndergradLLMExtractor.ts"
 Cohesion: 0.09
@@ -2649,8 +2607,8 @@ Cohesion: 0.07
 Nodes (49): authConfig, authDebug(), AuthenticatedSessionUser, buildDirectoryUpdate(), casLogin(), DEV_LOGIN_PROFILES, ensureDevLoginUser(), findOrCreateUser() (+41 more)
 
 ### Community 21 - "Navbar.tsx"
-Cohesion: 0.04
-Nodes (36): AboutButton(), AnalyticsButton(), FeedbackButton(), getAcademicDisciplineColor(), getResearchAreaChipColor(), listingQuickFilters, Navbar(), NavbarSearchBar() (+28 more)
+Cohesion: 0.05
+Nodes (32): AboutButton(), AnalyticsButton(), FeedbackButton(), getAcademicDisciplineColor(), getResearchAreaChipColor(), listingQuickFilters, Navbar(), NavbarSearchBar() (+24 more)
 
 ### Community 22 - "undergradFellowshipRecipientScraper.ts"
 Cohesion: 0.10
@@ -2710,7 +2668,7 @@ Nodes (51): actionRepairReasons, applyStudentVisibilityGatePlans(), buildNameOnl
 
 ### Community 38 - "User"
 Cohesion: 0.05
-Nodes (43): normalizeUserType(), publicationSchema, User, userSchema, ProfileBackedFacultyResearchAreaMemberDeps, ScraperOrchestrator, ArxivPreprintScraper, ArxivPreprintScraperOptions (+35 more)
+Nodes (46): normalizeUserType(), publicationSchema, User, userSchema, ProfileBackedFacultyResearchAreaMemberDeps, ScraperOrchestrator, arxivEntryToObservations(), ArxivFetcher (+38 more)
 
 ### Community 39 - "userService.ts"
 Cohesion: 0.08
@@ -2733,8 +2691,8 @@ Cohesion: 0.13
 Nodes (29): aggregateCountMap(), AuditEntityRecord, buildBulkAudit(), buildObservationFlags(), buildResearchEntityCoverageAuditOutput(), buildSlugAudit(), countMap(), __dirname (+21 more)
 
 ### Community 44 - "axios.ts"
-Cohesion: 0.05
-Nodes (42): mockedAxios, mockedAxios, HttpStatusNotifier(), CourseTableCourse, CourseTableSection(), CourseTableSectionProps, formatSeason(), ProfileListingsProps (+34 more)
+Cohesion: 0.07
+Nodes (27): mockedAxios, mockedAxios, HttpStatusNotifier(), CourseTableCourse, CourseTableSection(), CourseTableSectionProps, formatSeason(), ProfileListingsProps (+19 more)
 
 ### Community 45 - "sourceHealth.ts"
 Cohesion: 0.06
@@ -2749,8 +2707,8 @@ Cohesion: 0.15
 Nodes (24): buildResearchGroupMemberUpsert(), centerRelationshipTypeForResolvedTarget(), findExistingResearchEntityByFacultyResearchAreaIdentity(), findUniqueUserForResearchGroupMember(), findUniqueUserIdByPersonName(), idValue(), isFacultyResearchAreaKey(), latestObservationDate() (+16 more)
 
 ### Community 48 - "officialProfilePiBackfillScraper.test.ts"
-Cohesion: 0.12
-Nodes (38): annotateEntitiesWithLeadUsers(), annotateEntitiesWithSourceObservationUrls(), annotateProfileDescriptionPreferredSourceEvidence(), entityLeadDirectWebsiteToObservations(), entityResearchHomeToObservations(), firstNonDuplicateLeadDirectWebsiteUrl(), identityToResearchEntityDescriptionObservations(), identityToResearchEntityPiKeyObservations() (+30 more)
+Cohesion: 0.13
+Nodes (37): annotateEntitiesWithLeadUsers(), annotateEntitiesWithSourceObservationUrls(), annotateProfileDescriptionPreferredSourceEvidence(), entityLeadDirectWebsiteToObservations(), entityResearchHomeToObservations(), firstNonDuplicateLeadDirectWebsiteUrl(), identityToResearchEntityDescriptionObservations(), identityToResearchEntityPiKeyObservations() (+29 more)
 
 ### Community 49 - "listingService.ts"
 Cohesion: 0.10
@@ -2785,8 +2743,8 @@ Cohesion: 0.11
 Nodes (27): getOpportunityById(), normalizeOpportunityIdParam(), mocks, compactStrings(), evidenceExcerpt(), firstEvidenceText(), getOpportunityApplicationLabel(), getOpportunityApplicationState() (+19 more)
 
 ### Community 57 - "staleObservationConflictReview.ts"
-Cohesion: 0.08
-Nodes (25): ACCESS_EVIDENCE_CONFLICT_FIELDS, ADDITIVE_METADATA_CONFLICT_FIELDS, AggregatedObservationConflictGroup, ALL_KNOWN_CONFLICT_FIELDS, CONTENT_CONFLICT_FIELDS, __filename, FUNDING_CONTEXT_CONFLICT_FIELDS, IDENTITY_OR_ROUTING_CONFLICT_FIELDS (+17 more)
+Cohesion: 0.07
+Nodes (29): ACCESS_EVIDENCE_CONFLICT_FIELDS, ADDITIVE_METADATA_CONFLICT_FIELDS, AggregatedObservationConflictGroup, ALL_KNOWN_CONFLICT_FIELDS, buildMongoFieldFilter(), CONTENT_CONFLICT_FIELDS, __filename, FUNDING_CONTEXT_CONFLICT_FIELDS (+21 more)
 
 ### Community 58 - "researchEntityDescriptionQuality.ts"
 Cohesion: 0.13
@@ -2849,8 +2807,8 @@ Cohesion: 0.13
 Nodes (30): CompensationType, PostedOpportunityStatus, activeListingBackfillFilter(), backfillPostedOpportunitiesFromListings(), BackfillPostedOpportunitiesFromListingsOptions, BackfillPostedOpportunitiesFromListingsResult, compactObject(), firstUrl() (+22 more)
 
 ### Community 74 - "profileController.ts"
-Cohesion: 0.12
-Nodes (25): addIfDefined(), getProfile(), getProfileCourses(), getProfileListings(), getPublications(), normalizePublicationPagination(), PUBLICATION_SORT_FIELDS, publicationSortValue() (+17 more)
+Cohesion: 0.13
+Nodes (23): addIfDefined(), getProfile(), getProfileCourses(), getProfileListings(), getPublications(), normalizePublicationPagination(), PUBLICATION_SORT_FIELDS, publicationSortValue() (+15 more)
 
 ### Community 75 - "analytics.ts"
 Cohesion: 0.09
@@ -2889,8 +2847,8 @@ Cohesion: 0.06
 Nodes (42): BetaRepairQueueGateArtifact, buildQueueSummaries(), buildReleaseQueueSummary(), buildSourceFreshness(), classifyOperatorQueueReason(), compactProgramSample(), compactResearchSample(), countByTier() (+34 more)
 
 ### Community 84 - "Listing"
-Cohesion: 0.11
-Nodes (24): ListingEditor(), COLUMNS, KanbanBoardProps, SearchContextProvider(), SearchContextProviderProps, createInitialOwnListingsState(), OwnListingsAction, ownListingsReducer() (+16 more)
+Cohesion: 0.08
+Nodes (31): ListingEditor(), COLUMNS, KanbanBoardProps, SearchContextProvider(), SearchContextProviderProps, createInitialListingFormState(), ListingFormAction, ListingFormErrors (+23 more)
 
 ### Community 85 - "promoteAcceptedBetaCopy.ts"
 Cohesion: 0.11
@@ -2953,12 +2911,12 @@ Cohesion: 0.12
 Nodes (31): DuplicatePersonGroup, buildUserIdentityDedupePlan(), buildUserIdentityDedupeSummary(), canonicalScore(), chooseCanonicalUser(), clusterUsersByCompatibleName(), comparePlannedGroups(), compareStrings() (+23 more)
 
 ### Community 101 - "opportunityDetail.tsx"
-Cohesion: 0.20
-Nodes (17): assertBetaSeedAllowed(), BetaSeedEnvironmentCliOptions, BetaSeedPlan, BetaSeedPlanStep, BetaSeedRunResult, buildBetaSeedPlan(), __filename, main() (+9 more)
+Cohesion: 0.09
+Nodes (22): PrivateRoute(), PrivateRouteProps, InfiniteScrollLoadingDots(), InfiniteScrollLoadingDotsProps, LoadingSpinner(), LoadingSpinnerProps, sizeMap, applicationStateTone() (+14 more)
 
 ### Community 103 - "ScraperContext"
-Cohesion: 0.12
-Nodes (21): CrossrefFetcher, CrossrefMessage, crossrefMessageToObservations(), CrossrefPaperScraper, CrossrefPaperScraperOptions, dateFromParts(), normalizeDoi(), classifyUserType() (+13 more)
+Cohesion: 0.08
+Nodes (38): CrossrefFetcher, CrossrefMessage, crossrefMessageToObservations(), CrossrefPaperScraper, CrossrefPaperScraperOptions, dateFromParts(), normalizeDoi(), classifyUserType() (+30 more)
 
 ### Community 104 - "buildAdminOperatorBoard"
 Cohesion: 0.16
@@ -2969,8 +2927,8 @@ Cohesion: 0.09
 Nodes (32): Analytics(), analyticsRanges, defaultAdminAccess, defaultUserActivity, SortOrder, UserActivitySort, analyticsData, mockedAxios (+24 more)
 
 ### Community 106 - "officialProfilePiBackfillScraper.ts"
-Cohesion: 0.09
-Nodes (46): absolutize(), affiliationValuesFromProfiles(), canonicalLegacyResearchHomeUrl(), canonicalResearchHomeName(), canonicalUrlFromHtml(), classifyResearchHome(), cleanInterestForBio(), cleanProfileCardLabWebsiteLabel() (+38 more)
+Cohesion: 0.08
+Nodes (60): absolutize(), canonicalLegacyResearchHomeUrl(), canonicalUrlFromHtml(), cleanInterestForBio(), cleanOfficialProfileDisplayName(), cleanOfficialProfileTitle(), clipOfficialProfileBio(), derivedBioFromOfficialProfile() (+52 more)
 
 ### Community 107 - "pathwaySearchService.ts"
 Cohesion: 0.06
@@ -2989,8 +2947,8 @@ Cohesion: 0.15
 Nodes (24): applyRepairPlan(), archiveArtifact(), ARTIFACT_SPECS, ArtifactSpec, assertArchivedEntityArtifactRepairApplyAllowed(), buildRepairArchivedEntityArtifactsOutput(), collectionExists(), __filename (+16 more)
 
 ### Community 111 - "profileService.ts"
-Cohesion: 0.09
-Nodes (31): buildProfileResearchMembershipFilter(), cleanPublicSourceLabel(), cleanScholarlyTitle(), cleanUrl(), dateToIso(), hasInspectableOpenAlexDestination(), isDatasetLikeScholarlyLink(), isGeneratedOfficialProfilePublicationAnchor() (+23 more)
+Cohesion: 0.17
+Nodes (16): buildProfileResearchMembershipFilter(), cleanUrl(), isDatasetLikeScholarlyLink(), isGeneratedOfficialProfilePublicationAnchor(), isOfficialProfileScholarlyLink(), isOfficialProfileSourcePagePublicationPointer(), isPublicResearchPaperLink(), loadProfileResearchEntities() (+8 more)
 
 ### Community 113 - "betaRepairQueue.ts"
 Cohesion: 0.22
@@ -3017,8 +2975,8 @@ Cohesion: 0.18
 Nodes (19): absoluteUrl(), cleanText(), DEFAULT_YALE_RESEARCH_DIRECTORY_CONFIGS, entityFromRecord(), entityToObservations(), inferResearchYaleKind(), pageUrlForIndex(), parseDirectory() (+11 more)
 
 ### Community 123 - "Adding a New Endpoint"
-Cohesion: 0.31
-Nodes (7): createInitialListingFormState(), ListingFormAction, ListingFormErrors, listingFormReducer(), ListingFormState, researchAreasFromListing(), resolve()
+Cohesion: 0.25
+Nodes (16): affiliationValuesFromProfiles(), canonicalResearchHomeName(), classifyResearchHome(), cleanProfileCardLabWebsiteLabel(), dedupeRepeatedProfileCardLabel(), disallowedProfileLinkedResearchHome(), extractOfficialProfileResearchHomes(), genericOrganizationName() (+8 more)
 
 ### Community 124 - "visibilityRepairQueueService.ts"
 Cohesion: 0.10
@@ -3029,8 +2987,8 @@ Cohesion: 0.18
 Nodes (16): candidateProfileUrls(), defaultVerifier(), DESC_BLOCK_REASONS, __dirname, __filename, isTrustedYaleProfileUrl(), LEAD_ROLES, main() (+8 more)
 
 ### Community 126 - "fellowships.tsx"
-Cohesion: 0.06
-Nodes (38): FellowshipModal(), FellowshipModalProps, RichText(), trackFellowshipApplyClick(), sortOptions, copy, FirstSaveCallout(), FirstSaveCalloutProps (+30 more)
+Cohesion: 0.07
+Nodes (30): ActiveFilterChip, ActiveFiltersProps, QuickFilterDef, sortOptions, copy, FirstSaveCallout(), FirstSaveCalloutProps, ViewModeToggle() (+22 more)
 
 ### Community 127 - "researchEntityDescriptionText.ts"
 Cohesion: 0.18
@@ -3041,8 +2999,8 @@ Cohesion: 0.12
 Nodes (29): buildResearchEntitySearchIndexDocument(), buildResearchEntitySearchIndexDocuments(), buildResearchEntitySearchIndexDocumentsWithMemberNames(), cleanPersonName(), emptyMemberNameFields(), facultyDisplayName(), fetchResearchEntitySearchMemberNames(), getResearchEntitySearchIndexSettings() (+21 more)
 
 ### Community 129 - "arxivPreprintScraper.ts"
-Cohesion: 0.21
-Nodes (12): arxivEntryToObservations(), ArxivFetcher, buildAuthorSearchQuery(), normalizeArxivId(), normalizeArxivText(), parseArxivFeed(), ParsedArxivEntry, shouldProcessFaculty() (+4 more)
+Cohesion: 0.22
+Nodes (14): LaunchReviewExceptionCliOptions, buildLaunchTrustContractOutput(), CliOptions, __filename, main(), parseLaunchTrustContractArgs(), parsePositiveInteger(), parseRequiredValue() (+6 more)
 
 ### Community 131 - "launchReviewExceptions.ts"
 Cohesion: 0.06
@@ -3081,12 +3039,12 @@ Cohesion: 0.12
 Nodes (37): ContactRouteType, applicationRouteBackfillDerivationKey(), ApplicationRoutePathwayBackfillDeps, ApplicationRoutePathwayBackfillEntity, ApplicationRoutePathwayBackfillOptions, ApplicationRoutePathwayBackfillResult, ApplicationRoutePathwayBackfillRoute, backfillApplicationRoutePathways() (+29 more)
 
 ### Community 142 - "textValue"
-Cohesion: 0.12
-Nodes (29): cleanOfficialProfileDisplayName(), cleanOfficialProfileTitle(), clipOfficialProfileBio(), extractBio(), extractDepartments(), extractEmail(), extractImageUrl(), extractOfficialProfileIdentity() (+21 more)
+Cohesion: 0.21
+Nodes (13): capitalizeSentenceStart(), cleanResearchHomeSummaryForBio(), dedupeProfileResearchEntities(), entityNameMatchesUser(), isIndividualResearchEntity(), isLeadRole(), isUsefulResearchHomeBioSummary(), looksLikePersonOnlyResearchHomeName() (+5 more)
 
 ### Community 143 - "assertScriptApplyAllowed"
 Cohesion: 0.06
-Nodes (49): assertDepartmentMigrationApplyAllowed(), buildDepartmentMigrationOutput(), ChangeLog, DepartmentDoc, DepartmentMigrationCliOptions, DepartmentMigrationResult, __dirname, __filename (+41 more)
+Nodes (58): assertDepartmentMigrationApplyAllowed(), buildDepartmentMigrationOutput(), ChangeLog, DepartmentDoc, DepartmentMigrationCliOptions, DepartmentMigrationResult, __dirname, __filename (+50 more)
 
 ### Community 144 - "centerDirectorLLMExtractor.ts"
 Cohesion: 0.15
@@ -3113,8 +3071,8 @@ Cohesion: 0.10
 Nodes (24): AccessReviewCounts, AccessReviewDetail, AccessReviewEntitySummary, AccessSignal, AdminAccessReview(), ContactRoute, EntryPathway, evidenceIds() (+16 more)
 
 ### Community 150 - "ObservationInput"
-Cohesion: 0.22
-Nodes (17): ACCESS_DETAIL_CONFIGS, accessObservationsForEntity(), cleanName(), entityToObservations(), inferKind(), normalizeUrl(), pageText(), parseCenters() (+9 more)
+Cohesion: 0.31
+Nodes (9): cleanPrimaryDepartment(), cleanSecondaryDepartments(), hasPathPrefix(), importFaculty(), KNOWN_DEPARTMENTS, RawFacultyEntry, resolveSafeFacultyImportJsonPath(), SORTED_KNOWN_DEPTS (+1 more)
 
 ### Community 151 - "studentDecisionExplanationService.ts"
 Cohesion: 0.23
@@ -3125,8 +3083,8 @@ Cohesion: 0.05
 Nodes (70): ACCESS_EVIDENCE_CONFLICT_FIELDS, ADDITIVE_METADATA_CONFLICT_FIELDS, AggregatedCrossSourceObservationConflictGroup, asString(), asStringArray(), buildCandidateSample(), buildCategoryCounts(), buildConflictPlan() (+62 more)
 
 ### Community 153 - "migrateResearchEntities.ts"
-Cohesion: 0.12
-Nodes (31): mapResearchGroupKindToEntityType(), assertResearchEntityMigrationWriteAllowed(), BACKFILL_ARRAY_FIELD_PAIRS, BACKFILL_FIELD_PAIRS, backfillReferences(), buildResearchEntityMigrationOutput(), buildResearchEntityMigrationReferenceMatch(), collectionExists() (+23 more)
+Cohesion: 0.13
+Nodes (30): mapResearchGroupKindToEntityType(), assertResearchEntityMigrationWriteAllowed(), BACKFILL_ARRAY_FIELD_PAIRS, BACKFILL_FIELD_PAIRS, backfillReferences(), buildResearchEntityMigrationOutput(), collectionExists(), copyResearchEntities() (+22 more)
 
 ### Community 154 - "researchEntityQuality.ts"
 Cohesion: 0.14
@@ -3149,8 +3107,8 @@ Cohesion: 0.18
 Nodes (21): addPublicPaperField(), buildLeadPiOutreachContactRoute(), getResearchGroupDetail(), memberDisplayName(), PUBLIC_PAPER_STAGES, publicAccessSignalForResearchDetail(), publicContactRouteForResearchDetail(), publicEntryPathwayForResearchDetail() (+13 more)
 
 ### Community 163 - "normalizePublicProfile"
-Cohesion: 0.18
-Nodes (19): cleanProfileUrlsForPerson(), cleanPublicHttpUrl(), hasProfileDirectoryLabelContamination(), normalizePublicProfile(), officialYaleProfileUrlForUser(), PUBLIC_PROFILE_BASE_ARRAY_FIELDS, PUBLIC_PROFILE_BASE_TEXT_FIELDS, publicProfileBase() (+11 more)
+Cohesion: 0.23
+Nodes (14): getProfileByNetid(), hasProfileDirectoryLabelContamination(), normalizePublicProfile(), PUBLIC_PROFILE_BASE_ARRAY_FIELDS, PUBLIC_PROFILE_BASE_TEXT_FIELDS, publicProfileBase(), publicProfileImageUrl(), publicProfileResearchEntity() (+6 more)
 
 ### Community 164 - "disambiguateSurnameLabNames.ts"
 Cohesion: 0.12
@@ -3193,8 +3151,8 @@ Cohesion: 0.17
 Nodes (18): BETA_ROLLOUT_ORDER, BetaReadinessGateCliOptions, buildBetaReadinessCommands(), buildBetaReadinessGateOutput(), collectionCount(), describeMongoTarget(), __dirname, EXPECTED_SOURCE_NAMES (+10 more)
 
 ### Community 178 - "updateOwnProfile"
-Cohesion: 0.31
-Nodes (10): ADMIN_PROFILE_USER_TYPES, adminUpdateProfile(), boundedAdminProfileEmail(), boundedAdminProfileNumber(), boundedAdminProfileText(), boundedProfileString(), boundedProfileStringArray(), sanitizeAdminProfileScalarFields() (+2 more)
+Cohesion: 0.22
+Nodes (13): ADMIN_PROFILE_USER_TYPES, adminUpdateProfile(), boundedAdminProfileEmail(), boundedAdminProfileNumber(), boundedAdminProfileText(), boundedProfileString(), boundedProfileStringArray(), isProfileUpdatePayload() (+5 more)
 
 ### Community 180 - "adminAccessReviewService.ts"
 Cohesion: 0.14
@@ -3237,8 +3195,8 @@ Cohesion: 0.18
 Nodes (15): MaterializerObservationLike, CenterDirectorsBackfillCliOptions, CenterDirectorsBackfillResult, __dirname, __filename, findCenterDirectorCandidates(), LEAD_ROLES, main() (+7 more)
 
 ### Community 190 - "migrateMongoNaming.ts"
-Cohesion: 0.16
-Nodes (20): assertMongoNamingMigrationWriteAllowed(), buildMongoNamingMigrationOutput(), buildUserFieldSetStage(), COLLECTION_RENAMES, collectionExists(), CollectionRenameResult, main(), migrateMongoNaming() (+12 more)
+Cohesion: 0.15
+Nodes (21): assertMongoNamingMigrationWriteAllowed(), buildMongoNamingMigrationOutput(), buildUserFieldSetStage(), COLLECTION_RENAMES, collectionExists(), CollectionRenameResult, main(), migrateMongoNaming() (+13 more)
 
 ### Community 191 - "researchEntityPiDedupeCore.ts"
 Cohesion: 0.17
@@ -3261,8 +3219,8 @@ Cohesion: 0.22
 Nodes (11): ListingEditorProps, container, root, UserContextProvider(), sampleUser, createInitialUserState(), UserAction, userReducer() (+3 more)
 
 ### Community 196 - "resolveSafeJsonReportOutputPath"
-Cohesion: 0.10
-Nodes (36): Fellowship, CliOptions, main(), parseArgs(), BackfillEntry, CliOptions, DEFAULT_INPUT, isCommunityForcePortal() (+28 more)
+Cohesion: 0.12
+Nodes (30): Fellowship, CliOptions, main(), parseArgs(), assertBackfillProgramClassificationsApplyAllowed(), BackfillProgramClassificationsCliOptions, buildBackfillProgramClassificationsOutput(), main() (+22 more)
 
 ### Community 197 - "dependencies"
 Cohesion: 0.12
@@ -3295,10 +3253,6 @@ Nodes (13): applyRepairs(), assertRepairListingResearchEntityProfilesApplyAllowe
 ### Community 204 - "researchGroupFilters.ts"
 Cohesion: 0.33
 Nodes (6): acceptanceLevelClauses(), AcceptanceLevelInput, buildResearchGroupFilterString(), escapeMeiliFilterValue(), orEqualsClause(), ResearchGroupFilterInput
-
-### Community 205 - "Adding Things"
-Cohesion: 0.29
-Nodes (7): applyStaleObservationSupersessions(), buildMongoFieldFilter(), defaultStaleObservationApplyDeps(), loadSameSourceConflictGroups(), mongoFieldFilterForCategory(), runStaleObservationConflictReview(), stringifyId()
 
 ### Community 206 - "AdminFacultyProfilesTable.tsx"
 Cohesion: 0.16
@@ -3385,8 +3339,8 @@ Cohesion: 0.11
 Nodes (18): compilerOptions, esModuleInterop, forceConsistentCasingInFileNames, lib, module, moduleResolution, noImplicitAny, outDir (+10 more)
 
 ### Community 233 - "trustedLeadResearchHomeBioFallback"
-Cohesion: 0.40
-Nodes (6): hasPersonScopedYaleDirectoryPath(), isLabOrResearchGroupUrl(), isOfficialYaleProfileUrlForUser(), isYaleHost(), parseProfileUrl(), pathSegments()
+Cohesion: 0.08
+Nodes (48): ADMIN_UPDATE_FIELDS, ALLOWED_SELF_UPDATE_FIELDS, boundedProfileUrlKey(), boundedPublicationNumber(), boundedPublicationText(), boundedPublicProfileUrl(), cleanProfileUrlsForPerson(), cleanPublicHttpUrl() (+40 more)
 
 ### Community 234 - "cli.ts"
 Cohesion: 0.15
@@ -3469,8 +3423,8 @@ Cohesion: 0.18
 Nodes (11): CTA Vocabulary, Entity Page Questions, Explore Research, Navigation Shape, North Star, Primary Surfaces, Product Context, Product Premise (+3 more)
 
 ### Community 272 - "apiBaseUrl.ts"
-Cohesion: 0.12
-Nodes (20): AdminRoute(), AdminRouteProps, getLocalAdminDevLoginUrl(), getSafeLocalAdminRedirectTarget(), PrivateRoute(), PrivateRouteProps, InfiniteScrollLoadingDots(), InfiniteScrollLoadingDotsProps (+12 more)
+Cohesion: 0.22
+Nodes (13): AdminRoute(), AdminRouteProps, getLocalAdminDevLoginUrl(), getSafeLocalAdminRedirectTarget(), SignOutButton(), storeLogoutReturnPath(), buildApiUrl(), getApiBaseUrl() (+5 more)
 
 ### Community 273 - "resolutions"
 Cohesion: 0.12
@@ -3641,8 +3595,8 @@ Cohesion: 0.43
 Nodes (5): findSecretFindings(), isAllowedPlaceholder(), lineNumberForIndex(), PLACEHOLDER_PATTERNS, SECRET_RULES
 
 ### Community 408 - "runStaleObservationConflictReview"
-Cohesion: 0.50
-Nodes (4): sameStringSet(), StaleObservationConflictObservation, validateStaleObservationReviewDecision(), validateStaleObservationReviewDecisions()
+Cohesion: 0.29
+Nodes (7): applyStaleObservationSupersessions(), defaultStaleObservationApplyDeps(), runStaleObservationConflictReview(), sameStringSet(), StaleObservationConflictObservation, validateStaleObservationReviewDecision(), validateStaleObservationReviewDecisions()
 
 ### Community 409 - "Graphify repo memory"
 Cohesion: 0.15
@@ -3677,24 +3631,24 @@ Cohesion: 0.09
 Nodes (33): AccessSignal, accessSignalSchema, ContactRoute, contactRouteSchema, EntryPathway, entryPathwaySchema, grantSchema, fieldProvenanceSchema (+25 more)
 
 ## Knowledge Gaps
-- **4377 isolated node(s):** `name`, `version`, `private`, `node`, `@emotion/react` (+4372 more)
+- **4337 isolated node(s):** `name`, `version`, `private`, `node`, `@emotion/react` (+4332 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **2246 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **2205 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `sanitizeLogValue()` connect `sanitizeLogValue` to `departmentRosterScraper.ts`, `logSanitizer.ts`, `labMicrositeUndergradLLMExtractor.ts`, `entityMaterializer.ts`, `labMicrositeDescriptionLLMExtractor.ts`, `passport.ts`, `undergradFellowshipRecipientScraper.ts`, `duplicateEntityNameReview.ts`, `dedupeResearchEntitiesByPi.ts`, `admin.ts`, `profileDataQualityAudit.ts`, `centersInstitutesScraper.ts`, `nihReporterScraper.ts`, `User`, `userService.ts`, `serializedDocumentId`, `researchEntityCoverageAudit.ts`, `sourceHealth.ts`, `repairOfficialProfilePublicationPointers.ts`, `officialProfilePiBackfillScraper.test.ts`, `listingService.ts`, `runReport.ts`, `opportunityDetailService.ts`, `staleObservationConflictReview.ts`, `betaDataQuality.ts`, `listingController.ts`, `analyticsService.ts`, `entryPathwayService.ts`, `yaleCollegeFellowshipsOfficeScraper.ts`, `nsfAwardScraper.ts`, `scholarlyLinkSuppressionAudit.ts`, `postedOpportunityService.ts`, `profileController.ts`, `openAlexPaperScraper.ts`, `types.ts`, `ResearchGroupMember`, `promoteAcceptedBetaCopy.ts`, `paperAuthorshipAudit.ts`, `Observation`, `assertPublicHttpUrl`, `studentDecisionLLMExtractor.ts`, `backfillProfileBiosFromOfficialUrls.ts`, `rebuildPathwaySearchIndex.ts`, `claimGate.ts`, `opportunityDetail.tsx`, `ScraperContext`, `officialProfilePiBackfillScraper.ts`, `repairArchivedEntityArtifacts.ts`, `betaRepairQueue.ts`, `materializeEntity`, `pathwayQualityAudit.ts`, `cronRunner.ts`, `backfillResearchHomeOfficialUrls.ts`, `arxivPreprintScraper.ts`, `launchReviewExceptions.ts`, `acceptedInputs.ts`, `dedupeUsersByIdentity.ts`, `fellowshipController.ts`, `applicationRoutePathwayBackfillCore.ts`, `assertScriptApplyAllowed`, `centerDirectorLLMExtractor.ts`, `crossSourceObservationConflictReview.ts`, `migrateResearchEntities.ts`, `researchQualitySearchReview.ts`, `migrateResearchEntityCollections.ts`, `researchGroupController.ts`, `disambiguateSurnameLabNames.ts`, `repairDuplicateAccessSignals.ts`, `profileBioCoverageAudit.ts`, `programController.ts`, `repairMismatchedPersonEmailsCore.ts`, `betaReadinessGate.ts`, `studentVisibilityRepairTargets.ts`, `cleanupLegacyMongoCollections.ts`, `seedSources.ts`, `configService.ts`, `backfillCenterDirectors.ts`, `migrateMongoNaming.ts`, `resolveSafeJsonReportOutputPath`, `userEmailHygiene.ts`, `orcidWorksScraper.ts`, `repairListingResearchEntityProfiles.ts`, `meiliSyncService.ts`, `index.ts`, `repairProfileDescriptionBackfillConflicts.ts`, `clearBetaStudentAnalytics.ts`, `scraperIntegrityDuplicateReview.ts`, `auditResearchEntityRename.ts`, `backfillPostedOpportunitiesFromListings.ts`, `paperQualityService.ts`, `pathwayRelevanceReview.ts`, `scraperIntegrityGate.ts`, `programs.ts`, `cli.ts`, `listings.ts`, `researchEntity.ts`, `seed.ts`, `users.ts`, `launchAcquisitionReport.ts`, `index.ts`, `refreshGateScorecards.ts`, `dedupeExploratoryContactPathways.ts`, `materializePaperObservationsFromRun`, `courseTableService.ts`, `errorHandler.ts`?**
+- **Why does `sanitizeLogValue()` connect `sanitizeLogValue` to `departmentRosterScraper.ts`, `logSanitizer.ts`, `labMicrositeUndergradLLMExtractor.ts`, `entityMaterializer.ts`, `labMicrositeDescriptionLLMExtractor.ts`, `passport.ts`, `undergradFellowshipRecipientScraper.ts`, `duplicateEntityNameReview.ts`, `dedupeResearchEntitiesByPi.ts`, `admin.ts`, `profileDataQualityAudit.ts`, `centersInstitutesScraper.ts`, `nihReporterScraper.ts`, `User`, `userService.ts`, `serializedDocumentId`, `researchEntityCoverageAudit.ts`, `sourceHealth.ts`, `repairOfficialProfilePublicationPointers.ts`, `officialProfilePiBackfillScraper.test.ts`, `listingService.ts`, `runReport.ts`, `opportunityDetailService.ts`, `staleObservationConflictReview.ts`, `betaDataQuality.ts`, `listingController.ts`, `analyticsService.ts`, `entryPathwayService.ts`, `yaleCollegeFellowshipsOfficeScraper.ts`, `nsfAwardScraper.ts`, `scholarlyLinkSuppressionAudit.ts`, `postedOpportunityService.ts`, `profileController.ts`, `openAlexPaperScraper.ts`, `types.ts`, `ResearchGroupMember`, `promoteAcceptedBetaCopy.ts`, `paperAuthorshipAudit.ts`, `Observation`, `assertPublicHttpUrl`, `studentDecisionLLMExtractor.ts`, `backfillProfileBiosFromOfficialUrls.ts`, `rebuildPathwaySearchIndex.ts`, `claimGate.ts`, `ScraperContext`, `officialProfilePiBackfillScraper.ts`, `repairArchivedEntityArtifacts.ts`, `betaRepairQueue.ts`, `materializeEntity`, `pathwayQualityAudit.ts`, `cronRunner.ts`, `backfillResearchHomeOfficialUrls.ts`, `arxivPreprintScraper.ts`, `launchReviewExceptions.ts`, `acceptedInputs.ts`, `dedupeUsersByIdentity.ts`, `fellowshipController.ts`, `applicationRoutePathwayBackfillCore.ts`, `assertScriptApplyAllowed`, `centerDirectorLLMExtractor.ts`, `ObservationInput`, `crossSourceObservationConflictReview.ts`, `migrateResearchEntities.ts`, `researchQualitySearchReview.ts`, `migrateResearchEntityCollections.ts`, `researchGroupController.ts`, `disambiguateSurnameLabNames.ts`, `repairDuplicateAccessSignals.ts`, `profileBioCoverageAudit.ts`, `programController.ts`, `repairMismatchedPersonEmailsCore.ts`, `betaReadinessGate.ts`, `studentVisibilityRepairTargets.ts`, `cleanupLegacyMongoCollections.ts`, `seedSources.ts`, `configService.ts`, `backfillCenterDirectors.ts`, `migrateMongoNaming.ts`, `resolveSafeJsonReportOutputPath`, `userEmailHygiene.ts`, `orcidWorksScraper.ts`, `repairListingResearchEntityProfiles.ts`, `meiliSyncService.ts`, `index.ts`, `repairProfileDescriptionBackfillConflicts.ts`, `clearBetaStudentAnalytics.ts`, `scraperIntegrityDuplicateReview.ts`, `auditResearchEntityRename.ts`, `backfillPostedOpportunitiesFromListings.ts`, `paperQualityService.ts`, `pathwayRelevanceReview.ts`, `scraperIntegrityGate.ts`, `programs.ts`, `cli.ts`, `listings.ts`, `researchEntity.ts`, `seed.ts`, `users.ts`, `launchAcquisitionReport.ts`, `index.ts`, `refreshGateScorecards.ts`, `dedupeExploratoryContactPathways.ts`, `materializePaperObservationsFromRun`, `courseTableService.ts`, `errorHandler.ts`?**
   _High betweenness centrality (0.085) - this node is a cross-community bridge._
-- **Why does `field()` connect `dedupeUsersByIdentity.ts` to `arxivPreprintScraper.ts`, `logSanitizer.ts`, `adminFellowshipsTableReducer.ts`, `ImportRootDataFiles.ts`, `safeHttpUrl`, `labMicrositeUndergradLLMExtractor.ts`, `textValue`, `integrityGate.ts`, `crossSourceObservationConflictReview.ts`, `index.ts`, `normalizePublicProfile`, `User`, `sourceHealth.ts`, `fellowshipService.ts`, `runReport.ts`, `betaDataQuality.ts`, `analyticsService.ts`, `acceptedInputsCore.ts`, `entryPathwayService.ts`, `workPlanner.ts`, `orcidWorksScraper.ts`, `AdminListingsTable.tsx`, `openAlexPaperScraper.ts`, `AdminFacultyProfilesTable.tsx`, `scraperIntegrityDuplicateReview.ts`, `promoteAcceptedBetaCopy.ts`, `ScraperContext`, `confidenceResolver.ts`, `materializeEntity`, `buildStaleObservationConflictSummary`, `visibilityRepairQueueService.ts`?**
+- **Why does `field()` connect `dedupeUsersByIdentity.ts` to `logSanitizer.ts`, `adminFellowshipsTableReducer.ts`, `ImportRootDataFiles.ts`, `safeHttpUrl`, `labMicrositeUndergradLLMExtractor.ts`, `integrityGate.ts`, `crossSourceObservationConflictReview.ts`, `index.ts`, `normalizePublicProfile`, `User`, `sourceHealth.ts`, `fellowshipService.ts`, `runReport.ts`, `betaDataQuality.ts`, `analyticsService.ts`, `acceptedInputsCore.ts`, `entryPathwayService.ts`, `workPlanner.ts`, `orcidWorksScraper.ts`, `AdminListingsTable.tsx`, `openAlexPaperScraper.ts`, `AdminFacultyProfilesTable.tsx`, `scraperIntegrityDuplicateReview.ts`, `promoteAcceptedBetaCopy.ts`, `ScraperContext`, `officialProfilePiBackfillScraper.ts`, `confidenceResolver.ts`, `materializeEntity`, `buildStaleObservationConflictSummary`, `visibilityRepairQueueService.ts`?**
   _High betweenness centrality (0.047) - this node is a cross-community bridge._
 - **Why does `ResearchGroup` connect `researchGroup.ts` to `labDetailReducer.test.ts`, `browsable.ts`, `labDetail.ts`, `ImportRootDataFiles.ts`, `BackfillV4FacultyMembers.ts`?**
-  _High betweenness centrality (0.036) - this node is a cross-community bridge._
+  _High betweenness centrality (0.037) - this node is a cross-community bridge._
 - **What connects `name`, `version`, `private` to the rest of the system?**
-  _4380 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _4339 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Decisions` be split into smaller, more focused modules?**
   _Cohesion score 0.10526315789473684 - nodes in this community are weakly interconnected._
 - **Should `labDetail.tsx` be split into smaller, more focused modules?**
   _Cohesion score 0.0734006734006734 - nodes in this community are weakly interconnected._
 - **Should `browsable.ts` be split into smaller, more focused modules?**
-  _Cohesion score 0.05985915492957746 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.05025394279604384 - nodes in this community are weakly interconnected._

--- a/scripts/security-preflight.test.mjs
+++ b/scripts/security-preflight.test.mjs
@@ -5488,7 +5488,7 @@ test('public PI official profile routes reject credential-bearing URLs', () => {
   assert.match(source, /if \(!isPublicHttpUrl\(trimmed\)\) return false/);
   assert.match(
     source,
-    /Object\.entries\(value as Record<string, unknown>\)\.filter\(\s*\(\[, url\]\) => publicHttpUrl\(url\),/,
+    /Object\.entries\(value as Record<string, unknown>\)\.filter\(\s*\(\[, url\]\) => publicHttpUrl\(url\)\s*,?\s*\)/,
   );
   assert.match(
     source,

--- a/server/src/scrapers/entityMaterializer.ts
+++ b/server/src/scrapers/entityMaterializer.ts
@@ -526,7 +526,7 @@ const MEMBER_ROLES = new Set([
   'affiliate',
 ]);
 
-/** Roles the public "Principal Investigator" panel renders as the entity lead. */
+/** Roles the public research detail leadership UI renders as entity leads. */
 const LEAD_MEMBER_ROLES = new Set(['pi', 'co-pi', 'director', 'co-director']);
 /** Non-lead roster roles a promoted director supersedes within an entity. */
 const SUPERSEDED_BY_DIRECTOR_ROLES = ['core-faculty', 'affiliated', 'affiliate'];

--- a/server/src/scrapers/entityMaterializer.ts
+++ b/server/src/scrapers/entityMaterializer.ts
@@ -17,11 +17,7 @@ import { ScrapeRun } from '../models/scrapeRun';
 import { PostedOpportunity } from '../models/postedOpportunity';
 import { ResearchScholarlyLink } from '../models/researchScholarlyLink';
 import { deriveShortDescriptionFromFullDescription } from '../utils/researchEntityDescriptionQuality';
-import {
-  resolveAllFields,
-  ResolverObservation,
-  ResolvedField,
-} from './confidenceResolver';
+import { resolveAllFields, ResolverObservation, ResolvedField } from './confidenceResolver';
 import { syncEntity, isSyncableEntityType } from '../services/meiliSyncService';
 import { recomputeBrowseRankForEntities } from '../services/researchEntityBrowseRankService';
 import { materializeAccessForResearchGroup } from './accessMaterializer';
@@ -257,7 +253,8 @@ function normalizeOfficialProfilePublication(
 } | null {
   const title = cleanScholarlyText(value.title);
   if (!title) return null;
-  const sourceUrl = cleanScholarlyHttpUrl(value.sourceUrl) || cleanScholarlyHttpUrl(fallbackSourceUrl);
+  const sourceUrl =
+    cleanScholarlyHttpUrl(value.sourceUrl) || cleanScholarlyHttpUrl(fallbackSourceUrl);
   if (!sourceUrl) return null;
   const url = cleanScholarlyHttpUrl(value.url);
   if (!url) return null;
@@ -284,7 +281,11 @@ function normalizeOfficialProfilePublication(
   };
 }
 
-function officialProfilePublicationUrl(publication: { title: string; url?: string; sourceUrl: string }): string {
+function officialProfilePublicationUrl(publication: {
+  title: string;
+  url?: string;
+  sourceUrl: string;
+}): string {
   if (publication.url) return publication.url;
   return '';
 }
@@ -387,7 +388,11 @@ function materializedFieldValue(
   if (isResearchEntityObservationType(entityType) && field === 'sourceUrls') {
     return sanitizeResearchEntitySourceUrlsForMaterialization(value);
   }
-  if (isResearchEntityObservationType(entityType) && PUBLIC_QUOTE_FIELDS.has(field) && typeof value === 'string') {
+  if (
+    isResearchEntityObservationType(entityType) &&
+    PUBLIC_QUOTE_FIELDS.has(field) &&
+    typeof value === 'string'
+  ) {
     return redactDirectContactInfo(value);
   }
   if (entityType === 'user' && field === 'userType') {
@@ -446,7 +451,9 @@ function fieldProvenanceForResolvedObservation(
   const resolvedValue = comparableObservationValue(resolved.value);
   const contributingSources = new Set(resolved.contributingSources);
   const match = observations
-    .filter((obs) => obs.field === field && obs.sourceName && contributingSources.has(obs.sourceName))
+    .filter(
+      (obs) => obs.field === field && obs.sourceName && contributingSources.has(obs.sourceName),
+    )
     .find((obs) => comparableObservationValue(obs.value) === resolvedValue);
   if (!match) return null;
 
@@ -462,12 +469,10 @@ function fieldProvenanceForResolvedObservation(
 export function buildInferredPiMemberUpsert(
   researchEntityId: string,
   observation: InferredPiObservation,
-):
-  | {
-      filter: Record<string, unknown>;
-      update: { $set: Record<string, unknown>; $setOnInsert: Record<string, unknown> };
-    }
-  | null {
+): {
+  filter: Record<string, unknown>;
+  update: { $set: Record<string, unknown>; $setOnInsert: Record<string, unknown> };
+} | null {
   const userId = String(observation.value || '').trim();
   const safeResearchEntityId = normalizeMaterializerObjectId(researchEntityId);
   const safeUserId = normalizeMaterializerObjectId(userId);
@@ -532,7 +537,9 @@ const LEAD_MEMBER_ROLES = new Set(['pi', 'co-pi', 'director', 'co-director']);
 const SUPERSEDED_BY_DIRECTOR_ROLES = ['core-faculty', 'affiliated', 'affiliate'];
 
 const objectRecord = (value: unknown): Record<string, unknown> =>
-  value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
 
 function memberNameFromInferredUserName(value: unknown): string {
   const record = objectRecord(value);
@@ -586,13 +593,13 @@ export function buildResearchGroupMemberUpsert(
   researchEntityId: string,
   resolved: Record<string, ProvenanceResolvedField>,
   user: Record<string, unknown> | null = null,
-):
-  | ResearchGroupMemberMaterializationPatch
-  | null {
+): ResearchGroupMemberMaterializationPatch | null {
   if (!normalizeMaterializerObjectId(researchEntityId)) return null;
   const role = normalizeMemberRole(resolved.role?.value);
   if (!role) return null;
-  const name = textValue(resolved.name?.value) || memberNameFromInferredUserName(resolved.inferredUserName?.value);
+  const name =
+    textValue(resolved.name?.value) ||
+    memberNameFromInferredUserName(resolved.inferredUserName?.value);
   const userId = idValue(user?._id);
   const facultyMemberId = idValue(user?.facultyMemberId);
   if (!name && !userId && !facultyMemberId) return null;
@@ -608,8 +615,8 @@ export function buildResearchGroupMemberUpsert(
   const identityFilter: Record<string, unknown> = userId
     ? { userId }
     : facultyMemberId
-    ? { facultyMemberId }
-    : { name };
+      ? { facultyMemberId }
+      : { name };
   const filter = {
     researchEntityId,
     role,
@@ -689,7 +696,10 @@ async function materializeResearchGroupMember(
     };
   }
 
-  const entity: any = await ResearchEntity.findOne({ slug: researchGroupKey, archived: { $ne: true } })
+  const entity: any = await ResearchEntity.findOne({
+    slug: researchGroupKey,
+    archived: { $ne: true },
+  })
     .select('_id')
     .lean();
   if (!entity?._id) {
@@ -742,10 +752,10 @@ async function materializeResearchGroupMember(
     const identity = patch.filter.userId
       ? { userId: patch.filter.userId }
       : patch.filter.facultyMemberId
-      ? { facultyMemberId: patch.filter.facultyMemberId }
-      : patch.filter.name
-      ? { name: patch.filter.name }
-      : null;
+        ? { facultyMemberId: patch.filter.facultyMemberId }
+        : patch.filter.name
+          ? { name: patch.filter.name }
+          : null;
     if (identity) {
       const existingLead = await ResearchGroupMember.findOne({
         researchEntityId: patch.filter.researchEntityId,
@@ -790,8 +800,9 @@ function withResolvedFieldProvenance(
   const output: Record<string, ProvenanceResolvedField> = {};
   for (const [field, value] of Object.entries(resolved)) {
     const source =
-      observations.find((observation) => observation.field === field && observation.value === value.value) ||
-      observations.find((observation) => observation.field === field);
+      observations.find(
+        (observation) => observation.field === field && observation.value === value.value,
+      ) || observations.find((observation) => observation.field === field);
     output[field] = {
       ...value,
       ...(source?.sourceName ? { sourceName: source.sourceName } : {}),
@@ -816,10 +827,7 @@ async function materializeInferredPiMembership(
   const piKeyObservations = observations.filter((obs) => obs.field === 'inferredPiUserKey');
   const inferredPiDepartments = departmentValuesForInferredPiLookup(observations);
   for (const observation of piKeyObservations) {
-    const filters = userLookupFiltersForInferredPiUserKey(
-      observation.value,
-      inferredPiDepartments,
-    );
+    const filters = userLookupFiltersForInferredPiUserKey(observation.value, inferredPiDepartments);
     if (filters.length === 0) continue;
     const users = await User.find(filters.length === 1 ? filters[0] : { $or: filters })
       .select('_id')
@@ -1025,9 +1033,12 @@ function piCompatibleResearchEntityNames(firstName: string, lastName: string): S
   const first = firstName.trim();
   const last = lastName.trim();
   return new Set(
-    [`${first} ${last} Lab`, `${first} ${last} Laboratory`, `${last} Lab`, `${last} Laboratory`].map(
-      (value) => normalizeResearchEntityName(value),
-    ),
+    [
+      `${first} ${last} Lab`,
+      `${first} ${last} Laboratory`,
+      `${last} Lab`,
+      `${last} Laboratory`,
+    ].map((value) => normalizeResearchEntityName(value)),
   );
 }
 
@@ -1044,7 +1055,9 @@ async function findUniqueUserByPersonName(personName: string): Promise<any | nul
     .lean();
   const expectedFullName = compactPersonName(`${first} ${last}`);
   const matches = users.filter((user: any) => {
-    const candidateFullName = compactPersonName(`${textValue(user.fname)} ${textValue(user.lname)}`);
+    const candidateFullName = compactPersonName(
+      `${textValue(user.fname)} ${textValue(user.lname)}`,
+    );
     return candidateFullName === expectedFullName;
   });
   return matches.length === 1 && matches[0]?._id ? matches[0] : null;
@@ -1083,7 +1096,11 @@ export async function findExistingResearchEntityByFacultyResearchAreaIdentity(
     .select('researchEntityId')
     .lean();
   const candidateIds = Array.from(
-    new Set(memberships.map((member: any) => normalizeMaterializerObjectId(member.researchEntityId)).filter(Boolean)),
+    new Set(
+      memberships
+        .map((member: any) => normalizeMaterializerObjectId(member.researchEntityId))
+        .filter(Boolean),
+    ),
   );
   if (candidateIds.length === 0) return null;
 
@@ -1249,13 +1266,16 @@ async function materializeResearchEntityRelationship(
   }
 
   if (!canonicalFacultyResearchAreaTarget && target?._id) {
-    await syncProfileBackedFacultyResearchAreaMemberFromIdentity(normalizeMaterializerObjectId(target._id) || '', {
-      entityKey: targetEntityKey,
-      name: target.name,
-      entityType: 'FACULTY_RESEARCH_AREA',
-      sourceUrl: textValue(resolved.sourceUrl?.value),
-      confidence: Math.max(0, ...observations.map((o) => Number(o.confidence) || 0)),
-    });
+    await syncProfileBackedFacultyResearchAreaMemberFromIdentity(
+      normalizeMaterializerObjectId(target._id) || '',
+      {
+        entityKey: targetEntityKey,
+        name: target.name,
+        entityType: 'FACULTY_RESEARCH_AREA',
+        sourceUrl: textValue(resolved.sourceUrl?.value),
+        confidence: Math.max(0, ...observations.map((o) => Number(o.confidence) || 0)),
+      },
+    );
   }
 
   const sourceResearchEntityId = normalizeMaterializerObjectId(source._id) || '';
@@ -1360,7 +1380,10 @@ function nameRegexFromSlugParts(parts: string[]): RegExp | null {
   return new RegExp(`^${normalized.map(escapeRegex).join('[\\s-]+')}$`, 'i');
 }
 
-function deptUserNameFilters(value: unknown, departments: string[]): Array<Record<string, unknown>> {
+function deptUserNameFilters(
+  value: unknown,
+  departments: string[],
+): Array<Record<string, unknown>> {
   const raw = typeof value === 'string' ? value.trim() : '';
   const match = raw.match(DEPT_USER_KEY_PATTERN);
   if (!match || departments.length === 0) return [];
@@ -1546,7 +1569,14 @@ export function officialProfileObservationMatchesUser(
   if (departmentTokens.length === 0) return false;
 
   const userNameTokens = identityTokens(
-    uniqueStrings([user.fname, user.firstName, user.lname, user.lastName, user.name, user.displayName]).join(' '),
+    uniqueStrings([
+      user.fname,
+      user.firstName,
+      user.lname,
+      user.lastName,
+      user.name,
+      user.displayName,
+    ]).join(' '),
   );
   if (!userNameTokens.includes(nameParts.lastToken)) return false;
   if (!userNameTokens.some((token) => token.charAt(0) === nameParts.firstInitial)) return false;
@@ -1727,8 +1757,7 @@ export function uniqueKeyValueForIdentifier(
   obs: Array<{ field?: string; value?: unknown }>,
 ): string | undefined {
   if (entityType === 'user') {
-    const observedNetid = obs
-      .find((o) => o.field === 'netid' && typeof o.value === 'string')
+    const observedNetid = obs.find((o) => o.field === 'netid' && typeof o.value === 'string')
       ?.value as string | undefined;
     if (observedNetid?.trim()) return observedNetid.trim();
     return entityKey?.replace(/^netid:/i, '').trim() || undefined;
@@ -1788,11 +1817,7 @@ async function findEntityDocByIdentifier(
   if (!keyValue) return null;
 
   if (entityType === 'user') {
-    const byOfficialProfile = await findUserDocByOfficialProfileObservations(
-      Model,
-      obs,
-      keyValue,
-    );
+    const byOfficialProfile = await findUserDocByOfficialProfileObservations(Model, obs, keyValue);
     if (byOfficialProfile) return byOfficialProfile;
   }
 
@@ -1800,9 +1825,7 @@ async function findEntityDocByIdentifier(
   if (exact) return exact;
 
   if (entityType === 'user') {
-    const emailObservation = obs.find(
-      (o) => o.field === 'email' && typeof o.value === 'string',
-    );
+    const emailObservation = obs.find((o) => o.field === 'email' && typeof o.value === 'string');
     const observedEmail =
       typeof emailObservation?.value === 'string'
         ? emailObservation.value.trim().toLowerCase()
@@ -1816,7 +1839,9 @@ async function findEntityDocByIdentifier(
   if (entityType === 'paper') {
     const doiValues = observedDoiValues(obs);
     if (doiValues.length > 0) {
-      const byDoi = await Model.find({ doi: { $in: doiValues } }).limit(2).lean();
+      const byDoi = await Model.find({ doi: { $in: doiValues } })
+        .limit(2)
+        .lean();
       if (byDoi.length === 1) return byDoi[0];
     }
   }
@@ -1824,9 +1849,7 @@ async function findEntityDocByIdentifier(
   return null;
 }
 
-function paperIdentityBuckets(
-  groups: Map<string, PaperMaterializationObservation[]>,
-): {
+function paperIdentityBuckets(groups: Map<string, PaperMaterializationObservation[]>): {
   openAlexKeys: string[];
   arxivKeys: string[];
   doiKeys: string[];
@@ -1909,7 +1932,11 @@ const PAPER_MATERIALIZATION_ONLY_FIELDS = new Set([PAPER_AUTHORSHIP_EVIDENCE_FIE
 
 export function mergeUniqueArrayValues(existing: unknown, next: unknown): unknown[] {
   const values = [
-    ...(Array.isArray(existing) ? existing : existing === undefined || existing === null ? [] : [existing]),
+    ...(Array.isArray(existing)
+      ? existing
+      : existing === undefined || existing === null
+        ? []
+        : [existing]),
     ...(Array.isArray(next) ? next : next === undefined || next === null ? [] : [next]),
   ];
   const seen = new Set<string>();
@@ -2240,7 +2267,10 @@ export async function materializeEntity(
       entityType === 'paper' && PAPER_SET_FIELDS.has(field)
         ? mergeUniqueArrayValues(entityDoc?.[field], r.value)
         : r.value;
-    if (entityType === 'user' && shouldPreserveExistingUserIdentityField(field, nextValue, entityDoc)) {
+    if (
+      entityType === 'user' &&
+      shouldPreserveExistingUserIdentityField(field, nextValue, entityDoc)
+    ) {
       continue;
     }
     set[field] = materializedFieldValue(entityType, field, nextValue);
@@ -2338,15 +2368,11 @@ export async function materializeEntity(
   } else {
     const keyField = uniqueKeyFieldForIdentifier(entityType, identifier.entityKey);
     if (!keyField || !identifier.entityKey) {
-      throw new Error(
-        `Cannot create new ${entityType}: missing entityKey or no keyField defined`,
-      );
+      throw new Error(`Cannot create new ${entityType}: missing entityKey or no keyField defined`);
     }
     const keyValue = uniqueKeyValueForIdentifier(entityType, identifier.entityKey, obs);
     if (!keyValue) {
-      throw new Error(
-        `Cannot create new ${entityType}: missing normalized unique key value`,
-      );
+      throw new Error(`Cannot create new ${entityType}: missing normalized unique key value`);
     }
     const insert: Record<string, unknown> = { ...set, [keyField]: keyValue };
     if (!hasRequiredFieldsForCreate(entityType, insert)) {

--- a/server/src/scrapers/sources/centerDirectorLLMExtractor.ts
+++ b/server/src/scrapers/sources/centerDirectorLLMExtractor.ts
@@ -4,8 +4,8 @@
  * Organizational research homes (CENTER / INSTITUTE / INITIATIVE / CORE_FACILITY)
  * have no single PI, so the membership rosters scraped by
  * `centersInstitutesScraper` tag everyone `core-faculty` and the public
- * "Principal Investigator" panel renders empty. The actual leader — the
- * center's Director / Executive Director / Faculty Director — is named on a
+ * research detail leadership display renders empty. The actual leader - the
+ * center's Director / Executive Director / Faculty Director - is named on a
  * separate leadership/about page that the roster scrape never reads.
  *
  * This source closes that gap. For each organizational home with an official

--- a/server/src/scrapers/sources/centerDirectorLLMExtractor.ts
+++ b/server/src/scrapers/sources/centerDirectorLLMExtractor.ts
@@ -268,7 +268,12 @@ async function defaultCallLLM(input: {
   if (!content || typeof content !== 'string') throw new Error('LLM returned empty content');
   const parsed = JSON.parse(content) as Partial<CenterDirectorExtraction>;
   const director = parsed.director && typeof parsed.director === 'object' ? parsed.director : null;
-  return { director: director && textValue((director as CenterDirector).name) ? (director as CenterDirector) : null };
+  return {
+    director:
+      director && textValue((director as CenterDirector).name)
+        ? (director as CenterDirector)
+        : null,
+  };
 }
 
 async function defaultCenterFinder(
@@ -276,7 +281,9 @@ async function defaultCenterFinder(
 ): Promise<CandidateCenter[]> {
   // Local import to keep the model graph lazy and avoid a hard cycle.
   const { ResearchGroupMember } = await import('../../models/researchGroupMember');
-  const only = Array.from(new Set((options.only || []).map((value) => value.trim()).filter(Boolean)));
+  const only = Array.from(
+    new Set((options.only || []).map((value) => value.trim()).filter(Boolean)),
+  );
   const onlyObjectIds = only
     .map((value) => normalizeCenterDirectorObjectId(value))
     .filter((value): value is string => Boolean(value))
@@ -348,7 +355,11 @@ export class CenterDirectorLLMExtractor implements IScraper {
   async extractDirectorForCenter(
     center: CandidateCenter,
     log: (msg: string) => void = () => {},
-  ): Promise<{ observations: ObservationInput[]; director: CenterDirector; sourceUrl: string } | null> {
+  ): Promise<{
+    observations: ObservationInput[];
+    director: CenterDirector;
+    sourceUrl: string;
+  } | null> {
     if (!this.apiKey || !center.websiteUrl || !center.slug) return null;
     let landing: { url: string; html: string } | null = null;
     try {
@@ -366,7 +377,9 @@ export class CenterDirectorLLMExtractor implements IScraper {
         try {
           page = await this.fetchPage(url);
         } catch (error) {
-          log(`[${center.slug}] leadership fetch failed for discovered center URL: ${sanitizeLogValue(error)}`);
+          log(
+            `[${center.slug}] leadership fetch failed for discovered center URL: ${sanitizeLogValue(error)}`,
+          );
           continue;
         }
       }

--- a/server/src/services/__tests__/researchEntityDto.test.ts
+++ b/server/src/services/__tests__/researchEntityDto.test.ts
@@ -289,4 +289,20 @@ describe('researchEntityDto', () => {
     expect(detail.researchEntity.entityType).toBe('INDIVIDUAL_RESEARCH');
     expect(detail.members).toEqual([]);
   });
+
+  it('exposes only safe public lead identity fields', () => {
+    const dto = toPublicResearchEntityDto({
+      slug: 'lead-review-lab',
+      name: 'Lead Review Lab',
+      leadIdentityStatus: 'under_review',
+      leadProfessorPublicKey: 'reviewed-professor-pi',
+      qualitySummary: { repairFlags: ['pi_identity_conflict'], privateNote: 'operator only' },
+    });
+
+    expect(dto).toMatchObject({
+      leadIdentityStatus: 'under_review',
+      leadProfessorPublicKey: 'reviewed-professor-pi',
+    });
+    expect(dto).not.toHaveProperty('qualitySummary');
+  });
 });

--- a/server/src/services/__tests__/researchEntityDto.test.ts
+++ b/server/src/services/__tests__/researchEntityDto.test.ts
@@ -193,16 +193,19 @@ describe('researchEntityDto', () => {
       enumerable: true,
     });
 
-    const dto = toPublicResearchEntityDto({
-      id: 'entity-dto-bounds',
-      slug: 'dto-bounds-lab',
-      name: 'DTO Bounds Lab',
-      description: 'x'.repeat(6000),
-      researchAreas,
-      sourceUrls,
-      studentDecisionExplanation: { reasons },
-      qualitySummary,
-    }, { includeOperatorFields: true });
+    const dto = toPublicResearchEntityDto(
+      {
+        id: 'entity-dto-bounds',
+        slug: 'dto-bounds-lab',
+        name: 'DTO Bounds Lab',
+        description: 'x'.repeat(6000),
+        researchAreas,
+        sourceUrls,
+        studentDecisionExplanation: { reasons },
+        qualitySummary,
+      },
+      { includeOperatorFields: true },
+    );
 
     expect(dto.description).toHaveLength(5000);
     expect(dto.researchAreas).toHaveLength(100);

--- a/server/src/services/__tests__/researchGroupService.test.ts
+++ b/server/src/services/__tests__/researchGroupService.test.ts
@@ -128,7 +128,7 @@ import {
 // One fully chainable query double: the service composes find().sort().limit()
 // .select().lean() in different orders per call site, so every helper returns
 // the same permissive chain to survive query-shape refactors.
-const queryResult = <T,>(value: T) => {
+const queryResult = <T>(value: T) => {
   const query: any = {
     lean: async () => value,
   };
@@ -138,15 +138,15 @@ const queryResult = <T,>(value: T) => {
   return query;
 };
 
-const leanResult = <T,>(value: T) => queryResult(value);
+const leanResult = <T>(value: T) => queryResult(value);
 
-const sortLeanResult = <T,>(value: T) => queryResult(value);
+const sortLeanResult = <T>(value: T) => queryResult(value);
 
-const sortLimitLeanResult = <T,>(value: T) => queryResult(value);
+const sortLimitLeanResult = <T>(value: T) => queryResult(value);
 
-const selectSortLimitLeanResult = <T,>(value: T) => queryResult(value);
+const selectSortLimitLeanResult = <T>(value: T) => queryResult(value);
 
-const selectLeanResult = <T,>(value: T) => queryResult(value);
+const selectLeanResult = <T>(value: T) => queryResult(value);
 
 beforeEach(() => {
   mocks.search.mockReset();
@@ -222,7 +222,8 @@ describe('searchResearchGroupsViaMeili', () => {
         ],
         estimatedTotalHits: 1,
       });
-    mocks.researchEntityFind.mockReturnValue(queryResult([
+    mocks.researchEntityFind.mockReturnValue(
+      queryResult([
         {
           _id: entityId,
           slug: 'reilly-lab',
@@ -232,7 +233,8 @@ describe('searchResearchGroupsViaMeili', () => {
           researchAreas: [],
           sourceUrls: [],
         },
-      ]));
+      ]),
+    );
 
     const result = await searchResearchGroupsViaMeili('reilly', {}, 1, 1);
 
@@ -280,7 +282,8 @@ describe('searchResearchGroupsViaMeili', () => {
       ],
       estimatedTotalHits: 2,
     });
-    mocks.researchEntityFind.mockReturnValue(queryResult([
+    mocks.researchEntityFind.mockReturnValue(
+      queryResult([
         {
           _id: entityId,
           slug: 'safe-lab',
@@ -291,7 +294,8 @@ describe('searchResearchGroupsViaMeili', () => {
           sourceUrls: [],
           studentVisibilityTier: 'student_ready',
         },
-      ]));
+      ]),
+    );
 
     await searchResearchGroupsViaMeili('', {}, 1, 24);
 
@@ -320,7 +324,8 @@ describe('searchResearchGroupsViaMeili', () => {
       ],
       estimatedTotalHits: 2,
     });
-    mocks.researchEntityFind.mockReturnValue(queryResult([
+    mocks.researchEntityFind.mockReturnValue(
+      queryResult([
         {
           _id: currentEntityId,
           slug: 'current-lab',
@@ -330,7 +335,8 @@ describe('searchResearchGroupsViaMeili', () => {
           researchAreas: [],
           sourceUrls: [],
         },
-      ]));
+      ]),
+    );
 
     const result = await searchResearchGroupsViaMeili('', {}, 1, 2);
 
@@ -434,7 +440,8 @@ describe('searchResearchGroupsViaMeili', () => {
       hits: [{ id: reviewEntityId, slug: 'review-lab', name: 'Review Lab' }],
       estimatedTotalHits: 1,
     });
-    mocks.researchEntityFind.mockReturnValue(queryResult([
+    mocks.researchEntityFind.mockReturnValue(
+      queryResult([
         {
           _id: reviewEntityId,
           slug: 'review-lab',
@@ -445,7 +452,8 @@ describe('searchResearchGroupsViaMeili', () => {
           sourceUrls: [],
           studentVisibilityTier: 'operator_review',
         },
-      ]));
+      ]),
+    );
 
     const result = await searchResearchGroupsViaMeili(
       '',
@@ -469,7 +477,8 @@ describe('searchResearchGroupsViaMeili', () => {
   it('sorts and filters admin default browse by weakest quality first', async () => {
     const strongEntityId = '67d8928150621bcef434a1d8';
     const weakEntityId = '67d8928150621bcef434a1d9';
-    mocks.researchEntityFind.mockReturnValue(queryResult([
+    mocks.researchEntityFind.mockReturnValue(
+      queryResult([
         {
           _id: strongEntityId,
           slug: 'strong-lab',
@@ -488,8 +497,11 @@ describe('searchResearchGroupsViaMeili', () => {
           departments: [],
           researchAreas: [],
         },
-      ]));
-    mocks.researchGroupMemberFind.mockReturnValue(queryResult([{ researchEntityId: strongEntityId, role: 'pi', userId: 'user-1' }]));
+      ]),
+    );
+    mocks.researchGroupMemberFind.mockReturnValue(
+      queryResult([{ researchEntityId: strongEntityId, role: 'pi', userId: 'user-1' }]),
+    );
 
     const result = await searchResearchGroupsViaMeili(
       '',
@@ -1154,7 +1166,8 @@ describe('getResearchGroupDetail', () => {
         researchAreas: [],
         sourceUrls: ['https://music.yale.edu/people/david-lang'],
         description: '',
-        profileSynthesisDescription: "David Lang's lab studies how humans process complex sound patterns.",
+        profileSynthesisDescription:
+          "David Lang's lab studies how humans process complex sound patterns.",
         descriptionSource: 'PI_PROFILE_SYNTHESIS',
         studentVisibilityTier: 'student_ready',
       }),
@@ -1207,9 +1220,8 @@ describe('getResearchGroupDetail', () => {
         sourceUrls: ['https://music.yale.edu/people/david-lang'],
         descriptionSource: 'PI_PROFILE_SYNTHESIS',
         profileSynthesisDescription:
-          "This music has been performed by major music, dance, and theater organizations throughout the world, and in the most renowned concert halls and festivals in the United States and Europe.",
-      },
-      ),
+          'This music has been performed by major music, dance, and theater organizations throughout the world, and in the most renowned concert halls and festivals in the United States and Europe.',
+      }),
     );
     mocks.researchGroupMemberFind.mockReturnValue(
       leanResult([
@@ -1265,7 +1277,8 @@ describe('listResearchEntityRelationshipPayload', () => {
     const publicInstituteId = '67d8928150621bcef434a1d6';
     const reviewInstituteId = '67d8928150621bcef434a1d7';
 
-    mocks.researchEntityRelationshipFind.mockReturnValue(queryResult([
+    mocks.researchEntityRelationshipFind.mockReturnValue(
+      queryResult([
         {
           _id: 'rel-yqi',
           sourceResearchEntityId: publicInstituteId,
@@ -1286,8 +1299,10 @@ describe('listResearchEntityRelationshipPayload', () => {
           evidenceStrength: 'MODERATE',
           evidenceQuote: 'Held private operator note',
         },
-      ]));
-    mocks.researchEntityFind.mockReturnValue(queryResult([
+      ]),
+    );
+    mocks.researchEntityFind.mockReturnValue(
+      queryResult([
         {
           _id: publicInstituteId,
           slug: 'center-yale-quantum-institute',
@@ -1306,7 +1321,8 @@ describe('listResearchEntityRelationshipPayload', () => {
           studentVisibilityTier: 'operator_review',
           archived: false,
         },
-      ]));
+      ]),
+    );
 
     const result = await listResearchEntityRelationshipPayload(currentEntityId);
 

--- a/server/src/services/__tests__/researchGroupService.test.ts
+++ b/server/src/services/__tests__/researchGroupService.test.ts
@@ -121,6 +121,7 @@ import {
   listResearchEntityRelationshipPayload,
   normalizeResearchGroupObjectId,
   publicMemberUserForRow,
+  researchDetailLeadIdentity,
   searchResearchGroupsViaMeili,
 } from '../researchGroupService';
 
@@ -1563,6 +1564,57 @@ describe('publicMemberUserForRow', () => {
       lname: 'Collaborator',
     });
     expect(publicUser).not.toHaveProperty('email');
+  });
+});
+
+describe('researchDetailLeadIdentity', () => {
+  const members = [
+    {
+      role: 'pi',
+      user: {
+        displayName: 'First Investigator',
+        profileUrls: { official: 'https://medicine.yale.edu/profile/first-investigator/' },
+      },
+      row: { facultyMemberId: 'faculty-1' },
+    },
+    {
+      role: 'co-pi',
+      user: {
+        displayName: 'Second Investigator',
+        profileUrls: { official: 'https://medicine.yale.edu/profile/second-investigator/' },
+      },
+      row: { facultyMemberId: 'faculty-2' },
+    },
+  ];
+
+  it('identifies a unique lead only from entity-owned official profile evidence', () => {
+    expect(
+      researchDetailLeadIdentity(
+        { sourceUrls: ['https://medicine.yale.edu/profile/second-investigator/'] },
+        members,
+      ),
+    ).toEqual({
+      leadIdentityStatus: 'verified',
+      leadProfessorPublicKey: 'second-investigator-co-pi',
+    });
+  });
+
+  it('omits the lead when entity evidence does not uniquely match a member', () => {
+    expect(researchDetailLeadIdentity({ sourceUrls: [] }, members)).toEqual({
+      leadIdentityStatus: 'verified',
+    });
+  });
+
+  it('derives the public review state from canonical PI identity conflicts', () => {
+    expect(
+      researchDetailLeadIdentity({}, [
+        {
+          role: 'pi',
+          user: { displayName: 'Disputed Investigator', facultyMemberId: 'faculty-user' },
+          row: { userId: 'user-1', facultyMemberId: 'faculty-row' },
+        },
+      ]),
+    ).toEqual({ leadIdentityStatus: 'under_review' });
   });
 });
 

--- a/server/src/services/__tests__/researchGroupService.test.ts
+++ b/server/src/services/__tests__/researchGroupService.test.ts
@@ -872,6 +872,72 @@ describe('getResearchGroupDetail', () => {
     expect(detail?.members[0].user).not.toHaveProperty('netid');
   });
 
+  it('derives PI identity review from raw records before public member replacement', async () => {
+    const entityId = '67d8928150621bcef434a1d5';
+    const wrongUserId = '67d8928150621bcef434a1d6';
+    const correctUserId = '67d8928150621bcef434a1d7';
+    const wrongFacultyId = '67d8928150621bcef434a1d8';
+    const correctFacultyId = '67d8928150621bcef434a1d9';
+    mocks.researchEntityFindOne.mockReturnValue(
+      leanResult({
+        _id: entityId,
+        slug: 'disputed-pi-lab',
+        name: 'Disputed PI Lab',
+        departments: [],
+        researchAreas: [],
+        sourceUrls: ['https://medicine.yale.edu/profile/correct-scholar/'],
+        studentVisibilityTier: 'student_ready',
+      }),
+    );
+    mocks.researchGroupMemberFind.mockReturnValue(
+      sortLimitLeanResult([
+        {
+          _id: 'member-1',
+          researchEntityId: entityId,
+          userId: wrongUserId,
+          facultyMemberId: correctFacultyId,
+          role: 'pi',
+          archived: false,
+          isCurrentMember: true,
+        },
+      ]),
+    );
+    mocks.userFind.mockReturnValue(
+      leanResult([
+        {
+          _id: wrongUserId,
+          fname: 'Wrong',
+          lname: 'Person',
+          facultyMemberId: wrongFacultyId,
+        },
+      ]),
+    );
+    mocks.facultyMemberFind.mockReturnValue(
+      selectLeanResult([
+        {
+          _id: correctFacultyId,
+          userId: correctUserId,
+          firstName: 'Correct',
+          lastName: 'Scholar',
+          profileUrls: {
+            official: 'https://medicine.yale.edu/profile/correct-scholar/',
+          },
+        },
+      ]),
+    );
+
+    const detail = await getResearchGroupDetail('disputed-pi-lab');
+
+    expect(detail?.researchEntity).toMatchObject({ leadIdentityStatus: 'under_review' });
+    expect(detail?.researchEntity).not.toHaveProperty('leadProfessorPublicKey');
+    expect(detail?.members[0].user).toMatchObject({
+      fname: 'Correct',
+      lname: 'Scholar',
+    });
+    expect(detail?.members[0].user).not.toHaveProperty('facultyMemberId');
+    expect(detail?.members[0].user).not.toHaveProperty('userId');
+  });
+
   it('minimizes public research detail paper payloads', async () => {
     const entityId = '67d8928150621bcef434a1d5';
     mocks.researchEntityFindOne.mockReturnValue(

--- a/server/src/services/researchEntityDto.ts
+++ b/server/src/services/researchEntityDto.ts
@@ -135,10 +135,7 @@ const OPTIONAL_PUBLIC_RESEARCH_ENTITY_FIELDS = [
   'researchAreaSource',
 ] as const;
 
-const OPERATOR_PUBLIC_RESEARCH_ENTITY_FIELDS = [
-  'qualitySummary',
-  'studentVisibilityTier',
-] as const;
+const OPERATOR_PUBLIC_RESEARCH_ENTITY_FIELDS = ['qualitySummary', 'studentVisibilityTier'] as const;
 
 export interface PublicResearchEntityDtoOptions {
   includeOperatorFields?: boolean;
@@ -237,9 +234,7 @@ export function addResearchEntitySearchAliases<T extends { hits: Record<string, 
   };
 }
 
-export function addResearchEntityDetailAlias<
-  T extends { group: Record<string, any> },
->(
+export function addResearchEntityDetailAlias<T extends { group: Record<string, any> }>(
   detail: T,
   options: PublicResearchEntityDtoOptions = {},
 ): Omit<T, 'group'> & {

--- a/server/src/services/researchEntityDto.ts
+++ b/server/src/services/researchEntityDto.ts
@@ -198,6 +198,18 @@ export function toPublicResearchEntityDto(
     }
   }
 
+  if (group.leadIdentityStatus === 'verified' || group.leadIdentityStatus === 'under_review') {
+    dto.leadIdentityStatus = group.leadIdentityStatus;
+  }
+  if (typeof group.leadProfessorPublicKey === 'string') {
+    const leadProfessorPublicKey = group.leadProfessorPublicKey
+      .toLowerCase()
+      .replace(/[^a-z0-9-]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 160);
+    if (leadProfessorPublicKey) dto.leadProfessorPublicKey = leadProfessorPublicKey;
+  }
+
   if (options.includeOperatorFields) {
     for (const field of OPERATOR_PUBLIC_RESEARCH_ENTITY_FIELDS) {
       if (group[field] !== undefined) {

--- a/server/src/services/researchGroupService.ts
+++ b/server/src/services/researchGroupService.ts
@@ -1276,11 +1276,13 @@ const normalizePublicUrlDestination = (url?: string | null): string => {
 export function researchDetailLeadIdentity(
   group: Record<string, any>,
   members: Array<{ user: any; role: string; row?: any }>,
+  rawLeadMembers?: Array<Record<string, any>>,
 ): { leadIdentityStatus: 'verified' | 'under_review'; leadProfessorPublicKey?: string } {
   const leadMembers = members.filter((member) => PUBLIC_LEAD_ROLES.has(member.role));
   const qualitySummary = buildResearchEntityQualitySummary({
     entity: group,
-    leadMembers: leadMembers.map((member) => ({ ...member.row, user: member.user })),
+    leadMembers:
+      rawLeadMembers || leadMembers.map((member) => ({ ...member.row, user: member.user })),
   });
   if (qualitySummary.repairFlags.includes('pi_identity_conflict')) {
     return { leadIdentityStatus: 'under_review' };
@@ -1954,9 +1956,35 @@ export async function getResearchGroupDetail(slug: string): Promise<{
     .sort((a, b) => (ROLE_PRIORITY[a.role] ?? 99) - (ROLE_PRIORITY[b.role] ?? 99));
   const imageGuardedMembersWithRows = await withPublicMemberImageGuards(membersWithRows);
   const dedupedMembersWithRows = dedupeSameNameLeadMembers(imageGuardedMembersWithRows, group);
+  const rawLeadMembers = memberRows
+    .filter((row) => PUBLIC_LEAD_ROLES.has(row.role))
+    .map((row) => {
+      const user = row.userId ? usersById.get(researchGroupDocumentId(row.userId)) : undefined;
+      const facultyMember = row.facultyMemberId
+        ? facultyMembersById.get(researchGroupDocumentId(row.facultyMemberId))
+        : undefined;
+      return {
+        ...row,
+        userId: normalizeResearchGroupObjectId(row.userId),
+        facultyMemberId: normalizeResearchGroupObjectId(row.facultyMemberId),
+        user: user
+          ? {
+              ...user,
+              facultyMemberId: normalizeResearchGroupObjectId(user.facultyMemberId),
+            }
+          : undefined,
+        facultyMember: facultyMember
+          ? {
+              ...facultyMember,
+              userId: normalizeResearchGroupObjectId(facultyMember.userId),
+            }
+          : undefined,
+      };
+    });
   const leadIdentity = researchDetailLeadIdentity(
     group as Record<string, any>,
     dedupedMembersWithRows,
+    rawLeadMembers,
   );
   const piOutreachRoute = buildLeadPiOutreachContactRoute(dedupedMembersWithRows, group);
   const leadMemberNames = dedupedMembersWithRows

--- a/server/src/services/researchGroupService.ts
+++ b/server/src/services/researchGroupService.ts
@@ -1273,6 +1273,49 @@ const normalizePublicUrlDestination = (url?: string | null): string => {
   }
 };
 
+export function researchDetailLeadIdentity(
+  group: Record<string, any>,
+  members: Array<{ user: any; role: string; row?: any }>,
+): { leadIdentityStatus: 'verified' | 'under_review'; leadProfessorPublicKey?: string } {
+  const leadMembers = members.filter((member) => PUBLIC_LEAD_ROLES.has(member.role));
+  const qualitySummary = buildResearchEntityQualitySummary({
+    entity: group,
+    leadMembers: leadMembers.map((member) => ({ ...member.row, user: member.user })),
+  });
+  if (qualitySummary.repairFlags.includes('pi_identity_conflict')) {
+    return { leadIdentityStatus: 'under_review' };
+  }
+
+  const entityProfileDestinations = new Set(
+    [
+      group.websiteUrl,
+      group.website,
+      ...(Array.isArray(group.sourceUrls) ? group.sourceUrls : []),
+      ...Object.values(safeProfileUrlObject(group.profileUrls || group.profile_urls)),
+    ]
+      .filter(isLikelyOfficialPersonProfileUrl)
+      .map((url) => normalizePublicUrlDestination(String(url)))
+      .filter(Boolean),
+  );
+  const matchingMembers = leadMembers.filter((member) =>
+    entityProfileDestinations.has(
+      normalizePublicUrlDestination(resolveLeadOfficialProfileUrl(member)),
+    ),
+  );
+
+  return {
+    leadIdentityStatus: 'verified',
+    ...(matchingMembers.length === 1
+      ? {
+          leadProfessorPublicKey: publicMemberKeyForResearchDetail(
+            matchingMembers[0].user,
+            matchingMembers[0].role,
+          ),
+        }
+      : {}),
+  };
+}
+
 function isResearchWebsiteFacultyPiRoute(route: any, group: any): boolean {
   if (route?.routeType !== 'FACULTY_PI') return false;
   const researchWebsiteDestinations = new Set(
@@ -1911,6 +1954,10 @@ export async function getResearchGroupDetail(slug: string): Promise<{
     .sort((a, b) => (ROLE_PRIORITY[a.role] ?? 99) - (ROLE_PRIORITY[b.role] ?? 99));
   const imageGuardedMembersWithRows = await withPublicMemberImageGuards(membersWithRows);
   const dedupedMembersWithRows = dedupeSameNameLeadMembers(imageGuardedMembersWithRows, group);
+  const leadIdentity = researchDetailLeadIdentity(
+    group as Record<string, any>,
+    dedupedMembersWithRows,
+  );
   const piOutreachRoute = buildLeadPiOutreachContactRoute(dedupedMembersWithRows, group);
   const leadMemberNames = dedupedMembersWithRows
     .filter((member) => PUBLIC_LEAD_ROLES.has(member.role))
@@ -2104,6 +2151,7 @@ export async function getResearchGroupDetail(slug: string): Promise<{
   return addResearchEntityDetailAlias({
     group: {
       ...publicGroupForResponse,
+      ...leadIdentity,
       accessSummary,
       studentDecisionExplanation: studentDecisionExplanation || undefined,
     },

--- a/server/src/services/researchGroupService.ts
+++ b/server/src/services/researchGroupService.ts
@@ -34,10 +34,7 @@ import {
   getAccessSummaryForResearchEntity,
   listAccessSummariesForResearchEntities,
 } from './accessSummaryService';
-import {
-  buildResearchGroupFilterString,
-  ResearchGroupFilterInput,
-} from './researchGroupFilters';
+import { buildResearchGroupFilterString, ResearchGroupFilterInput } from './researchGroupFilters';
 import {
   buildResearchEntityQualitySummary,
   type ResearchEntityQualitySummary,
@@ -161,9 +158,7 @@ export async function findOrCreateForOwner(owner: OwnerLike): Promise<{
         (existingMember as any).researchEntityId || (existingMember as any).researchGroupId,
       );
       if (existingResearchEntityId) {
-        const group = await ResearchEntity.findById(
-          existingResearchEntityId,
-        ).lean();
+        const group = await ResearchEntity.findById(existingResearchEntityId).lean();
         if (group) return { group, created: false };
       }
     }
@@ -239,10 +234,7 @@ export interface ResearchGroupSearchSort {
   sortOrder?: 'asc' | 'desc';
 }
 
-export type ResearchGroupQualityFilter =
-  | 'description-issue'
-  | 'missing-lead'
-  | 'profile-fallback';
+export type ResearchGroupQualityFilter = 'description-issue' | 'missing-lead' | 'profile-fallback';
 
 export interface ResearchGroupSearchOptions {
   includeNonPublic?: boolean;
@@ -291,9 +283,7 @@ const isAcceptanceLevelInput = (
 ): value is NonNullable<ResearchGroupFilterInput['acceptanceLevel']> =>
   value === 'verified' || value === 'verified-or-likely' || value === 'all';
 
-const isResearchGroupQualityFilter = (
-  value: unknown,
-): value is ResearchGroupQualityFilter =>
+const isResearchGroupQualityFilter = (value: unknown): value is ResearchGroupQualityFilter =>
   value === 'description-issue' || value === 'missing-lead' || value === 'profile-fallback';
 
 const sanitizeResearchGroupSearchFilters = (
@@ -317,9 +307,9 @@ const sanitizeResearchGroupSearchOptions = (
 ): ResearchGroupSearchOptions => ({
   includeNonPublic: options.includeNonPublic === true,
   lowQualityFirst: options.lowQualityFirst === true,
-  qualityFilters: boundedResearchFilterValues(options.qualityFilters as string[] | undefined).filter(
-    isResearchGroupQualityFilter,
-  ),
+  qualityFilters: boundedResearchFilterValues(
+    options.qualityFilters as string[] | undefined,
+  ).filter(isResearchGroupQualityFilter),
 });
 
 const mongoVisibilityFilter = (
@@ -480,7 +470,9 @@ export async function searchResearchGroupsViaMeili(
       .sort((a, b) => {
         const scoreDiff = b.qualitySummary.score - a.qualitySummary.score;
         if (scoreDiff !== 0) return scoreDiff;
-        return String(a.displayName || a.name || '').localeCompare(String(b.displayName || b.name || ''));
+        return String(a.displayName || a.name || '').localeCompare(
+          String(b.displayName || b.name || ''),
+        );
       });
     const pageEntities = filteredCandidates.slice(offset, offset + safePageSize);
     const pageEntityIds = pageEntities.map((entity) => entity._id);
@@ -608,7 +600,9 @@ export async function searchResearchGroupsViaMeili(
   const visibleEntitiesById = new Map(
     (visibleEntities as any[]).map((entity) => [researchGroupDocumentId(entity._id), entity]),
   );
-  const visibleHitIds = hitIds.filter((id: any) => visibleEntitiesById.has(researchGroupDocumentId(id)));
+  const visibleHitIds = hitIds.filter((id: any) =>
+    visibleEntitiesById.has(researchGroupDocumentId(id)),
+  );
   const activeListingGroupIds =
     visibleHitIds.length > 0
       ? await Listing.distinct('researchEntityId', {
@@ -697,20 +691,18 @@ const sortResearchEntitiesForMongoFallback = (
     sorted.sort((a, b) => {
       const rankDiff = Number(b.browseRankScore || 0) - Number(a.browseRankScore || 0);
       if (rankDiff !== 0) return rankDiff;
-      return (
-        new Date(b.lastObservedAt || 0).getTime() -
-        new Date(a.lastObservedAt || 0).getTime()
-      );
+      return new Date(b.lastObservedAt || 0).getTime() - new Date(a.lastObservedAt || 0).getTime();
     });
     return sorted;
   }
 
   sorted.sort((a, b) => {
     const observedDiff =
-      new Date(b.lastObservedAt || 0).getTime() -
-      new Date(a.lastObservedAt || 0).getTime();
+      new Date(b.lastObservedAt || 0).getTime() - new Date(a.lastObservedAt || 0).getTime();
     if (observedDiff !== 0) return observedDiff;
-    return String(a.displayName || a.name || '').localeCompare(String(b.displayName || b.name || ''));
+    return String(a.displayName || a.name || '').localeCompare(
+      String(b.displayName || b.name || ''),
+    );
   });
   return sorted;
 };
@@ -865,7 +857,10 @@ const publicMemberProfileUrlMap = (value: unknown): Record<string, string> | und
   if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
   const entries = Object.entries(value as Record<string, unknown>)
     .flatMap(([key, rawUrl]) => {
-      const normalizedKey = key.trim().toLowerCase().replace(/[^a-z0-9_-]+/g, '-');
+      const normalizedKey = key
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9_-]+/g, '-');
       const url = publicOfficialYalePersonProfileUrl(rawUrl);
       return normalizedKey &&
         PUBLIC_MEMBER_PROFILE_URL_KEYS.has(normalizedKey) &&
@@ -918,7 +913,9 @@ const hasPublicMemberProfileUrls = (value: Record<string, any>): boolean =>
 
 function publicMemberUserFromFaculty(faculty: any): any | null {
   if (!faculty) return null;
-  const [fallbackFirstName = '', ...rest] = String(faculty.name || '').trim().split(/\s+/);
+  const [fallbackFirstName = '', ...rest] = String(faculty.name || '')
+    .trim()
+    .split(/\s+/);
   const fallbackLastName = rest.join(' ');
   const publicUser: Record<string, any> = {
     _id: faculty.userId || faculty._id,
@@ -945,10 +942,7 @@ const addPublicMemberField = (target: Record<string, any>, key: string, value: a
 };
 
 function publicMemberKeyForResearchDetail(user: any, role?: string): string {
-  return [
-    user?.displayName || [user?.fname, user?.lname].filter(Boolean).join(' '),
-    role,
-  ]
+  return [user?.displayName || [user?.fname, user?.lname].filter(Boolean).join(' '), role]
     .filter(Boolean)
     .join(':')
     .toLowerCase()
@@ -1021,7 +1015,10 @@ async function withPublicMemberImageGuards<T extends { user: any }>(members: T[]
       sameImageUsers as any[],
     );
     const publicImageUrl = shouldSuppress ? '' : imageUrl;
-    return { ...member, user: { ...member.user, imageUrl: publicImageUrl, image_url: publicImageUrl } };
+    return {
+      ...member,
+      user: { ...member.user, imageUrl: publicImageUrl, image_url: publicImageUrl },
+    };
   });
 }
 
@@ -1110,7 +1107,9 @@ export async function listResearchEntityRelationshipPayload(entityId: unknown): 
   const affiliatedRelationships = (relationships as any[]).filter((relationship) =>
     idEquals(relationship.targetResearchEntityId, safeEntityId),
   );
-  const relatedEntityIds = relatedRelationships.map((relationship) => relationship.targetResearchEntityId);
+  const relatedEntityIds = relatedRelationships.map(
+    (relationship) => relationship.targetResearchEntityId,
+  );
   const affiliatedEntityIds = affiliatedRelationships.map(
     (relationship) => relationship.sourceResearchEntityId,
   );
@@ -1203,9 +1202,7 @@ const OFFICIAL_PROFILE_URL_KEYS = [
 const safeProfileUrlObject = (value: unknown): Record<string, string> => {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
   return Object.fromEntries(
-    Object.entries(value as Record<string, unknown>).filter(
-      ([, url]) => publicHttpUrl(url),
-    ),
+    Object.entries(value as Record<string, unknown>).filter(([, url]) => publicHttpUrl(url)),
   ) as Record<string, string>;
 };
 
@@ -1333,12 +1330,18 @@ function isResearchWebsiteFacultyPiRoute(route: any, group: any): boolean {
 }
 
 function contactRouteDedupeKey(route: any): string {
-  const routeType = String(route?.routeType || 'UNKNOWN').trim().toUpperCase();
+  const routeType = String(route?.routeType || 'UNKNOWN')
+    .trim()
+    .toUpperCase();
   const destination =
     normalizePublicUrlDestination(route?.url) ||
     normalizePublicUrlDestination(route?.sourceUrl) ||
-    String(route?.email || '').trim().toLowerCase() ||
-    String(route?.label || route?.name || '').trim().toLowerCase();
+    String(route?.email || '')
+      .trim()
+      .toLowerCase() ||
+    String(route?.label || route?.name || '')
+      .trim()
+      .toLowerCase();
   return `${routeType}:${destination}`;
 }
 
@@ -1441,8 +1444,9 @@ function departmentMatchScore(user: any, group: any): number {
   if (departments.length === 0) return 0;
 
   const primary: string[] = normalizedWordsForMatch(user?.primaryDepartment);
-  const secondary: string[] = (Array.isArray(user?.secondaryDepartments) ? user.secondaryDepartments : [])
-    .flatMap(normalizedWordsForMatch);
+  const secondary: string[] = (
+    Array.isArray(user?.secondaryDepartments) ? user.secondaryDepartments : []
+  ).flatMap(normalizedWordsForMatch);
 
   if (departments.some((word: string) => primary.includes(word))) return 30;
   if (departments.some((word: string) => secondary.includes(word))) return 12;
@@ -1452,10 +1456,18 @@ function departmentMatchScore(user: any, group: any): number {
 function memberEvidenceScore(member: { user: any; role: string; row?: any }, group: any): number {
   const user = member.user || {};
   const row = member.row || {};
-  const contactEmail = String(group?.contactEmail || '').trim().toLowerCase();
-  const email = String(user.email || '').trim().toLowerCase();
-  const contactNetid = contactEmail.endsWith('@yale.edu') ? contactEmail.replace(/@yale\.edu$/, '') : '';
-  const netid = String(user.netid || '').trim().toLowerCase();
+  const contactEmail = String(group?.contactEmail || '')
+    .trim()
+    .toLowerCase();
+  const email = String(user.email || '')
+    .trim()
+    .toLowerCase();
+  const contactNetid = contactEmail.endsWith('@yale.edu')
+    ? contactEmail.replace(/@yale\.edu$/, '')
+    : '';
+  const netid = String(user.netid || '')
+    .trim()
+    .toLowerCase();
   const sourceUrl = String(row.sourceUrl || '').trim();
 
   return (
@@ -1479,8 +1491,12 @@ function samePersonLeadRoleKey(member: { user: any; role: string }): string {
   const user = member.user || {};
   const name = normalizedMemberName(member);
   const title = normalizedWordsForMatch(user.title).join(' ');
-  const department = normalizedWordsForMatch(user.primaryDepartment || user.primary_department).join(' ');
-  const image = String(user.imageUrl || user.image_url || '').trim().toLowerCase();
+  const department = normalizedWordsForMatch(
+    user.primaryDepartment || user.primary_department,
+  ).join(' ');
+  const image = String(user.imageUrl || user.image_url || '')
+    .trim()
+    .toLowerCase();
   return [name, title, department, image].filter(Boolean).join('|');
 }
 
@@ -1533,7 +1549,9 @@ export function dedupeSameNameLeadMembers<T extends { user: any; role: string; r
       [...bucket].sort((a, b) => {
         const byScore = memberEvidenceScore(b, group) - memberEvidenceScore(a, group);
         if (byScore !== 0) return byScore;
-        return researchGroupDocumentId(a.user?._id).localeCompare(researchGroupDocumentId(b.user?._id));
+        return researchGroupDocumentId(a.user?._id).localeCompare(
+          researchGroupDocumentId(b.user?._id),
+        );
       })[0],
     );
   }
@@ -1550,7 +1568,9 @@ export function dedupeSameNameLeadMembers<T extends { user: any; role: string; r
         if (byRole !== 0) return byRole;
         const byScore = memberEvidenceScore(b, group) - memberEvidenceScore(a, group);
         if (byScore !== 0) return byScore;
-        return researchGroupDocumentId(a.user?._id).localeCompare(researchGroupDocumentId(b.user?._id));
+        return researchGroupDocumentId(a.user?._id).localeCompare(
+          researchGroupDocumentId(b.user?._id),
+        );
       })[0],
     );
   }
@@ -1599,56 +1619,56 @@ export function buildResearchActivityLinkPayload({
 
   const scholarlyLinks = [
     ...entityScholarlyLinks.map((link) =>
-      withoutInternalResearchActivityIds(scholarlyLinkToPublicLink(link, {
-        researchEntityId,
-        relationshipBasis: 'explicit_entity_link',
-        evidenceLabel: 'Linked to this research profile',
-      })),
+      withoutInternalResearchActivityIds(
+        scholarlyLinkToPublicLink(link, {
+          researchEntityId,
+          relationshipBasis: 'explicit_entity_link',
+          evidenceLabel: 'Linked to this research profile',
+        }),
+      ),
     ),
     ...entityLinkedPapers.map((paper) => ({
       ...paperToScholarlyLink(paper),
       relationshipBasis: 'explicit_entity_link',
       evidenceLabel: 'Linked to this research profile',
     })),
-  ]
-    .filter((link) => {
-      const key = uniqueKey(link.relationshipBasis || '', link._id);
-      if (seen.has(key) || !isPublicResearchPaperLink(link)) return false;
-      seen.add(key);
-      return true;
-    });
+  ].filter((link) => {
+    const key = uniqueKey(link.relationshipBasis || '', link._id);
+    if (seen.has(key) || !isPublicResearchPaperLink(link)) return false;
+    seen.add(key);
+    return true;
+  });
 
   const memberScholarlyLinks = [
     ...memberScholarlyLinkPairs
       .filter((pair) => pair.memberDisplayId)
-      .map((pair) =>
-        ({
-          ...withoutInternalResearchActivityIds(scholarlyLinkToPublicLink(pair.link, {
-          relationshipBasis: pair.relationshipBasis || 'identity_authorship',
-          evidenceLabel: pair.evidenceLabel || 'Authored by a verified Yale faculty identity',
-          confidence: pair.confidence,
-          observedAt: pair.observedAt,
-          sourceName: pair.sourceName,
-          sourceUrl: pair.sourceUrl,
-          })),
-          memberKey: pair.memberDisplayId,
-        }),
-      ),
+      .map((pair) => ({
+        ...withoutInternalResearchActivityIds(
+          scholarlyLinkToPublicLink(pair.link, {
+            relationshipBasis: pair.relationshipBasis || 'identity_authorship',
+            evidenceLabel: pair.evidenceLabel || 'Authored by a verified Yale faculty identity',
+            confidence: pair.confidence,
+            observedAt: pair.observedAt,
+            sourceName: pair.sourceName,
+            sourceUrl: pair.sourceUrl,
+          }),
+        ),
+        memberKey: pair.memberDisplayId,
+      })),
     ...memberPaperPairs
-    .filter((pair) => pair.memberDisplayId)
-    .map((pair) => ({
-      ...paperToScholarlyLink(pair.paper),
-      memberKey: pair.memberDisplayId,
-      relationshipBasis: 'member_authorship',
-      evidenceLabel: 'Authored by a listed professor',
-    })),
-  ]
-    .filter((link: any) => {
-      const key = uniqueKey(link.relationshipBasis || '', link._id, link.memberKey);
-      if (seen.has(key) || !isPublicResearchPaperLink(link)) return false;
-      seen.add(key);
-      return true;
-    });
+      .filter((pair) => pair.memberDisplayId)
+      .map((pair) => ({
+        ...paperToScholarlyLink(pair.paper),
+        memberKey: pair.memberDisplayId,
+        relationshipBasis: 'member_authorship',
+        evidenceLabel: 'Authored by a listed professor',
+      })),
+  ].filter((link: any) => {
+    const key = uniqueKey(link.relationshipBasis || '', link._id, link.memberKey);
+    if (seen.has(key) || !isPublicResearchPaperLink(link)) return false;
+    seen.add(key);
+    return true;
+  });
 
   return {
     scholarlyLinks,
@@ -1680,13 +1700,12 @@ const publicString = (value: unknown): string | undefined =>
 
 const publicStringArray = (values: unknown): string[] =>
   Array.isArray(values)
-    ? values
-        .slice(0, MAX_PUBLIC_DETAIL_ARRAY_ITEMS)
-        .flatMap((value) => publicString(value) ?? [])
+    ? values.slice(0, MAX_PUBLIC_DETAIL_ARRAY_ITEMS).flatMap((value) => publicString(value) ?? [])
     : [];
 
 const publicPaperDate = (value: unknown): string | undefined => {
-  const date = value instanceof Date ? value : typeof value === 'string' ? new Date(value) : undefined;
+  const date =
+    value instanceof Date ? value : typeof value === 'string' ? new Date(value) : undefined;
   return date && !Number.isNaN(date.getTime()) ? date.toISOString() : undefined;
 };
 
@@ -1893,7 +1912,9 @@ export async function getResearchGroupDetail(slug: string): Promise<{
       : Promise.resolve([]),
     memberFacultyIds.length
       ? FacultyMember.find({ _id: { $in: memberFacultyIds }, archived: { $ne: true } })
-          .select('netid userId name firstName lastName photoUrl primarySchool title bio email websiteUrl profileUrls')
+          .select(
+            'netid userId name firstName lastName photoUrl primarySchool title bio email websiteUrl profileUrls',
+          )
           .lean()
       : Promise.resolve([]),
   ]);
@@ -1949,7 +1970,9 @@ export async function getResearchGroupDetail(slug: string): Promise<{
             candidate.user.netid ||
             researchGroupDocumentId(candidate.user._id) ||
             [candidate.user.fname, candidate.user.lname].filter(Boolean).join(' ');
-          return `${(publicString(candidateUserKey) || '').toLowerCase()}:${candidate.role}` === key;
+          return (
+            `${(publicString(candidateUserKey) || '').toLowerCase()}:${candidate.role}` === key
+          );
         })
       );
     })
@@ -2008,7 +2031,7 @@ export async function getResearchGroupDetail(slug: string): Promise<{
       })
       .filter((entry): entry is [string, string] => Boolean(entry)),
   );
-  const members = dedupedMembersWithRows.map(({ row, ...member }) => {
+  const members = dedupedMembersWithRows.map(({ row: _row, ...member }) => {
     return {
       ...member,
       user: {
@@ -2030,7 +2053,11 @@ export async function getResearchGroupDetail(slug: string): Promise<{
         .lean()
     : [];
   const attributedScholarlyLinkIds = Array.from(
-    new Set(attributionRows.map((row: any) => researchGroupDocumentId(row.scholarlyLinkId)).filter(Boolean)),
+    new Set(
+      attributionRows
+        .map((row: any) => researchGroupDocumentId(row.scholarlyLinkId))
+        .filter(Boolean),
+    ),
   );
 
   const [
@@ -2071,8 +2098,8 @@ export async function getResearchGroupDetail(slug: string): Promise<{
       researchEntityId: (group as any)._id,
       archived: { $ne: true },
     })
-          .sort({ observedAt: -1, year: -1, updatedAt: -1 })
-          .limit(10)
+      .sort({ observedAt: -1, year: -1, updatedAt: -1 })
+      .limit(10)
       .lean(),
     attributedScholarlyLinkIds.length
       ? ResearchScholarlyLink.find({
@@ -2127,21 +2154,24 @@ export async function getResearchGroupDetail(slug: string): Promise<{
       return id ? [[id, link] as const] : [];
     }),
   );
-  const memberScholarlyLinkPairs = (attributionRows as any[])
-    .flatMap((row) => {
-      const link = scholarlyLinksById.get(researchGroupDocumentId(row.scholarlyLinkId));
-      if (!link) return [];
-      return [{
+  const memberScholarlyLinkPairs = (attributionRows as any[]).flatMap((row) => {
+    const link = scholarlyLinksById.get(researchGroupDocumentId(row.scholarlyLinkId));
+    if (!link) return [];
+    return [
+      {
         link,
-        memberDisplayId: publicMemberKeysByInternalId.get(researchGroupDocumentId(row.targetUserId)),
+        memberDisplayId: publicMemberKeysByInternalId.get(
+          researchGroupDocumentId(row.targetUserId),
+        ),
         relationshipBasis: row.relationshipBasis,
         evidenceLabel: row.evidenceLabel,
         confidence: row.confidence,
         observedAt: row.observedAt,
         sourceName: row.sourceName,
         sourceUrl: row.sourceUrl,
-      }];
-    });
+      },
+    ];
+  });
   const researchActivity = buildResearchActivityLinkPayload({
     researchEntityId: (group as any)._id,
     entityScholarlyLinks: entityScholarlyLinks as any[],


### PR DESCRIPTION
## Intent

Consolidate redundant leadership information on research detail pages for issue #190. When a research entity has exactly one verified PI, show that person once in the decision summary using the existing rich PI card and remove the separate PI section. When it has multiple PIs, keep the dedicated plural Principal Investigators section and also show a rich Lead professor card only for the PI whose official Yale faculty profile matches the lab's official profile, with no arbitrary fallback. Preserve missing and identity-under-review states. Make sidebar cards denser with smaller text and wrapping so long titles and department labels remain visible. Create a PR that links and closes YaleComputerSociety/ylabs issue #190.

## What Changed

- Consolidate a sole verified principal investigator into the decision summary, while retaining a plural section for entities with multiple PIs.
- Derive public lead identity status and uniquely matched lead-professor metadata from raw membership and official profile evidence, withholding disputed identities without an arbitrary fallback.
- Render denser leadership cards that preserve long titles and department labels, with updated tests and documentation for the new display behavior.

## Risk Assessment

✅ Low: The changes are well-bounded and correctly derive identity conflicts before sanitization, uniquely match multi-PI leads using entity-owned profile evidence, and preserve the intended single-PI, multi-PI, missing, and review-state rendering behavior.

## Testing

Focused client and service tests passed, then the actual research-detail UI was exercised with API-backed single-PI and multiple-PI fixtures at desktop and 390 px mobile widths; screenshots confirm consolidation, official-profile lead selection, dense wrapping, and no horizontal overflow. The unmatched-lead, missing-PI, and identity-under-review behaviors were also covered by the focused automated cases.

- Evidence: Single verified PI shown once in decision summary (local file: <code>/tmp/no-mistakes-evidence/01KXHSYGY3GN42EV0VQTHKNYWY/single-pi-decision-summary.png</code>)
- Evidence: Multiple PIs with officially matched lead professor (local file: <code>/tmp/no-mistakes-evidence/01KXHSYGY3GN42EV0VQTHKNYWY/multiple-pis-visible-viewport.png</code>)
- Evidence: Mobile layout with wrapped long PI title and department (local file: <code>/tmp/no-mistakes-evidence/01KXHSYGY3GN42EV0VQTHKNYWY/multiple-pis-mobile-wrapping.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `README.md` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- 🚨 `client/src/pages/labDetail.tsx:1155` - Do not infer the multi-PI lead from `decisionProfileUrl`. The detail service derives its `FACULTY_PI` route by selecting the first lead member with an official profile, so this comparison will usually select that arbitrary first member even when the research entity&#39;s own official profile does not identify them. Match against entity-owned profile evidence instead, or omit the Lead professor card when no such match exists.
- 🚨 `client/src/pages/labDetail.tsx:1150` - The identity-review branch checks `leadIdentityStatus`, but that field is not part of the ResearchEntity model or public detail DTO. Actual conflicts are represented by `qualitySummary.repairFlags` containing `pi_identity_conflict`, and operator-only quality data is also omitted from the public detail response. Consequently this branch cannot activate for real API payloads and may expose the attached PI card instead of the intended review state. Define and return a public review-status field, or derive a safe status server-side.

🔧 Fix: Derive safe PI identity and lead selection
1 error still open:
- 🚨 `server/src/services/researchGroupService.ts:1283` - The new review status is still unreachable for real detail payloads. `publicMemberUserForRow` replaces a mismatched user with a sanitized faculty projection that contains neither `facultyMemberId` nor the original faculty/user relationship, and no `facultyMember` object is passed here. As a result, `buildResearchEntityQualitySummary` cannot detect either supported PI identity-conflict condition. Derive the conflict from the raw member row plus loaded user/faculty records before sanitizing or replacing the member; update the test to exercise that production-shaped path.

🔧 Fix: Derive PI conflicts before public identity sanitization
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `yarn --cwd client test:ci src/pages/__tests__/labDetail.test.tsx src/components/labs/__tests__/LabMembersList.test.tsx`
- `yarn --cwd server test src/services/__tests__/researchGroupService.test.ts src/services/__tests__/researchEntityDto.test.ts`
- <code>Started the actual Vite client with `yarn --cwd client dev --host 127.0.0.1` and rendered API-backed fixtures through Playwright.</code>
- `bash scripts/with-playwright-libs.sh node /tmp/no-mistakes-evidence/01KXHSYGY3GN42EV0VQTHKNYWY/capture-pi-evidence.mjs`
- `Manually reviewed desktop screenshots for the single-PI and multiple-PI states and a 390 px mobile screenshot for wrapping and layout.`
- <code>Verified at 390 px that `clientWidth` and `scrollWidth` were both 390, the plural PI and lead headings appeared once, and the complete long title and department remained present.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
