### PR TITLE
IM-01: measure the claim-specific research journey

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -347,20 +347,19 @@ The Meilisearch client (`server/src/utils/meiliClient.ts`) exports:
 Analytics events are stored in MongoDB with a 3-year TTL.
 Route-level middleware logs successful server-observed events by wrapping `res.send` or `res.json`, so analytics stay outside controller and service business logic.
 
-Research-surface analytics cover the canonical research entities (`profile`, `listing`, and `fellowship`) and use these event types:
+The canonical research-student journey uses claim-specific events for terminal search outcomes, entity impressions, profile opens, source review, filter changes, entity save/removal, comparison, persisted plan updates, and qualified actions.
+The complete event and payload contract is documented in [`docs/research-journey-analytics.md`](docs/research-journey-analytics.md).
+Legacy `research_view`, `pathway_save`, `ways_in_click`, `contact_route_click`, and `source_link_click` events remain for older profile, listing, and fellowship instrumentation, but they are not access conversions.
 
-| Event type            | Meaning                                                                             |
-| --------------------- | ----------------------------------------------------------------------------------- |
-| `research_view`       | A profile, listing, or fellowship detail surface opened                             |
-| `pathway_save`        | A listing or fellowship was saved, unsaved, or re-staged                            |
-| `ways_in_click`       | A best-next-step, apply, planning, listings, courses, or similar action was clicked |
-| `contact_route_click` | A guarded route such as an official application or public source route was clicked  |
-| `source_link_click`   | A source link such as a lab site, publication, or application was clicked           |
+Client interactions are sent to `POST /api/analytics/research` for authenticated users.
+Journey payloads use event-specific allowlists of bounded enums and count buckets, and the server validates canonical entity identifiers before persistence.
+They never retain raw query text, URLs, hostnames, direct contact destinations, private notes, plan contents, filter values, or client-supplied cross-event search identifiers.
+Every interaction uses a bounded idempotency key with per-actor server uniqueness, and client tracking is fire-and-forget so analytics failures cannot change student behavior.
 
-Client-only interactions are sent to `POST /api/analytics/research` for authenticated users.
-Server-observed views and save/favorite actions are emitted from route middleware in listings, fellowships, profiles, and users.
-Research analytics sanitize payloads before persistence: contact clicks keep only a coarse `contactMethod`, source clicks keep only `sourceCategory` plus the bare hostname, and labels reject raw contact addresses or URL-like values.
-The admin analytics dashboard segments research engagement by event type, entity type, user type, and top viewed entities over the trailing 30 days.
+Only `research_qualified_action` counts as access conversion, and the server re-qualifies its category against the current QA-01 planning-context projection.
+Source review, profile open, filters, saves, comparisons, plan updates, and legacy research events never count as action.
+The admin funnel reports source inspections, official-route attempts, application opens, and self-reported outcomes separately.
+Beta suppresses real student analytics while permitting fixture and admin validation.
 
 ---
 

--- a/client/src/components/accounts/SavedPathwaysSection.tsx
+++ b/client/src/components/accounts/SavedPathwaysSection.tsx
@@ -1198,48 +1198,44 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
     ) {
       return;
     }
