### PR TITLE
EF-02: Add compact adaptive Research filter disclosure

### DIFF
--- a/client/src/components/research/ResearchFilterDisclosure.tsx
+++ b/client/src/components/research/ResearchFilterDisclosure.tsx
@@ -1,0 +1,352 @@
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
+
+type FacetDistribution = Record<string, Record<string, number>>;
+
+interface ResearchFilterDisclosureProps {
+  facetDistribution: FacetDistribution;
+  selectedSchool: string;
+  selectedDepartment: string;
+  isApplying: boolean;
+  hasFacetError: boolean;
+  departmentLabel: (value: string) => string;
+  onSchoolChange: (value: string) => void;
+  onDepartmentChange: (value: string) => void;
+  onClearAll: () => void;
+}
+
+interface FacetOption {
+  value: string;
+  count?: number;
+}
+
+const positiveFacetOptions = (values: Record<string, number> | undefined): FacetOption[] =>
+  Object.entries(values || {})
+    .filter(([value, count]) => value.trim().length > 0 && Number.isFinite(count) && count > 0)
+    .map(([value, count]) => ({ value, count }))
+    .sort((a, b) => a.value.localeCompare(b.value));
+
+const withSelectedOption = (options: FacetOption[], selected: string): FacetOption[] => {
+  if (!selected || options.some((option) => option.value === selected)) return options;
+  return [{ value: selected }, ...options];
+};
+
+const ResearchFilterDisclosure = ({
+  facetDistribution,
+  selectedSchool,
+  selectedDepartment,
+  isApplying,
+  hasFacetError,
+  departmentLabel,
+  onSchoolChange,
+  onDepartmentChange,
+  onClearAll,
+}: ResearchFilterDisclosureProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const closeRef = useRef<HTMLButtonElement | null>(null);
+  const firstSchoolRef = useRef<HTMLSelectElement | null>(null);
+  const firstDepartmentRef = useRef<HTMLSelectElement | null>(null);
+  const panelId = useId();
+
+  const positiveSchools = useMemo(
+    () => positiveFacetOptions(facetDistribution.school),
+    [facetDistribution.school],
+  );
+  const positiveDepartments = useMemo(
+    () => positiveFacetOptions(facetDistribution.departments),
+    [facetDistribution.departments],
+  );
+  const schoolOptions = useMemo(
+    () => withSelectedOption(positiveSchools, selectedSchool),
+    [positiveSchools, selectedSchool],
+  );
+  const departmentOptions = useMemo(
+    () => withSelectedOption(positiveDepartments, selectedDepartment),
+    [positiveDepartments, selectedDepartment],
+  );
+  const showSchool = positiveSchools.length > 1 || Boolean(selectedSchool);
+  const showDepartment = positiveDepartments.length > 1 || Boolean(selectedDepartment);
+  const activeCount = Number(Boolean(selectedSchool)) + Number(Boolean(selectedDepartment));
+  const visibleFacetKey = `${String(showSchool)}:${String(showDepartment)}`;
+
+  const getFocusableElements = () =>
+    Array.from(
+      panelRef.current?.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ) || [],
+    );
+
+  const focusFirstControl = () => {
+    const desktop = window.matchMedia?.('(min-width: 640px)').matches ?? false;
+    if (desktop) {
+      (firstSchoolRef.current || firstDepartmentRef.current || closeRef.current)?.focus();
+      return;
+    }
+    closeRef.current?.focus();
+  };
+
+  const closeFilters = (restoreFocus = true) => {
+    setIsOpen(false);
+    if (restoreFocus) window.setTimeout(() => triggerRef.current?.focus(), 0);
+  };
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const timeout = window.setTimeout(focusFirstControl, 0);
+    return () => window.clearTimeout(timeout);
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const timeout = window.setTimeout(() => {
+      if (!panelRef.current?.contains(document.activeElement)) focusFirstControl();
+    }, 0);
+    return () => window.clearTimeout(timeout);
+  }, [isOpen, visibleFacetKey]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      event.preventDefault();
+      closeFilters();
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handlePointerOutside = (event: MouseEvent) => {
+      if (!(window.matchMedia?.('(min-width: 640px)').matches ?? false)) return;
+      if (
+        panelRef.current?.contains(event.target as Node) ||
+        triggerRef.current?.contains(event.target as Node)
+      ) {
+        return;
+      }
+      closeFilters(false);
+    };
+    document.addEventListener('mousedown', handlePointerOutside);
+    return () => document.removeEventListener('mousedown', handlePointerOutside);
+  }, [isOpen]);
+
+  const emptyMessage = hasFacetError
+    ? 'Filter options are temporarily unavailable. Your search still works, and active filters can be cleared.'
+    : isApplying
+      ? 'Filter options will appear when this search finishes.'
+      : 'No additional filters can narrow these results.';
+
+  return (
+    <div className="mt-3 min-w-0 max-w-full">
+      <div className="relative min-w-0 max-w-full">
+        <button
+          ref={triggerRef}
+          type="button"
+          aria-expanded={isOpen}
+          aria-haspopup="dialog"
+          aria-controls={isOpen ? panelId : undefined}
+          aria-label={`Filters${activeCount > 0 ? `, ${activeCount} active` : ''}`}
+          onClick={() => (isOpen ? closeFilters() : setIsOpen(true))}
+          className="inline-flex min-h-11 max-w-full items-center gap-2 rounded-md border border-[var(--yr-line-strong)] bg-[var(--yr-panel)] px-3 text-sm font-semibold text-slate-700 transition-colors hover:bg-[var(--yr-panel-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+        >
+          <svg
+            aria-hidden="true"
+            className="h-4 w-4 shrink-0"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M3 5h18M6 12h12M10 19h4"
+            />
+          </svg>
+          <span>Filters</span>
+          {activeCount > 0 && (
+            <span className="min-w-5 rounded-full bg-[var(--yr-blue)] px-1.5 py-0.5 text-center text-xs font-semibold text-white">
+              {activeCount}
+            </span>
+          )}
+          <svg
+            aria-hidden="true"
+            className={`h-4 w-4 shrink-0 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+            fill="currentColor"
+            viewBox="0 0 20 20"
+          >
+            <path d="M5.2 7.5 10 12.3l4.8-4.8 1.4 1.4-6.2 6.2-6.2-6.2 1.4-1.4Z" />
+          </svg>
+        </button>
+
+        {isOpen && (
+          <>
+            <div
+              data-testid="research-filter-backdrop"
+              aria-hidden="true"
+              onMouseDown={() => closeFilters()}
+              className="fixed inset-0 z-40 bg-slate-950/30 sm:hidden"
+            />
+            <div
+              id={panelId}
+              ref={panelRef}
+              role="dialog"
+              aria-modal="true"
+              aria-label="Research filters"
+              aria-busy={isApplying}
+              onKeyDown={(event) => {
+                if (event.key !== 'Tab') return;
+                const focusable = getFocusableElements();
+                if (focusable.length === 0) return;
+                const first = focusable[0];
+                const last = focusable[focusable.length - 1];
+                if (event.shiftKey && document.activeElement === first) {
+                  event.preventDefault();
+                  last.focus();
+                } else if (!event.shiftKey && document.activeElement === last) {
+                  event.preventDefault();
+                  first.focus();
+                }
+              }}
+              className="fixed inset-x-0 bottom-0 z-50 max-h-[85dvh] w-full max-w-full overflow-y-auto rounded-t-md border border-[var(--yr-line)] bg-[var(--yr-panel)] shadow-lg sm:absolute sm:inset-x-auto sm:bottom-auto sm:right-0 sm:top-full sm:mt-1 sm:w-[22rem] sm:max-w-[calc(100vw-2rem)] sm:rounded-md"
+            >
+              <div className="flex min-w-0 items-center justify-between gap-3 border-b border-[var(--yr-line)] px-4 py-3">
+                <div className="min-w-0">
+                  <h3 className="truncate text-base font-semibold text-slate-950">
+                    Research filters
+                  </h3>
+                  {isApplying && (
+                    <p role="status" className="mt-0.5 text-xs text-slate-600">
+                      Applying filters...
+                    </p>
+                  )}
+                </div>
+                <button
+                  ref={closeRef}
+                  type="button"
+                  aria-label="Close filters"
+                  onClick={() => closeFilters()}
+                  className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-md text-2xl text-slate-600 hover:bg-[var(--yr-panel-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+                >
+                  <span aria-hidden="true">×</span>
+                </button>
+              </div>
+
+              <div className="min-w-0 space-y-4 p-4">
+                {hasFacetError && (showSchool || showDepartment) && (
+                  <p className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+                    Current filter counts are unavailable. Active values remain clearable.
+                  </p>
+                )}
+                {showSchool || showDepartment ? (
+                  <fieldset className="min-w-0 space-y-4 border-0 p-0">
+                    <legend className="sr-only">Narrow research results</legend>
+                    {showSchool && (
+                      <label className="block min-w-0 text-sm font-medium text-slate-800">
+                        School
+                        <select
+                          ref={firstSchoolRef}
+                          aria-label="Filter by school"
+                          value={selectedSchool}
+                          onChange={(event) => onSchoolChange(event.target.value)}
+                          className="mt-1 min-h-11 w-full min-w-0 rounded-md border border-[var(--yr-line-strong)] bg-white px-3 text-sm text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+                        >
+                          <option value="">All schools</option>
+                          {schoolOptions.map((option) => (
+                            <option key={option.value} value={option.value}>
+                              {option.value}
+                              {option.count !== undefined ? ` (${option.count})` : ''}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                    )}
+                    {showDepartment && (
+                      <label className="block min-w-0 text-sm font-medium text-slate-800">
+                        Department
+                        <select
+                          ref={!showSchool ? firstDepartmentRef : undefined}
+                          aria-label="Filter by department"
+                          value={selectedDepartment}
+                          onChange={(event) => onDepartmentChange(event.target.value)}
+                          className="mt-1 min-h-11 w-full min-w-0 rounded-md border border-[var(--yr-line-strong)] bg-white px-3 text-sm text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+                        >
+                          <option value="">All departments</option>
+                          {departmentOptions.map((option) => (
+                            <option key={option.value} value={option.value}>
+                              {departmentLabel(option.value)}
+                              {option.count !== undefined ? ` (${option.count})` : ''}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                    )}
+                  </fieldset>
+                ) : (
+                  <p className="text-sm leading-relaxed text-slate-600">{emptyMessage}</p>
+                )}
+
+                {activeCount > 0 && (
+                  <button
+                    type="button"
+                    onClick={onClearAll}
+                    className="inline-flex min-h-11 w-full items-center justify-center rounded-md border border-[var(--yr-line-strong)] px-3 text-sm font-semibold text-slate-700 hover:bg-[var(--yr-panel-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+                  >
+                    Clear all filters
+                  </button>
+                )}
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+
+      {activeCount > 0 && (
+        <div
+          className="mt-2 flex min-w-0 max-w-full flex-wrap gap-2"
+          aria-label="Active research filters"
+        >
+          {selectedSchool && (
+            <button
+              type="button"
+              onClick={() => onSchoolChange('')}
+              aria-label={`Remove School: ${selectedSchool}`}
+              className="inline-flex min-h-11 max-w-full min-w-0 items-center gap-2 rounded-md border border-[var(--yr-line)] bg-[var(--yr-panel)] px-3 text-sm text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+            >
+              <span className="min-w-0 truncate">School: {selectedSchool}</span>
+              <span aria-hidden="true" className="shrink-0">
+                ×
+              </span>
+            </button>
+          )}
+          {selectedDepartment && (
+            <button
+              type="button"
+              onClick={() => onDepartmentChange('')}
+              aria-label={`Remove Department: ${departmentLabel(selectedDepartment)}`}
+              className="inline-flex min-h-11 max-w-full min-w-0 items-center gap-2 rounded-md border border-[var(--yr-line)] bg-[var(--yr-panel)] px-3 text-sm text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+            >
+              <span className="min-w-0 truncate">
+                Department: {departmentLabel(selectedDepartment)}
+              </span>
+              <span aria-hidden="true" className="shrink-0">
+                ×
+              </span>
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onClearAll}
+            className="inline-flex min-h-11 shrink-0 items-center rounded-md px-2 text-sm font-semibold text-slate-600 hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+          >
+            Clear all active filters
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ResearchFilterDisclosure;

--- a/client/src/components/research/ResearchFilterDisclosure.tsx
+++ b/client/src/components/research/ResearchFilterDisclosure.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 
 type FacetDistribution = Record<string, Record<string, number>>;
 
@@ -42,6 +42,9 @@ const ResearchFilterDisclosure = ({
   onClearAll,
 }: ResearchFilterDisclosureProps) => {
   const [isOpen, setIsOpen] = useState(false);
+  const [isDesktop, setIsDesktop] = useState(
+    () => window.matchMedia?.('(min-width: 640px)').matches ?? false,
+  );
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const panelRef = useRef<HTMLDivElement | null>(null);
   const closeRef = useRef<HTMLButtonElement | null>(null);
@@ -77,14 +80,22 @@ const ResearchFilterDisclosure = ({
       ) || [],
     );
 
-  const focusFirstControl = () => {
-    const desktop = window.matchMedia?.('(min-width: 640px)').matches ?? false;
-    if (desktop) {
+  const focusFirstControl = useCallback(() => {
+    if (isDesktop) {
       (firstSchoolRef.current || firstDepartmentRef.current || closeRef.current)?.focus();
       return;
     }
     closeRef.current?.focus();
-  };
+  }, [isDesktop]);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia?.('(min-width: 640px)');
+    if (!mediaQuery) return;
+    const handleChange = (event: MediaQueryListEvent) => setIsDesktop(event.matches);
+    setIsDesktop(mediaQuery.matches);
+    mediaQuery.addEventListener?.('change', handleChange);
+    return () => mediaQuery.removeEventListener?.('change', handleChange);
+  }, []);
 
   const closeFilters = (restoreFocus = true) => {
     setIsOpen(false);
@@ -95,7 +106,7 @@ const ResearchFilterDisclosure = ({
     if (!isOpen) return;
     const timeout = window.setTimeout(focusFirstControl, 0);
     return () => window.clearTimeout(timeout);
-  }, [isOpen]);
+  }, [focusFirstControl, isOpen]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -103,7 +114,7 @@ const ResearchFilterDisclosure = ({
       if (!panelRef.current?.contains(document.activeElement)) focusFirstControl();
     }, 0);
     return () => window.clearTimeout(timeout);
-  }, [isOpen, visibleFacetKey]);
+  }, [focusFirstControl, isOpen, visibleFacetKey]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -119,7 +130,7 @@ const ResearchFilterDisclosure = ({
   useEffect(() => {
     if (!isOpen) return;
     const handlePointerOutside = (event: MouseEvent) => {
-      if (!(window.matchMedia?.('(min-width: 640px)').matches ?? false)) return;
+      if (!isDesktop) return;
       if (
         panelRef.current?.contains(event.target as Node) ||
         triggerRef.current?.contains(event.target as Node)
@@ -130,7 +141,7 @@ const ResearchFilterDisclosure = ({
     };
     document.addEventListener('mousedown', handlePointerOutside);
     return () => document.removeEventListener('mousedown', handlePointerOutside);
-  }, [isOpen]);
+  }, [isDesktop, isOpen]);
 
   const emptyMessage = hasFacetError
     ? 'Filter options are temporarily unavailable. Your search still works, and active filters can be cleared.'
@@ -193,11 +204,11 @@ const ResearchFilterDisclosure = ({
               id={panelId}
               ref={panelRef}
               role="dialog"
-              aria-modal="true"
+              aria-modal={isDesktop ? undefined : true}
               aria-label="Research filters"
               aria-busy={isApplying}
               onKeyDown={(event) => {
-                if (event.key !== 'Tab') return;
+                if (isDesktop || event.key !== 'Tab') return;
                 const focusable = getFocusableElements();
                 if (focusable.length === 0) return;
                 const first = focusable[0];

--- a/client/src/components/research/__tests__/ResearchFilterDisclosure.test.tsx
+++ b/client/src/components/research/__tests__/ResearchFilterDisclosure.test.tsx
@@ -1,0 +1,116 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import ResearchFilterDisclosure from '../ResearchFilterDisclosure';
+
+const originalMatchMedia = window.matchMedia;
+
+const renderFilters = (
+  overrides: Partial<ComponentProps<typeof ResearchFilterDisclosure>> = {},
+) => {
+  const props: ComponentProps<typeof ResearchFilterDisclosure> = {
+    facetDistribution: {
+      school: { 'Yale College': 8, 'School of Medicine': 4 },
+      departments: { 'Computer Science': 5, Neuroscience: 3 },
+    },
+    selectedSchool: '',
+    selectedDepartment: '',
+    isApplying: false,
+    hasFacetError: false,
+    departmentLabel: (value) => value,
+    onSchoolChange: vi.fn(),
+    onDepartmentChange: vi.fn(),
+    onClearAll: vi.fn(),
+    ...overrides,
+  };
+  return { ...render(<ResearchFilterDisclosure {...props} />), props };
+};
+
+afterEach(() => {
+  window.matchMedia = originalMatchMedia;
+  vi.restoreAllMocks();
+});
+
+describe('ResearchFilterDisclosure', () => {
+  it('moves and contains mobile focus, then restores the trigger on Escape and backdrop close', async () => {
+    window.matchMedia = vi.fn().mockReturnValue({ matches: false }) as typeof window.matchMedia;
+    renderFilters({ selectedSchool: 'Yale College' });
+
+    const trigger = screen.getByRole('button', { name: 'Filters, 1 active' });
+    fireEvent.click(trigger);
+    const dialog = screen.getByRole('dialog', { name: 'Research filters' });
+    const close = within(dialog).getByRole('button', { name: 'Close filters' });
+    await waitFor(() => expect(close).toHaveFocus());
+
+    const last = within(dialog).getByRole('button', { name: 'Clear all filters' });
+    last.focus();
+    fireEvent.keyDown(dialog, { key: 'Tab' });
+    expect(close).toHaveFocus();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByRole('dialog', { name: 'Research filters' })).toBeNull();
+    expect(screen.queryByLabelText('Filter by school')).toBeNull();
+    await waitFor(() => expect(trigger).toHaveFocus());
+
+    fireEvent.click(trigger);
+    await screen.findByRole('dialog', { name: 'Research filters' });
+    fireEvent.mouseDown(screen.getByTestId('research-filter-backdrop'));
+    expect(screen.queryByRole('dialog', { name: 'Research filters' })).toBeNull();
+    await waitFor(() => expect(trigger).toHaveFocus());
+  });
+
+  it('starts desktop disclosure focus on the first useful facet', async () => {
+    window.matchMedia = vi.fn().mockReturnValue({ matches: true }) as typeof window.matchMedia;
+    renderFilters();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Filters' }));
+    const dialog = screen.getByRole('dialog', { name: 'Research filters' });
+    expect(dialog.className).toContain('sm:absolute');
+    await waitFor(() => expect(within(dialog).getByLabelText('Filter by school')).toHaveFocus());
+    expect(within(dialog).getByRole('button', { name: 'Close filters' })).not.toHaveFocus();
+  });
+
+  it.each([320, 375])(
+    'keeps the mobile sheet and long active chips bounded at %ipx',
+    async (width) => {
+      Object.defineProperty(window, 'innerWidth', { configurable: true, value: width });
+      window.matchMedia = vi.fn().mockReturnValue({ matches: false }) as typeof window.matchMedia;
+      renderFilters({
+        selectedSchool: 'A very long school name that must stay inside the narrow viewport',
+        selectedDepartment: 'A very long department name that must not force horizontal overflow',
+        facetDistribution: {},
+      });
+
+      const schoolChip = screen.getByRole('button', {
+        name: /Remove School: A very long school name/,
+      });
+      const departmentChip = screen.getByRole('button', {
+        name: /Remove Department: A very long department name/,
+      });
+      expect(schoolChip.className).toContain('max-w-full');
+      expect(schoolChip.className).toContain('min-w-0');
+      expect(departmentChip.className).toContain('max-w-full');
+
+      fireEvent.click(screen.getByRole('button', { name: 'Filters, 2 active' }));
+      const dialog = screen.getByRole('dialog', { name: 'Research filters' });
+      expect(dialog.className).toContain('inset-x-0');
+      expect(dialog.className).toContain('w-full');
+      expect(dialog.className).toContain('max-w-full');
+    },
+  );
+
+  it('hides single and non-positive facets unless selected', () => {
+    renderFilters({
+      facetDistribution: {
+        school: { 'Yale College': 1, Unknown: 0 },
+        departments: { Neuroscience: -1 },
+      },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Filters' }));
+    expect(screen.queryByLabelText('Filter by school')).toBeNull();
+    expect(screen.queryByLabelText('Filter by department')).toBeNull();
+    expect(screen.getByText('No additional filters can narrow these results.')).toBeTruthy();
+  });
+});

--- a/client/src/components/research/__tests__/ResearchFilterDisclosure.test.tsx
+++ b/client/src/components/research/__tests__/ResearchFilterDisclosure.test.tsx
@@ -40,6 +40,7 @@ describe('ResearchFilterDisclosure', () => {
     const trigger = screen.getByRole('button', { name: 'Filters, 1 active' });
     fireEvent.click(trigger);
     const dialog = screen.getByRole('dialog', { name: 'Research filters' });
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
     const close = within(dialog).getByRole('button', { name: 'Close filters' });
     await waitFor(() => expect(close).toHaveFocus());
 
@@ -60,15 +61,23 @@ describe('ResearchFilterDisclosure', () => {
     await waitFor(() => expect(trigger).toHaveFocus());
   });
 
-  it('starts desktop disclosure focus on the first useful facet', async () => {
+  it('keeps the desktop disclosure non-modal and lets Tab leave it', async () => {
     window.matchMedia = vi.fn().mockReturnValue({ matches: true }) as typeof window.matchMedia;
     renderFilters();
 
     fireEvent.click(screen.getByRole('button', { name: 'Filters' }));
     const dialog = screen.getByRole('dialog', { name: 'Research filters' });
     expect(dialog.className).toContain('sm:absolute');
+    expect(dialog).not.toHaveAttribute('aria-modal');
     await waitFor(() => expect(within(dialog).getByLabelText('Filter by school')).toHaveFocus());
     expect(within(dialog).getByRole('button', { name: 'Close filters' })).not.toHaveFocus();
+
+    const last = within(dialog).getByLabelText('Filter by department');
+    last.focus();
+    const tabEvent = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    dialog.dispatchEvent(tabEvent);
+    expect(tabEvent.defaultPrevented).toBe(false);
+    expect(last).toHaveFocus();
   });
 
   it.each([320, 375])(

--- a/client/src/pages/__tests__/research.test.tsx
+++ b/client/src/pages/__tests__/research.test.tsx
@@ -1368,6 +1368,68 @@ describe('Research page', () => {
     );
   });
 
+  it('preserves facet availability when loading more search results fails', async () => {
+    class MockIntersectionObserver {
+      constructor(callback: IntersectionObserverCallback) {
+        intersectionCallback = callback;
+      }
+
+      observe = vi.fn();
+      disconnect = vi.fn();
+      unobserve = vi.fn();
+      takeRecords = vi.fn(() => []);
+    }
+
+    window.IntersectionObserver =
+      MockIntersectionObserver as unknown as typeof IntersectionObserver;
+    globalThis.IntersectionObserver =
+      MockIntersectionObserver as unknown as typeof IntersectionObserver;
+    Element.prototype.getBoundingClientRect = vi.fn(() => ({
+      bottom: 2000,
+      height: 1,
+      left: 0,
+      right: 1,
+      top: 2000,
+      width: 1,
+      x: 0,
+      y: 2000,
+      toJSON: () => ({}),
+    }));
+
+    mockedAxios.post.mockImplementation((url: string, body: { page?: number }) => {
+      if (url !== '/research/search') return Promise.reject(unexpectedSearchEndpoint(url));
+      if (body.page === 2) return Promise.reject(new Error('pagination unavailable'));
+      return Promise.resolve(
+        researchSearchResponse([researchEntity], {
+          estimatedTotalHits: 25,
+          facetDistribution: {
+            school: { 'Yale College': 8, 'School of Medicine': 4 },
+            departments: { 'Computer Science': 5, Neuroscience: 3 },
+          },
+        }),
+      );
+    });
+
+    renderResearch(departments, ['/research?q=protein+folding']);
+
+    await screen.findByRole('heading', { name: 'AI Safety Lab' });
+    await waitFor(() => expect(intersectionCallback).toBeDefined());
+    await act(async () => {
+      intersectionCallback?.(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      );
+    });
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'More research homes are temporarily unavailable.',
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Filters' }));
+    expect(screen.getByLabelText('Filter by school')).toBeTruthy();
+    expect(screen.getByLabelText('Filter by department')).toBeTruthy();
+    expect(screen.queryByText('Filter options are temporarily unavailable.')).toBeNull();
+  });
+
   it('does not expose server-provided or hardcoded example search chips', async () => {
     mockedAxios.get.mockResolvedValueOnce({
       data: {

--- a/client/src/pages/__tests__/research.test.tsx
+++ b/client/src/pages/__tests__/research.test.tsx
@@ -204,6 +204,20 @@ const NavigateToResearchQuery = ({ query }: { query: string }) => {
   );
 };
 
+const ResearchHistoryButtons = () => {
+  const navigate = useNavigate();
+  return (
+    <>
+      <button type="button" onClick={() => navigate(-1)}>
+        Previous research search
+      </button>
+      <button type="button" onClick={() => navigate(1)}>
+        Next research search
+      </button>
+    </>
+  );
+};
+
 const renderResearchWithDetailRoute = () =>
   render(
     <StrictMode>
@@ -548,7 +562,7 @@ describe('Research page', () => {
     expect(screen.getByTestId('location').textContent).toBe('/research?q=quantum+materials');
   });
 
-  it('filters search results by school, department, and undergraduate evidence in the URL', async () => {
+  it('keeps school and department filters compact, URL-backed, and individually clearable', async () => {
     mockSearchResponses((url) => {
       if (url !== '/research/search') return unexpectedSearchEndpoint(url);
       return researchSearchResponse([researchEntity], {
@@ -577,6 +591,12 @@ describe('Research page', () => {
     );
 
     await screen.findByRole('heading', { name: 'AI Safety Lab' });
+    const trigger = screen.getByRole('button', { name: 'Filters' });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByLabelText('Filter by school')).toBeNull();
+
+    fireEvent.click(trigger);
+    expect(screen.getByRole('dialog', { name: 'Research filters' })).toBeTruthy();
     fireEvent.change(screen.getByLabelText('Filter by school'), {
       target: { value: 'Yale College' },
     });
@@ -584,8 +604,12 @@ describe('Research page', () => {
       expect(mockedAxios.post.mock.calls.at(-1)?.[1]).toEqual(
         expect.objectContaining({ filters: { school: ['Yale College'] }, page: 1 }),
       );
+      expect(screen.getByTestId('location').textContent).toBe(
+        '/research?q=machine+learning&school=Yale+College',
+      );
     });
 
+    await waitFor(() => expect(screen.getByLabelText('Filter by department')).not.toBeDisabled());
     fireEvent.change(screen.getByLabelText('Filter by department'), {
       target: { value: 'Computer Science' },
     });
@@ -599,9 +623,223 @@ describe('Research page', () => {
           page: 1,
         }),
       );
+      expect(screen.getByRole('button', { name: 'Filters, 2 active' })).toBeTruthy();
     });
 
+    fireEvent.click(screen.getByRole('button', { name: 'Close filters' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Remove School: Yale College' }));
+    await waitFor(() => {
+      expect(mockedAxios.post.mock.calls.at(-1)?.[1]).toEqual(
+        expect.objectContaining({ filters: { departments: ['Computer Science'] }, page: 1 }),
+      );
+      expect(screen.getByRole('button', { name: 'Filters, 1 active' })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove Department: Computer Science' }));
+    await waitFor(() => {
+      expect(mockedAxios.post.mock.calls.at(-1)?.[1]).toEqual(
+        expect.objectContaining({ filters: {}, page: 1 }),
+      );
+      expect(screen.getByTestId('location').textContent).toBe('/research?q=machine+learning');
+      expect(screen.queryByLabelText('Active research filters')).toBeNull();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Filters' }));
+    fireEvent.change(screen.getByLabelText('Filter by school'), {
+      target: { value: 'School of Medicine' },
+    });
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Close filters' })).not.toBeDisabled(),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Close filters' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Clear all active filters' }));
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Filters' })).toHaveAttribute(
+        'aria-expanded',
+        'false',
+      ),
+    );
+
     expect(screen.queryByLabelText('Undergraduate participation documented')).toBeNull();
+  });
+
+  it('restores active filters when their distribution disappears and never invents counts', async () => {
+    mockSearchResponses((url) => {
+      if (url !== '/research/search') return unexpectedSearchEndpoint(url);
+      return researchSearchResponse([researchEntity], {
+        estimatedTotalHits: 37,
+        facetDistribution: {
+          school: { 'School of Medicine': 0 },
+          departments: {},
+        },
+      });
+    });
+
+    render(
+      <MemoryRouter
+        initialEntries={[
+          '/research?q=machine+learning&school=Yale%20College&department=Computer%20Science&undergrad=1',
+        ]}
+      >
+        <ConfigContext.Provider
+          value={{
+            ...defaultConfigContext,
+            isLoading: false,
+            isLoaded: true,
+            departments,
+            departmentCategories: ['Computing & AI', 'Humanities & Arts', 'Life Sciences'],
+          }}
+        >
+          <LocationDisplay />
+          <Research />
+        </ConfigContext.Provider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole('button', { name: 'Filters, 2 active' })).toBeTruthy();
+    expect(mockedAxios.post).toHaveBeenLastCalledWith(
+      '/research/search',
+      expect.objectContaining({
+        filters: {
+          school: ['Yale College'],
+          departments: ['Computer Science'],
+        },
+      }),
+      expect.any(Object),
+    );
+    expect(screen.getByTestId('location').textContent).not.toContain('undergrad');
+    expect(screen.getByRole('button', { name: 'Remove School: Yale College' })).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: 'Remove Department: Computer Science' }),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Filters, 2 active' }));
+    const schoolSelect = screen.getByLabelText('Filter by school') as HTMLSelectElement;
+    const departmentSelect = screen.getByLabelText('Filter by department') as HTMLSelectElement;
+    expect(schoolSelect.value).toBe('Yale College');
+    expect(departmentSelect.value).toBe('Computer Science');
+    expect(within(schoolSelect).getByRole('option', { name: 'Yale College' })).toBeTruthy();
+    expect(within(departmentSelect).getByRole('option', { name: 'Computer Science' })).toBeTruthy();
+    expect(screen.queryByRole('option', { name: /\(37\)/ })).toBeNull();
+    expect(screen.queryByLabelText('Undergraduate participation documented')).toBeNull();
+  });
+
+  it('adapts facet visibility to positive query-scoped buckets while preserving selections', async () => {
+    mockSearchResponses((url, body) => {
+      if (url !== '/research/search') return unexpectedSearchEndpoint(url);
+      const hasSchool = Boolean((body.filters?.school as string[] | undefined)?.length);
+      return researchSearchResponse([researchEntity], {
+        facetDistribution: hasSchool
+          ? {
+              school: {},
+              departments: { 'Computer Science': 1, Neuroscience: 0 },
+            }
+          : {
+              school: { 'Yale College': 8, 'School of Medicine': 4, Unknown: 0 },
+              departments: { 'Computer Science': 5, Neuroscience: 3 },
+            },
+      });
+    });
+
+    renderResearch(departments, ['/research?q=machine+learning']);
+    await screen.findByRole('heading', { name: 'AI Safety Lab' });
+    fireEvent.click(screen.getByRole('button', { name: 'Filters' }));
+    expect(screen.getByLabelText('Filter by school')).toBeTruthy();
+    expect(screen.getByLabelText('Filter by department')).toBeTruthy();
+    expect(screen.queryByRole('option', { name: 'Unknown (0)' })).toBeNull();
+
+    fireEvent.change(screen.getByLabelText('Filter by school'), {
+      target: { value: 'Yale College' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Filter by school')).not.toBeDisabled();
+      expect(screen.queryByLabelText('Filter by department')).toBeNull();
+    });
+    const selectedOption = within(screen.getByLabelText('Filter by school')).getByRole('option', {
+      name: 'Yale College',
+    });
+    expect(selectedOption).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText('Filter by school'), { target: { value: '' } });
+    await waitFor(() => expect(screen.getByLabelText('Filter by department')).toBeTruthy());
+  });
+
+  it('keeps base search usable while facet distribution is loading or unavailable', async () => {
+    const response = createDeferred<ReturnType<typeof researchSearchResponse>>();
+    mockedAxios.post.mockImplementation((url: string, body: { q?: string }) => {
+      if (url === '/research/search' && body.q === 'machine learning') return response.promise;
+      if (url === '/research/search') return Promise.resolve(researchSearchResponse());
+      return Promise.reject(unexpectedSearchEndpoint(url));
+    });
+
+    renderResearch(departments, ['/research?q=machine+learning']);
+    expect(await screen.findByText("Showing research matches for 'machine learning'")).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Filters' }));
+    expect(
+      within(screen.getByRole('dialog', { name: 'Research filters' })).getByRole('status'),
+    ).toHaveTextContent('Applying filters...');
+    expect(screen.getByText('Filter options will appear when this search finishes.')).toBeTruthy();
+    expect(screen.queryByLabelText('Filter by school')).toBeNull();
+
+    response.reject(new Error('facet service unavailable'));
+    expect(
+      await screen.findByText(
+        'Filter options are temporarily unavailable. Your search still works, and active filters can be cleared.',
+      ),
+    ).toBeTruthy();
+    expect(screen.getByRole('alert')).toHaveTextContent('Live search metadata is unavailable');
+    expect(screen.getByRole('button', { name: 'Filters' })).not.toBeDisabled();
+  });
+
+  it('restores URL-backed filters across back and forward navigation', async () => {
+    mockSearchResponses((url) =>
+      url === '/research/search'
+        ? researchSearchResponse([researchEntity], {
+            facetDistribution: {
+              school: { 'Yale College': 8, 'School of Medicine': 4 },
+              departments: { 'Computer Science': 5, Neuroscience: 3 },
+            },
+          })
+        : unexpectedSearchEndpoint(url),
+    );
+
+    render(
+      <MemoryRouter
+        initialEntries={[
+          '/research?q=first&school=Yale%20College',
+          '/research?q=second&department=Computer%20Science',
+        ]}
+        initialIndex={1}
+      >
+        <ConfigContext.Provider
+          value={{
+            ...defaultConfigContext,
+            isLoading: false,
+            isLoaded: true,
+            departments,
+            departmentCategories: ['Computing & AI', 'Humanities & Arts', 'Life Sciences'],
+          }}
+        >
+          <ResearchHistoryButtons />
+          <LocationDisplay />
+          <Research />
+        </ConfigContext.Provider>
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByRole('button', { name: 'Remove Department: Computer Science' }),
+    ).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Previous research search' }));
+    expect(await screen.findByRole('button', { name: 'Remove School: Yale College' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Remove Department/ })).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next research search' }));
+    expect(
+      await screen.findByRole('button', { name: 'Remove Department: Computer Science' }),
+    ).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Remove School/ })).toBeNull();
   });
 
   it('returns to default research homes when clearing a quick-start search', async () => {

--- a/client/src/pages/research.tsx
+++ b/client/src/pages/research.tsx
@@ -129,6 +129,7 @@ interface ResearchPageSnapshot {
   defaultSearchTotal: number;
   defaultSearchExhausted: boolean;
   searchError: string;
+  hasFacetError: boolean;
   defaultSearchError: string;
 }
 
@@ -387,6 +388,9 @@ const Research = () => {
   const [searchError, setSearchError] = useState(
     () => restoredSnapshotRef.current?.searchError ?? '',
   );
+  const [hasFacetError, setHasFacetError] = useState(
+    () => restoredSnapshotRef.current?.hasFacetError ?? false,
+  );
   const [defaultSearchError, setDefaultSearchError] = useState(
     () => restoredSnapshotRef.current?.defaultSearchError ?? '',
   );
@@ -572,6 +576,7 @@ const Research = () => {
     setFacetDistribution({});
     setSearchLoading(true);
     setSearchError('');
+    setHasFacetError(false);
     setGroupedResults(emptyGroupedResults(resultQueryLabel));
     if (options.syncUrl !== false) {
       writeResearchSearchParams(
@@ -605,6 +610,7 @@ const Research = () => {
 
       const researchEntities = researchEntitiesPage.researchEntities;
       setSearchError('');
+      setHasFacetError(false);
       setSearchResultResearchEntities(researchEntities);
       setSearchTotal(researchEntitiesPage.estimatedTotalHits);
       setFacetDistribution(researchEntitiesPage.facetDistribution);
@@ -627,6 +633,7 @@ const Research = () => {
         setSearchError(
           'Live search metadata is unavailable right now. Try another topic or check back soon.',
         );
+        setHasFacetError(true);
         setSearchExhausted(true);
       }
     } finally {
@@ -730,6 +737,7 @@ const Research = () => {
     setSearchExhausted(true);
     setActiveSearchRequest(null);
     setSearchError('');
+    setHasFacetError(false);
     setSearchLoading(false);
     setDefaultSearchExhausted(false);
     setDefaultSearchPage(1);
@@ -888,6 +896,7 @@ const Research = () => {
     setSearchExhausted(true);
     setActiveSearchRequest(null);
     setSearchError('');
+    setHasFacetError(false);
     setSearchLoading(false);
     setDefaultResearchEntities([]);
     setDefaultSearchTotal(0);
@@ -936,6 +945,7 @@ const Research = () => {
       defaultSearchTotal,
       defaultSearchExhausted,
       searchError,
+      hasFacetError,
       defaultSearchError,
     };
   }, [
@@ -961,6 +971,7 @@ const Research = () => {
     defaultSearchTotal,
     defaultSearchExhausted,
     searchError,
+    hasFacetError,
     defaultSearchError,
   ]);
 
@@ -1306,7 +1317,7 @@ const Research = () => {
                   selectedSchool={selectedSchool}
                   selectedDepartment={selectedDepartment}
                   isApplying={searchLoading}
-                  hasFacetError={Boolean(searchError)}
+                  hasFacetError={hasFacetError}
                   departmentLabel={departmentFacetLabel}
                   onSchoolChange={(school) => applyStudentFacets(school, selectedDepartment)}
                   onDepartmentChange={(department) =>

--- a/client/src/pages/research.tsx
+++ b/client/src/pages/research.tsx
@@ -3,6 +3,7 @@ import { isCancel } from 'axios';
 import { useLocation, useSearchParams } from 'react-router-dom';
 
 import ResearchHomeCard from '../components/research/ResearchHomeCard';
+import ResearchFilterDisclosure from '../components/research/ResearchFilterDisclosure';
 import InfiniteScrollLoadingDots from '../components/shared/InfiniteScrollLoadingDots';
 import LabPapersList from '../components/labs/LabPapersList';
 import UserContext from '../contexts/UserContext';
@@ -116,7 +117,6 @@ interface ResearchPageSnapshot {
   trustTierFilters: ResearchTrustTierFilter[];
   selectedSchool: string;
   selectedDepartment: string;
-  requireUndergradEvidence: boolean;
   facetDistribution: Record<string, Record<string, number>>;
   groupedResults: GroupedResearchResults;
   searchResultResearchEntities: ResearchEntity[];
@@ -350,11 +350,6 @@ const Research = () => {
   const [selectedDepartment, setSelectedDepartment] = useState(
     () => restoredSnapshotRef.current?.selectedDepartment ?? searchParams.get('department') ?? '',
   );
-  const [requireUndergradEvidence, setRequireUndergradEvidence] = useState(
-    () =>
-      restoredSnapshotRef.current?.requireUndergradEvidence ??
-      searchParams.get('undergrad') === '1',
-  );
   const [facetDistribution, setFacetDistribution] = useState<
     Record<string, Record<string, number>>
   >(() => restoredSnapshotRef.current?.facetDistribution ?? {});
@@ -430,7 +425,6 @@ const Research = () => {
       trustTiers?: ResearchTrustTierFilter[];
       school?: string;
       department?: string;
-      requireUndergradEvidence?: boolean;
     },
     options: { replace?: boolean; markPending?: boolean } = {},
   ) => {
@@ -441,7 +435,6 @@ const Research = () => {
     if (departmentLabel) params.set('dept', departmentLabel);
     if (nextState.school?.trim()) params.set('school', nextState.school.trim());
     if (nextState.department?.trim()) params.set('department', nextState.department.trim());
-    if (nextState.requireUndergradEvidence) params.set('undergrad', '1');
 
     if (isAdmin) {
       if (nextState.showWeakest) params.set('weak', '1');
@@ -576,6 +569,7 @@ const Research = () => {
     setQuery(trimmed);
     setSubmittedQuery(resultQueryLabel);
     setDepartmentSearch(options.departmentSearch ?? null);
+    setFacetDistribution({});
     setSearchLoading(true);
     setSearchError('');
     setGroupedResults(emptyGroupedResults(resultQueryLabel));
@@ -586,7 +580,6 @@ const Research = () => {
           departmentLabel: options.departmentSearch?.label,
           school: filters.school?.[0],
           department: filters.departments?.[0],
-          requireUndergradEvidence: filters.acceptanceLevel === 'verified-or-likely',
           showWeakest: showWeakestProfilesFirst,
           quality: qualityFilters,
           trustTiers: trustTierFilters,
@@ -707,11 +700,9 @@ const Research = () => {
   const studentSearchFilters = (
     school = selectedSchool,
     department = selectedDepartment,
-    undergradEvidence = requireUndergradEvidence,
   ): ResearchSearchFilters => ({
     ...(school ? { school: [school] } : {}),
     ...(department ? { departments: [department] } : {}),
-    ...(undergradEvidence ? { acceptanceLevel: 'verified-or-likely' as const } : {}),
   });
 
   const onSubmit = (event: FormEvent<HTMLFormElement>) => {
@@ -731,7 +722,6 @@ const Research = () => {
     setDepartmentSearch(null);
     setSelectedSchool('');
     setSelectedDepartment('');
-    setRequireUndergradEvidence(false);
     setFacetDistribution({});
     setGroupedResults(emptyGroupedResults(''));
     setSearchResultResearchEntities([]);
@@ -774,11 +764,16 @@ const Research = () => {
       pendingSearchSourceParamsRef.current = null;
       pendingSearchSourceLocationKeyRef.current = null;
     }
+    if (searchParams.has('undergrad')) {
+      const canonicalParams = new URLSearchParams(searchParams);
+      canonicalParams.delete('undergrad');
+      setSearchParams(canonicalParams, { replace: true });
+      return;
+    }
     const urlQuery = searchParams.get('q') || '';
     const urlDepartmentLabel = searchParams.get('dept') || '';
     const urlSchool = searchParams.get('school') || '';
     const urlDepartment = searchParams.get('department') || '';
-    const urlRequiresUndergradEvidence = searchParams.get('undergrad') === '1';
     const urlWeakestFirst = isAdmin && searchParams.get('weak') === '1';
     const urlQualityFilters = isAdmin
       ? readSearchParamList(
@@ -821,15 +816,9 @@ const Research = () => {
       setSelectedDepartment(urlDepartment);
       return;
     }
-    if (requireUndergradEvidence !== urlRequiresUndergradEvidence) {
-      setRequireUndergradEvidence(urlRequiresUndergradEvidence);
-      return;
-    }
-
     const studentFilters: ResearchSearchFilters = {
       ...(urlSchool ? { school: [urlSchool] } : {}),
       ...(urlDepartment ? { departments: [urlDepartment] } : {}),
-      ...(urlRequiresUndergradEvidence ? { acceptanceLevel: 'verified-or-likely' as const } : {}),
     };
 
     const urlDepartmentSearch = urlDepartmentLabel
@@ -907,6 +896,7 @@ const Research = () => {
     void runDefaultResearchHomeSearchRef.current(1);
   }, [
     searchParams,
+    setSearchParams,
     location.key,
     pageSnapshotKey,
     isAdmin,
@@ -915,7 +905,6 @@ const Research = () => {
     trustTierFilters,
     selectedSchool,
     selectedDepartment,
-    requireUndergradEvidence,
     departmentSearchTargetByLabel,
     departmentSearch,
     hasSubmittedSearch,
@@ -935,7 +924,6 @@ const Research = () => {
       trustTierFilters,
       selectedSchool,
       selectedDepartment,
-      requireUndergradEvidence,
       facetDistribution,
       groupedResults,
       searchResultResearchEntities,
@@ -961,7 +949,6 @@ const Research = () => {
     trustTierFilters,
     selectedSchool,
     selectedDepartment,
-    requireUndergradEvidence,
     facetDistribution,
     groupedResults,
     searchResultResearchEntities,
@@ -1012,40 +999,19 @@ const Research = () => {
     totalRawCount: searchTotal,
     filteredCount: searchResultResearchEntities.length,
   });
-  const hasStudentFacetSelection = Boolean(
-    selectedSchool || selectedDepartment || requireUndergradEvidence,
-  );
+  const hasStudentFacetSelection = Boolean(selectedSchool || selectedDepartment);
   const searchDisabled = searchLoading || (query.trim().length === 0 && !hasStudentFacetSelection);
   const searchHelpText = query.trim()
     ? 'Press Enter or Search to see matching research homes.'
     : hasStudentFacetSelection
       ? 'Search with the selected filters.'
       : 'Enter a topic or name to enable Search.';
-  const schoolOptions = useMemo(
-    () =>
-      Array.from(
-        new Set([
-          ...Object.keys(facetDistribution.school || {}),
-          ...(selectedSchool ? [selectedSchool] : []),
-        ]),
-      ).sort((a, b) => a.localeCompare(b)),
-    [facetDistribution.school, selectedSchool],
-  );
-  const departmentOptions = useMemo(
-    () =>
-      Array.from(
-        new Set([
-          ...Object.keys(facetDistribution.departments || {}),
-          ...(selectedDepartment ? [selectedDepartment] : []),
-        ]),
-      ).sort((a, b) => a.localeCompare(b)),
-    [facetDistribution.departments, selectedDepartment],
-  );
-  const applyStudentFacets = (school: string, department: string, undergradEvidence: boolean) => {
+  const departmentFacetLabel = (department: string) =>
+    getUniqueDepartmentLabels([department], departments)[0] || department;
+  const applyStudentFacets = (school: string, department: string) => {
     setSelectedSchool(school);
     setSelectedDepartment(department);
-    setRequireUndergradEvidence(undergradEvidence);
-    const filters = studentSearchFilters(school, department, undergradEvidence);
+    const filters = studentSearchFilters(school, department);
     if (!query.trim() && !hasStructuredFilters(filters)) {
       resetSearch();
       return;
@@ -1335,135 +1301,19 @@ const Research = () => {
                   </div>
                 </div>
 
-                {(schoolOptions.length > 1 ||
-                  departmentOptions.length > 1 ||
-                  hasStudentFacetSelection) && (
-                  <fieldset className="mt-3 border-0 p-0">
-                    <legend className="sr-only">Narrow research results</legend>
-                    <div className="grid gap-4 rounded-md border border-[var(--yr-line)] bg-[var(--yr-panel)] p-3 sm:grid-cols-2 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto_auto] xl:items-end">
-                      {(schoolOptions.length > 1 || selectedSchool) && (
-                        <label className="block text-sm font-medium text-slate-800">
-                          School
-                          <select
-                            aria-label="Filter by school"
-                            value={selectedSchool}
-                            onChange={(event) =>
-                              applyStudentFacets(
-                                event.target.value,
-                                selectedDepartment,
-                                requireUndergradEvidence,
-                              )
-                            }
-                            className="mt-1 min-h-11 w-full rounded-md border border-[var(--yr-line-strong)] bg-white px-3 text-sm text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
-                          >
-                            <option value="">All schools</option>
-                            {schoolOptions.map((school) => (
-                              <option key={school} value={school}>
-                                {school} ({facetDistribution.school?.[school] ?? searchTotal})
-                              </option>
-                            ))}
-                          </select>
-                        </label>
-                      )}
-                      {(departmentOptions.length > 1 || selectedDepartment) && (
-                        <label className="block text-sm font-medium text-slate-800">
-                          Department
-                          <select
-                            aria-label="Filter by department"
-                            value={selectedDepartment}
-                            onChange={(event) =>
-                              applyStudentFacets(
-                                selectedSchool,
-                                event.target.value,
-                                requireUndergradEvidence,
-                              )
-                            }
-                            className="mt-1 min-h-11 w-full rounded-md border border-[var(--yr-line-strong)] bg-white px-3 text-sm text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
-                          >
-                            <option value="">All departments</option>
-                            {departmentOptions.map((department) => (
-                              <option key={department} value={department}>
-                                {getUniqueDepartmentLabels([department], departments)[0] ||
-                                  department}{' '}
-                                ({facetDistribution.departments?.[department] ?? searchTotal})
-                              </option>
-                            ))}
-                          </select>
-                        </label>
-                      )}
-                      {requireUndergradEvidence && (
-                        <label className="inline-flex min-h-11 items-center gap-2 rounded-md border border-[var(--yr-line)] bg-white px-3 py-2 text-sm font-medium text-slate-800">
-                          <input
-                            type="checkbox"
-                            checked={requireUndergradEvidence}
-                            onChange={(event) =>
-                              applyStudentFacets(
-                                selectedSchool,
-                                selectedDepartment,
-                                event.target.checked,
-                              )
-                            }
-                            className="h-4 w-4 rounded border-[var(--yr-line-strong)] text-blue-700 focus:ring-blue-200"
-                          />
-                          Undergraduate participation documented
-                        </label>
-                      )}
-                      {hasStudentFacetSelection && (
-                        <button
-                          type="button"
-                          onClick={() => applyStudentFacets('', '', false)}
-                          className="min-h-11 rounded-md border border-[var(--yr-line-strong)] bg-white px-3 text-sm font-semibold text-slate-700 hover:bg-[var(--yr-panel-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
-                        >
-                          Clear filters
-                        </button>
-                      )}
-                    </div>
-                  </fieldset>
-                )}
-
-                {hasStudentFacetSelection && (
-                  <div className="mt-3 flex flex-wrap gap-2" aria-label="Active research filters">
-                    {selectedSchool && (
-                      <button
-                        type="button"
-                        onClick={() =>
-                          applyStudentFacets('', selectedDepartment, requireUndergradEvidence)
-                        }
-                        aria-label={`Remove School: ${selectedSchool}`}
-                        className="rounded-md border px-3 py-2 text-sm"
-                      >
-                        School: {selectedSchool} ×
-                      </button>
-                    )}
-                    {selectedDepartment && (
-                      <button
-                        type="button"
-                        onClick={() =>
-                          applyStudentFacets(selectedSchool, '', requireUndergradEvidence)
-                        }
-                        aria-label={`Remove Department: ${selectedDepartment}`}
-                        className="rounded-md border px-3 py-2 text-sm"
-                      >
-                        Department:{' '}
-                        {getUniqueDepartmentLabels([selectedDepartment], departments)[0] ||
-                          selectedDepartment}{' '}
-                        ×
-                      </button>
-                    )}
-                    {requireUndergradEvidence && (
-                      <button
-                        type="button"
-                        onClick={() =>
-                          applyStudentFacets(selectedSchool, selectedDepartment, false)
-                        }
-                        aria-label="Remove Undergraduate participation documented"
-                        className="rounded-md border px-3 py-2 text-sm"
-                      >
-                        Undergraduate participation documented ×
-                      </button>
-                    )}
-                  </div>
-                )}
+                <ResearchFilterDisclosure
+                  facetDistribution={facetDistribution}
+                  selectedSchool={selectedSchool}
+                  selectedDepartment={selectedDepartment}
+                  isApplying={searchLoading}
+                  hasFacetError={Boolean(searchError)}
+                  departmentLabel={departmentFacetLabel}
+                  onSchoolChange={(school) => applyStudentFacets(school, selectedDepartment)}
+                  onDepartmentChange={(department) =>
+                    applyStudentFacets(selectedSchool, department)
+                  }
+                  onClearAll={() => applyStudentFacets('', '')}
+                />
 
                 {searchError && (
                   <div

--- a/docs/research-student-journey-delivery-plan.md
+++ b/docs/research-student-journey-delivery-plan.md
@@ -84,9 +84,10 @@ An open or draft PR is evidence of work in progress, never evidence that a requi
 - **Status:** Active.
 - **Depends on:** accurate query-scoped facet distributions.
 - **Acceptance criteria:** school and department controls appear only when their positive buckets can narrow the current results; selected filters remain visible and clearable; missing facet counts never fall back to the total result count; mobile controls do not overflow; a future documented-way-in control follows EF-03 rather than reviving the retired undergraduate-evidence filter.
-- **Validation evidence:** PR `#171` hides school and department controls when current distributions cannot narrow and removes the unsupported inactive undergraduate-evidence control.
-  The count-fallback and final adaptive documented-way-in distribution contract remain to be completed.
-- **PRs:** [#171](https://github.com/YaleComputerSociety/ylabs/pull/171).
+- **Validation evidence:** PR `#171` removed the unsupported undergraduate-evidence control.
+  The pending EF-02 change adds one adaptive Research filter disclosure, query-scoped positive school and department choices, persistent selected values without invented counts, URL-backed removable chips, clear-one and clear-all actions, independent facet-error handling, a non-modal desktop disclosure, and a focus-contained mobile sheet with focused responsive and accessibility tests.
+  The documented-way-in distribution remains separate EF-03 work and is not exposed as a filter.
+- **PRs:** [#171](https://github.com/YaleComputerSociety/ylabs/pull/171); issue [#184](https://github.com/YaleComputerSociety/ylabs/issues/184) change pending merge.
 
 #### EF-03 - Sparse Documented-Way-In Signal
 
@@ -234,9 +235,8 @@ An open or draft PR is evidence of work in progress, never evidence that a requi
 - **Depends on:** surface-specific facet contracts and accessible focus management.
 - **Acceptance criteria:** Research and Programs use one shared filter-sheet interaction pattern on small viewports while retaining their own facets; opening moves focus into a labelled modal/sheet; Escape, close, apply, and focus return work by keyboard and screen reader; selected-count and clear behavior are honest; desktop remains quiet; no horizontal overflow.
 - **Validation evidence:** PR `#175` added the bounded, labelled Programs mobile sheet with focus entry, containment, Escape close, and focus restoration.
-  The shared listing filters intentionally retain their anchored non-modal presentation, so Research does not yet satisfy the cross-surface acceptance criterion.
-  PR `#171` only simplified Research filters and must not be credited with FR-37.
-- **PRs:** [#175](https://github.com/YaleComputerSociety/ylabs/pull/175) completed the Programs portion; Research remains outstanding.
+  The pending EF-02 change gives Research the same small-screen interaction contract while retaining a non-modal desktop disclosure, active count, clear actions, focus containment and restoration, and narrow-viewport overflow guards.
+- **PRs:** [#175](https://github.com/YaleComputerSociety/ylabs/pull/175); issue [#184](https://github.com/YaleComputerSociety/ylabs/issues/184) Research change pending merge.
 
 #### CP-09 - Honest Logged-Out Saving - FR-14
 
@@ -441,7 +441,7 @@ Its evidence is therefore current Beta source, routes, tests, and merged history
 | Claim                                                                                                  | Current support                                                                                                                                                                  | Delivery interpretation                                                                                                                                         |
 | ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Entity-first discovery is the correct current baseline.                                                | **Supported.** PR `#171` removes the parallel pathway request and stream and keeps research profiles primary.                                                                    | Keep EF-01 Complete and protect it with regression tests.                                                                                                       |
-| Discovery filters are fully adaptive and progressively disclosed.                                      | **Disputed as complete.** Programs has a bounded mobile filter sheet, while shared Research/listing filters remain anchored and missing facet counts may fall back to the total. | Keep EF-02 and CP-08 / FR-37 Active until the remaining Research behavior and facet-count gaps are resolved.                                                    |
+| Discovery filters are fully adaptive and progressively disclosed.                                      | **Pending merge.** The EF-02 change gives Research its own compact desktop disclosure and mobile sheet, uses only positive query-scoped facet counts, preserves selected values without invented counts, and keeps base search usable when facet metadata fails. | Keep EF-02 Active until the change merges into Beta; keep the documented-way-in filter governed separately by EF-03.                                            |
 | A server-qualified sparse planning summary exists.                                                     | **Not supported.** No bounded claim-specific summary or useful-state distribution exists.                                                                                        | Keep EF-03 Not started and dependent on QA-01.                                                                                                                  |
 | Research homes can be saved independently of pathways.                                                 | **Supported.** Saves and private plan details are keyed by canonical ResearchEntity ID, including entities without an indexed pathway.                                           | Keep CP-05 / FR-45 Complete and preserve migration-continuity coverage as FR-17 and FR-24 build on entity identity.                                             |
 | Canonical research analytics distinguish search, profile, source, filters, save, and qualified action. | **Not supported.** The current taxonomy is broader and canonical browse/detail lacks the complete invisible journey emissions.                                                   | Keep IM-01 Not started and IM-02 Active until QA-01 stabilizes conversion meaning.                                                                              |
@@ -449,7 +449,7 @@ Its evidence is therefore current Beta source, routes, tests, and merged history
 | Historical persona findings describe current Beta behavior.                                            | **Validation pending.** Several cited defects were changed by merged PRs, while the referenced transcript and fresh browser replay were unavailable.                             | Use historical observations as discovery inputs only; require current code, test, data, or CAS-preserving browser evidence before changing status or rationale. |
 
 Unresolved UX choices remain validation-pending even when engineering dependencies are known.
-These include the anonymous-save policy, final qualified-action enum and thresholds, exact material-use threshold for a documented-way-in filter, comparison layout, and the Research-side mobile filter-sheet presentation.
+These include the anonymous-save policy, final qualified-action enum and thresholds, exact material-use threshold for a documented-way-in filter, and comparison layout.
 An implementing PR must resolve only the choice in its accepted scope and update the corresponding requirement and decision evidence.
 
 ## Maintenance Protocol

--- a/docs/ui-ux-direction.md
+++ b/docs/ui-ux-direction.md
@@ -42,13 +42,16 @@ Use [`docs/product-context.md`](./product-context.md), [`docs/research-model.md`
 
 ## Current Interface Shape
 
-The current app uses a quiet, operational UI: white backgrounds, gray text, Yale-blue accents, compact cards, filter sidebars, small status chips, and grid/list browsing. This is the right general tone. It should feel like a focused student research tool, not a marketing site.
+The current app uses a quiet, operational UI: white backgrounds, gray text, Yale-blue accents, compact cards, restrained filter disclosures, small status chips, and grid/list browsing.
+This is the right general tone.
+It should feel like a focused student research tool, not a marketing site.
 
 Current implementation anchors:
 
 - [`client/src/App.tsx`](../client/src/App.tsx): routes `/` to `/research`, exposes `/research`, `/research/:slug`, `/opportunities/:id`, and `/programs`, and redirects retired `/listings` and `/fellowships` URLs.
 - [`client/src/components/Navbar.tsx`](../client/src/components/Navbar.tsx): primary navigation, including Research, Programs & Fellowships, and Dashboard.
 - [`client/src/pages/research.tsx`](../client/src/pages/research.tsx): `/research` browse page for labs, centers, programs, faculty research, and related groups.
+- [`client/src/components/research/ResearchFilterDisclosure.tsx`](../client/src/components/research/ResearchFilterDisclosure.tsx): adaptive school and department filters for Research search.
 - [`client/src/pages/labDetail.tsx`](../client/src/pages/labDetail.tsx): `/research/:slug` detail page.
 - [`client/src/pages/home.tsx`](../client/src/pages/home.tsx): retained implementation module that is no longer reachable from the retired `/listings` route.
 - [`client/src/components/shared/BrowseCard.tsx`](../client/src/components/shared/BrowseCard.tsx): shared card treatment for listings, fellowships, and research groups.
@@ -66,9 +69,18 @@ The page should answer: "What research structures are out there, and which are w
 Primary UX ingredients:
 
 - Search by topic, method, entity name, department, and research area.
-- Filter by kind, school, department, research area, and access/evidence status.
+- Narrow results by school and department through one compact Filters control.
 - Cards that prioritize entity name, kind, discipline, short description, evidence, source routes, and compact planning-context signals.
 - Avoid making active openings the only success state.
+
+Research filter behavior:
+
+- School and department selections are URL-backed so reload, sharing, and browser navigation preserve them.
+- Active selections appear as individually removable chips, with a clear-all action and an active count on the Filters control.
+- The control opens as a non-modal desktop disclosure and an accessible, focus-contained mobile sheet.
+- Facet choices come from positive counts for the current query, while an active value remains available even if a later distribution omits it.
+- Missing, loading, or failed facet metadata must not disable base search, invent counts from total results, or expose hidden focusable controls.
+- Undergraduate-evidence and speculative documented-way-in filters are not part of the current student filter surface.
 
 Current gap: the shared verdict adapter now prefers access-summary/pathway evidence, but filters and older labels still contain some "acceptance" and "accepting undergrads" language. Move progressively toward "Planning Context," "Evidence," and "Best Next Step."
 


### PR DESCRIPTION
## Summary

- Replace permanently expanded Research filters with one compact adaptive control.
- Keep school and department choices query-scoped, positive-count-only, and visible when already selected.
- Preserve URL-backed active counts, removable chips, clear-one, clear-all, reload, and browser-navigation behavior.
- Use a focus-contained modal sheet on narrow viewports and a restrained non-modal disclosure on desktop.
- Keep base results and valid facets available when facet metadata or later pagination requests fail.

## Accessibility and responsive behavior

- Moves focus into the mobile sheet and restores it after Escape, backdrop, close, or apply.
- Traps focus only in the mobile modal and prevents hidden controls from receiving focus.
- Covers 320px and 375px overflow behavior plus desktop disclosure semantics.

## Validation

- `yarn --cwd client test:ci` - 98 files and 806 tests passed.
- `yarn --cwd client build` - passed.
- Focused ESLint for the four implementation and regression-test files - no errors.
- no-mistakes review, test, documentation, lint, push, PR, and CI workflow completed; its delivery artifact was reconstructed on `beta` after the tool incorrectly targeted `main`.
- Browser evidence covered desktop, 320px mobile, and 375px mobile layouts.

Closes #184