-    setPlans((current) => {
-      const currentPlan = current[pathwayId];
-      if (!currentPlan) return current;
-      const nextPlan = { ...currentPlan, ...patch };
-      const analyticsFields = planAnalyticsFields(currentPlan, nextPlan, patch);
-      setPlanSaveStatus((statuses) => ({ ...statuses, [pathwayId]: 'Saving plan...' }));
-      axios
-        .put(
-          planApiMode === 'entity'
-            ? `/users/savedResearchEntityPlans/${planApiId}`
-            : `/users/savedResearchPlanDetails/${planApiId}`,
-          { data: { plan: nextPlan } },
-          { withCredentials: true },
-        )
-        .then(() => {
-          setPlanSaveStatus((statuses) => ({ ...statuses, [pathwayId]: 'Plan saved.' }));
-          analyticsFields.forEach((field) => {
-            const analyticsEntityId = analyticsEntityIdForPlanningItem(
-              pathways.find((pathway) => pathway._id === pathwayId) ||
-                ({ _id: pathwayId } as PathwaySearchHit),
-            );
-            void trackResearchEvent({
-              eventType: 'research_plan_update',
-              entityType: 'research_entity',
-              entityId: analyticsEntityId,
-              payload: { field },
-              dedupeKey: createResearchAnalyticsInteractionId('plan'),
-            });
+    const currentPlan = plans[pathwayId];
+    const nextPlan = { ...currentPlan, ...patch };
+    const analyticsFields = planAnalyticsFields(currentPlan, nextPlan, patch);
+    const analyticsInteractionId = createResearchAnalyticsInteractionId('plan');
+    const analyticsEntityId = analyticsEntityIdForPlanningItem(
+      pathways.find((pathway) => pathway._id === pathwayId) ||
+        ({ _id: pathwayId } as PathwaySearchHit),
+    );
+
+    setPlans((current) => ({ ...current, [pathwayId]: nextPlan }));
+    setPlanSaveStatus((statuses) => ({ ...statuses, [pathwayId]: 'Saving plan...' }));
+    axios
+      .put(
+        planApiMode === 'entity'
+          ? `/users/savedResearchEntityPlans/${planApiId}`
+          : `/users/savedResearchPlanDetails/${planApiId}`,
+        { data: { plan: nextPlan } },
+        { withCredentials: true },
+      )
+      .then(() => {
+        setPlanSaveStatus((statuses) => ({ ...statuses, [pathwayId]: 'Plan saved.' }));
+        analyticsFields.forEach((field) => {
+          void trackResearchEvent({
+            eventType: 'research_plan_update',
+            entityType: 'research_entity',
+            entityId: analyticsEntityId,
+            payload: { field },
+            dedupeKey: `${analyticsInteractionId}:${field}`,
           });
-        })
-        .catch(() => {
-          console.error('Error saving research plan.');
-          setPlanSaveStatus((statuses) => ({
-            ...statuses,
-            [pathwayId]: 'Plan could not be saved.',
-          }));
         });
-      return {
-        ...current,
-        [pathwayId]: nextPlan,
-      };
-    });
+      })
+      .catch(() => {
+        console.error('Error saving research plan.');
+        setPlanSaveStatus((statuses) => ({
+          ...statuses,
+          [pathwayId]: 'Plan could not be saved.',
+        }));
+      });
   };
 
   const toggleChecklistItem = (pathwayId: string, itemKey: string, checked: boolean) => {

--- a/client/src/components/accounts/SavedPathwaysSection.tsx
+++ b/client/src/components/accounts/SavedPathwaysSection.tsx
@@ -5,6 +5,11 @@ import type { PathwaySearchHit } from '../../types/pathway';
 import axios from '../../utils/axios';
 import UserContext from '../../contexts/UserContext';
 import { EXTERNAL_LINK_REL, safeHttpUrl, safeHttpUrlList, safeRouteSegment } from '../../utils/url';
+import {
+  createResearchAnalyticsInteractionId,
+  researchCountBucket,
+  trackResearchEvent,
+} from '../../utils/researchAnalytics';
 
 type PlanningIntent = 'thesis' | 'outreach' | 'credit' | 'funding' | 'apply' | 'later';
 type PlanningStage = 'saved' | 'researching' | 'ready' | 'acted' | 'archived';
@@ -27,6 +32,36 @@ export interface ChecklistHistoryItem {
 }
 
 export type PathwayPlanMap = Record<string, PathwayPlan>;
+
+type PlanAnalyticsField =
+  | 'intent'
+  | 'stage'
+  | 'note_presence'
+  | 'checklist'
+  | 'target_deadline'
+  | 'acted_on_date'
+  | 'follow_up';
+
+export const planAnalyticsFields = (
+  current: PathwayPlan,
+  next: PathwayPlan,
+  patch: Partial<PathwayPlan>,
+): PlanAnalyticsField[] => {
+  const fields: PlanAnalyticsField[] = [];
+  if ('intent' in patch) fields.push('intent');
+  if ('stage' in patch) fields.push('stage');
+  if ('note' in patch && Boolean(current.note.trim()) !== Boolean(next.note.trim())) {
+    fields.push('note_presence');
+  }
+  if ('checklist' in patch || 'checklistHistory' in patch) fields.push('checklist');
+  if ('targetDeadline' in patch) fields.push('target_deadline');
+  if ('actedOnDate' in patch) fields.push('acted_on_date');
+  if ('followUpIntervalDays' in patch) fields.push('follow_up');
+  return Array.from(new Set(fields));
+};
+
+const analyticsEntityIdForPlanningItem = (item: PathwaySearchHit): string =>
+  item.researchEntity?._id || item._id;
 
 export interface FellowshipFundingMatch {
   fellowshipId: string;
@@ -1167,6 +1202,7 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
       const currentPlan = current[pathwayId];
       if (!currentPlan) return current;
       const nextPlan = { ...currentPlan, ...patch };
+      const analyticsFields = planAnalyticsFields(currentPlan, nextPlan, patch);
       setPlanSaveStatus((statuses) => ({ ...statuses, [pathwayId]: 'Saving plan...' }));
       axios
         .put(
@@ -1176,7 +1212,22 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
           { data: { plan: nextPlan } },
           { withCredentials: true },
         )
-        .then(() => setPlanSaveStatus((statuses) => ({ ...statuses, [pathwayId]: 'Plan saved.' })))
+        .then(() => {
+          setPlanSaveStatus((statuses) => ({ ...statuses, [pathwayId]: 'Plan saved.' }));
+          analyticsFields.forEach((field) => {
+            const analyticsEntityId = analyticsEntityIdForPlanningItem(
+              pathways.find((pathway) => pathway._id === pathwayId) ||
+                ({ _id: pathwayId } as PathwaySearchHit),
+            );
+            void trackResearchEvent({
+              eventType: 'research_plan_update',
+              entityType: 'research_entity',
+              entityId: analyticsEntityId,
+              payload: { field },
+              dedupeKey: createResearchAnalyticsInteractionId('plan'),
+            });
+          });
+        })
         .catch(() => {
           console.error('Error saving research plan.');
           setPlanSaveStatus((statuses) => ({
@@ -1257,6 +1308,7 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
       return;
     }
     const previous = pathways;
+    const removedPathway = pathways.find((pathway) => pathway._id === pathwayId);
     setPathways((current) => current.filter((pathway) => pathway._id !== pathwayId));
     setExpandedPlanIds((current) => {
       const next = { ...current };
@@ -1279,6 +1331,13 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
         const next = { ...current };
         delete next[pathwayId];
         return next;
+      });
+      void trackResearchEvent({
+        eventType: 'research_save',
+        entityType: 'research_entity',
+        entityId: removedPathway ? analyticsEntityIdForPlanningItem(removedPathway) : pathwayId,
+        payload: { operation: 'remove', surface: 'saved_plans' },
+        dedupeKey: createResearchAnalyticsInteractionId('save'),
       });
     } catch {
       console.error('Error removing saved research plan.');
@@ -1312,6 +1371,19 @@ const SavedPathwaysSection = ({ onSummaryChange }: SavedPathwaysSectionProps) =>
     }
     setExportError('');
     setShowExportPreview(true);
+    const comparisonId = createResearchAnalyticsInteractionId('compare');
+    const entityCountBucket = researchCountBucket(selectedExportItems.length);
+    pathways
+      .filter((pathway) => selectedExportIds[pathway._id] && plans[pathway._id])
+      .forEach((pathway) => {
+        void trackResearchEvent({
+          eventType: 'research_compare',
+          entityType: 'research_entity',
+          entityId: analyticsEntityIdForPlanningItem(pathway),
+          payload: { entityCountBucket },
+          dedupeKey: `${comparisonId}:${analyticsEntityIdForPlanningItem(pathway)}`,
+        });
+      });
     window.setTimeout(() => exportPreviewRef.current?.focus(), 0);
   };
 

--- a/client/src/components/accounts/__tests__/SavedPathwaysSection.test.ts
+++ b/client/src/components/accounts/__tests__/SavedPathwaysSection.test.ts
@@ -14,6 +14,7 @@ import SavedPathwaysSection, {
   fundingCueForPathway,
   legacyPathwayPlanTargetsAreUnique,
   planningCueForPlan,
+  planAnalyticsFields,
   readStoredPlans,
   remapFundingMatchesToResearchEntities,
   remapLegacyPathwayPlansToResearchEntities,
@@ -150,6 +151,20 @@ afterEach(() => {
 });
 
 describe('saved research plan hydration helpers', () => {
+  it('reduces private plan changes to bounded field categories', () => {
+    const current = plan();
+    const next = plan({ note: 'Private advising note', targetDeadline: '2026-08-01' });
+
+    expect(
+      planAnalyticsFields(current, next, {
+        note: next.note,
+        targetDeadline: next.targetDeadline,
+      }),
+    ).toEqual(['note_presence', 'target_deadline']);
+    expect(JSON.stringify(planAnalyticsFields(current, next, { note: next.note }))).not.toContain(
+      'Private advising note',
+    );
+  });
   it('uses local calendar dates for upcoming deadlines and overdue follow-ups', () => {
     const now = new Date(2026, 6, 12, 23, 30);
     expect(
@@ -614,6 +629,15 @@ describe('SavedPathwaysSection advising export', () => {
     });
     expect(screen.getByText('Checklist for: Outreach')).toBeTruthy();
     expect(screen.getByRole('status').textContent).toBe('Plan saved.');
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      '/analytics/research',
+      expect.objectContaining({
+        eventType: 'research_plan_update',
+        entityId: 'entity-1',
+        payload: { field: 'checklist' },
+      }),
+      { withCredentials: true },
+    );
   });
 
   it('uses the mapped pathway id when only canonical plan loading falls back', async () => {
@@ -1033,7 +1057,16 @@ describe('SavedPathwaysSection advising export', () => {
     await user.click(screen.getByRole('button', { name: 'Preview advising export' }));
     expect(screen.getByRole('dialog')).toHaveFocus();
     expect(screen.queryByText('Discuss with my advisor.')).toBeNull();
-    expect(mockedAxios.post).not.toHaveBeenCalled();
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      '/analytics/research',
+      expect.objectContaining({
+        eventType: 'research_compare',
+        entityId: 'entity-1',
+        payload: { entityCountBucket: '1' },
+      }),
+      { withCredentials: true },
+    );
+    expect(JSON.stringify(mockedAxios.post.mock.calls)).not.toContain('Discuss with my advisor.');
   });
 
   it('previews translated labels, unknown professor, opted-in note, and prints', async () => {

--- a/client/src/hooks/__tests__/useFavorites.test.tsx
+++ b/client/src/hooks/__tests__/useFavorites.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import useFavorites from '../useFavorites';
@@ -10,6 +10,7 @@ vi.mock('../../utils/axios', () => ({
     get: vi.fn(),
     put: vi.fn(),
     delete: vi.fn(),
+    post: vi.fn(),
   },
 }));
 
@@ -21,6 +22,7 @@ const mockedAxios = axios as unknown as {
   get: ReturnType<typeof vi.fn>;
   put: ReturnType<typeof vi.fn>;
   delete: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
 };
 
 const mockedSwal = swal as unknown as ReturnType<typeof vi.fn>;
@@ -73,5 +75,42 @@ describe('useFavorites', () => {
     expect(mockedAxios.get).toHaveBeenCalledWith('/users/savedResearchEntityIds', {
       withCredentials: true,
     });
+  });
+
+  it('records a save only after the canonical entity mutation succeeds', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { savedResearchEntityIds: [] } });
+    mockedAxios.put.mockResolvedValueOnce({ data: { savedResearchEntityIds: ['entity-1'] } });
+    mockedAxios.post.mockResolvedValueOnce({ status: 202 });
+    const { result } = renderHook(() => useFavorites('researchPlans'));
+    await waitFor(() => expect(mockedAxios.get).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.setFavorite('entity-1', true);
+    });
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      '/analytics/research',
+      expect.objectContaining({
+        eventType: 'research_save',
+        entityType: 'research_entity',
+        entityId: 'entity-1',
+        payload: { operation: 'save', surface: 'profile' },
+      }),
+      { withCredentials: true },
+    );
+  });
+
+  it('does not record a save when the canonical mutation fails', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    mockedAxios.get.mockResolvedValueOnce({ data: { savedResearchEntityIds: [] } });
+    mockedAxios.put.mockRejectedValueOnce(new Error('offline'));
+    const { result } = renderHook(() => useFavorites('researchPlans'));
+    await waitFor(() => expect(mockedAxios.get).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.setFavorite('entity-1', true);
+    });
+
+    expect(mockedAxios.post).not.toHaveBeenCalled();
   });
 });

--- a/client/src/hooks/useFavorites.ts
+++ b/client/src/hooks/useFavorites.ts
@@ -5,6 +5,10 @@
 import { useCallback, useEffect, useState, type MouseEvent } from 'react';
 import axios from '../utils/axios';
 import swal from 'sweetalert';
+import {
+  createResearchAnalyticsInteractionId,
+  trackResearchEvent,
+} from '../utils/researchAnalytics';
 
 type FavoritesKind = 'listings' | 'programs' | 'researchPlans';
 
@@ -81,6 +85,15 @@ export const useFavorites = (kind: FavoritesKind) => {
           await axios.delete(config.collectionPath, {
             withCredentials: true,
             data: { [config.payloadKey]: [id] },
+          });
+        }
+        if (kind === 'researchPlans') {
+          void trackResearchEvent({
+            eventType: 'research_save',
+            entityType: 'research_entity',
+            entityId: id,
+            payload: { operation: favorite ? 'save' : 'remove', surface: 'profile' },
+            dedupeKey: createResearchAnalyticsInteractionId('save'),
           });
         }
       } catch {

--- a/client/src/pages/__tests__/labDetail.test.tsx
+++ b/client/src/pages/__tests__/labDetail.test.tsx
@@ -5,12 +5,14 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import LabDetail from '../labDetail';
 import axios from '../../utils/axios';
 import { LabDetailPayload } from '../../types/labDetail';
+import { resetResearchAnalyticsDedupeForTests } from '../../utils/researchAnalytics';
 
 vi.mock('../../utils/axios', () => ({
   default: {
     get: vi.fn(),
     put: vi.fn(),
     delete: vi.fn(),
+    post: vi.fn(),
   },
 }));
 
@@ -18,6 +20,7 @@ const mockedAxios = axios as unknown as {
   get: ReturnType<typeof vi.fn>;
   put: ReturnType<typeof vi.fn>;
   delete: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
 };
 
 const DEFAULT_SLUG = 'sample-research-profile';
@@ -95,10 +98,96 @@ function renderLabDetail(payload: LabDetailPayload = basePayload) {
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  resetResearchAnalyticsDedupeForTests();
   localStorage.clear();
 });
 
 describe('LabDetail page', () => {
+  it('records one profile open after the canonical profile loads', async () => {
+    mockedAxios.post.mockResolvedValue({ status: 202 });
+    renderLabDetail();
+
+    await screen.findByText(DEFAULT_ENTITY_NAME);
+    await waitFor(() =>
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        '/analytics/research',
+        expect.objectContaining({
+          eventType: 'research_profile_open',
+          entityType: 'research_entity',
+          entityId: 'entity-1',
+          payload: { source: 'direct' },
+        }),
+        { withCredentials: true },
+      ),
+    );
+    expect(
+      mockedAxios.post.mock.calls.filter((call) => call[1]?.eventType === 'research_profile_open'),
+    ).toHaveLength(1);
+  });
+
+  it('keeps generic source review separate from a qualified action', async () => {
+    mockedAxios.post.mockResolvedValue({ status: 202 });
+    renderLabDetail();
+    await screen.findByText(DEFAULT_ENTITY_NAME);
+
+    fireEvent.click(screen.getByRole('link', { name: 'Open source' }));
+
+    await waitFor(() =>
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        '/analytics/research',
+        expect.objectContaining({
+          eventType: 'research_source_review',
+          payload: { sourceCategory: 'faculty_profile' },
+        }),
+        { withCredentials: true },
+      ),
+    );
+    expect(
+      mockedAxios.post.mock.calls.some(
+        (call) => call[1]?.eventType === 'research_qualified_action',
+      ),
+    ).toBe(false);
+  });
+
+  it('emits the server-owned category for a matching qualified route without its URL', async () => {
+    mockedAxios.post.mockResolvedValue({ status: 202 });
+    renderLabDetail({
+      ...basePayload,
+      group: {
+        ...basePayload.group,
+        sourceUrls: [JOIN_PAGE_URL],
+        planningContext: {
+          category: 'official_application',
+          label: 'Official application',
+          url: JOIN_PAGE_URL,
+        },
+      },
+    });
+    await screen.findByText(DEFAULT_ENTITY_NAME);
+    const actionLink = screen
+      .getAllByRole('link', { name: 'Open source' })
+      .find((link) => link.getAttribute('href') === JOIN_PAGE_URL);
+    expect(actionLink).toBeTruthy();
+
+    fireEvent.click(actionLink!);
+
+    await waitFor(() =>
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        '/analytics/research',
+        expect.objectContaining({
+          eventType: 'research_qualified_action',
+          entityId: 'entity-1',
+          payload: { actionCategory: 'official_application' },
+        }),
+        { withCredentials: true },
+      ),
+    );
+    const actionCall = mockedAxios.post.mock.calls.find(
+      (call) => call[1]?.eventType === 'research_qualified_action',
+    );
+    expect(JSON.stringify(actionCall)).not.toContain(JOIN_PAGE_URL);
+  });
+
   it('shows an official-profile next step when no pathways or contact routes exist', async () => {
     renderLabDetail();
 

--- a/client/src/pages/__tests__/research.test.tsx
+++ b/client/src/pages/__tests__/research.test.tsx
@@ -8,6 +8,7 @@ import axios from '../../utils/axios';
 import ConfigContext, { defaultConfigContext } from '../../contexts/ConfigContext';
 import UserContext, { defaultUserContext } from '../../contexts/UserContext';
 import type { User } from '../../types/types';
+import { resetResearchAnalyticsDedupeForTests } from '../../utils/researchAnalytics';
 
 vi.mock('../../utils/axios', () => ({
   default: {
@@ -75,7 +76,10 @@ const mockSearchResponses = (
         browseQuality?: string;
         qualityFilters?: string[];
       },
-    ) => Promise.resolve(resolver(url, body)),
+    ) =>
+      url === '/analytics/research'
+        ? Promise.resolve({ data: { ok: true }, status: 202 })
+        : Promise.resolve(resolver(url, body)),
   );
 };
 
@@ -328,6 +332,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   __resetResearchPageSnapshotForTests();
+  resetResearchAnalyticsDedupeForTests();
   vi.clearAllMocks();
   vi.restoreAllMocks();
   intersectionCallback = undefined;
@@ -474,7 +479,7 @@ describe('Research page', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Ancient DNA' }));
 
     await screen.findByRole('heading', { name: 'Ancient DNA Example' });
-    expect(mockedAxios.post).toHaveBeenLastCalledWith(
+    expect(mockedAxios.post).toHaveBeenCalledWith(
       '/research/search',
       expect.objectContaining({
         q: 'ancient DNA',
@@ -509,7 +514,7 @@ describe('Research page', () => {
     expect((screen.getByLabelText('Search Yale research') as HTMLInputElement).value).toBe(
       'ancient DNA',
     );
-    expect(mockedAxios.post).toHaveBeenLastCalledWith(
+    expect(mockedAxios.post).toHaveBeenCalledWith(
       '/research/search',
       expect.objectContaining({
         q: 'ancient DNA',
@@ -1701,6 +1706,48 @@ describe('Research page', () => {
     expect(mockedAxios.post.mock.calls.filter(([url]) => url === '/pathways/search')).toHaveLength(
       0,
     );
+    const searchJourneyCalls = mockedAxios.post.mock.calls.filter(
+      ([url, body]) => url === '/analytics/research' && body.eventType === 'research_search',
+    );
+    expect(searchJourneyCalls).toHaveLength(1);
+    expect(searchJourneyCalls[0][1].payload).toEqual({
+      outcome: 'results',
+      resultCountBucket: '1-5',
+      searchKind: 'query',
+      filterCountBucket: '0',
+    });
+    expect(JSON.stringify(searchJourneyCalls[0][1])).not.toContain('machine learning');
+  });
+
+  it('records exactly one terminal error outcome without the raw query', async () => {
+    mockedAxios.post.mockImplementation((url: string, body: { q?: string }) => {
+      if (url === '/analytics/research') return Promise.resolve({ status: 202 });
+      if (url === '/research/search' && body.q === '') {
+        return Promise.resolve(researchSearchResponse());
+      }
+      if (url === '/research/search' && body.q === 'private mentor query') {
+        return Promise.reject(new Error('offline'));
+      }
+      return Promise.reject(unexpectedSearchEndpoint(url));
+    });
+    renderResearch();
+
+    fireEvent.change(screen.getByLabelText('Search Yale research'), {
+      target: { value: 'private mentor query' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+
+    expect(
+      await screen.findByText(
+        'Live search metadata is unavailable right now. Try another topic or check back soon.',
+      ),
+    ).toBeTruthy();
+    const searchJourneyCalls = mockedAxios.post.mock.calls.filter(
+      ([url, body]) => url === '/analytics/research' && body.eventType === 'research_search',
+    );
+    expect(searchJourneyCalls).toHaveLength(1);
+    expect(searchJourneyCalls[0][1].payload).toMatchObject({ outcome: 'error' });
+    expect(JSON.stringify(searchJourneyCalls[0][1])).not.toContain('private mentor query');
   });
 
   it('reveals one research-home result stream with inline ways-in context after a search', async () => {

--- a/client/src/pages/__tests__/research.test.tsx
+++ b/client/src/pages/__tests__/research.test.tsx
@@ -702,7 +702,10 @@ describe('Research page', () => {
     );
 
     expect(await screen.findByRole('button', { name: 'Filters, 2 active' })).toBeTruthy();
-    expect(mockedAxios.post).toHaveBeenLastCalledWith(
+    const researchSearchCall = mockedAxios.post.mock.calls.find(
+      ([url]) => url === '/research/search',
+    );
+    expect(researchSearchCall).toEqual([
       '/research/search',
       expect.objectContaining({
         filters: {
@@ -711,7 +714,7 @@ describe('Research page', () => {
         },
       }),
       expect.any(Object),
-    );
+    ]);
     expect(screen.getByTestId('location').textContent).not.toContain('undergrad');
     expect(screen.getByRole('button', { name: 'Remove School: Yale College' })).toBeTruthy();
     expect(
@@ -2071,8 +2074,8 @@ describe('Research page', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Back to research' }));
 
     expect(await screen.findByRole('heading', { name: 'AI Safety Lab' })).toBeTruthy();
-    expect(
-      mockedAxios.post.mock.calls.filter(([url]) => url === '/research/search'),
-    ).toHaveLength(initialSearchCalls);
+    expect(mockedAxios.post.mock.calls.filter(([url]) => url === '/research/search')).toHaveLength(
+      initialSearchCalls,
+    );
   });
 });

--- a/client/src/pages/__tests__/research.test.tsx
+++ b/client/src/pages/__tests__/research.test.tsx
@@ -939,7 +939,7 @@ describe('Research page', () => {
     fireEvent.click(toggle);
 
     await screen.findByRole('heading', { name: 'Sparse Lab' });
-    expect(mockedAxios.post).toHaveBeenLastCalledWith(
+    expect(mockedAxios.post).toHaveBeenCalledWith(
       '/research/search',
       expect.objectContaining({
         q: '',
@@ -1075,7 +1075,7 @@ describe('Research page', () => {
 
     await screen.findByRole('heading', { name: 'AI Safety Lab' });
     expect(screen.queryByRole('heading', { name: 'Sparse Lab' })).toBeNull();
-    expect(mockedAxios.post).toHaveBeenLastCalledWith(
+    expect(mockedAxios.post).toHaveBeenCalledWith(
       '/research/search',
       expect.objectContaining({
         q: '',
@@ -1719,6 +1719,37 @@ describe('Research page', () => {
     expect(JSON.stringify(searchJourneyCalls[0][1])).not.toContain('machine learning');
   });
 
+  it('dedupes browse impressions per StrictMode load but records a later visit', async () => {
+    mockSearchResponses((url) =>
+      url === '/research/search'
+        ? researchSearchResponse([researchEntity])
+        : unexpectedSearchEndpoint(url),
+    );
+
+    const firstVisit = renderResearchStrict();
+    await screen.findByRole('heading', { name: 'AI Safety Lab' });
+    await waitFor(() => {
+      expect(
+        mockedAxios.post.mock.calls.filter(
+          ([url, body]) =>
+            url === '/analytics/research' && body.eventType === 'research_entity_impression',
+        ),
+      ).toHaveLength(1);
+    });
+    firstVisit.unmount();
+
+    renderResearchStrict();
+    await screen.findByRole('heading', { name: 'AI Safety Lab' });
+    await waitFor(() => {
+      const impressionCalls = mockedAxios.post.mock.calls.filter(
+        ([url, body]) =>
+          url === '/analytics/research' && body.eventType === 'research_entity_impression',
+      );
+      expect(impressionCalls).toHaveLength(2);
+      expect(impressionCalls[0][1].dedupeKey).not.toBe(impressionCalls[1][1].dedupeKey);
+    });
+  });
+
   it('records exactly one terminal error outcome without the raw query', async () => {
     mockedAxios.post.mockImplementation((url: string, body: { q?: string }) => {
       if (url === '/analytics/research') return Promise.resolve({ status: 202 });
@@ -2029,7 +2060,9 @@ describe('Research page', () => {
     renderResearchWithDetailRoute();
 
     expect(await screen.findByRole('heading', { name: 'AI Safety Lab' })).toBeTruthy();
-    const initialSearchCalls = mockedAxios.post.mock.calls.length;
+    const initialSearchCalls = mockedAxios.post.mock.calls.filter(
+      ([url]) => url === '/research/search',
+    ).length;
     expect(initialSearchCalls).toBeGreaterThan(0);
 
     fireEvent.click(screen.getByRole('link', { name: 'View profile →' }));
@@ -2038,6 +2071,8 @@ describe('Research page', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Back to research' }));
 
     expect(await screen.findByRole('heading', { name: 'AI Safety Lab' })).toBeTruthy();
-    expect(mockedAxios.post).toHaveBeenCalledTimes(initialSearchCalls);
+    expect(
+      mockedAxios.post.mock.calls.filter(([url]) => url === '/research/search'),
+    ).toHaveLength(initialSearchCalls);
   });
 });

--- a/client/src/pages/__tests__/research.test.tsx
+++ b/client/src/pages/__tests__/research.test.tsx
@@ -894,7 +894,7 @@ describe('Research page', () => {
     expect(await screen.findByText('Research homes to explore')).toBeTruthy();
     expect(screen.queryByLabelText('Search results')).toBeNull();
     expect(screen.queryByText("Showing research matches for 'quantum materials'")).toBeNull();
-    expect(screen.getByRole('heading', { name: 'Default Research Home' })).toBeTruthy();
+    expect(await screen.findByRole('heading', { name: 'Default Research Home' })).toBeTruthy();
   });
 
   it('uses research search enrichment from research entities', async () => {

--- a/client/src/pages/analytics.tsx
+++ b/client/src/pages/analytics.tsx
@@ -579,6 +579,12 @@ const Analytics = () => {
     { key: 'applications', label: 'Outreach Clicked', count: funnel?.applicantCount || 0 },
   ].filter((stage) => stage.count > 0);
   const funnelStages: AnalyticsFunnelStage[] = funnel?.stages || fallbackFunnelStages;
+  const journeyMetrics = funnel?.journeyMetrics || {
+    sourceInspections: 0,
+    officialRouteAttempts: 0,
+    applicationOpens: 0,
+    confirmedOutcomes: 0,
+  };
   const selectedRangeLabel =
     analyticsRanges.find((range) => range.value === analyticsRange)?.label || 'Selected range';
   const searchSuccessRate = searchTotal > 0 ? engagedSearches / searchTotal : null;
@@ -656,7 +662,7 @@ const Analytics = () => {
             <DashboardMetric
               title="Student action funnel"
               value={formatPercent(funnel?.overallConversionRate)}
-              context="Share of visitors reaching a concrete save or outreach-style action."
+              context="Share of logged-in visitors using a currently qualified route."
               tone="blue"
             />
             <DashboardMetric
@@ -670,6 +676,33 @@ const Analytics = () => {
               value={formatNumber(attentionCount)}
               context={topAction}
               tone={healthTone}
+            />
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 border-t border-[var(--yr-line)] p-5 sm:grid-cols-2 lg:grid-cols-4">
+            <DashboardMetric
+              title="Source inspections"
+              value={formatNumber(journeyMetrics.sourceInspections)}
+              context="Profile, publication, website, ORCID, and evidence review. Never conversion."
+              tone="blue"
+            />
+            <DashboardMetric
+              title="Official-route attempts"
+              value={formatNumber(journeyMetrics.officialRouteAttempts)}
+              context="Clicks whose category was re-qualified by the server at event time."
+              tone="blue"
+            />
+            <DashboardMetric
+              title="Application opens"
+              value={formatNumber(journeyMetrics.applicationOpens)}
+              context="Qualified open-position and official-application routes only."
+              tone="green"
+            />
+            <DashboardMetric
+              title="Confirmed outcomes"
+              value={formatNumber(journeyMetrics.confirmedOutcomes)}
+              context="Self-reported outcomes remain separate from route attempts."
+              tone="green"
             />
           </div>
 

--- a/client/src/pages/labDetail.tsx
+++ b/client/src/pages/labDetail.tsx
@@ -13,7 +13,7 @@
  */
 import { useContext, useEffect, useReducer, useRef, useState } from 'react';
 import { isCancel } from 'axios';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
 import axios from '../utils/axios';
 import { createInitialLabDetailState, labDetailReducer } from '../reducers/labDetailReducer';
 import LabHeader from '../components/labs/LabHeader';
@@ -62,6 +62,11 @@ import {
 import { getUniqueDepartmentLabels } from '../utils/departmentNames';
 import UserContext from '../contexts/UserContext';
 import ListingClaimRequestPanel from '../components/faculty/ListingClaimRequestPanel';
+import {
+  createResearchAnalyticsInteractionId,
+  trackResearchEvent,
+  trackResearchEventOnce,
+} from '../utils/researchAnalytics';
 
 const FIRST_RESEARCH_PLAN_SAVE_KEY = 'yale-research.firstResearchPlanSave.v1';
 
@@ -961,6 +966,7 @@ const hasSpecificWaysToApproach = (
 const LabDetail = () => {
   const { user } = useContext(UserContext);
   const { slug } = useParams<{ slug: string }>();
+  const location = useLocation();
   const [state, dispatch] = useReducer(labDetailReducer, undefined, () =>
     createInitialLabDetailState(),
   );
@@ -1005,6 +1011,17 @@ const LabDetail = () => {
       fetchAbortRef.current?.abort();
     };
   }, [slug]);
+
+  useEffect(() => {
+    const entity = payload?.researchEntity || payload?.group;
+    if (!entity?._id) return;
+    void trackResearchEventOnce(`profile:${location.key}:${entity._id}`, {
+      eventType: 'research_profile_open',
+      entityType: 'research_entity',
+      entityId: entity._id,
+      payload: { source: 'direct' },
+    });
+  }, [location.key, payload]);
 
   if (loading && !payload) {
     return (
@@ -1120,6 +1137,47 @@ const LabDetail = () => {
     ['professor', 'faculty', 'staff'].includes(user?.userType || '') &&
     activeListings.length > 0;
 
+  const handleDetailLinkOpen = (event: React.MouseEvent<HTMLElement>) => {
+    const anchor = (event.target as HTMLElement).closest('a');
+    const sourceUrl = safeHttpUrl(anchor?.getAttribute('href'));
+    if (!sourceUrl) return;
+    const planningContext = group.planningContext;
+    const isQualifiedAction =
+      planningContext && normalizeSourceUrl(planningContext.url) === normalizeSourceUrl(sourceUrl);
+    if (isQualifiedAction) {
+      void trackResearchEvent({
+        eventType: 'research_qualified_action',
+        entityType: 'research_entity',
+        entityId: group._id,
+        payload: { actionCategory: planningContext.category },
+        dedupeKey: createResearchAnalyticsInteractionId('action'),
+      });
+      return;
+    }
+
+    const sourceText = `${anchor?.textContent || ''} ${sourceUrl}`.toLowerCase();
+    const sourceCategory =
+      sourceText.includes('publication') || sourceText.includes('doi.org')
+        ? 'publication'
+        : sourceText.includes('orcid')
+          ? 'orcid'
+          : sourceText.includes('faculty') || sourceText.includes('profile')
+            ? 'faculty_profile'
+            : sourceText.includes('website') ||
+                (Boolean(group.websiteUrl) && sourceText.includes(group.websiteUrl.toLowerCase()))
+              ? 'entity_website'
+              : sourceText.includes('evidence') || sourceText.includes('application')
+                ? 'evidence'
+                : 'other';
+    void trackResearchEvent({
+      eventType: 'research_source_review',
+      entityType: 'research_entity',
+      entityId: group._id,
+      payload: { sourceCategory },
+      dedupeKey: createResearchAnalyticsInteractionId('source'),
+    });
+  };
+
   const handleToggleSavedResearchPlan = (entityId: string, shouldSave: boolean) => {
     setSavedResearchPlanFavorite(entityId, shouldSave);
     if (shouldSave && !window.localStorage.getItem(FIRST_RESEARCH_PLAN_SAVE_KEY)) {
@@ -1129,7 +1187,10 @@ const LabDetail = () => {
   };
 
   return (
-    <div className="mx-auto w-full max-w-screen-2xl px-4 py-6 sm:py-8 lg:px-8">
+    <div
+      className="mx-auto w-full max-w-screen-2xl px-4 py-6 sm:py-8 lg:px-8"
+      onClickCapture={handleDetailLinkOpen}
+    >
       <div className="grid grid-cols-1 gap-6 lg:gap-8">
         <div className="lg:mx-auto lg:w-full lg:max-w-5xl space-y-6 sm:space-y-8">
           {showResearchPlanSavedCallout && (

--- a/client/src/pages/research.tsx
+++ b/client/src/pages/research.tsx
@@ -409,6 +409,7 @@ const Research = () => {
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const searchRequestIdRef = useRef(0);
   const defaultSearchRequestIdRef = useRef(0);
+  const browseAnalyticsSessionRef = useRef(createResearchAnalyticsInteractionId('browse'));
   const searchAbortRef = useRef<AbortController | null>(null);
   const defaultSearchAbortRef = useRef<AbortController | null>(null);
   const activeSearchKeyRef = useRef<string | null>(null);
@@ -479,6 +480,24 @@ const Research = () => {
   }, []);
 
   useEffect(() => {
+    restoredSnapshotRef.current?.defaultResearchEntities.forEach((entity, index) => {
+      if (!entity._id) return;
+      void trackResearchEventOnce(
+        `${browseAnalyticsSessionRef.current}:restored:${entity._id}`,
+        {
+          eventType: 'research_entity_impression',
+          entityType: 'research_entity',
+          entityId: entity._id,
+          payload: {
+            surface: 'browse',
+            positionBucket: researchPositionBucket(index + 1),
+          },
+        },
+      );
+    });
+  }, []);
+
+  useEffect(() => {
     if (isAdmin) return;
     if (showWeakestProfilesFirst) setShowWeakestProfilesFirst(false);
     if (qualityFilters.length > 0) setQualityFilters([]);
@@ -487,6 +506,7 @@ const Research = () => {
 
   const runDefaultResearchHomeSearch = async (page = 1) => {
     const requestId = ++defaultSearchRequestIdRef.current;
+    const browseLoadAnalyticsKey = `${browseAnalyticsSessionRef.current}:${requestId}:${page}`;
     const controller = new AbortController();
     defaultSearchAbortRef.current?.abort();
     defaultSearchAbortRef.current = controller;
@@ -524,7 +544,7 @@ const Research = () => {
       setDefaultSearchError('');
       researchEntities.forEach((entity, index) => {
         if (!entity._id) return;
-        void trackResearchEventOnce(`browse:${page}:${entity._id}`, {
+        void trackResearchEventOnce(`${browseLoadAnalyticsKey}:${entity._id}`, {
           eventType: 'research_entity_impression',
           entityType: 'research_entity',
           entityId: entity._id,

--- a/client/src/pages/research.tsx
+++ b/client/src/pages/research.tsx
@@ -23,6 +23,13 @@ import {
 import { getUniqueDepartmentLabels } from '../utils/departmentNames';
 import useDocumentTitle from '../hooks/useDocumentTitle';
 import type { PathwaySearchFilters } from '../types/pathway';
+import {
+  createResearchAnalyticsInteractionId,
+  researchPositionBucket,
+  researchResultCountBucket,
+  trackResearchEvent,
+  trackResearchEventOnce,
+} from '../utils/researchAnalytics';
 
 interface DepartmentResearchHomeConfig {
   abbreviation?: string;
@@ -104,6 +111,11 @@ interface ActiveResearchSearchRequest {
   searchQuery: string;
   filters: ResearchSearchFilters;
   options?: ResearchEntitySearchOptions;
+}
+
+interface ResearchFilterAnalyticsChange {
+  operation: 'apply' | 'remove';
+  filter: 'school' | 'department' | 'documented_way_in';
 }
 
 interface ResearchPageSnapshot {
@@ -400,6 +412,7 @@ const Research = () => {
   const searchAbortRef = useRef<AbortController | null>(null);
   const defaultSearchAbortRef = useRef<AbortController | null>(null);
   const activeSearchKeyRef = useRef<string | null>(null);
+  const activeSearchAnalyticsKeyRef = useRef<string | null>(null);
   const pendingSearchParamsRef = useRef<string | null>(null);
   const pendingSearchSourceParamsRef = useRef<string | null>(null);
   const pendingSearchSourceLocationKeyRef = useRef<string | null>(null);
@@ -509,6 +522,20 @@ const Research = () => {
       setDefaultSearchTotal(researchEntitiesPage.estimatedTotalHits);
       setDefaultSearchExhausted(isResearchEntitySearchExhausted(researchEntitiesPage));
       setDefaultSearchError('');
+      researchEntities.forEach((entity, index) => {
+        if (!entity._id) return;
+        void trackResearchEventOnce(`browse:${page}:${entity._id}`, {
+          eventType: 'research_entity_impression',
+          entityType: 'research_entity',
+          entityId: entity._id,
+          payload: {
+            surface: 'browse',
+            positionBucket: researchPositionBucket(
+              (page - 1) * DEFAULT_RESEARCH_HOME_LIMIT + index + 1,
+            ),
+          },
+        });
+      });
     } catch (error) {
       if (
         requestId === defaultSearchRequestIdRef.current &&
@@ -532,6 +559,7 @@ const Research = () => {
       hasFilterSelections?: boolean;
       departmentSearch?: DepartmentSearchTarget | null;
       syncUrl?: boolean;
+      filterChanges?: ResearchFilterAnalyticsChange[];
     } = {},
   ) => {
     defaultSearchAbortRef.current?.abort();
@@ -542,6 +570,12 @@ const Research = () => {
     if (!trimmed && !hasFilters) return;
     if (!searchQuery.trim() && !hasFilters) return;
     const resultQueryLabel = trimmed || 'filtered research';
+    const searchKind = options.departmentSearch ? 'department' : hasFilters ? 'filtered' : 'query';
+    const filterCount = Object.values(filters).filter((value) =>
+      Array.isArray(value) ? value.length > 0 : Boolean(value),
+    ).length;
+    const filterCountBucket =
+      filterCount === 0 ? '0' : filterCount === 1 ? '1' : filterCount === 2 ? '2' : '3+';
 
     const requestKey = JSON.stringify({
       query: searchQuery.trim(),
@@ -553,6 +587,8 @@ const Research = () => {
     activeSearchKeyRef.current = requestKey;
 
     const requestId = ++searchRequestIdRef.current;
+    const analyticsKey = createResearchAnalyticsInteractionId('search');
+    activeSearchAnalyticsKeyRef.current = analyticsKey;
     const controller = new AbortController();
     searchAbortRef.current?.abort();
     searchAbortRef.current = controller;
@@ -624,6 +660,33 @@ const Research = () => {
           papers: [],
         }),
       );
+      const resultCount = researchEntitiesPage.estimatedTotalHits;
+      void trackResearchEvent({
+        eventType: 'research_search',
+        payload: {
+          outcome: resultCount > 0 ? 'results' : 'zero_results',
+          resultCountBucket: researchResultCountBucket(resultCount),
+          searchKind,
+          filterCountBucket,
+        },
+        dedupeKey: analyticsKey,
+      });
+      researchEntities.forEach((entity, index) => {
+        if (!entity._id) return;
+        void trackResearchEventOnce(`${analyticsKey}:i:${entity._id}`, {
+          eventType: 'research_entity_impression',
+          entityType: 'research_entity',
+          entityId: entity._id,
+          payload: { surface: 'search', positionBucket: researchPositionBucket(index + 1) },
+        });
+      });
+      options.filterChanges?.forEach((change) => {
+        void trackResearchEvent({
+          eventType: 'research_filter_change',
+          payload: change,
+          dedupeKey: createResearchAnalyticsInteractionId('filter'),
+        });
+      });
     } catch (error) {
       if (
         requestId === searchRequestIdRef.current &&
@@ -635,6 +698,16 @@ const Research = () => {
         );
         setHasFacetError(true);
         setSearchExhausted(true);
+        void trackResearchEvent({
+          eventType: 'research_search',
+          payload: {
+            outcome: 'error',
+            resultCountBucket: '0',
+            searchKind,
+            filterCountBucket,
+          },
+          dedupeKey: analyticsKey,
+        });
       }
     } finally {
       if (activeSearchKeyRef.current === requestKey) activeSearchKeyRef.current = null;
@@ -679,6 +752,21 @@ const Research = () => {
         );
         return nextResearchEntities;
       });
+      const analyticsKey = activeSearchAnalyticsKeyRef.current;
+      if (analyticsKey) {
+        visibleResearchEntities.forEach((entity, index) => {
+          if (!entity._id) return;
+          void trackResearchEventOnce(`${analyticsKey}:i:${entity._id}`, {
+            eventType: 'research_entity_impression',
+            entityType: 'research_entity',
+            entityId: entity._id,
+            payload: {
+              surface: 'search',
+              positionBucket: researchPositionBucket((page - 1) * 24 + index + 1),
+            },
+          });
+        });
+      }
       setSearchTotal(researchEntitiesPage.estimatedTotalHits);
       setSearchExhausted(isResearchEntitySearchExhausted(researchEntitiesPage));
     } catch (error) {
@@ -736,6 +824,7 @@ const Research = () => {
     setSearchTotal(0);
     setSearchExhausted(true);
     setActiveSearchRequest(null);
+    activeSearchAnalyticsKeyRef.current = null;
     setSearchError('');
     setHasFacetError(false);
     setSearchLoading(false);
@@ -1020,16 +1109,31 @@ const Research = () => {
   const departmentFacetLabel = (department: string) =>
     getUniqueDepartmentLabels([department], departments)[0] || department;
   const applyStudentFacets = (school: string, department: string) => {
+    const filterChanges: ResearchFilterAnalyticsChange[] = [];
+    if (school !== selectedSchool) {
+      filterChanges.push({ operation: school ? 'apply' : 'remove', filter: 'school' });
+    }
+    if (department !== selectedDepartment) {
+      filterChanges.push({ operation: department ? 'apply' : 'remove', filter: 'department' });
+    }
     setSelectedSchool(school);
     setSelectedDepartment(department);
     const filters = studentSearchFilters(school, department);
     if (!query.trim() && !hasStructuredFilters(filters)) {
+      filterChanges.forEach((change) => {
+        void trackResearchEvent({
+          eventType: 'research_filter_change',
+          payload: change,
+          dedupeKey: createResearchAnalyticsInteractionId('filter'),
+        });
+      });
       resetSearch();
       return;
     }
     runSearch(query.trim(), {
       filters,
       hasFilterSelections: hasStructuredFilters(filters),
+      filterChanges,
     });
   };
   const runDepartmentSearch = (target: DepartmentSearchTarget) =>

--- a/client/src/reducers/analyticsReducer.ts
+++ b/client/src/reducers/analyticsReducer.ts
@@ -310,6 +310,12 @@ export interface AnalyticsFunnelResponse {
   profileUpdateCount?: number;
   listingCreateCount?: number;
   overallConversionRate?: number;
+  journeyMetrics?: {
+    sourceInspections: number;
+    officialRouteAttempts: number;
+    applicationOpens: number;
+    confirmedOutcomes: number;
+  };
 }
 
 export interface AnalyticsActionNeededItem {

--- a/client/src/types/researchGroup.ts
+++ b/client/src/types/researchGroup.ts
@@ -55,6 +55,12 @@ export interface AccessSummary {
   bestNextStep: string;
 }
 
+export interface ResearchPlanningContext {
+  category: 'open_position' | 'official_application' | 'reviewed_route' | 'qualified_participation';
+  label: string;
+  url: string;
+}
+
 export type StudentDecisionRecommendedAction =
   | 'APPLY'
   | 'OPEN_OFFICIAL_ROUTE'
@@ -178,6 +184,7 @@ export interface ResearchGroup {
    */
   hasActiveListing?: boolean;
   accessSummary?: AccessSummary;
+  planningContext?: ResearchPlanningContext;
   studentDecisionExplanation?: StudentDecisionExplanation;
   studentVisibilityTier?: 'student_ready' | 'limited_but_safe' | 'operator_review' | 'suppressed';
 }

--- a/client/src/utils/__tests__/researchAnalytics.test.ts
+++ b/client/src/utils/__tests__/researchAnalytics.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import axios from '../axios';
+import {
+  researchCountBucket,
+  researchPositionBucket,
+  researchResultCountBucket,
+  resetResearchAnalyticsDedupeForTests,
+  trackResearchEvent,
+  trackResearchEventOnce,
+} from '../researchAnalytics';
+
+vi.mock('../axios', () => ({
+  default: {
+    post: vi.fn(),
+  },
+}));
+
+const post = (axios as unknown as { post: ReturnType<typeof vi.fn> }).post;
+
+afterEach(() => {
+  vi.clearAllMocks();
+  resetResearchAnalyticsDedupeForTests();
+});
+
+describe('research journey analytics client', () => {
+  it('sends the canonical search contract without raw query text', async () => {
+    post.mockResolvedValue({ status: 202 });
+
+    await trackResearchEvent({
+      eventType: 'research_search',
+      payload: {
+        outcome: 'zero_results',
+        resultCountBucket: '0',
+        searchKind: 'query',
+        filterCountBucket: '0',
+      },
+      dedupeKey: 'search:fixture-1',
+    });
+
+    expect(post).toHaveBeenCalledWith(
+      '/analytics/research',
+      {
+        eventType: 'research_search',
+        payload: {
+          outcome: 'zero_results',
+          resultCountBucket: '0',
+          searchKind: 'query',
+          filterCountBucket: '0',
+        },
+        dedupeKey: 'search:fixture-1',
+      },
+      { withCredentials: true },
+    );
+    expect(JSON.stringify(post.mock.calls[0][1])).not.toContain('queryText');
+  });
+
+  it.each([
+    ['research_profile_open', { source: 'direct' }],
+    ['research_source_review', { sourceCategory: 'publication' }],
+    ['research_save', { operation: 'save', surface: 'profile' }],
+    ['research_compare', { entityCountBucket: '2' }],
+    ['research_plan_update', { field: 'note_presence' }],
+    ['research_qualified_action', { actionCategory: 'official_application' }],
+  ] as const)('sends %s as an entity-scoped event', async (eventType, payload) => {
+    post.mockResolvedValue({ status: 202 });
+
+    await trackResearchEvent({
+      eventType,
+      entityType: 'research_entity',
+      entityId: '507f1f77bcf86cd799439011',
+      payload,
+      dedupeKey: `${eventType}:fixture-1`,
+    });
+
+    expect(post).toHaveBeenCalledWith(
+      '/analytics/research',
+      expect.objectContaining({
+        eventType,
+        entityType: 'research_entity',
+        entityId: '507f1f77bcf86cd799439011',
+        payload,
+      }),
+      { withCredentials: true },
+    );
+  });
+
+  it('collapses Strict Mode and navigation replay keys', async () => {
+    post.mockResolvedValue({ status: 202 });
+    const event = {
+      eventType: 'research_profile_open' as const,
+      entityType: 'research_entity' as const,
+      entityId: '507f1f77bcf86cd799439011',
+      payload: { source: 'direct' as const },
+    };
+
+    await Promise.all([
+      trackResearchEventOnce('profile:route1:entity1', event),
+      trackResearchEventOnce('profile:route1:entity1', event),
+    ]);
+
+    expect(post).toHaveBeenCalledOnce();
+  });
+
+  it('swallows blocked-tracker and offline failures', async () => {
+    post.mockRejectedValue(new Error('blocked'));
+
+    await expect(
+      trackResearchEvent({
+        eventType: 'research_save',
+        entityType: 'research_entity',
+        entityId: '507f1f77bcf86cd799439011',
+        payload: { operation: 'save', surface: 'profile' },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('uses bounded result, position, and comparison buckets', () => {
+    expect([0, 1, 6, 21, 51].map(researchResultCountBucket)).toEqual([
+      '0',
+      '1-5',
+      '6-20',
+      '21-50',
+      '51+',
+    ]);
+    expect([1, 4, 11, 25].map(researchPositionBucket)).toEqual(['1-3', '4-10', '11-24', '25+']);
+    expect([1, 2, 4, 5].map(researchCountBucket)).toEqual(['1', '2', '3-4', '5+']);
+  });
+});

--- a/client/src/utils/researchAnalytics.ts
+++ b/client/src/utils/researchAnalytics.ts
@@ -1,37 +1,152 @@
 import axios from './axios';
 
-export type ResearchEventType =
+export type LegacyResearchEventType =
   | 'research_view'
   | 'pathway_save'
   | 'ways_in_click'
   | 'contact_route_click'
   | 'source_link_click';
 
-export type ResearchEntityType = 'profile' | 'listing' | 'fellowship';
+export const RESEARCH_JOURNEY_EVENT_TYPES = [
+  'research_search',
+  'research_entity_impression',
+  'research_profile_open',
+  'research_source_review',
+  'research_filter_change',
+  'research_save',
+  'research_compare',
+  'research_plan_update',
+  'research_qualified_action',
+] as const;
+
+export type ResearchJourneyEventType = (typeof RESEARCH_JOURNEY_EVENT_TYPES)[number];
+export type ResearchEventType = LegacyResearchEventType | ResearchJourneyEventType;
+export type ResearchEntityType = 'profile' | 'listing' | 'fellowship' | 'research_entity';
+export type PlanningContextCategory =
+  | 'open_position'
+  | 'official_application'
+  | 'reviewed_route'
+  | 'qualified_participation';
+
+export type ResearchJourneyPayload =
+  | {
+      outcome: 'results' | 'zero_results' | 'error';
+      resultCountBucket: '0' | '1-5' | '6-20' | '21-50' | '51+';
+      searchKind: 'query' | 'filtered' | 'department';
+      filterCountBucket: '0' | '1' | '2' | '3+';
+    }
+  | {
+      surface: 'browse' | 'search' | 'saved_plans';
+      positionBucket: '1-3' | '4-10' | '11-24' | '25+';
+    }
+  | { source: 'browse' | 'search' | 'direct' | 'saved_plans' }
+  | {
+      sourceCategory:
+        | 'entity_website'
+        | 'faculty_profile'
+        | 'orcid'
+        | 'publication'
+        | 'evidence'
+        | 'other';
+    }
+  | {
+      operation: 'apply' | 'remove' | 'clear' | 'panel_open' | 'panel_close';
+      filter: 'school' | 'department' | 'documented_way_in' | 'admin_quality' | 'admin_trust';
+    }
+  | { operation: 'save' | 'remove'; surface: 'profile' | 'search' | 'saved_plans' }
+  | { entityCountBucket: '1' | '2' | '3-4' | '5+' }
+  | {
+      field:
+        | 'intent'
+        | 'stage'
+        | 'note_presence'
+        | 'checklist'
+        | 'target_deadline'
+        | 'acted_on_date'
+        | 'follow_up';
+    }
+  | { actionCategory: PlanningContextCategory };
 
 interface TrackResearchEventParams {
   eventType: ResearchEventType;
-  entityType: ResearchEntityType;
-  entityId: string;
-  payload?: Record<string, string>;
+  entityType?: ResearchEntityType;
+  entityId?: string;
+  payload?: Record<string, string> | ResearchJourneyPayload;
+  dedupeKey?: string;
 }
 
-export const trackResearchEvent = ({
+const sentOnceKeys = new Set<string>();
+let fallbackInteractionSequence = 0;
+
+export const createResearchAnalyticsInteractionId = (prefix = 'journey'): string => {
+  const randomId = globalThis.crypto?.randomUUID?.().replace(/-/g, '');
+  if (randomId) return `${prefix}:${randomId}`;
+  fallbackInteractionSequence += 1;
+  return `${prefix}:${Date.now().toString(36)}:${fallbackInteractionSequence.toString(36)}`;
+};
+
+export const researchResultCountBucket = (
+  count: number,
+): '0' | '1-5' | '6-20' | '21-50' | '51+' => {
+  if (count <= 0) return '0';
+  if (count <= 5) return '1-5';
+  if (count <= 20) return '6-20';
+  if (count <= 50) return '21-50';
+  return '51+';
+};
+
+export const researchPositionBucket = (position: number): '1-3' | '4-10' | '11-24' | '25+' => {
+  if (position <= 3) return '1-3';
+  if (position <= 10) return '4-10';
+  if (position <= 24) return '11-24';
+  return '25+';
+};
+
+export const researchCountBucket = (count: number): '1' | '2' | '3-4' | '5+' => {
+  if (count <= 1) return '1';
+  if (count === 2) return '2';
+  if (count <= 4) return '3-4';
+  return '5+';
+};
+
+/**
+ * Fire-and-forget analytics. The promise always resolves so a blocked tracker,
+ * offline browser, or server failure can never affect the student interaction.
+ */
+export const trackResearchEvent = async ({
   eventType,
   entityType,
   entityId,
   payload,
-}: TrackResearchEventParams) => {
-  axios
-    .post(
+  dedupeKey,
+}: TrackResearchEventParams): Promise<void> => {
+  try {
+    await axios.post(
       '/analytics/research',
       {
         eventType,
-        entityType,
-        entityId,
-        payload,
+        ...(entityType ? { entityType } : {}),
+        ...(entityId ? { entityId } : {}),
+        ...(payload ? { payload } : {}),
+        ...(dedupeKey ? { dedupeKey } : {}),
       },
       { withCredentials: true },
-    )
-    .catch(() => undefined);
+    );
+  } catch {
+    // Analytics is deliberately non-blocking and invisible.
+  }
+};
+
+export const trackResearchEventOnce = (
+  onceKey: string,
+  event: TrackResearchEventParams,
+): Promise<void> => {
+  if (sentOnceKeys.has(onceKey)) return Promise.resolve();
+  sentOnceKeys.add(onceKey);
+  return trackResearchEvent({ ...event, dedupeKey: event.dedupeKey || onceKey });
+};
+
+export const resetResearchAnalyticsDedupeForTests = (): void => {
+  sentOnceKeys.clear();
+  fallbackInteractionSequence = 0;
 };

--- a/docs/research-journey-analytics.md
+++ b/docs/research-journey-analytics.md
@@ -1,0 +1,52 @@
+# Research Journey Analytics Contract
+
+Status: canonical contract for IM-01
+
+The research journey taxonomy is claim-specific and invisible to students.
+The canonical server enum is `AnalyticsEventType` in `server/src/models/analytics.ts`.
+The client mirrors the journey subset in `client/src/utils/researchAnalytics.ts`.
+Any enum or payload change must update both files and their focused contract tests in the same pull request.
+
+## Events
+
+| Event                        | Required entity   | Allowlisted payload                                               | Meaning                                                                                         |
+| ---------------------------- | ----------------- | ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `research_search`            | none              | `outcome`, `resultCountBucket`, `searchKind`, `filterCountBucket` | One terminal result, zero-result, or error outcome for one submitted canonical research search. |
+| `research_entity_impression` | `research_entity` | `surface`, `positionBucket`                                       | A canonical entity was returned in a visible result page.                                       |
+| `research_profile_open`      | `research_entity` | `source`                                                          | A canonical research profile loaded successfully.                                               |
+| `research_source_review`     | `research_entity` | `sourceCategory`                                                  | A student opened a profile, website, ORCID, publication, or evidence source.                    |
+| `research_filter_change`     | none              | `operation`, `filter`                                             | A bounded research filter was applied, removed, cleared, opened, or closed.                     |
+| `research_save`              | `research_entity` | `operation`, `surface`                                            | A first-class research-entity save or removal completed successfully.                           |
+| `research_compare`           | `research_entity` | `entityCountBucket`                                               | One entity participated in an explicit saved-home comparison or advising preview.               |
+| `research_plan_update`       | `research_entity` | `field`                                                           | A saved plan field group persisted successfully.                                                |
+| `research_qualified_action`  | `research_entity` | `actionCategory`                                                  | The student opened a route that the server re-qualified against the current QA-01 projection.   |
+
+The only access-conversion event is `research_qualified_action`.
+Its `actionCategory` is the `PlanningContextCategory` enum from `server/src/services/planningContextService.ts`: `open_position`, `official_application`, `reviewed_route`, or `qualified_participation`.
+The server rejects missing, stale, or mismatched qualifications and records the current server-owned category instead of trusting the client.
+
+Source review, profile open, impression, filter, save, compare, and plan events never count as access conversion.
+`outreach_outcome` remains a separate self-reported outcome and is not inferred from any click.
+
+## Privacy And Reliability
+
+Payloads are deny-by-default allowlists of short enums and count buckets.
+They do not retain raw query text, URLs, hostnames, contact destinations, notes, plan contents, filter values, or cross-event search identifiers.
+Entity identifiers are bounded canonical `ResearchEntity` identifiers and are validated before persistence.
+Action events never carry a query or search identifier, so raw-query and action records cannot be joined through a client-supplied key.
+
+Every client interaction carries a bounded idempotency key.
+The server enforces uniqueness per authenticated analytics actor, so Strict Mode replay and transport retries do not create duplicate events.
+Analytics requests are fire-and-forget and swallow tracker, offline, navigation, and server failures.
+They do not alter focus, copy, navigation, optimistic state, or completion feedback.
+
+The analytics collection uses the existing 1,095-day TTL index in `server/src/models/analytics.ts`.
+Beta continues to suppress real student analytics through `shouldSuppressBetaAnalyticsEvent`, while allowing fixture and admin validation.
+The endpoint remains first-party, authenticated, private, and covered by the existing analytics access controls.
+
+## Dashboard Semantics
+
+The admin funnel reports source inspections, official-route attempts, application opens, and confirmed outcomes separately.
+Application opens include only `open_position` and `official_application` qualified categories.
+Official-route attempts include all currently qualified categories.
+Confirmed outcomes remain `outreach_outcome` records and are never inferred from route attempts.

--- a/docs/research-student-journey-delivery-plan.md
+++ b/docs/research-student-journey-delivery-plan.md
@@ -356,7 +356,7 @@ An open or draft PR is evidence of work in progress, never evidence that a requi
 - **Acceptance criteria:** invisible events distinguish search, research-profile open, source review, qualified action, filter-panel open/close, filter apply/remove, and save/unsave; only a qualified action counts as access conversion; faculty profile, website, ORCID, publication, filter, and save events never count as action; analytics does not delay navigation or alter UI; payloads exclude raw URLs, queries on downstream events, and free-text notes.
 - **Validation evidence:** the pending IM-01 implementation adds the canonical contract in [`research-journey-analytics.md`](./research-journey-analytics.md), terminal search outcomes, canonical entity impressions and profile opens, source and filter events, first-class save/compare/plan events, server-requalified QA-01 actions, per-actor idempotency, and separately auditable admin journey metrics.
   Legacy generic events remain for older surfaces but do not count as access conversion.
-- **PRs:** pending IM-01 pull request against Beta.
+- **PRs:** [#198](https://github.com/YaleComputerSociety/ylabs/pull/198) is pending against Beta.
 
 #### IM-02 - Search Quality, Zero Results, And Funnel Integrity
 

--- a/docs/research-student-journey-delivery-plan.md
+++ b/docs/research-student-journey-delivery-plan.md
@@ -351,12 +351,13 @@ An open or draft PR is evidence of work in progress, never evidence that a requi
 
 #### IM-01 - Claim-Specific Journey Analytics
 
-- **Status:** Not started.
+- **Status:** Active.
 - **Depends on:** QA-01 server-owned qualifying signal and an accepted privacy-safe analytics taxonomy.
 - **Acceptance criteria:** invisible events distinguish search, research-profile open, source review, qualified action, filter-panel open/close, filter apply/remove, and save/unsave; only a qualified action counts as access conversion; faculty profile, website, ORCID, publication, filter, and save events never count as action; analytics does not delay navigation or alter UI; payloads exclude raw URLs, queries on downstream events, and free-text notes.
 - **Validation evidence:** current analytics distinguishes generic source, contact, pathway, save, and research-view events but canonical research browse/detail lacks the required complete taxonomy.
   One existing program filter-navigation event is still classified too broadly as `ways_in_click`.
-- **PRs:** none.
+  The pending IM-01 implementation adds the canonical contract in [`research-journey-analytics.md`](./research-journey-analytics.md), terminal search outcomes, canonical entity impressions and profile opens, source and filter events, first-class save/compare/plan events, server-requalified QA-01 actions, per-actor idempotency, and separately auditable admin journey metrics.
+- **PRs:** pending IM-01 pull request against Beta.
 
 #### IM-02 - Search Quality, Zero Results, And Funnel Integrity
 

--- a/docs/research-student-journey-delivery-plan.md
+++ b/docs/research-student-journey-delivery-plan.md
@@ -2,7 +2,7 @@
 
 Status: active delivery reference
 
-Last verified: 2026-07-13 against Beta commit `4316b21` and GitHub PRs `#156` through `#171`.
+Last verified: 2026-07-15 against Beta commit `0dbf9206` and the pending IM-01 implementation.
 
 This document is the durable execution map for the Yale Research student journey.
 It complements [`product-context.md`](./product-context.md), [`research-model.md`](./research-model.md), [`decisions.md`](./decisions.md), and [`tasks/priority-roadmap.md`](./tasks/priority-roadmap.md).
@@ -354,9 +354,8 @@ An open or draft PR is evidence of work in progress, never evidence that a requi
 - **Status:** Active.
 - **Depends on:** QA-01 server-owned qualifying signal and an accepted privacy-safe analytics taxonomy.
 - **Acceptance criteria:** invisible events distinguish search, research-profile open, source review, qualified action, filter-panel open/close, filter apply/remove, and save/unsave; only a qualified action counts as access conversion; faculty profile, website, ORCID, publication, filter, and save events never count as action; analytics does not delay navigation or alter UI; payloads exclude raw URLs, queries on downstream events, and free-text notes.
-- **Validation evidence:** current analytics distinguishes generic source, contact, pathway, save, and research-view events but canonical research browse/detail lacks the required complete taxonomy.
-  One existing program filter-navigation event is still classified too broadly as `ways_in_click`.
-  The pending IM-01 implementation adds the canonical contract in [`research-journey-analytics.md`](./research-journey-analytics.md), terminal search outcomes, canonical entity impressions and profile opens, source and filter events, first-class save/compare/plan events, server-requalified QA-01 actions, per-actor idempotency, and separately auditable admin journey metrics.
+- **Validation evidence:** the pending IM-01 implementation adds the canonical contract in [`research-journey-analytics.md`](./research-journey-analytics.md), terminal search outcomes, canonical entity impressions and profile opens, source and filter events, first-class save/compare/plan events, server-requalified QA-01 actions, per-actor idempotency, and separately auditable admin journey metrics.
+  Legacy generic events remain for older surfaces but do not count as access conversion.
 - **PRs:** pending IM-01 pull request against Beta.
 
 #### IM-02 - Search Quality, Zero Results, And Funnel Integrity
@@ -364,7 +363,7 @@ An open or draft PR is evidence of work in progress, never evidence that a requi
 - **Status:** Active.
 - **Depends on:** IM-01 and stable entity-first search result semantics.
 - **Acceptance criteria:** one submitted search records one results, zero-results, or error outcome; result counts are bucketed; action attribution stops at the next search; dashboards keep source review separate from qualified action; monitoring detects relevance degradation without storing query text on action events.
-- **Validation evidence:** existing search-quality analytics includes zero-result and engagement concepts, but canonical entity-first client emissions and the new conversion boundary are incomplete.
+- **Validation evidence:** the pending IM-01 implementation emits one idempotent terminal outcome per canonical search, uses bounded result-count buckets without raw query text, and keeps source inspections, qualified official-route attempts, application opens, and reported outcomes distinct in the admin funnel.
 - **PRs:** [#171](https://github.com/YaleComputerSociety/ylabs/pull/171) stabilizes the result model that measurement must follow.
 
 ## Delivery Phases
@@ -446,7 +445,7 @@ Its evidence is therefore current Beta source, routes, tests, and merged history
 | Discovery filters are fully adaptive and progressively disclosed.                                      | **Pending merge.** The EF-02 change gives Research its own compact desktop disclosure and mobile sheet, uses only positive query-scoped facet counts, preserves selected values without invented counts, and keeps base search usable when facet metadata fails. | Keep EF-02 Active until the change merges into Beta; keep the documented-way-in filter governed separately by EF-03.                                            |
 | A server-qualified sparse planning summary exists.                                                     | **Not supported.** No bounded claim-specific summary or useful-state distribution exists.                                                                                        | Keep EF-03 Not started and dependent on QA-01.                                                                                                                  |
 | Research homes can be saved independently of pathways.                                                 | **Supported.** Saves and private plan details are keyed by canonical ResearchEntity ID, including entities without an indexed pathway.                                           | Keep CP-05 / FR-45 Complete and preserve migration-continuity coverage as FR-17 and FR-24 build on entity identity.                                             |
-| Canonical research analytics distinguish search, profile, source, filters, save, and qualified action. | **Not supported.** The current taxonomy is broader and canonical browse/detail lacks the complete invisible journey emissions.                                                   | Keep IM-01 Not started and IM-02 Active until QA-01 stabilizes conversion meaning.                                                                              |
+| Canonical research analytics distinguish search, profile, source, filters, save, and qualified action. | **Supported in the pending IM-01 implementation.** The server owns the allowlisted taxonomy, entity validation, action re-qualification, and per-actor idempotency boundary.     | Keep IM-01 and IM-02 Active until the implementation merges into Beta; never reinterpret legacy generic events as conversion.                                   |
 | Publishing a target number of pathways establishes trustworthy access coverage.                        | **Disputed.** Quantity does not establish claim or route quality and can reward false positives.                                                                                 | The evidence and route review rollout uses claim precision, false-positive rate, rejection reasons, and reviewed-action quality instead.                        |
 | Historical persona findings describe current Beta behavior.                                            | **Validation pending.** Several cited defects were changed by merged PRs, while the referenced transcript and fresh browser replay were unavailable.                             | Use historical observations as discovery inputs only; require current code, test, data, or CAS-preserving browser evidence before changing status or rationale. |
 

--- a/docs/tasks/priority-roadmap.md
+++ b/docs/tasks/priority-roadmap.md
@@ -1,6 +1,6 @@
 # Priority Roadmap
 
-Last updated: 2026-07-04
+Last updated: 2026-07-15
 
 This is the single task source of truth for Yale Research.
 Keep it operational and compact.
@@ -29,7 +29,7 @@ Active themes:
 
 - Make public research discovery reliable when Meilisearch or hybrid search is degraded.
 - Decide and implement the logged-out read-only discovery posture for `/research`, `/research/:slug`, and `/about`.
-- Add launch observability: client error boundary, server/client error tracking, and analytics for canonical research actions.
+- Validate launch observability across the client error boundary, server/client error tracking, and claim-specific research journey analytics.
 - Improve evidence trust: dedupe repeated evidence, distinguish synthesized fallback from observed access evidence, and show observed/freshness dates.
 - Keep the operator gate flow compact and artifact-driven without committing transient reports.
 - Reduce maintenance surface by deleting obsolete docs, screenshots, proposals, dead routes, dead indexes, and unused dependencies.
@@ -42,7 +42,6 @@ Active themes:
 | P0 | Make `/research` degrade instead of failing closed on Meilisearch/hybrid errors. | Killing or misconfiguring Meilisearch locally leaves browse/search usable through a degraded path or shows an honest failure state, not "no matches." |
 | P0 | Decide logged-out discovery. | Logged-out users can read public research/about pages, or `docs/decisions.md` records why Yale-only access is intentional for the current phase. |
 | P0 | Add error tracking and a top-level React error boundary. | A client render error and a server route error are captured with release/environment context, and the SPA shows a recovery UI instead of a white screen. |
-| P1 | Add analytics for canonical research behavior. | Research entity views, research-plan saves, planning-context clicks, best-next-step clicks, and source-link clicks flow to analytics. |
 | P1 | Fix evidence trust UI. | Duplicate evidence chips are removed, synthesized access fallback is visually distinct from source-observed evidence, and evidence dates/freshness are visible. |
 | P1 | Add a faculty/student correction loop. | Detail pages offer a claim/correction/report path that feeds an admin review queue with authenticated reporter context. |
 | P1 | Add URL-backed search state and evidence facets. | Query and filters survive reload/share/back navigation, and facets use evidence/product-model concepts instead of legacy acceptance labels. |

--- a/server/src/models/__tests__/analytics.test.ts
+++ b/server/src/models/__tests__/analytics.test.ts
@@ -32,4 +32,30 @@ describe('AnalyticsEvent model', () => {
 
     expect(ascendingTimestampIndexes).toHaveLength(1);
   });
+
+  it('accepts canonical journey events and bounds idempotency keys', async () => {
+    const event = new AnalyticsEvent({
+      eventType: AnalyticsEventType.RESEARCH_QUALIFIED_ACTION,
+      netid: 'test123',
+      userType: 'undergraduate',
+      entityType: 'research_entity',
+      entityId: '507f1f77bcf86cd799439011',
+      dedupeKey: 'action:fixture-1',
+    });
+
+    await expect(event.validate()).resolves.toBeUndefined();
+    event.dedupeKey = 'x'.repeat(161);
+    await expect(event.validate()).rejects.toThrow();
+  });
+
+  it('declares a per-actor unique idempotency index', () => {
+    const dedupeIndex = AnalyticsEvent.schema
+      .indexes()
+      .find(([fields]) => fields.netid === 1 && fields.dedupeKey === 1);
+
+    expect(dedupeIndex?.[1]).toMatchObject({
+      unique: true,
+      partialFilterExpression: { dedupeKey: { $type: 'string' } },
+    });
+  });
 });

--- a/server/src/models/analytics.ts
+++ b/server/src/models/analytics.ts
@@ -31,9 +31,26 @@ export enum AnalyticsEventType {
   SOURCE_LINK_CLICK = 'source_link_click',
   OUTREACH_CONTACT_REVEAL = 'outreach_contact_reveal',
   OUTREACH_CONTACT_ATTEMPT = 'outreach_contact_attempt',
+  // Canonical research-student journey events. Keep these claim-specific so
+  // source inspection and planning activity can never be mistaken for access
+  // conversion.
+  RESEARCH_SEARCH = 'research_search',
+  RESEARCH_ENTITY_IMPRESSION = 'research_entity_impression',
+  RESEARCH_PROFILE_OPEN = 'research_profile_open',
+  RESEARCH_SOURCE_REVIEW = 'research_source_review',
+  RESEARCH_FILTER_CHANGE = 'research_filter_change',
+  RESEARCH_SAVE = 'research_save',
+  RESEARCH_COMPARE = 'research_compare',
+  RESEARCH_PLAN_UPDATE = 'research_plan_update',
+  RESEARCH_QUALIFIED_ACTION = 'research_qualified_action',
 }
 
-export const RESEARCH_ENTITY_TYPES = ['profile', 'listing', 'fellowship'] as const;
+export const RESEARCH_ENTITY_TYPES = [
+  'profile',
+  'listing',
+  'fellowship',
+  'research_entity',
+] as const;
 export type ResearchEntityType = (typeof RESEARCH_ENTITY_TYPES)[number];
 
 const analyticsEventSchema = new mongoose.Schema(
@@ -82,6 +99,10 @@ const analyticsEventSchema = new mongoose.Schema(
     metadata: {
       type: mongoose.Schema.Types.Mixed,
     },
+    dedupeKey: {
+      type: String,
+      maxlength: 160,
+    },
     timestamp: {
       type: Date,
       default: Date.now,
@@ -96,6 +117,10 @@ analyticsEventSchema.index({ eventType: 1, timestamp: -1 });
 analyticsEventSchema.index({ netid: 1, timestamp: -1 });
 analyticsEventSchema.index({ eventType: 1, netid: 1, timestamp: -1 });
 analyticsEventSchema.index({ eventType: 1, entityType: 1, timestamp: -1 });
+analyticsEventSchema.index(
+  { netid: 1, dedupeKey: 1 },
+  { unique: true, partialFilterExpression: { dedupeKey: { $type: 'string' } } },
+);
 analyticsEventSchema.index({ timestamp: -1 });
 
 analyticsEventSchema.index({ timestamp: 1 }, { expireAfterSeconds: 94608000 });

--- a/server/src/routes/__tests__/analyticsRoutes.test.ts
+++ b/server/src/routes/__tests__/analyticsRoutes.test.ts
@@ -9,6 +9,8 @@ const mocks = vi.hoisted(() => ({
   getSearchQualityAnalytics: vi.fn(),
   getUserAnalytics: vi.fn(),
   getUserAnalyticsDrilldown: vi.fn(),
+  emitResearchEvent: vi.fn(),
+  researchEntityExists: vi.fn(),
 }));
 
 vi.mock('../../models/analytics', async (importOriginal) => ({
@@ -27,6 +29,12 @@ vi.mock('../../services/analyticsService', async (importOriginal) => ({
   getSearchQualityAnalytics: mocks.getSearchQualityAnalytics,
   getUserAnalytics: mocks.getUserAnalytics,
   getUserAnalyticsDrilldown: mocks.getUserAnalyticsDrilldown,
+}));
+
+vi.mock('../../services/researchAnalytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../services/researchAnalytics')>()),
+  emitResearchEvent: mocks.emitResearchEvent,
+  researchEntityExists: mocks.researchEntityExists,
 }));
 
 import router from '../analytics';
@@ -104,12 +112,53 @@ describe('analytics routes', () => {
 
     const { res, next } = await invokeMiddleware('setPrivateAnalyticsCacheHeaders');
 
-    expect(res.setHeader).toHaveBeenCalledWith(
-      'Cache-Control',
-      'no-store, private, max-age=0',
-    );
+    expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store, private, max-age=0');
     expect(res.setHeader).toHaveBeenCalledWith('Pragma', 'no-cache');
     expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('accepts an entity-free canonical search outcome and forwards its idempotency key', async () => {
+    mocks.emitResearchEvent.mockResolvedValue(true);
+
+    const res = await invokeRouteHandler('/research', {
+      body: {
+        eventType: 'research_search',
+        payload: {
+          outcome: 'results',
+          resultCountBucket: '6-20',
+          searchKind: 'query',
+          filterCountBucket: '0',
+        },
+        dedupeKey: 'search:fixture-1',
+      },
+      user: { netId: 'test123', userType: 'undergraduate' },
+    });
+
+    expect(res.statusCode).toBe(202);
+    expect(mocks.researchEntityExists).not.toHaveBeenCalled();
+    expect(mocks.emitResearchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'research_search',
+        dedupeKey: 'search:fixture-1',
+      }),
+    );
+  });
+
+  it('requires a real canonical entity for entity-scoped journey events', async () => {
+    mocks.researchEntityExists.mockResolvedValue(false);
+
+    const res = await invokeRouteHandler('/research', {
+      body: {
+        eventType: 'research_source_review',
+        entityType: 'research_entity',
+        entityId: '507f1f77bcf86cd799439011',
+        payload: { sourceCategory: 'publication' },
+      },
+      user: { netId: 'test123', userType: 'undergraduate' },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(mocks.emitResearchEvent).not.toHaveBeenCalled();
   });
 
   it('does not leak internal messages from analytics helper-backed route failures', async () => {

--- a/server/src/routes/analytics.ts
+++ b/server/src/routes/analytics.ts
@@ -24,7 +24,9 @@ import {
   emitResearchEvent,
   isResearchEntityType,
   isResearchEventType,
+  isResearchJourneyEventType,
   researchEntityExists,
+  researchJourneyEventRequiresEntity,
 } from '../services/researchAnalytics';
 
 const router = Router();
@@ -54,21 +56,24 @@ router.post(
   '/research',
   isAuthenticated,
   asyncHandler(async (request: Request, response: Response) => {
-    const { eventType, entityType, entityId, payload } = request.body || {};
+    const { eventType, entityType, entityId, payload, dedupeKey } = request.body || {};
 
     if (!isResearchEventType(eventType)) {
       return response.status(400).json({ error: 'Invalid research analytics eventType' });
     }
 
-    if (!isResearchEntityType(entityType)) {
+    const requiresEntity =
+      !isResearchJourneyEventType(eventType) || researchJourneyEventRequiresEntity(eventType);
+
+    if (requiresEntity && !isResearchEntityType(entityType)) {
       return response.status(400).json({ error: 'Invalid research analytics entityType' });
     }
 
-    if (typeof entityId !== 'string' || entityId.trim() === '') {
+    if (requiresEntity && (typeof entityId !== 'string' || entityId.trim() === '')) {
       return response.status(400).json({ error: 'Invalid research analytics entityId' });
     }
 
-    if (!(await researchEntityExists(entityType, entityId))) {
+    if (requiresEntity && !(await researchEntityExists(entityType, entityId))) {
       return response.status(404).json({ error: 'Research analytics entity not found' });
     }
 
@@ -77,6 +82,7 @@ router.post(
       entityType,
       entityId,
       payload,
+      dedupeKey,
       user: request.user as { netId?: string; userType?: string },
     });
 
@@ -106,20 +112,14 @@ const parseAnalyticsRange = (range: unknown): AnalyticsDateRange => {
 
   if (range === 'semester') {
     const semesterStart =
-      now.getMonth() >= 6
-        ? new Date(now.getFullYear(), 6, 1)
-        : new Date(now.getFullYear(), 0, 1);
+      now.getMonth() >= 6 ? new Date(now.getFullYear(), 6, 1) : new Date(now.getFullYear(), 0, 1);
     return { start: semesterStart, end: now };
   }
 
   return { start: new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000), end: now };
 };
 
-const handleAnalyticsError = (
-  response: Response,
-  error: unknown,
-  fallbackMessage: string,
-) => {
+const handleAnalyticsError = (response: Response, error: unknown, fallbackMessage: string) => {
   const isValidationFailure = error instanceof AnalyticsRequestError;
   response.status(isValidationFailure ? 400 : 500).json({
     error: isValidationFailure ? 'Invalid analytics request' : fallbackMessage,
@@ -250,64 +250,75 @@ router.get('/users', isAuthenticated, isAdmin, async (request: Request, response
   }
 });
 
-router.get('/search-quality', isAuthenticated, isAdmin, async (request: Request, response: Response) => {
-  try {
-    const analytics = await getSearchQualityAnalytics(parseAnalyticsRange(request.query.range));
-    response.status(200).json({
-      ...analytics,
-      searchesWithResults: Math.max(analytics.totalSearches - analytics.zeroResultSearches, 0),
-      avgResultsPerSearch:
-        analytics.byQueryAndEntityType.length > 0
-          ? analytics.byQueryAndEntityType.reduce(
-              (sum, query) => sum + query.avgResultCount * query.totalSearches,
-              0,
-            ) / analytics.byQueryAndEntityType.reduce((sum, query) => sum + query.totalSearches, 0)
-          : 0,
-      topQueries: analytics.topQueries.map((query) => ({
-        ...query,
-        count: query.totalSearches,
-        zeroResults: query.zeroResultSearches,
-        avgResults: query.avgResultCount,
-      })),
-      zeroResultQueries: analytics.topZeroResultQueries.map((query) => ({
-        ...query,
-        count: query.totalSearches,
-        zeroResults: query.zeroResultSearches,
-        avgResults: query.avgResultCount,
-      })),
-      lowResultQueries: analytics.byQueryAndEntityType
-        .filter((query) => query.avgResultCount > 0 && query.avgResultCount <= 3)
-        .slice(0, 10)
-        .map((query) => ({
+router.get(
+  '/search-quality',
+  isAuthenticated,
+  isAdmin,
+  async (request: Request, response: Response) => {
+    try {
+      const analytics = await getSearchQualityAnalytics(parseAnalyticsRange(request.query.range));
+      response.status(200).json({
+        ...analytics,
+        searchesWithResults: Math.max(analytics.totalSearches - analytics.zeroResultSearches, 0),
+        avgResultsPerSearch:
+          analytics.byQueryAndEntityType.length > 0
+            ? analytics.byQueryAndEntityType.reduce(
+                (sum, query) => sum + query.avgResultCount * query.totalSearches,
+                0,
+              ) /
+              analytics.byQueryAndEntityType.reduce((sum, query) => sum + query.totalSearches, 0)
+            : 0,
+        topQueries: analytics.topQueries.map((query) => ({
           ...query,
           count: query.totalSearches,
           zeroResults: query.zeroResultSearches,
           avgResults: query.avgResultCount,
         })),
-    });
-  } catch (error) {
-    console.error('Error fetching search quality analytics:', sanitizeLogValue(error));
-    handleAnalyticsError(response, error, 'Failed to fetch search quality analytics');
-  }
-});
+        zeroResultQueries: analytics.topZeroResultQueries.map((query) => ({
+          ...query,
+          count: query.totalSearches,
+          zeroResults: query.zeroResultSearches,
+          avgResults: query.avgResultCount,
+        })),
+        lowResultQueries: analytics.byQueryAndEntityType
+          .filter((query) => query.avgResultCount > 0 && query.avgResultCount <= 3)
+          .slice(0, 10)
+          .map((query) => ({
+            ...query,
+            count: query.totalSearches,
+            zeroResults: query.zeroResultSearches,
+            avgResults: query.avgResultCount,
+          })),
+      });
+    } catch (error) {
+      console.error('Error fetching search quality analytics:', sanitizeLogValue(error));
+      handleAnalyticsError(response, error, 'Failed to fetch search quality analytics');
+    }
+  },
+);
 
-router.get('/search-queries', isAuthenticated, isAdmin, async (request: Request, response: Response) => {
-  try {
-    const analytics = await getSearchQueryAnalytics(parseAnalyticsRange(request.query.range), {
-      limit: parseAnalyticsLimit(request.query.limit, 100),
-    });
-    response.status(200).json(analytics);
-  } catch (error) {
-    console.error('Error fetching search query analytics:', sanitizeLogValue(error));
-    handleAnalyticsError(response, error, 'Failed to fetch search query analytics');
-  }
-});
+router.get(
+  '/search-queries',
+  isAuthenticated,
+  isAdmin,
+  async (request: Request, response: Response) => {
+    try {
+      const analytics = await getSearchQueryAnalytics(parseAnalyticsRange(request.query.range), {
+        limit: parseAnalyticsLimit(request.query.limit, 100),
+      });
+      response.status(200).json(analytics);
+    } catch (error) {
+      console.error('Error fetching search query analytics:', sanitizeLogValue(error));
+      handleAnalyticsError(response, error, 'Failed to fetch search query analytics');
+    }
+  },
+);
 
 router.get('/funnel', isAuthenticated, isAdmin, async (request: Request, response: Response) => {
   try {
     const analytics = await getFunnelAnalytics(parseAnalyticsRange(request.query.range));
     const viewerCount = analytics.listingViews + analytics.fellowshipViews;
-    const stages = [
+    const legacyStages = [
       { key: 'logins', label: 'Logged In', count: analytics.logins },
       { key: 'searches', label: 'Searched', count: analytics.searches },
       { key: 'views', label: 'Viewed', count: viewerCount },
@@ -315,6 +326,19 @@ router.get('/funnel', isAuthenticated, isAdmin, async (request: Request, respons
       { key: 'outreach', label: 'Outreach Clicked', count: analytics.outreachClicks },
       { key: 'outcomes', label: 'Outcome Reported', count: analytics.outreachOutcomes },
     ];
+    const journeyStages = [
+      { key: 'research_searches', label: 'Searched research', count: analytics.researchSearches },
+      { key: 'profile_opens', label: 'Opened a profile', count: analytics.researchProfileOpens },
+      { key: 'research_saves', label: 'Saved a research home', count: analytics.researchSaves },
+      { key: 'comparisons', label: 'Compared saved homes', count: analytics.researchComparisons },
+      { key: 'plans', label: 'Updated a plan', count: analytics.researchPlanUpdates },
+      {
+        key: 'qualified_actions',
+        label: 'Used a qualified route',
+        count: analytics.qualifiedActions,
+      },
+    ];
+    const stages = journeyStages.some((stage) => stage.count > 0) ? journeyStages : legacyStages;
 
     response.status(200).json({
       ...analytics,
@@ -329,8 +353,15 @@ router.get('/funnel', isAuthenticated, isAdmin, async (request: Request, respons
       searcherCount: analytics.searches,
       viewerCount,
       favoriteCount: analytics.favoritesOrSaves,
-      applicantCount: analytics.outreachClicks,
-      overallConversionRate: analytics.logins > 0 ? analytics.outreachOutcomes / analytics.logins : 0,
+      applicantCount: analytics.qualifiedActions,
+      journeyMetrics: {
+        sourceInspections: analytics.sourceInspections,
+        officialRouteAttempts: analytics.officialRouteAttempts,
+        applicationOpens: analytics.applicationOpens,
+        confirmedOutcomes: analytics.confirmedOutcomes,
+      },
+      overallConversionRate:
+        analytics.logins > 0 ? analytics.qualifiedActions / analytics.logins : 0,
     });
   } catch (error) {
     console.error('Error fetching funnel analytics:', sanitizeLogValue(error));

--- a/server/src/services/__tests__/analyticsService.test.ts
+++ b/server/src/services/__tests__/analyticsService.test.ts
@@ -142,19 +142,21 @@ describe('claim-specific research funnel', () => {
         eventType: 'research_qualified_action',
         actionCategory: 'official_application',
         count: 3,
+        uniqueNetids: ['student-1', 'student-2', 'student-3'],
       },
       {
         eventType: 'research_qualified_action',
         actionCategory: 'reviewed_route',
         count: 2,
+        uniqueNetids: ['student-1', 'student-4'],
       },
       { eventType: 'outreach_outcome', count: 1 },
     ]);
 
     await expect(getFunnelAnalytics()).resolves.toMatchObject({
       sourceInspections: 7,
-      qualifiedActions: 5,
-      officialRouteAttempts: 5,
+      qualifiedActions: 4,
+      officialRouteAttempts: 4,
       applicationOpens: 3,
       confirmedOutcomes: 1,
     });

--- a/server/src/services/__tests__/analyticsService.test.ts
+++ b/server/src/services/__tests__/analyticsService.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   analyticsAggregate: vi.fn(),
   analyticsCreate: vi.fn(),
   analyticsFind: vi.fn(),
+  analyticsUpdateOne: vi.fn(),
   userFindOneAndUpdate: vi.fn(),
 }));
 
@@ -31,12 +32,22 @@ vi.mock('../../models/analytics', () => ({
     WAYS_IN_CLICK: 'ways_in_click',
     CONTACT_ROUTE_CLICK: 'contact_route_click',
     SOURCE_LINK_CLICK: 'source_link_click',
+    RESEARCH_SEARCH: 'research_search',
+    RESEARCH_ENTITY_IMPRESSION: 'research_entity_impression',
+    RESEARCH_PROFILE_OPEN: 'research_profile_open',
+    RESEARCH_SOURCE_REVIEW: 'research_source_review',
+    RESEARCH_FILTER_CHANGE: 'research_filter_change',
+    RESEARCH_SAVE: 'research_save',
+    RESEARCH_COMPARE: 'research_compare',
+    RESEARCH_PLAN_UPDATE: 'research_plan_update',
+    RESEARCH_QUALIFIED_ACTION: 'research_qualified_action',
   },
-  RESEARCH_ENTITY_TYPES: ['profile', 'listing', 'fellowship'],
+  RESEARCH_ENTITY_TYPES: ['profile', 'listing', 'fellowship', 'research_entity'],
   AnalyticsEvent: {
     aggregate: mocks.analyticsAggregate,
     create: mocks.analyticsCreate,
     find: mocks.analyticsFind,
+    updateOne: mocks.analyticsUpdateOne,
   },
 }));
 
@@ -56,6 +67,7 @@ import {
   getUserAnalytics,
   getUserAnalyticsDrilldown,
   getSearchQualityAnalytics,
+  getFunnelAnalytics,
   logEvent,
   normalizeAnalyticsUserTypeBucket,
   shouldSuppressBetaAnalyticsEvent,
@@ -115,6 +127,37 @@ describe('search engagement attribution', () => {
     expect(JSON.stringify(lookup)).toContain('amount":30');
     expect(JSON.stringify(pipeline)).toContain('nextSearchAt');
     expect(JSON.stringify(pipeline)).toContain('$resultCount');
+  });
+});
+
+describe('claim-specific research funnel', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps source inspection, route attempts, application opens, and outcomes separate', async () => {
+    mocks.analyticsAggregate.mockResolvedValueOnce([
+      { eventType: 'research_source_review', count: 7 },
+      {
+        eventType: 'research_qualified_action',
+        actionCategory: 'official_application',
+        count: 3,
+      },
+      {
+        eventType: 'research_qualified_action',
+        actionCategory: 'reviewed_route',
+        count: 2,
+      },
+      { eventType: 'outreach_outcome', count: 1 },
+    ]);
+
+    await expect(getFunnelAnalytics()).resolves.toMatchObject({
+      sourceInspections: 7,
+      qualifiedActions: 5,
+      officialRouteAttempts: 5,
+      applicationOpens: 3,
+      confirmedOutcomes: 1,
+    });
   });
 });
 
@@ -337,6 +380,28 @@ describe('logEvent', () => {
         listingId: '507f1f77bcf86cd799439011',
         fellowshipId: '507f1f77bcf86cd799439012',
       }),
+    );
+  });
+
+  it('uses an atomic per-actor upsert for retry-safe journey events', async () => {
+    mocks.analyticsUpdateOne.mockResolvedValue({ upsertedCount: 1 });
+    mocks.userFindOneAndUpdate.mockReturnValue({ catch: vi.fn() });
+
+    await logEvent({
+      eventType: AnalyticsEventType.RESEARCH_SAVE,
+      netid: 'student123',
+      userType: 'undergraduate',
+      entityType: 'research_entity',
+      entityId: '507f1f77bcf86cd799439011',
+      metadata: { operation: 'save' },
+      dedupeKey: 'save:fixture-1',
+    });
+
+    expect(mocks.analyticsCreate).not.toHaveBeenCalled();
+    expect(mocks.analyticsUpdateOne).toHaveBeenCalledWith(
+      { netid: 'student123', dedupeKey: 'save:fixture-1' },
+      { $setOnInsert: expect.objectContaining({ eventType: 'research_save' }) },
+      { upsert: true },
     );
   });
 });

--- a/server/src/services/__tests__/researchAnalytics.test.ts
+++ b/server/src/services/__tests__/researchAnalytics.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { AnalyticsEventType } from '../../models/analytics';
-import { emitResearchEvent } from '../researchAnalytics';
+import { emitResearchEvent, sanitizeResearchPayload } from '../researchAnalytics';
 import type { LogEventParams } from '../analyticsService';
 
 const user = { netId: 'abc123', userType: 'undergraduate' };
@@ -159,5 +159,170 @@ describe('research analytics event emission', () => {
       action: 'stage_change',
       stage: 'Interviewing',
     });
+  });
+
+  it('records one privacy-bounded search outcome without raw query or downstream identifiers', async () => {
+    const events: LogEventParams[] = [];
+
+    await emitResearchEvent(
+      {
+        eventType: AnalyticsEventType.RESEARCH_SEARCH,
+        user,
+        entityType: undefined,
+        entityId: undefined,
+        dedupeKey: 'search:fixture-1',
+        payload: {
+          outcome: 'zero_results',
+          resultCountBucket: '0',
+          searchKind: 'filtered',
+          filterCountBucket: '2',
+          query: 'private mentor email fixture-mentor@yale.edu',
+          searchId: 'join-me-to-an-action',
+        },
+      },
+      async (event) => {
+        events.push(event);
+      },
+    );
+
+    expect(events).toEqual([
+      {
+        eventType: AnalyticsEventType.RESEARCH_SEARCH,
+        netid: 'abc123',
+        userType: 'undergraduate',
+        metadata: {
+          outcome: 'zero_results',
+          resultCountBucket: '0',
+          searchKind: 'filtered',
+          filterCountBucket: '2',
+        },
+        dedupeKey: 'search:fixture-1',
+      },
+    ]);
+    expect(JSON.stringify(events)).not.toContain('fixture-mentor');
+    expect(JSON.stringify(events)).not.toContain('searchId');
+  });
+
+  it.each([
+    [AnalyticsEventType.RESEARCH_ENTITY_IMPRESSION, { surface: 'search', positionBucket: '4-10' }],
+    [AnalyticsEventType.RESEARCH_PROFILE_OPEN, { source: 'direct' }],
+    [AnalyticsEventType.RESEARCH_SOURCE_REVIEW, { sourceCategory: 'publication' }],
+    [AnalyticsEventType.RESEARCH_SAVE, { operation: 'remove', surface: 'saved_plans' }],
+    [AnalyticsEventType.RESEARCH_COMPARE, { entityCountBucket: '3-4' }],
+    [AnalyticsEventType.RESEARCH_PLAN_UPDATE, { field: 'note_presence' }],
+  ])('allowlists %s payloads without free text', (eventType, expected) => {
+    expect(
+      sanitizeResearchPayload(eventType, {
+        ...expected,
+        note: 'private planning note',
+        email: 'fixture-mentor@yale.edu',
+        url: 'https://example.edu/private?student=abc123',
+        query: 'raw research query',
+      }),
+    ).toEqual(expected);
+  });
+
+  it('keeps filter changes non-converting and bounded', () => {
+    expect(
+      sanitizeResearchPayload(AnalyticsEventType.RESEARCH_FILTER_CHANGE, {
+        operation: 'remove',
+        filter: 'department',
+        value: 'student-specific department value',
+      }),
+    ).toEqual({ operation: 'remove', filter: 'department' });
+  });
+
+  it('emits a qualified action only from the current server-owned category', async () => {
+    const events: LogEventParams[] = [];
+    const resolve = async () =>
+      new Map([
+        [
+          '507f1f77bcf86cd799439010',
+          {
+            category: 'official_application' as const,
+            label: 'Official application',
+            url: 'https://example.edu/apply',
+          },
+        ],
+      ]);
+
+    const emitted = await emitResearchEvent(
+      {
+        eventType: AnalyticsEventType.RESEARCH_QUALIFIED_ACTION,
+        entityType: 'research_entity',
+        entityId: '507f1f77bcf86cd799439010',
+        user,
+        dedupeKey: 'action:fixture-1',
+        payload: {
+          actionCategory: 'official_application',
+          query: 'must not join',
+          url: 'https://example.edu/apply?student=abc123',
+          destination: 'fixture-mentor@yale.edu',
+          note: 'private plan',
+        },
+      },
+      async (event) => {
+        events.push(event);
+      },
+      resolve,
+    );
+
+    expect(emitted).toBe(true);
+    expect(events[0]).toMatchObject({
+      eventType: AnalyticsEventType.RESEARCH_QUALIFIED_ACTION,
+      entityType: 'research_entity',
+      entityId: '507f1f77bcf86cd799439010',
+      metadata: { actionCategory: 'official_application' },
+    });
+    expect(JSON.stringify(events[0])).not.toContain('query');
+    expect(JSON.stringify(events[0])).not.toContain('fixture-mentor');
+    expect(JSON.stringify(events[0])).not.toContain('private plan');
+  });
+
+  it('rejects stale, missing, and client-mismatched qualified actions', async () => {
+    const events: LogEventParams[] = [];
+    const missing = async () => new Map();
+    const qualified = async () =>
+      new Map([
+        [
+          '507f1f77bcf86cd799439010',
+          {
+            category: 'reviewed_route' as const,
+            label: 'Official contact route',
+            url: 'https://example.edu/contact',
+          },
+        ],
+      ]);
+
+    await expect(
+      emitResearchEvent(
+        {
+          eventType: AnalyticsEventType.RESEARCH_QUALIFIED_ACTION,
+          entityType: 'research_entity',
+          entityId: '507f1f77bcf86cd799439010',
+          user,
+          payload: { actionCategory: 'official_application' },
+        },
+        async (event) => {
+          events.push(event);
+        },
+        qualified,
+      ),
+    ).resolves.toBe(false);
+    await expect(
+      emitResearchEvent(
+        {
+          eventType: AnalyticsEventType.RESEARCH_QUALIFIED_ACTION,
+          entityType: 'research_entity',
+          entityId: '507f1f77bcf86cd799439010',
+          user,
+        },
+        async (event) => {
+          events.push(event);
+        },
+        missing,
+      ),
+    ).resolves.toBe(false);
+    expect(events).toHaveLength(0);
   });
 });

--- a/server/src/services/analyticsService.ts
+++ b/server/src/services/analyticsService.ts
@@ -19,6 +19,7 @@ export interface LogEventParams {
   searchQuery?: string;
   searchDepartments?: string[];
   metadata?: any;
+  dedupeKey?: string;
 }
 
 const MAX_ANALYTICS_METADATA_DEPTH = 5;
@@ -30,6 +31,7 @@ const MAX_ANALYTICS_USER_TYPE_LENGTH = 40;
 const ANALYTICS_USER_TYPE_RE = /^[A-Za-z0-9_-]{1,40}$/;
 const ANALYTICS_METADATA_KEY_RE = /^[A-Za-z0-9_-]{1,80}$/;
 const ANALYTICS_OBJECT_ID_RE = /^[a-fA-F0-9]{24}$/;
+const ANALYTICS_DEDUPE_KEY_RE = /^[A-Za-z0-9:_-]{1,160}$/;
 const ANALYTICS_EVENT_TYPES = new Set<AnalyticsEventType>(Object.values(AnalyticsEventType));
 const ANALYTICS_RESEARCH_ENTITY_TYPES = new Set<string>(RESEARCH_ENTITY_TYPES);
 
@@ -254,6 +256,16 @@ export interface FunnelAnalytics {
   favoritesOrSaves: number;
   outreachClicks: number;
   outreachOutcomes: number;
+  researchSearches: number;
+  researchProfileOpens: number;
+  researchSaves: number;
+  researchComparisons: number;
+  researchPlanUpdates: number;
+  sourceInspections: number;
+  qualifiedActions: number;
+  officialRouteAttempts: number;
+  applicationOpens: number;
+  confirmedOutcomes: number;
 }
 
 export interface HighSearchLowResultsAction {
@@ -434,6 +446,9 @@ const sanitizeResearchEntityId = (value: unknown): string | undefined => {
   const sanitized = sanitizeAnalyticsText(value);
   return sanitized && sanitized.trim() !== '' ? sanitized.slice(0, 128) : undefined;
 };
+
+const sanitizeAnalyticsDedupeKey = (value: unknown): string | undefined =>
+  typeof value === 'string' && ANALYTICS_DEDUPE_KEY_RE.test(value) ? value : undefined;
 
 const normalizeAnalyticsStoredObjectIdString = (value: unknown): string | undefined => {
   if (value instanceof Types.ObjectId) {
@@ -713,6 +728,7 @@ export const logEvent = async (params: LogEventParams): Promise<void> => {
     const fellowshipId = sanitizeAnalyticsObjectId(params.fellowshipId);
     const entityType = sanitizeResearchEntityType(params.entityType);
     const entityId = sanitizeResearchEntityId(params.entityId);
+    const dedupeKey = sanitizeAnalyticsDedupeKey(params.dedupeKey);
     const eventPayload: Record<string, unknown> = {
       eventType,
       netid,
@@ -726,8 +742,18 @@ export const logEvent = async (params: LogEventParams): Promise<void> => {
     if (fellowshipId) eventPayload.fellowshipId = fellowshipId;
     if (entityType) eventPayload.entityType = entityType;
     if (entityId) eventPayload.entityId = entityId;
+    if (dedupeKey) eventPayload.dedupeKey = dedupeKey;
 
-    await AnalyticsEvent.create(eventPayload);
+    if (dedupeKey) {
+      const result = await AnalyticsEvent.updateOne(
+        { netid, dedupeKey },
+        { $setOnInsert: eventPayload },
+        { upsert: true },
+      );
+      if (result.upsertedCount === 0) return;
+    } else {
+      await AnalyticsEvent.create(eventPayload);
+    }
 
     const now = new Date();
     const updateFields: any = {
@@ -874,11 +900,7 @@ export const getSearchQualityAnalytics = async (
               uniqueSearchers: { $addToSet: '$netid' },
               engagedSearches: {
                 $sum: {
-                  $cond: [
-                    { $and: [{ $gt: ['$resultCount', 0] }, '$hasAttributedAction'] },
-                    1,
-                    0,
-                  ],
+                  $cond: [{ $and: [{ $gt: ['$resultCount', 0] }, '$hasAttributedAction'] }, 1, 0],
                 },
               },
               returnedButIgnoredSearches: {
@@ -1113,6 +1135,13 @@ export const getFunnelAnalytics = async (
             AnalyticsEventType.FELLOWSHIP_FAVORITE,
             AnalyticsEventType.OUTREACH_CLICK,
             AnalyticsEventType.OUTREACH_OUTCOME,
+            AnalyticsEventType.RESEARCH_SEARCH,
+            AnalyticsEventType.RESEARCH_PROFILE_OPEN,
+            AnalyticsEventType.RESEARCH_SOURCE_REVIEW,
+            AnalyticsEventType.RESEARCH_SAVE,
+            AnalyticsEventType.RESEARCH_COMPARE,
+            AnalyticsEventType.RESEARCH_PLAN_UPDATE,
+            AnalyticsEventType.RESEARCH_QUALIFIED_ACTION,
           ],
         },
         ...buildRangeTimestampMatch(range),
@@ -1120,22 +1149,41 @@ export const getFunnelAnalytics = async (
     },
     {
       $group: {
-        _id: '$eventType',
+        _id: {
+          eventType: '$eventType',
+          actionCategory: '$metadata.actionCategory',
+        },
         uniqueNetids: { $addToSet: '$netid' },
       },
     },
     {
       $project: {
         _id: 0,
-        eventType: '$_id',
+        eventType: '$_id.eventType',
+        actionCategory: '$_id.actionCategory',
         count: { $size: '$uniqueNetids' },
       },
     },
   ]);
 
-  const counts = Object.fromEntries(
-    rows.map((row: { eventType: AnalyticsEventType; count: number }) => [row.eventType, row.count]),
-  ) as Partial<Record<AnalyticsEventType, number>>;
+  const counts = rows.reduce(
+    (
+      result: Partial<Record<AnalyticsEventType, number>>,
+      row: { eventType: AnalyticsEventType; count: number },
+    ) => {
+      result[row.eventType] = (result[row.eventType] || 0) + row.count;
+      return result;
+    },
+    {},
+  );
+  const qualifiedActionRows = rows.filter(
+    (row: { eventType: AnalyticsEventType }) =>
+      row.eventType === AnalyticsEventType.RESEARCH_QUALIFIED_ACTION,
+  );
+  const countQualifiedCategories = (categories: string[]) =>
+    qualifiedActionRows
+      .filter((row: { actionCategory?: string }) => categories.includes(row.actionCategory || ''))
+      .reduce((sum: number, row: { count: number }) => sum + row.count, 0);
 
   return {
     logins: counts[AnalyticsEventType.LOGIN] ?? 0,
@@ -1147,6 +1195,21 @@ export const getFunnelAnalytics = async (
       (counts[AnalyticsEventType.FELLOWSHIP_FAVORITE] ?? 0),
     outreachClicks: counts[AnalyticsEventType.OUTREACH_CLICK] ?? 0,
     outreachOutcomes: counts[AnalyticsEventType.OUTREACH_OUTCOME] ?? 0,
+    researchSearches: counts[AnalyticsEventType.RESEARCH_SEARCH] ?? 0,
+    researchProfileOpens: counts[AnalyticsEventType.RESEARCH_PROFILE_OPEN] ?? 0,
+    researchSaves: counts[AnalyticsEventType.RESEARCH_SAVE] ?? 0,
+    researchComparisons: counts[AnalyticsEventType.RESEARCH_COMPARE] ?? 0,
+    researchPlanUpdates: counts[AnalyticsEventType.RESEARCH_PLAN_UPDATE] ?? 0,
+    sourceInspections: counts[AnalyticsEventType.RESEARCH_SOURCE_REVIEW] ?? 0,
+    qualifiedActions: counts[AnalyticsEventType.RESEARCH_QUALIFIED_ACTION] ?? 0,
+    officialRouteAttempts: countQualifiedCategories([
+      'open_position',
+      'official_application',
+      'reviewed_route',
+      'qualified_participation',
+    ]),
+    applicationOpens: countQualifiedCategories(['open_position', 'official_application']),
+    confirmedOutcomes: counts[AnalyticsEventType.OUTREACH_OUTCOME] ?? 0,
   };
 };
 
@@ -1584,6 +1647,15 @@ export const getAnalytics = async () => {
     AnalyticsEventType.WAYS_IN_CLICK,
     AnalyticsEventType.CONTACT_ROUTE_CLICK,
     AnalyticsEventType.SOURCE_LINK_CLICK,
+    AnalyticsEventType.RESEARCH_SEARCH,
+    AnalyticsEventType.RESEARCH_ENTITY_IMPRESSION,
+    AnalyticsEventType.RESEARCH_PROFILE_OPEN,
+    AnalyticsEventType.RESEARCH_SOURCE_REVIEW,
+    AnalyticsEventType.RESEARCH_FILTER_CHANGE,
+    AnalyticsEventType.RESEARCH_SAVE,
+    AnalyticsEventType.RESEARCH_COMPARE,
+    AnalyticsEventType.RESEARCH_PLAN_UPDATE,
+    AnalyticsEventType.RESEARCH_QUALIFIED_ACTION,
   ];
   const researchStats = await AnalyticsEvent.aggregate([
     {

--- a/server/src/services/analyticsService.ts
+++ b/server/src/services/analyticsService.ts
@@ -1161,6 +1161,7 @@ export const getFunnelAnalytics = async (
         _id: 0,
         eventType: '$_id.eventType',
         actionCategory: '$_id.actionCategory',
+        uniqueNetids: 1,
         count: { $size: '$uniqueNetids' },
       },
     },
@@ -1179,11 +1180,19 @@ export const getFunnelAnalytics = async (
   const qualifiedActionRows = rows.filter(
     (row: { eventType: AnalyticsEventType }) =>
       row.eventType === AnalyticsEventType.RESEARCH_QUALIFIED_ACTION,
-  );
+  ) as Array<{ actionCategory?: string; uniqueNetids: string[] }>;
   const countQualifiedCategories = (categories: string[]) =>
-    qualifiedActionRows
-      .filter((row: { actionCategory?: string }) => categories.includes(row.actionCategory || ''))
-      .reduce((sum: number, row: { count: number }) => sum + row.count, 0);
+    new Set(
+      qualifiedActionRows
+        .filter((row) => categories.includes(row.actionCategory || ''))
+        .flatMap((row) => row.uniqueNetids),
+    ).size;
+  const qualifiedActions = countQualifiedCategories([
+    'open_position',
+    'official_application',
+    'reviewed_route',
+    'qualified_participation',
+  ]);
 
   return {
     logins: counts[AnalyticsEventType.LOGIN] ?? 0,
@@ -1201,7 +1210,7 @@ export const getFunnelAnalytics = async (
     researchComparisons: counts[AnalyticsEventType.RESEARCH_COMPARE] ?? 0,
     researchPlanUpdates: counts[AnalyticsEventType.RESEARCH_PLAN_UPDATE] ?? 0,
     sourceInspections: counts[AnalyticsEventType.RESEARCH_SOURCE_REVIEW] ?? 0,
-    qualifiedActions: counts[AnalyticsEventType.RESEARCH_QUALIFIED_ACTION] ?? 0,
+    qualifiedActions,
     officialRouteAttempts: countQualifiedCategories([
       'open_position',
       'official_application',

--- a/server/src/services/planningContextService.ts
+++ b/server/src/services/planningContextService.ts
@@ -9,11 +9,14 @@ import {
   isStudentPublishablePathway,
 } from './studentAccessPublicationPolicy';
 
-export type PlanningContextCategory =
-  | 'open_position'
-  | 'official_application'
-  | 'reviewed_route'
-  | 'qualified_participation';
+export const PLANNING_CONTEXT_CATEGORIES = [
+  'open_position',
+  'official_application',
+  'reviewed_route',
+  'qualified_participation',
+] as const;
+
+export type PlanningContextCategory = (typeof PLANNING_CONTEXT_CATEGORIES)[number];
 
 export interface PublicPlanningContext {
   category: PlanningContextCategory;

--- a/server/src/services/researchAnalytics.ts
+++ b/server/src/services/researchAnalytics.ts
@@ -16,10 +16,16 @@
 import { Request, Response, NextFunction } from 'express';
 import mongoose from 'mongoose';
 import { AnalyticsEventType, RESEARCH_ENTITY_TYPES, ResearchEntityType } from '../models/analytics';
-import { Fellowship, User } from '../models/index';
+import { Fellowship, ResearchEntity, User } from '../models/index';
 import { getListingModel } from '../db/connections';
 import { logEvent } from './analyticsService';
 import type { LogEventParams } from './analyticsService';
+import {
+  listPlanningContextsForResearchEntities,
+  PLANNING_CONTEXT_CATEGORIES,
+  type PlanningContextCategory,
+  type PublicPlanningContext,
+} from './planningContextService';
 
 /** The subset of AnalyticsEventType that describes research-surface activity. */
 export const RESEARCH_EVENT_TYPES: readonly AnalyticsEventType[] = [
@@ -28,7 +34,76 @@ export const RESEARCH_EVENT_TYPES: readonly AnalyticsEventType[] = [
   AnalyticsEventType.WAYS_IN_CLICK,
   AnalyticsEventType.CONTACT_ROUTE_CLICK,
   AnalyticsEventType.SOURCE_LINK_CLICK,
+  AnalyticsEventType.RESEARCH_SEARCH,
+  AnalyticsEventType.RESEARCH_ENTITY_IMPRESSION,
+  AnalyticsEventType.RESEARCH_PROFILE_OPEN,
+  AnalyticsEventType.RESEARCH_SOURCE_REVIEW,
+  AnalyticsEventType.RESEARCH_FILTER_CHANGE,
+  AnalyticsEventType.RESEARCH_SAVE,
+  AnalyticsEventType.RESEARCH_COMPARE,
+  AnalyticsEventType.RESEARCH_PLAN_UPDATE,
+  AnalyticsEventType.RESEARCH_QUALIFIED_ACTION,
 ];
+
+export const RESEARCH_JOURNEY_EVENT_TYPES: readonly AnalyticsEventType[] = [
+  AnalyticsEventType.RESEARCH_SEARCH,
+  AnalyticsEventType.RESEARCH_ENTITY_IMPRESSION,
+  AnalyticsEventType.RESEARCH_PROFILE_OPEN,
+  AnalyticsEventType.RESEARCH_SOURCE_REVIEW,
+  AnalyticsEventType.RESEARCH_FILTER_CHANGE,
+  AnalyticsEventType.RESEARCH_SAVE,
+  AnalyticsEventType.RESEARCH_COMPARE,
+  AnalyticsEventType.RESEARCH_PLAN_UPDATE,
+  AnalyticsEventType.RESEARCH_QUALIFIED_ACTION,
+];
+
+export const RESEARCH_SEARCH_OUTCOMES = ['results', 'zero_results', 'error'] as const;
+export const RESEARCH_RESULT_COUNT_BUCKETS = ['0', '1-5', '6-20', '21-50', '51+'] as const;
+export const RESEARCH_SEARCH_KINDS = ['query', 'filtered', 'department'] as const;
+export const RESEARCH_FILTER_COUNT_BUCKETS = ['0', '1', '2', '3+'] as const;
+export const RESEARCH_IMPRESSION_SURFACES = ['browse', 'search', 'saved_plans'] as const;
+export const RESEARCH_POSITION_BUCKETS = ['1-3', '4-10', '11-24', '25+'] as const;
+export const RESEARCH_PROFILE_OPEN_SOURCES = ['browse', 'search', 'direct', 'saved_plans'] as const;
+export const RESEARCH_SOURCE_CATEGORIES = [
+  'entity_website',
+  'faculty_profile',
+  'orcid',
+  'publication',
+  'evidence',
+  'other',
+] as const;
+export const RESEARCH_FILTER_OPERATIONS = [
+  'apply',
+  'remove',
+  'clear',
+  'panel_open',
+  'panel_close',
+] as const;
+export const RESEARCH_FILTER_KINDS = [
+  'school',
+  'department',
+  'documented_way_in',
+  'admin_quality',
+  'admin_trust',
+] as const;
+export const RESEARCH_SAVE_OPERATIONS = ['save', 'remove'] as const;
+export const RESEARCH_SAVE_SURFACES = ['profile', 'search', 'saved_plans'] as const;
+export const RESEARCH_COMPARE_COUNT_BUCKETS = ['1', '2', '3-4', '5+'] as const;
+export const RESEARCH_PLAN_FIELDS = [
+  'intent',
+  'stage',
+  'note_presence',
+  'checklist',
+  'target_deadline',
+  'acted_on_date',
+  'follow_up',
+] as const;
+
+const JOURNEY_EVENTS_WITHOUT_ENTITY = new Set<AnalyticsEventType>([
+  AnalyticsEventType.RESEARCH_SEARCH,
+  AnalyticsEventType.RESEARCH_FILTER_CHANGE,
+]);
+const ANALYTICS_DEDUPE_KEY_RE = /^[A-Za-z0-9:_-]{1,160}$/;
 
 /** Allowed coarse categories for a contact-route click. Never the address. */
 export const CONTACT_METHODS = ['email', 'phone', 'website', 'directory', 'other'] as const;
@@ -114,6 +189,49 @@ export const sanitizeResearchPayload = (
   const out: Record<string, string> = {};
 
   switch (eventType) {
+    case AnalyticsEventType.RESEARCH_SEARCH: {
+      out.outcome = oneOf(input.outcome, RESEARCH_SEARCH_OUTCOMES) ?? 'error';
+      out.resultCountBucket = oneOf(input.resultCountBucket, RESEARCH_RESULT_COUNT_BUCKETS) ?? '0';
+      out.searchKind = oneOf(input.searchKind, RESEARCH_SEARCH_KINDS) ?? 'query';
+      out.filterCountBucket = oneOf(input.filterCountBucket, RESEARCH_FILTER_COUNT_BUCKETS) ?? '0';
+      break;
+    }
+    case AnalyticsEventType.RESEARCH_ENTITY_IMPRESSION: {
+      out.surface = oneOf(input.surface, RESEARCH_IMPRESSION_SURFACES) ?? 'search';
+      out.positionBucket = oneOf(input.positionBucket, RESEARCH_POSITION_BUCKETS) ?? '25+';
+      break;
+    }
+    case AnalyticsEventType.RESEARCH_PROFILE_OPEN: {
+      out.source = oneOf(input.source, RESEARCH_PROFILE_OPEN_SOURCES) ?? 'direct';
+      break;
+    }
+    case AnalyticsEventType.RESEARCH_SOURCE_REVIEW: {
+      out.sourceCategory = oneOf(input.sourceCategory, RESEARCH_SOURCE_CATEGORIES) ?? 'other';
+      break;
+    }
+    case AnalyticsEventType.RESEARCH_FILTER_CHANGE: {
+      out.operation = oneOf(input.operation, RESEARCH_FILTER_OPERATIONS) ?? 'apply';
+      out.filter = oneOf(input.filter, RESEARCH_FILTER_KINDS) ?? 'department';
+      break;
+    }
+    case AnalyticsEventType.RESEARCH_SAVE: {
+      out.operation = oneOf(input.operation, RESEARCH_SAVE_OPERATIONS) ?? 'save';
+      out.surface = oneOf(input.surface, RESEARCH_SAVE_SURFACES) ?? 'profile';
+      break;
+    }
+    case AnalyticsEventType.RESEARCH_COMPARE: {
+      out.entityCountBucket = oneOf(input.entityCountBucket, RESEARCH_COMPARE_COUNT_BUCKETS) ?? '1';
+      break;
+    }
+    case AnalyticsEventType.RESEARCH_PLAN_UPDATE: {
+      out.field = oneOf(input.field, RESEARCH_PLAN_FIELDS) ?? 'stage';
+      break;
+    }
+    case AnalyticsEventType.RESEARCH_QUALIFIED_ACTION: {
+      const actionCategory = oneOf(input.actionCategory, PLANNING_CONTEXT_CATEGORIES);
+      if (actionCategory) out.actionCategory = actionCategory;
+      break;
+    }
     case AnalyticsEventType.CONTACT_ROUTE_CLICK: {
       const method = oneOf(input.contactMethod ?? input.method, CONTACT_METHODS) ?? 'other';
       out.contactMethod = method;
@@ -168,6 +286,12 @@ const cleanHost = (value: unknown): string | undefined => {
 export const isResearchEventType = (value: unknown): value is AnalyticsEventType =>
   isPlainString(value) && (RESEARCH_EVENT_TYPES as readonly string[]).includes(value);
 
+export const isResearchJourneyEventType = (value: unknown): value is AnalyticsEventType =>
+  isPlainString(value) && (RESEARCH_JOURNEY_EVENT_TYPES as readonly string[]).includes(value);
+
+export const researchJourneyEventRequiresEntity = (eventType: AnalyticsEventType): boolean =>
+  !JOURNEY_EVENTS_WITHOUT_ENTITY.has(eventType);
+
 export const isResearchEntityType = (value: unknown): value is ResearchEntityType =>
   isPlainString(value) && (RESEARCH_ENTITY_TYPES as readonly string[]).includes(value);
 
@@ -179,6 +303,10 @@ export const researchEntityExists = async (
 
   if (entityType === 'profile') {
     return Boolean(await User.exists({ netid: id }));
+  }
+
+  if (entityType === 'research_entity') {
+    return mongoose.isValidObjectId(id) && Boolean(await ResearchEntity.exists({ _id: id }));
   }
 
   if (!mongoose.isValidObjectId(id)) {
@@ -196,9 +324,10 @@ export interface BuildResearchEventInput {
   eventType: AnalyticsEventType;
   netid: string;
   userType: string;
-  entityType: ResearchEntityType;
-  entityId: string;
+  entityType?: ResearchEntityType;
+  entityId?: string;
   payload?: unknown;
+  dedupeKey?: string;
 }
 
 type AnalyticsUser = { netId?: string; userType?: string };
@@ -217,9 +346,10 @@ export const buildResearchEvent = (input: BuildResearchEventInput): LogEventPara
     eventType: input.eventType,
     netid: input.netid,
     userType: input.userType,
-    entityType: input.entityType,
-    entityId: String(input.entityId).slice(0, 128),
+    ...(input.entityType ? { entityType: input.entityType } : {}),
+    ...(input.entityId ? { entityId: String(input.entityId).slice(0, 128) } : {}),
     ...(metadata ? { metadata } : {}),
+    ...(input.dedupeKey ? { dedupeKey: input.dedupeKey } : {}),
   };
 };
 
@@ -229,19 +359,45 @@ export interface EmitResearchEventInput {
   entityId: unknown;
   user?: AnalyticsUser;
   payload?: unknown;
+  dedupeKey?: unknown;
 }
+
+type PlanningContextResolver = (
+  ids: Array<string | mongoose.Types.ObjectId>,
+) => Promise<Map<string, PublicPlanningContext>>;
 
 export const emitResearchEvent = async (
   input: EmitResearchEventInput,
   log: ResearchLogFn = logEvent,
+  resolvePlanningContexts: PlanningContextResolver = listPlanningContextsForResearchEntities,
 ): Promise<boolean> => {
-  if (
-    !isResearchEventType(input.eventType) ||
-    !isResearchEntityType(input.entityType) ||
-    !isNonEmptyString(input.entityId) ||
-    !isNonEmptyString(input.user?.netId)
-  ) {
+  if (!isResearchEventType(input.eventType) || !isNonEmptyString(input.user?.netId)) {
     return false;
+  }
+
+  const entityOptional = JOURNEY_EVENTS_WITHOUT_ENTITY.has(input.eventType);
+  const hasEntity = isResearchEntityType(input.entityType) && isNonEmptyString(input.entityId);
+  if (!entityOptional && !hasEntity) return false;
+  if (
+    input.dedupeKey !== undefined &&
+    !(typeof input.dedupeKey === 'string' && ANALYTICS_DEDUPE_KEY_RE.test(input.dedupeKey))
+  )
+    return false;
+
+  let payload = input.payload;
+  if (input.eventType === AnalyticsEventType.RESEARCH_QUALIFIED_ACTION) {
+    if (input.entityType !== 'research_entity' || !isNonEmptyString(input.entityId)) return false;
+    const contexts = await resolvePlanningContexts([input.entityId.trim()]);
+    const context = contexts.get(input.entityId.trim());
+    if (!context) return false;
+    const requestedCategory = (input.payload as { actionCategory?: unknown } | undefined)
+      ?.actionCategory;
+    if (
+      requestedCategory !== undefined &&
+      requestedCategory !== (context.category as PlanningContextCategory)
+    )
+      return false;
+    payload = { actionCategory: context.category };
   }
 
   await log(
@@ -249,9 +405,14 @@ export const emitResearchEvent = async (
       eventType: input.eventType,
       netid: input.user.netId,
       userType: input.user.userType || 'unknown',
-      entityType: input.entityType,
-      entityId: input.entityId.trim(),
-      payload: input.payload,
+      ...(hasEntity
+        ? {
+            entityType: input.entityType as ResearchEntityType,
+            entityId: (input.entityId as string).trim(),
+          }
+        : {}),
+      payload,
+      ...(typeof input.dedupeKey === 'string' ? { dedupeKey: input.dedupeKey } : {}),
     }),
   );
 


### PR DESCRIPTION
## Summary

- Adds one privacy-bounded, claim-specific research journey taxonomy for terminal search outcomes, entity impressions, profile opens, source review, filter changes, saves, comparison, persisted plan updates, and qualified actions.
- Re-qualifies every access-conversion event against the current server-owned QA-01 PlanningContext category and keeps generic profiles, websites, ORCID, publications, filters, saves, plans, and source clicks outside conversion.
- Makes delivery fire-and-forget and per-actor idempotent without retaining raw queries on downstream events, URLs, direct contact destinations, private notes, or unbounded payload values.
- Separates source inspections, official-route attempts, application opens, and confirmed outcomes in the admin dashboard and documents the canonical contract.

## Validation

- no-mistakes completed review, focused tests, documentation review, lint review, push, and PR lifecycle validation.
- Client focused analytics and integration suite: 133 tests passed.
- Server focused analytics suite: 46 tests passed.
- Server and client production builds passed.
- Affected-file ESLint passed with zero errors and one pre-existing React hook warning.
- The repository-documented Playwright library shim rendered and captured the bounded admin analytics dashboard, visibly separating all four journey metrics.

## Review fixes preserved

- Counts distinct students across qualified-action category sets instead of summing category groups.
- Reuses one plan-update interaction key outside React state-updater side effects.
- Deduplicates Strict Mode browse replay while allowing later SPA navigations to record new impressions.

The unrelated baseline email dependency and taxonomy lint drift was explicitly approved as outside this issue and is unchanged here.

Closes #188
