### PR TITLE
feat(server): add research model inventory tooling

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -248,6 +248,7 @@ The auth flow's verbose tracing (per-request deserialization, the find-or-create
 | `npx tsc --noEmit -p server/tsconfig.json`                        | Server typecheck                                                                   |
 | `yarn --cwd server beta:readiness --confirm-beta-backup --strict` | Read-only Beta release gate                                                        |
 | `yarn --cwd server beta:data-quality --include-samples`           | Read-only Beta data-quality scorecard                                              |
+| `yarn --cwd server model-refactor:inventory --environment beta`   | Read-only research-model collection, field, and reference inventory                |
 | `yarn --cwd server scraper:integrity-gate --include-samples`      | Read-only scraper materialization integrity gate                                   |
 | `SCRAPER_ENV=beta yarn --cwd server gates:refresh`                | Regenerate every canonical gate scorecard the operator board reads (single writer) |
 
@@ -276,6 +277,9 @@ Use the server workspace scripts for current data flows:
 yarn scrape help
 yarn meili:seed
 ```
+
+The research-model refactor inventory is read-only and uses `MONGODBURL`.
+Follow [`docs/research-model-refactor-phase0.md`](docs/research-model-refactor-phase0.md) for its required environment label, guarded JSON output, report interpretation, and rollback prerequisites.
 
 Historical `data-migration/` scripts remain for one-off migrations only.
 Run them through the `data-migration` package scripts when available, so dry-run defaults, target validation, and JSON summaries stay in place:

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Use Playwright MCP for exploratory browser passes, then codify durable findings 
 
 See **[DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md)** for full setup instructions, architecture details, environment configuration, and contribution guidelines.
 Agents should start with **[AGENTS.md](AGENTS.md)** and the focused skills in **[skills/](skills/)**.
+See **[docs/research-model.md](docs/research-model.md)** for the current model and **[docs/research-model-refactor.md](docs/research-model-refactor.md)** for the accepted target and migration phases.
 See **[docs/scraper-deployment-runbook.md](docs/scraper-deployment-runbook.md)** for scraper rollout and cron posture.
 
 ## Acknowledgements

--- a/client/src/pages/__tests__/research.test.tsx
+++ b/client/src/pages/__tests__/research.test.tsx
@@ -1018,8 +1018,10 @@ describe('Research page', () => {
         expect.any(Object),
       );
     });
-    expect(screen.getByText('Needs description')).toBeTruthy();
-    expect(screen.getByLabelText('Admin quality flags').textContent).toContain('Missing lead');
+    expect(await screen.findByText('Needs description')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByLabelText('Admin quality flags').textContent).toContain('Missing lead');
+    });
   });
 
   it('does not show the weakest-first browse toggle to non-admin users', async () => {

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -17,6 +17,7 @@ For product, schema, or architecture decisions, also check the durable docs:
 
 - [`docs/product-context.md`](product-context.md) for stable product context.
 - [`docs/research-model.md`](research-model.md) for schema and modeling decisions.
+- [`docs/research-model-refactor.md`](research-model-refactor.md) for the accepted target model and phased migration.
 - [`docs/decisions.md`](decisions.md) for dated product and architecture decisions.
 - [`docs/ui-ux-direction.md`](ui-ux-direction.md) for UI direction.
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4,6 +4,13 @@ This file records durable product and architecture decisions only.
 Do not append continuation logs, security hardening transcripts, or task progress here.
 Put tactical work in `docs/tasks/priority-roadmap.md` and keep transient artifacts outside `docs/`.
 
+## 2026-07-24: Refactor Around Research Navigation And Evidence
+
+The accepted target separates accounts, public people, role assignments, research entities, evidence claims, and private research plans while retaining bounded REST projections.
+Yale Research will own evidence-backed research navigation, not a mirrored professor-profile or publication product.
+Migration will proceed through measured vertical cutovers, beginning with the read-only inventory in [`research-model-refactor.md`](./research-model-refactor.md).
+The current runtime remains authoritative until each phase completes its documented verification gates.
+
 ## 2026-07-12: Bound Embedded Research Entity Summaries
 
 Public research detail responses embed related entities as strict card summaries rather than full public profile DTOs.

--- a/docs/research-model-refactor-phase0.md
+++ b/docs/research-model-refactor-phase0.md
@@ -4,6 +4,7 @@ Status: tooling in place, production measurement pending.
 
 Phase 0 of [`research-model-refactor.md`](./research-model-refactor.md) resolves integration state and measures production before any target collection is written or any legacy storage is dropped.
 This runbook covers the inventory tool, how to read its output, and the export and rollback steps that must exist before later phases run destructive cleanup.
+The tooling PR does not complete Phase 0: reviewed Beta and production-copy inventory evidence, plus verified rollback evidence, remain operational exit work.
 
 ## Inventory tool
 

--- a/docs/research-model-refactor-phase0.md
+++ b/docs/research-model-refactor-phase0.md
@@ -12,17 +12,19 @@ It writes nothing to MongoDB.
 
 ```bash
 # Print the report to stdout
-yarn --cwd server model-refactor:inventory
+yarn --cwd server model-refactor:inventory --environment beta
 
 # Also write a JSON report (guarded to a tmp root)
-yarn --cwd server model-refactor:inventory --output /tmp/model-inventory.json
+yarn --cwd server model-refactor:inventory --environment beta --output /tmp/model-inventory.json
 
 # Keep more orphan sample ids per reference edge (default 20)
-yarn --cwd server model-refactor:inventory --sample-limit 100
+yarn --cwd server model-refactor:inventory --environment beta --sample-limit 100
 ```
 
 The tool connects with the standard `MONGODBURL` from `server/.env`, so point it at the environment you want to measure.
+The required `--environment` label must describe that target and accepts `development`, `beta`, `production-copy`, `production`, or `test`.
 Run it against beta first, then against a production copy once access and rollback artifacts are in place.
+Connection diagnostics go to stderr, so stdout contains only the JSON report.
 
 Implementation:
 
@@ -40,6 +42,7 @@ Headline counts for a quick read:
 - `unclassifiedCollections`: live collections the refactor spec does not yet name.
 Investigate each one before trusting a cutover.
 - `retirementFieldsStillPresent`: how many legacy fields still appear on live documents.
+- `referenceEdgesChecked` and `referenceEdgesSkipped`: how many reference edges were measurable and how many had no source collection to inspect.
 - `referenceEdgesWithOrphans` and `totalOrphans`: reference-integrity health.
 
 ### `collections`
@@ -57,7 +60,14 @@ A field with high prevalence gates its retirement phase until the canonical repl
 
 Orphan counts for the access and membership graph, for example membership rows whose `researchEntityId` does not resolve to a research entity.
 The check is type-agnostic, so it stays correct whether references are stored as ObjectId or string.
+Each row has a `status`: `checked`, `target-missing`, `source-missing`, or `not-gathered`.
+A missing source is skipped with `clean: null`.
+A present source with a missing target is scanned, and every non-null reference is reported as orphaned with `clean: false`.
 Any edge with `clean: false` must be resolved or explained before the referenced collection is migrated.
+
+The top-level `environment` is the required operator-supplied label.
+The `db` field records the connected database name, and `target` records a credential-free host/database label derived from `MONGODBURL`.
+Review all three before preserving an inventory as migration evidence.
 
 ## Complementary audits
 

--- a/docs/research-model-refactor-phase0.md
+++ b/docs/research-model-refactor-phase0.md
@@ -24,7 +24,8 @@ yarn --cwd server model-refactor:inventory --environment beta --sample-limit 100
 The tool uses a dedicated native MongoDB client with the standard `MONGODBURL` from `server/.env`, so point it at the environment you want to measure.
 It does not load Mongoose models, create collections, build indexes, or open the migration database configured by `MONGODBURL_MIGRATION`.
 The client is closed after success or failure.
-Collection scans are capped at four concurrent groups, and retirement-field probes reuse the collection census totals.
+Collection scans are capped at four concurrent groups.
+Retirement-field probes reuse the collection census totals, each reference target ID set is loaded once, and all tracked fields from a source collection are checked in one scan.
 The required `--environment` label must describe that target and accepts `development`, `beta`, `production-copy`, `production`, or `test`.
 Run it against beta first, then against a production copy once access and rollback artifacts are in place.
 Errors go to stderr, so stdout contains only the JSON report.
@@ -52,11 +53,16 @@ Investigate each one before trusting a cutover.
 - `retirementFieldsStillPresent`: how many legacy fields still appear on live documents.
 - `referenceEdgesChecked` and `referenceEdgesSkipped`: how many reference edges were measurable and how many had no source collection to inspect.
 - `referenceEdgesWithOrphans` and `totalOrphans`: reference-integrity health.
+- `coverageScope`: the explicit boundary for interpreting the headline counts.
+
+The collection, retirement-field, and scalar reference-edge sets are curated for this refactor and are not an exhaustive database-integrity proof.
+In particular, `totalOrphans: 0` means no orphans were found among the tracked edges, not that every reference in the database is valid.
 
 ### `collections`
 
 One row per refactor-relevant collection with its group, owning migration phase, target mapping, document count, and `schemaVersion` distribution.
-The `schemaVersions` bucket labels documents with no `schemaVersion` as `unset`, which is expected before Phase 1 versioning lands.
+Each `schemaVersions` bucket records `bsonType`, `value` when present, and `count`.
+The `missing` BSON type distinguishes documents without `schemaVersion` from documents whose value is explicitly `null`, and numeric and string values remain separate.
 
 ### `retirementFields`
 
@@ -72,6 +78,7 @@ Each row has a `status`: `checked`, `target-missing`, `source-missing`, or `not-
 Each row also records the local field and whether the current Mongoose schema requires it.
 A missing source is skipped with `clean: null`.
 A present source with a missing target is scanned, and every non-null reference is reported as orphaned with `clean: false`.
+If that scan finds no references, the row remains explicitly `target-missing` with `clean: null` instead of becoming a cutover blocker.
 For a required edge, a source document with a missing or null local reference is also reported as orphaned.
 For an optional edge, a missing or null local reference is skipped.
 Any edge with `clean: false` must be resolved or explained before the referenced collection is migrated.

--- a/docs/research-model-refactor-phase0.md
+++ b/docs/research-model-refactor-phase0.md
@@ -14,7 +14,7 @@ It writes nothing to MongoDB.
 # Print the report to stdout
 yarn --cwd server model-refactor:inventory --environment beta
 
-# Also write a JSON report (guarded to a tmp root)
+# Also write a JSON report under an allowed tmp root
 yarn --cwd server model-refactor:inventory --environment beta --output /tmp/model-inventory.json
 
 # Keep more orphan sample ids per reference edge (default 20)
@@ -30,6 +30,7 @@ Reference checks scan all tracked fields from each source collection once, retai
 The required `--environment` label must describe that target and accepts `development`, `beta`, `production-copy`, `production`, or `test`.
 Run it against beta first, then against a production copy once access and rollback artifacts are in place.
 Errors go to stderr, so stdout contains only the JSON report.
+The optional output path must end in `.json`, must resolve under the operating-system temp directory or `./tmp` from the runner's working directory, and must have an existing parent directory.
 
 Run the inventory against a restored, immutable copy whenever possible.
 If an immutable copy is unavailable, use a declared low-write or quiescent window and prevent migration or scraper writes for the duration of the export and inventory.
@@ -48,6 +49,7 @@ Implementation:
 Headline counts for a quick read:
 
 - `collectionsPresent` out of `collectionsClassified`.
+- `totalDocuments`: the sum of document counts across classified collections.
 - `legacyResidueCollections`: expected-gone collections that still hold documents, such as `research_groups` or `applications`.
 - `unclassifiedCollections`: live collections the refactor spec does not yet name.
 Investigate each one before trusting a cutover.
@@ -62,6 +64,7 @@ In particular, `totalOrphans: 0` means no orphans were found among the tracked e
 ### `collections`
 
 One row per refactor-relevant collection with its group, owning migration phase, target mapping, document count, and `schemaVersion` distribution.
+The `present` flag distinguishes a missing collection from an empty one, while `residue` is true only when an expected-gone collection still contains documents.
 Each `schemaVersions` bucket records `bsonType`, `value` when present, and `count`.
 The `missing` BSON type distinguishes documents without `schemaVersion` from documents whose value is explicitly `null`, and numeric and string values remain separate.
 
@@ -82,8 +85,10 @@ A present source with a missing target is scanned, and every non-null reference 
 If that scan finds no references, the row remains explicitly `target-missing` with `clean: null` instead of becoming a cutover blocker.
 For a required edge, a source document with a missing or null local reference is also reported as orphaned.
 For an optional edge, a missing or null local reference is skipped.
+The `checked`, `orphaned`, and `orphanRate` fields quantify each edge, and `sampleOrphanIds` contains bounded source-document IDs for investigation.
 Any edge with `clean: false` must be resolved or explained before the referenced collection is migrated.
 
+The top-level `generatedAt` records report creation time, while `options` preserves the parsed CLI settings.
 The top-level `environment` is the required operator-supplied label.
 The `db` field records the connected database name, and `target` records a credential-free host/database label derived from `MONGODBURL`.
 Review all three before preserving an inventory as migration evidence.

--- a/docs/research-model-refactor-phase0.md
+++ b/docs/research-model-refactor-phase0.md
@@ -27,7 +27,9 @@ The client is closed after success or failure.
 Collection scans are capped at four concurrent groups.
 Retirement-field probes reuse the collection census totals and count all tracked fields in one aggregation per collection.
 Reference checks scan all tracked fields from each source collection once, retain only distinct referenced IDs, and stream each target collection once without materializing all target IDs.
-The required `--environment` label must describe that target and accepts `development`, `beta`, `production-copy`, `production`, or `test`.
+The required `--environment` accepts `development`, `beta`, `production-copy`, `production`, or `test`.
+The runner fails before connecting unless the database named in `MONGODBURL` matches the declared environment, and it validates the database name resolved by MongoDB again after connecting.
+The deployed database names are `Development`, `Beta`, `ProductionCopy`, and `Production`; explicit test fixtures may use `Test` or a database name ending in `-test` or `_test`.
 Run it against beta first, then against a production copy once access and rollback artifacts are in place.
 Errors go to stderr, so stdout contains only the JSON report.
 The optional output path must end in `.json`, must resolve under the operating-system temp directory or `./tmp` from the runner's working directory, and must have an existing parent directory.
@@ -52,7 +54,7 @@ Headline counts for a quick read:
 - `totalDocuments`: the sum of document counts across classified collections.
 - `legacyResidueCollections`: expected-gone collections that still hold documents, such as `research_groups` or `applications`.
 - `unclassifiedCollections`: live collections the refactor spec does not yet name.
-Investigate each one before trusting a cutover.
+  Investigate each one before trusting a cutover.
 - `retirementFieldsStillPresent`: how many legacy fields still appear on live documents.
 - `referenceEdgesChecked` and `referenceEdgesSkipped`: how many reference edges were measurable and how many had no source collection to inspect.
 - `referenceEdgesWithOrphans` and `totalOrphans`: reference-integrity health.
@@ -89,7 +91,7 @@ The `checked`, `orphaned`, and `orphanRate` fields quantify each edge, and `samp
 Any edge with `clean: false` must be resolved or explained before the referenced collection is migrated.
 
 The top-level `generatedAt` records report creation time, while `options` preserves the parsed CLI settings.
-The top-level `environment` is the required operator-supplied label.
+The top-level `environment` is the required label verified against the configured and connected database names.
 The `db` field records the connected database name, and `target` records a credential-free host/database label derived from `MONGODBURL`.
 Review all three before preserving an inventory as migration evidence.
 

--- a/docs/research-model-refactor-phase0.md
+++ b/docs/research-model-refactor-phase0.md
@@ -26,7 +26,8 @@ It does not load Mongoose models, create collections, build indexes, or open the
 The client is closed after success or failure.
 Collection scans are capped at four concurrent groups.
 Retirement-field probes reuse the collection census totals and count all tracked fields in one aggregation per collection.
-Reference checks scan all tracked fields from each source collection once, retain only distinct referenced IDs, and stream each target collection once without materializing all target IDs.
+Reference checks scan all tracked fields from each source collection once and resolve references in batches of 1,000 source documents.
+Client memory remains bounded by the scan concurrency, batch size, tracked edges, and configured orphan sample limit rather than collection cardinality.
 The required `--environment` accepts `development`, `beta`, `production-copy`, `production`, or `test`.
 The runner fails before connecting unless the database named in `MONGODBURL` matches the declared environment, and it validates the database name resolved by MongoDB again after connecting.
 The deployed database names are `Development`, `Beta`, `ProductionCopy`, and `Production`; explicit test fixtures may use `Test` or a database name ending in `-test` or `_test`.

--- a/docs/research-model-refactor-phase0.md
+++ b/docs/research-model-refactor-phase0.md
@@ -21,10 +21,13 @@ yarn --cwd server model-refactor:inventory --environment beta --output /tmp/mode
 yarn --cwd server model-refactor:inventory --environment beta --sample-limit 100
 ```
 
-The tool connects with the standard `MONGODBURL` from `server/.env`, so point it at the environment you want to measure.
+The tool uses a dedicated native MongoDB client with the standard `MONGODBURL` from `server/.env`, so point it at the environment you want to measure.
+It does not load Mongoose models, create collections, build indexes, or open the migration database configured by `MONGODBURL_MIGRATION`.
+The client is closed after success or failure.
+Collection scans are capped at four concurrent groups, and retirement-field probes reuse the collection census totals.
 The required `--environment` label must describe that target and accepts `development`, `beta`, `production-copy`, `production`, or `test`.
 Run it against beta first, then against a production copy once access and rollback artifacts are in place.
-Connection diagnostics go to stderr, so stdout contains only the JSON report.
+Errors go to stderr, so stdout contains only the JSON report.
 
 Implementation:
 
@@ -58,7 +61,7 @@ A field with high prevalence gates its retirement phase until the canonical repl
 
 ### `referenceIntegrity`
 
-Orphan counts for the access and membership graph, for example membership rows whose `researchEntityId` does not resolve to a research entity.
+Orphan counts for the access, membership, and private student-record graph, for example membership rows whose `researchEntityId` does not resolve to a research entity.
 The check is type-agnostic, so it stays correct whether references are stored as ObjectId or string.
 Each row has a `status`: `checked`, `target-missing`, `source-missing`, or `not-gathered`.
 A missing source is skipped with `clean: null`.

--- a/docs/research-model-refactor-phase0.md
+++ b/docs/research-model-refactor-phase0.md
@@ -1,0 +1,85 @@
+# Research Model Refactor - Phase 0 Runbook
+
+Status: tooling in place, production measurement pending.
+
+Phase 0 of [`research-model-refactor.md`](./research-model-refactor.md) resolves integration state and measures production before any target collection is written or any legacy storage is dropped.
+This runbook covers the inventory tool, how to read its output, and the export and rollback steps that must exist before later phases run destructive cleanup.
+
+## Inventory tool
+
+The inventory is read-only.
+It writes nothing to MongoDB.
+
+```bash
+# Print the report to stdout
+yarn --cwd server model-refactor:inventory
+
+# Also write a JSON report (guarded to a tmp root)
+yarn --cwd server model-refactor:inventory --output /tmp/model-inventory.json
+
+# Keep more orphan sample ids per reference edge (default 20)
+yarn --cwd server model-refactor:inventory --sample-limit 100
+```
+
+The tool connects with the standard `MONGODBURL` from `server/.env`, so point it at the environment you want to measure.
+Run it against beta first, then against a production copy once access and rollback artifacts are in place.
+
+Implementation:
+
+- [`server/src/scripts/researchModelInventory.ts`](../server/src/scripts/researchModelInventory.ts) gathers the facts from MongoDB.
+- [`server/src/scripts/researchModelInventoryCore.ts`](../server/src/scripts/researchModelInventoryCore.ts) holds the collection spec, field probes, reference edges, and report shaping, and is unit tested without a database.
+
+## What the report contains
+
+### `summary`
+
+Headline counts for a quick read:
+
+- `collectionsPresent` out of `collectionsClassified`.
+- `legacyResidueCollections`: expected-gone collections that still hold documents, such as `research_groups` or `applications`.
+- `unclassifiedCollections`: live collections the refactor spec does not yet name.
+Investigate each one before trusting a cutover.
+- `retirementFieldsStillPresent`: how many legacy fields still appear on live documents.
+- `referenceEdgesWithOrphans` and `totalOrphans`: reference-integrity health.
+
+### `collections`
+
+One row per refactor-relevant collection with its group, owning migration phase, target mapping, document count, and `schemaVersion` distribution.
+The `schemaVersions` bucket labels documents with no `schemaVersion` as `unset`, which is expected before Phase 1 versioning lands.
+
+### `retirementFields`
+
+Prevalence of each legacy field slated for removal, for example `research_entities.acceptingUndergrads` or `users.publications`.
+A field at zero prevalence is safe to drop once no reader references it.
+A field with high prevalence gates its retirement phase until the canonical replacement is materialized.
+
+### `referenceIntegrity`
+
+Orphan counts for the access and membership graph, for example membership rows whose `researchEntityId` does not resolve to a research entity.
+The check is type-agnostic, so it stays correct whether references are stored as ObjectId or string.
+Any edge with `clean: false` must be resolved or explained before the referenced collection is migrated.
+
+## Complementary audits
+
+The inventory is a census.
+Deeper collision and identity analysis already lives in dedicated scripts and should be run alongside it:
+
+- `yarn --cwd server users:dedupe-by-identity` for same-person user shells.
+- `yarn --cwd server research-entity-members:audit-user-refs` for membership reference integrity.
+- `yarn --cwd server research-entity:duplicate-name-review` for duplicate entity identities.
+- `yarn --cwd server research-entity:coverage-audit` for entity evidence coverage.
+
+## Export and rollback prerequisites
+
+No later phase may drop or overwrite a collection until these exist and are verified:
+
+1. A recoverable export or Atlas point-in-time restore instruction for the target environment, captured immediately before the destructive step.
+2. Recorded source and target document counts, so parity can be proven after a cutover.
+3. A written rollback plan naming the exact collections touched and the restore command for each.
+
+Record the inventory JSON alongside the export so the pre-change state is auditable.
+
+## Exit condition
+
+Phase 0 exits on a reviewed inventory, an ownership map of which phase owns each collection and field, and a rollback plan.
+The collection spec in `researchModelInventoryCore.ts` is the machine-readable form of that ownership map, and should be extended whenever the report surfaces an unclassified collection.

--- a/docs/research-model-refactor-phase0.md
+++ b/docs/research-model-refactor-phase0.md
@@ -29,6 +29,11 @@ The required `--environment` label must describe that target and accepts `develo
 Run it against beta first, then against a production copy once access and rollback artifacts are in place.
 Errors go to stderr, so stdout contains only the JSON report.
 
+Run the inventory against a restored, immutable copy whenever possible.
+If an immutable copy is unavailable, use a declared low-write or quiescent window and prevent migration or scraper writes for the duration of the export and inventory.
+Record the JSON report alongside the export from the same window so its collection counts, schema-version buckets, and reference checks describe a meaningful point in time.
+The runner intentionally does not add transaction or snapshot read-concern behavior.
+
 Implementation:
 
 - [`server/src/scripts/researchModelInventory.ts`](../server/src/scripts/researchModelInventory.ts) gathers the facts from MongoDB.
@@ -64,8 +69,11 @@ A field with high prevalence gates its retirement phase until the canonical repl
 Orphan counts for the access, membership, and private student-record graph, for example membership rows whose `researchEntityId` does not resolve to a research entity.
 The check is type-agnostic, so it stays correct whether references are stored as ObjectId or string.
 Each row has a `status`: `checked`, `target-missing`, `source-missing`, or `not-gathered`.
+Each row also records the local field and whether the current Mongoose schema requires it.
 A missing source is skipped with `clean: null`.
 A present source with a missing target is scanned, and every non-null reference is reported as orphaned with `clean: false`.
+For a required edge, a source document with a missing or null local reference is also reported as orphaned.
+For an optional edge, a missing or null local reference is skipped.
 Any edge with `clean: false` must be resolved or explained before the referenced collection is migrated.
 
 The top-level `environment` is the required operator-supplied label.

--- a/docs/research-model-refactor-phase0.md
+++ b/docs/research-model-refactor-phase0.md
@@ -25,7 +25,8 @@ The tool uses a dedicated native MongoDB client with the standard `MONGODBURL` f
 It does not load Mongoose models, create collections, build indexes, or open the migration database configured by `MONGODBURL_MIGRATION`.
 The client is closed after success or failure.
 Collection scans are capped at four concurrent groups.
-Retirement-field probes reuse the collection census totals, each reference target ID set is loaded once, and all tracked fields from a source collection are checked in one scan.
+Retirement-field probes reuse the collection census totals and count all tracked fields in one aggregation per collection.
+Reference checks scan all tracked fields from each source collection once, retain only distinct referenced IDs, and stream each target collection once without materializing all target IDs.
 The required `--environment` label must describe that target and accepts `development`, `beta`, `production-copy`, `production`, or `test`.
 Run it against beta first, then against a production copy once access and rollback artifacts are in place.
 Errors go to stderr, so stdout contains only the JSON report.

--- a/docs/research-model-refactor.md
+++ b/docs/research-model-refactor.md
@@ -18,14 +18,14 @@ The target model follows five principles:
 
 1. Research discovery centers on `ResearchEntity`.
 2. Public people are minimal identity anchors connected to research through dated role assignments.
-3. Official Yale profiles and ORCID remain outbound sources rather than content feeds to mirror.
+3. Official Yale, Google Scholar, and ORCID profiles remain outbound sources rather than content feeds to mirror.
 4. Scrapers preserve source evidence before materializers derive student-facing records.
 5. Public APIs return bounded product projections over REST while keeping the model compatible with a possible future GraphQL read layer.
 
 The intended product boundary is:
 
 > Yale Research owns structured research navigation and evidence-backed next steps.
-> Yale and ORCID own professor presentation and scholarly output.
+> Yale, Google Scholar, and ORCID own professor presentation and scholarly output.
 
 ## Product Experience
 
@@ -50,16 +50,16 @@ Yale Research should not create a separate internal professor-profile mirror.
 
 ### Student questions and data ownership
 
-| Student question | Yale Research record | Public attribution |
-| --- | --- | --- |
-| What is this research structure? | `ResearchEntity` | Official entity, program, or department source |
-| What does it study? | Entity description, topics, and methods | Source link and verification date |
-| Who leads it? | `RoleAssignment` plus `Person` | Official Yale person profile |
-| Have undergraduates participated? | `AccessSignal` | Evidence excerpt, source, and observation date |
-| Is there an active opening? | `PostedOpportunity` | Official posting, status, and deadline source |
-| How might I approach it? | `EntryPathway` | Supporting evidence and explanation |
-| What should I do next? | Computed planning context plus `ContactRoute` | Supporting claims and source route |
-| What has this professor published? | Not stored by Yale Research | Official Yale profile or ORCID |
+| Student question                   | Yale Research record                          | Public attribution                             |
+| ---------------------------------- | --------------------------------------------- | ---------------------------------------------- |
+| What is this research structure?   | `ResearchEntity`                              | Official entity, program, or department source |
+| What does it study?                | Entity description, topics, and methods       | Source link and verification date              |
+| Who leads it?                      | `RoleAssignment` plus `Person`                | Official Yale person profile                   |
+| Have undergraduates participated?  | `AccessSignal`                                | Evidence excerpt, source, and observation date |
+| Is there an active opening?        | `PostedOpportunity`                           | Official posting, status, and deadline source  |
+| How might I approach it?           | `EntryPathway`                                | Supporting evidence and explanation            |
+| What should I do next?             | Computed planning context plus `ContactRoute` | Supporting claims and source route             |
+| What has this professor published? | Not stored by Yale Research                   | Official Yale, Google Scholar, or ORCID profile |
 
 ## Target Model Overview
 
@@ -122,6 +122,12 @@ type Person = {
   identifiers?: {
     orcid?: string;
   };
+  outboundProfiles?: {
+    googleScholar?: {
+      url: string;
+      verifiedAt: Date;
+    };
+  };
   status: 'ACTIVE' | 'DEPARTED' | 'UNKNOWN';
   archived: boolean;
 };
@@ -131,9 +137,9 @@ type Person = {
 It should not store mirrored biographies, publication arrays, citation metrics, h-index values, paper-derived topics, or copied contact information.
 Search may index a person's display name through related research-entity projections so a professor-name query can return the research homes they lead.
 
-ORCID may enrich or disambiguate a Yale-confirmed person.
-ORCID must not create a person record by itself.
-ORCID is an optional outbound researcher link, not a public verification badge and not an undergraduate-access signal.
+Google Scholar and ORCID may enrich or disambiguate a Yale-confirmed person.
+Neither source may create a person record by itself.
+Their verified profiles are optional outbound researcher links, not public verification badges or undergraduate-access signals.
 
 ### `role_assignments`
 
@@ -366,21 +372,21 @@ The following ingestion paths should be retired after their reads and launch gat
 - paper-authorship materialization and audits;
 - professor and research-detail publication DTO fallbacks.
 
-ORCID remains useful as:
+Google Scholar and ORCID remain useful as:
 
 - an external identity signal;
 - a reviewed disambiguation aid;
 - an optional outbound public researcher link.
 
-ORCID is not used as:
+Google Scholar and ORCID are not used as:
 
 - a source that creates Yale people;
 - a feed that rebuilds a publication corpus;
+- input to ranking, visibility, search content, or research-home descriptions;
 - evidence of undergraduate access;
-- a source for public research-home descriptions.
 
 Paper storage should be reconsidered only if Yale Research adopts an explicit product requirement for native publication search, paper-level filtering, offline scholarly browsing, or consistent in-app activity comparison.
-Until then, the official Yale profile is the preferred destination for highlighted publications and ORCID is the optional destination for a broader public works record.
+Until then, the official Yale profile is the preferred destination for highlighted publications, while verified Google Scholar and ORCID profiles are optional outbound identity links.
 
 ## Evidence and Attribution Contract
 
@@ -597,21 +603,22 @@ Meilisearch would continue to power search even if GraphQL were introduced.
 
 ## Current-to-Target Mapping
 
-| Current shape | Target | Migration intent |
-| --- | --- | --- |
-| Auth, student state, and faculty profile fields on `User` | `Account`, `StudentProfile`, `ResearchPlan`, optional `Person` | Split private account state from public research identity |
-| `FacultyMember` plus professor-shaped `User` | `Person` | Deterministically merge accepted identities and quarantine conflicts |
-| `ResearchGroupMember` with dual entity and person references | `RoleAssignment` | Rewrite references to one entity ID and one person ID |
-| `ResearchEntity` registered from `researchGroupSchema` | Clean `ResearchEntity` schema | Cut reads to canonical fields, then remove legacy fields |
-| `ResearchGroup` and `researchGroupId` residue | `ResearchEntity` and `researchEntityId` | Remove compatibility references after verified parity |
-| `Listing` | `EntryPathway` plus `PostedOpportunity` | Preserve real postings and remove legacy listing ownership fields |
-| `Fellowship` | `ResearchEntity`, `EntryPathway`, `PostedOpportunity`, or formalization summary | Classify by behavior rather than by legacy collection |
-| `acceptingUndergrads` and openness caches | `AccessSignal` plus computed access summary | Remove binary and duplicated access state |
-| Official person profile treated as contact | `Person.officialProfile` | Keep navigation separate from permission to contact |
-| `User.publications`, `Paper`, `PaperAuthor`, and scholarly sidecars | No target collection | Remove reads, stop ingestion, archive, then drop |
-| ORCID works ingestion | `Person.identifiers.orcid` | Retain identity and outbound link only |
-| Field-name-based `Observation` | Predicate-based `EvidenceClaim` | Dual-emit temporarily, reconcile, then cut over |
-| Mixed saved-plan maps on `User` | `ResearchPlan` | Migrate one plan per account and target |
+| Current shape                                                       | Target                                                                          | Migration intent                                                     |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Auth, student state, and faculty profile fields on `User`           | `Account`, `StudentProfile`, `ResearchPlan`, optional `Person`                  | Split private account state from public research identity            |
+| `FacultyMember` plus professor-shaped `User`                        | `Person`                                                                        | Deterministically merge accepted identities and quarantine conflicts |
+| `ResearchGroupMember` with dual entity and person references        | `RoleAssignment`                                                                | Rewrite references to one entity ID and one person ID                |
+| `ResearchEntity` registered from `researchGroupSchema`              | Clean `ResearchEntity` schema                                                   | Cut reads to canonical fields, then remove legacy fields             |
+| `ResearchGroup` and `researchGroupId` residue                       | `ResearchEntity` and `researchEntityId`                                         | Remove compatibility references after verified parity                |
+| `Listing`                                                           | `EntryPathway` plus `PostedOpportunity`                                         | Preserve real postings and remove legacy listing ownership fields    |
+| `Fellowship`                                                        | `ResearchEntity`, `EntryPathway`, `PostedOpportunity`, or formalization summary | Classify by behavior rather than by legacy collection                |
+| `acceptingUndergrads` and openness caches                           | `AccessSignal` plus computed access summary                                     | Remove binary and duplicated access state                            |
+| Official person profile treated as contact                          | `Person.officialProfile`                                                        | Keep navigation separate from permission to contact                  |
+| `User.publications`, `Paper`, `PaperAuthor`, and scholarly sidecars | No target collection                                                            | Remove reads, stop ingestion, archive, then drop                     |
+| ORCID works ingestion                                               | `Person.identifiers.orcid`                                                      | Retain identity and outbound link only                               |
+| `User.googleScholarId` and `FacultyMember.googleScholarId`          | `Person.outboundProfiles.googleScholar`                                          | Migrate the reviewed profile URL, then remove the legacy identifiers |
+| Field-name-based `Observation`                                      | Predicate-based `EvidenceClaim`                                                 | Dual-emit temporarily, reconcile, then cut over                      |
+| Mixed saved-plan maps on `User`                                     | `ResearchPlan`                                                                  | Migrate one plan per account and target                              |
 
 ## Migration Strategy
 
@@ -652,7 +659,8 @@ Exit condition: student-facing research reads no longer require `FacultyMember` 
 ### Phase 3: retire professor and publication mirrors
 
 - Switch professor navigation to verified official Yale profile URLs.
-- Expose ORCID only as an optional outbound identity link.
+- Migrate reviewed legacy Google Scholar identifiers into canonical verified `Person.outboundProfiles.googleScholar` links.
+- Expose Google Scholar and ORCID only as optional outbound identity links.
 - Remove professor and research-detail publication sections and compatibility DTO fields.
 - Disable paper, preprint, ORCID-works, and bibliographic hydration scrapers.
 - Remove paper-quality and authorship gates after replacement launch criteria are documented.

--- a/docs/research-model-refactor.md
+++ b/docs/research-model-refactor.md
@@ -648,7 +648,7 @@ Exit condition: new collections and readers can coexist safely with current runt
 ### Phase 2: split account and person identity
 
 - Create canonical people from accepted Yale-confirmed identity evidence.
-- Link accounts to people when a deterministic match exists.
+- Set `Person.accountId` when a deterministic account-person match exists.
 - Quarantine same-name, conflicting-email, and conflicting-identifier cases.
 - Introduce role assignments with canonical entity and person references.
 - Switch public leadership and search-name projections to canonical roles.

--- a/docs/research-model-refactor.md
+++ b/docs/research-model-refactor.md
@@ -620,6 +620,8 @@ Each phase must remove a compatibility read before the corresponding legacy stor
 
 ### Phase 0: resolve integration state and measure production
 
+Use the [`Phase 0 runbook`](./research-model-refactor-phase0.md) for the read-only inventory command, report interpretation, and rollback prerequisites.
+
 - Resolve the existing merge conflicts before implementation changes begin.
 - Inventory collection counts, schema versions, field distributions, and reference integrity.
 - Identify actual read paths, index use, and query cost.
@@ -758,5 +760,5 @@ Likely implementation areas include:
 - `docs/decisions.md`;
 - scraper and architecture skills.
 
-After the existing merge is resolved, this document should be linked from the canonical research-model documentation.
+Keep this document linked from the canonical research-model documentation while the phased migration is active.
 When the migration is complete, the stable decisions should be folded into [`research-model.md`](./research-model.md), and this document should either become the concise historical decision record or be removed to avoid maintaining duplicate truth.

--- a/docs/research-model-refactor.md
+++ b/docs/research-model-refactor.md
@@ -630,7 +630,7 @@ Each phase must remove a compatibility read before the corresponding legacy stor
 Use the [`Phase 0 runbook`](./research-model-refactor-phase0.md) for the read-only inventory command, report interpretation, and rollback prerequisites.
 
 - Resolve the existing merge conflicts before implementation changes begin.
-- Inventory collection counts, schema versions, field distributions, and reference integrity.
+- Inventory collection counts, schema versions, tracked retirement-field prevalence, and reference integrity.
 - Identify actual read paths, index use, and query cost.
 - Record data collisions and unresolved identity conflicts.
 - Produce recoverable export or Atlas restore instructions before destructive cleanup.

--- a/docs/research-model-refactor.md
+++ b/docs/research-model-refactor.md
@@ -50,15 +50,15 @@ Yale Research should not create a separate internal professor-profile mirror.
 
 ### Student questions and data ownership
 
-| Student question                   | Yale Research record                          | Public attribution                             |
-| ---------------------------------- | --------------------------------------------- | ---------------------------------------------- |
-| What is this research structure?   | `ResearchEntity`                              | Official entity, program, or department source |
-| What does it study?                | Entity description, topics, and methods       | Source link and verification date              |
-| Who leads it?                      | `RoleAssignment` plus `Person`                | Official Yale person profile                   |
-| Have undergraduates participated?  | `AccessSignal`                                | Evidence excerpt, source, and observation date |
-| Is there an active opening?        | `PostedOpportunity`                           | Official posting, status, and deadline source  |
-| How might I approach it?           | `EntryPathway`                                | Supporting evidence and explanation            |
-| What should I do next?             | Computed planning context plus `ContactRoute` | Supporting claims and source route             |
+| Student question                   | Yale Research record                          | Public attribution                              |
+| ---------------------------------- | --------------------------------------------- | ----------------------------------------------- |
+| What is this research structure?   | `ResearchEntity`                              | Official entity, program, or department source  |
+| What does it study?                | Entity description, topics, and methods       | Source link and verification date               |
+| Who leads it?                      | `RoleAssignment` plus `Person`                | Official Yale person profile                    |
+| Have undergraduates participated?  | `AccessSignal`                                | Evidence excerpt, source, and observation date  |
+| Is there an active opening?        | `PostedOpportunity`                           | Official posting, status, and deadline source   |
+| How might I approach it?           | `EntryPathway`                                | Supporting evidence and explanation             |
+| What should I do next?             | Computed planning context plus `ContactRoute` | Supporting claims and source route              |
 | What has this professor published? | Not stored by Yale Research                   | Official Yale, Google Scholar, or ORCID profile |
 
 ## Target Model Overview
@@ -108,25 +108,22 @@ The model may represent faculty, directors, staff, postdoctoral researchers, gra
 Suggested shape:
 
 ```ts
+type PersonProfileLink = {
+  kind: 'YALE_OFFICIAL' | 'LAB_ABOUT' | 'PERSONAL_ACADEMIC' | 'GOOGLE_SCHOLAR' | 'ORCID';
+  purpose: 'PRIMARY_IDENTITY' | 'SCHOLARLY';
+  url: string;
+  verifiedAt: Date;
+  healthStatus: 'HEALTHY' | 'UNAVAILABLE' | 'UNKNOWN';
+};
+
 type Person = {
   id: string;
   schemaVersion: number;
   displayName: string;
   accountId?: string;
-  officialProfile?: {
-    url: string;
-    verifiedAt: Date;
-    healthStatus: 'HEALTHY' | 'UNAVAILABLE' | 'UNKNOWN';
-    lastCheckedAt?: Date;
-  };
+  profileLinks?: PersonProfileLink[];
   identifiers?: {
     orcid?: string;
-  };
-  outboundProfiles?: {
-    googleScholar?: {
-      url: string;
-      verifiedAt: Date;
-    };
   };
   status: 'ACTIVE' | 'DEPARTED' | 'UNKNOWN';
   archived: boolean;
@@ -136,6 +133,8 @@ type Person = {
 `Person` must not become another full professor-profile document.
 It should not store mirrored biographies, publication arrays, citation metrics, h-index values, paper-derived topics, or copied contact information.
 Search may index a person's display name through related research-entity projections so a professor-name query can return the research homes they lead.
+`profileLinks` is a small bounded set with at most one reviewed link of each kind.
+Public projections expose one selected primary profile and a bounded `researchProfiles` array containing only secondary link kind, label, and canonical URL.
 
 Google Scholar and ORCID may enrich or disambiguate a Yale-confirmed person.
 Neither source may create a person record by itself.
@@ -613,10 +612,10 @@ Meilisearch would continue to power search even if GraphQL were introduced.
 | `Listing`                                                           | `EntryPathway` plus `PostedOpportunity`                                         | Preserve real postings and remove legacy listing ownership fields    |
 | `Fellowship`                                                        | `ResearchEntity`, `EntryPathway`, `PostedOpportunity`, or formalization summary | Classify by behavior rather than by legacy collection                |
 | `acceptingUndergrads` and openness caches                           | `AccessSignal` plus computed access summary                                     | Remove binary and duplicated access state                            |
-| Official person profile treated as contact                          | `Person.officialProfile`                                                        | Keep navigation separate from permission to contact                  |
+| Official person profile treated as contact                          | `Person.profileLinks` with `PRIMARY_IDENTITY` purpose                           | Keep navigation separate from permission to contact                  |
 | `User.publications`, `Paper`, `PaperAuthor`, and scholarly sidecars | No target collection                                                            | Remove reads, stop ingestion, archive, then drop                     |
-| ORCID works ingestion                                               | `Person.identifiers.orcid`                                                      | Retain identity and outbound link only                               |
-| `User.googleScholarId` and `FacultyMember.googleScholarId`          | `Person.outboundProfiles.googleScholar`                                          | Migrate the reviewed profile URL, then remove the legacy identifiers |
+| ORCID works ingestion                                               | `Person.identifiers.orcid` plus a verified `PersonProfileLink`                  | Retain identity and outbound link only                               |
+| `User.googleScholarId` and `FacultyMember.googleScholarId`          | Verified `PersonProfileLink` with kind `GOOGLE_SCHOLAR`                         | Migrate the reviewed profile URL, then remove the legacy identifiers |
 | Field-name-based `Observation`                                      | Predicate-based `EvidenceClaim`                                                 | Dual-emit temporarily, reconcile, then cut over                      |
 | Mixed saved-plan maps on `User`                                     | `ResearchPlan`                                                                  | Migrate one plan per account and target                              |
 
@@ -659,7 +658,7 @@ Exit condition: student-facing research reads no longer require `FacultyMember` 
 ### Phase 3: retire professor and publication mirrors
 
 - Switch professor navigation to verified official Yale profile URLs.
-- Migrate reviewed legacy Google Scholar identifiers into canonical verified `Person.outboundProfiles.googleScholar` links.
+- Migrate reviewed legacy Google Scholar identifiers into canonical verified `PersonProfileLink` records with kind `GOOGLE_SCHOLAR`.
 - Expose Google Scholar and ORCID only as optional outbound identity links.
 - Remove professor and research-detail publication sections and compatibility DTO fields.
 - Disable paper, preprint, ORCID-works, and bibliographic hydration scrapers.

--- a/docs/research-model-refactor.md
+++ b/docs/research-model-refactor.md
@@ -1,0 +1,762 @@
+# Research Model Refactor
+
+Status: accepted product and architecture direction, implementation pending
+
+Decision date: 2026-07-24
+
+This document records the target Yale Research data model and the migration boundaries agreed during the July 2026 model review.
+It is a durable design contract, not a claim that the current runtime already implements the target.
+Until the migration is complete, [`research-model.md`](./research-model.md) and the source code remain authoritative descriptions of current compatibility behavior.
+
+## Executive Decision
+
+Yale Research will remain a research-home-first discovery and planning product.
+It will own the structured model that connects research homes, people, undergraduate-access evidence, pathways, postings, official action routes, and private student plans.
+It will not maintain a competing professor-profile or scholarly-publication product.
+
+The target model follows five principles:
+
+1. Research discovery centers on `ResearchEntity`.
+2. Public people are minimal identity anchors connected to research through dated role assignments.
+3. Official Yale profiles and ORCID remain outbound sources rather than content feeds to mirror.
+4. Scrapers preserve source evidence before materializers derive student-facing records.
+5. Public APIs return bounded product projections over REST while keeping the model compatible with a possible future GraphQL read layer.
+
+The intended product boundary is:
+
+> Yale Research owns structured research navigation and evidence-backed next steps.
+> Yale and ORCID own professor presentation and scholarly output.
+
+## Product Experience
+
+The target experience must be more than a directory of links.
+Its value comes from making fragmented Yale research information searchable, comparable, attributable, and actionable.
+
+A student should be able to:
+
+1. Search by topic, method, professor, department, entity type, or practical constraint.
+2. Find a plausible research home even when no opening is posted.
+3. Understand what the research home studies and which methods it uses.
+4. See who leads it and who might supervise undergraduates.
+5. Review source-backed evidence about undergraduate participation or constraints.
+6. Distinguish a durable pathway from a currently open opportunity.
+7. Understand the safest supported next step.
+8. Follow the official Yale source for deeper professor or research details.
+9. Save the research home and maintain a private plan.
+
+The primary public experience remains `/research` and `/research/:slug`.
+Professor names should link to official Yale profiles when those links are verified.
+Yale Research should not create a separate internal professor-profile mirror.
+
+### Student questions and data ownership
+
+| Student question | Yale Research record | Public attribution |
+| --- | --- | --- |
+| What is this research structure? | `ResearchEntity` | Official entity, program, or department source |
+| What does it study? | Entity description, topics, and methods | Source link and verification date |
+| Who leads it? | `RoleAssignment` plus `Person` | Official Yale person profile |
+| Have undergraduates participated? | `AccessSignal` | Evidence excerpt, source, and observation date |
+| Is there an active opening? | `PostedOpportunity` | Official posting, status, and deadline source |
+| How might I approach it? | `EntryPathway` | Supporting evidence and explanation |
+| What should I do next? | Computed planning context plus `ContactRoute` | Supporting claims and source route |
+| What has this professor published? | Not stored by Yale Research | Official Yale profile or ORCID |
+
+## Target Model Overview
+
+```text
+Account 0..1 ── Person ── RoleAssignment ── ResearchEntity
+                                             │
+                       ┌─────────────────────┼─────────────────────┐
+                       │                     │                     │
+                 EntryPathway          AccessSignal         ContactRoute
+                       │
+                PostedOpportunity
+
+SourceDocument ── EvidenceClaim ── supports materialized domain records
+ReviewDecision ──────────────────── records manual resolution and locks
+
+Account ── StudentProfile
+Account ── ResearchPlan ── ResearchEntity
+```
+
+The diagram is a domain graph.
+It does not imply that the refactor must adopt GraphQL.
+
+## Collection Responsibilities
+
+### `accounts`
+
+`Account` owns authentication and private account state.
+It replaces the use of a single `User` document as both an authenticated principal and a public professor profile.
+
+Suggested responsibilities:
+
+- CAS identity and session linkage;
+- account email and authorization state;
+- private preferences;
+- timestamps and account lifecycle state.
+
+An account is not evidence that a public research person exists.
+A public person may exist without an account, and most student accounts do not require public person records.
+When a public person and account are the same individual, the indexed optional relationship is stored as `Person.accountId` rather than duplicated in both documents.
+
+### `people`
+
+`Person` is a minimal, role-neutral identity anchor for named people connected to research.
+The model may represent faculty, directors, staff, postdoctoral researchers, graduate students, undergraduates, and other named supervisors when source and visibility policy permit.
+
+Suggested shape:
+
+```ts
+type Person = {
+  id: string;
+  schemaVersion: number;
+  displayName: string;
+  accountId?: string;
+  officialProfile?: {
+    url: string;
+    verifiedAt: Date;
+    healthStatus: 'HEALTHY' | 'UNAVAILABLE' | 'UNKNOWN';
+    lastCheckedAt?: Date;
+  };
+  identifiers?: {
+    orcid?: string;
+  };
+  status: 'ACTIVE' | 'DEPARTED' | 'UNKNOWN';
+  archived: boolean;
+};
+```
+
+`Person` must not become another full professor-profile document.
+It should not store mirrored biographies, publication arrays, citation metrics, h-index values, paper-derived topics, or copied contact information.
+Search may index a person's display name through related research-entity projections so a professor-name query can return the research homes they lead.
+
+ORCID may enrich or disambiguate a Yale-confirmed person.
+ORCID must not create a person record by itself.
+ORCID is an optional outbound researcher link, not a public verification badge and not an undergraduate-access signal.
+
+### `role_assignments`
+
+`RoleAssignment` connects a person to a research entity or Yale organizational unit.
+It replaces the dual `User` and `FacultyMember` references and legacy `ResearchGroupMember` naming.
+
+Suggested shape:
+
+```ts
+type RoleAssignment = {
+  id: string;
+  schemaVersion: number;
+  personId: string;
+  target: {
+    kind: 'RESEARCH_ENTITY' | 'ORG_UNIT';
+    id: string;
+  };
+  role:
+    | 'PI'
+    | 'CO_PI'
+    | 'DIRECTOR'
+    | 'CO_DIRECTOR'
+    | 'CORE_FACULTY'
+    | 'AFFILIATED'
+    | 'STAFF'
+    | 'POSTDOC'
+    | 'GRADUATE_STUDENT'
+    | 'UNDERGRADUATE';
+  state: 'CURRENT' | 'HISTORICAL' | 'UNKNOWN';
+  startedAt?: Date;
+  endedAt?: Date;
+  evidenceClaimIds: string[];
+  confidence: number;
+  reviewStatus: 'UNREVIEWED' | 'APPROVED' | 'DISPUTED';
+  archived: boolean;
+};
+```
+
+Roles are facts about a relationship, not permanent person types.
+The model must preserve historical roles without presenting them as current.
+Name-only role extraction must enter review unless it resolves to a unique Yale-confirmed person.
+
+### `org_units`
+
+`OrgUnit` provides canonical identity for Yale schools, departments, offices, and similar organizational structures.
+Research entities and people should reference organization IDs rather than maintaining several independent arrays of department and school strings.
+
+Frequently displayed organization labels may be copied into bounded search or DTO projections.
+The ID remains the canonical relationship.
+
+### `taxonomy_terms`
+
+`TaxonomyTerm` provides stable identity for controlled research topics and methods.
+It replaces the combination of research-area IDs, copied labels, scraper-generated strings, and search-only aliases acting as competing classifications.
+
+Suggested fields include:
+
+- term kind such as `TOPIC` or `METHOD`;
+- canonical label;
+- normalized aliases;
+- optional parent term;
+- review and lifecycle state.
+
+Search-specific synonyms may extend this vocabulary in Meilisearch.
+They must not silently create new canonical taxonomy terms.
+
+### `research_entities`
+
+`ResearchEntity` remains the central browseable concept.
+It covers labs, centers, institutes, faculty projects, faculty research areas, digital humanities initiatives, collections projects, archives, RA programs, mentor-matching fellowship programs, and similar durable research structures.
+
+The clean target schema must be declared directly.
+It must not continue to register `ResearchEntity` from the legacy `researchGroupSchema`.
+
+Suggested shape:
+
+```ts
+type ResearchEntity = {
+  id: string;
+  schemaVersion: number;
+  slug: string;
+  name: string;
+  entityType: ResearchEntityType;
+  description?: string;
+  officialWebsiteUrl?: string;
+  orgUnitIds: string[];
+  topicIds: string[];
+  methodIds: string[];
+  sourceEvidenceClaimIds: string[];
+  discovery: {
+    leads: Array<{
+      personId: string;
+      displayName: string;
+      role: string;
+      officialProfileUrl?: string;
+    }>;
+    accessState: string;
+    bestNextStepCategory?: string;
+    openOpportunityCount: number;
+    browseRankScore: number;
+    visibilityState: string;
+    computedAt: Date;
+  };
+  archived: boolean;
+};
+```
+
+The `discovery` object is a bounded computed projection for read-heavy research cards and search indexing.
+It is not a second source of truth.
+Lead arrays and other embedded summaries must have explicit product bounds.
+Full roles, pathways, signals, routes, and evidence remain first-class records.
+
+Legacy fields such as `kind`, duplicate description fields, `acceptingUndergrads`, `openness`, `acceptanceConfidence`, embedded openness signals, and legacy research-group references must be retired after canonical reads cut over.
+
+### `entity_relationships`
+
+`EntityRelationship` represents source-backed relationships between research entities.
+Examples include affiliation, hosting, membership, umbrella structure, and succession.
+
+Relationships remain first-class because they are many-to-many, independently evidenced, and queried in both directions.
+Public entity-detail DTOs should expose only bounded related-entity summaries.
+
+### `entry_pathways`
+
+`EntryPathway` describes a durable, evidence-backed way a student might approach a plausible research home.
+It does not mean that a position is currently open.
+
+Examples include:
+
+- a recurring program;
+- an official application process;
+- a center internship;
+- faculty supervision;
+- a supported exploratory route;
+- a mentor-matching program;
+- a lab-manager or program-manager route.
+
+Course credit is not an entry pathway.
+Fellowship funding is normally not an entry pathway unless the fellowship itself provides mentor matching, project placement, or another genuine discovery route.
+
+### `posted_opportunities`
+
+`PostedOpportunity` represents a specific active, rolling, closed, or archived posting.
+It belongs to an `EntryPathway`.
+
+Term, deadline, application URL, compensation, eligibility, and status belong on the posted instance when the source supports them.
+Legacy `Listing` records should migrate into pathways and posted opportunities before the listing model is retired.
+
+### `access_signals`
+
+`AccessSignal` represents source-backed evidence about undergraduate access.
+Positive signals and explicit negative constraints are stored.
+Absence of evidence is normally computed.
+
+Examples include:
+
+- current undergraduate participation;
+- past undergraduate participation;
+- official application form;
+- recurring undergraduate program;
+- faculty supervision of student projects;
+- application-only policy;
+- explicit current unavailability.
+
+Papers, preprints, grants, citation counts, and general research activity do not prove undergraduate access.
+
+### `contact_routes`
+
+`ContactRoute` represents an actual reviewed route for action.
+It remains fail-closed and visibility-scoped.
+
+Examples include:
+
+- official application;
+- program application;
+- lab-manager instructions;
+- explicitly permitted faculty contact;
+- official department inquiry route.
+
+An official professor profile is not automatically a contact route.
+The profile URL belongs on `Person` unless the page itself provides and permits a specific action route.
+Public DTOs must not expose unreviewed scraped emails or phone numbers.
+
+### Formalization options
+
+Course credit, paid RA work, fellowship funding, thesis advising, and volunteer arrangements are ways a research relationship may be formalized after home and mentor fit.
+This refactor does not create a separate `formalization_options` collection initially.
+
+Materializers may derive a bounded formalization summary for Planning Context from source-backed claims and access signals.
+A first-class collection should be introduced only if formalization options gain independent lifecycle, filtering, or editing requirements.
+
+### `student_profiles`
+
+`StudentProfile` stores bounded onboarding and discovery preferences.
+It remains private account data and should not be mixed into public person identity.
+
+### `research_plans`
+
+`ResearchPlan` stores one private planning relationship between an account and a research entity or program.
+It replaces loosely typed saved arrays and mixed plan maps on `User`.
+
+Suggested responsibilities:
+
+- saved state;
+- planning stage;
+- private notes;
+- checklist state;
+- relevant deadlines;
+- explicit export preferences.
+
+Private notes must remain excluded from exports unless the student explicitly opts in.
+
+### `engagement_events`
+
+`EngagementEvent` remains append-only product analytics with a retention policy separate from research evidence.
+Analytics must not become canonical evidence that a research home accepts undergraduates.
+
+## Publication and Professor-Profile Decision
+
+The target model does not include `Paper`, `PaperAuthor`, `ScholarlyWork`, or scholarly-attribution collections.
+It also does not retain an embedded publications array on `Account` or `Person`.
+
+The following ingestion paths should be retired after their reads and launch gates are removed:
+
+- OpenAlex paper ingestion;
+- arXiv preprint ingestion;
+- ORCID works ingestion;
+- Europe PMC and PubMed paper ingestion;
+- Crossref bibliographic hydration;
+- paper-authorship materialization and audits;
+- professor and research-detail publication DTO fallbacks.
+
+ORCID remains useful as:
+
+- an external identity signal;
+- a reviewed disambiguation aid;
+- an optional outbound public researcher link.
+
+ORCID is not used as:
+
+- a source that creates Yale people;
+- a feed that rebuilds a publication corpus;
+- evidence of undergraduate access;
+- a source for public research-home descriptions.
+
+Paper storage should be reconsidered only if Yale Research adopts an explicit product requirement for native publication search, paper-level filtering, offline scholarly browsing, or consistent in-app activity comparison.
+Until then, the official Yale profile is the preferred destination for highlighted publications and ORCID is the optional destination for a broader public works record.
+
+## Evidence and Attribution Contract
+
+Every material student-facing claim must be traceable to source evidence.
+Attribution must operate at the claim level rather than only at the page level.
+
+### `sources`
+
+`Source` records source identity, trust posture, coverage, cadence, and policy.
+Source coverage metadata is a planning contract, not evidence that a particular claim is true.
+
+### `source_documents`
+
+`SourceDocument` identifies the exact fetched page or API resource used as evidence.
+
+Suggested fields include:
+
+- canonical URL or external resource key;
+- source ID;
+- retrieval time;
+- content hash;
+- HTTP and link-health state;
+- snapshot pointer when retention policy permits;
+- sensitivity and retention classification.
+
+Raw snapshots may contain contact details or other sensitive material.
+Snapshot access and retention must follow source-specific policy and must not imply public visibility.
+
+### `evidence_claims`
+
+`EvidenceClaim` records what a source asserted using a stable domain predicate.
+Predicates must not be current Mongoose field names.
+
+Suggested shape:
+
+```ts
+type EvidenceClaim = {
+  id: string;
+  schemaVersion: number;
+  subject: {
+    kind:
+      | 'PERSON'
+      | 'ROLE_ASSIGNMENT'
+      | 'RESEARCH_ENTITY'
+      | 'ENTITY_RELATIONSHIP'
+      | 'ENTRY_PATHWAY'
+      | 'POSTED_OPPORTUNITY';
+    id?: string;
+    key?: string;
+  };
+  predicate: string;
+  value: unknown;
+  sourceDocumentId: string;
+  observedAt: Date;
+  confidence: number;
+  sensitivity: 'PUBLIC' | 'AUTHENTICATED' | 'ADMIN_ONLY';
+  status: 'ACTIVE' | 'SUPERSEDED' | 'REJECTED' | 'DISPUTED';
+  supersededByClaimId?: string;
+};
+```
+
+Example predicates include:
+
+- `PERSON_HAS_OFFICIAL_PROFILE`;
+- `PERSON_HAS_ORCID`;
+- `PERSON_LEADS_ENTITY`;
+- `ENTITY_HAS_DESCRIPTION`;
+- `ENTITY_USES_METHOD`;
+- `UNDERGRAD_PARTICIPATION_OBSERVED`;
+- `OFFICIAL_APPLICATION_EXISTS`;
+- `OPPORTUNITY_HAS_DEADLINE`;
+- `DIRECT_CONTACT_NOT_PERMITTED`.
+
+### Materialized provenance
+
+Materialized records must retain the claims that support them.
+
+```ts
+type MaterializedProvenance = {
+  evidenceClaimIds: string[];
+  materializer: string;
+  materializerVersion: number;
+  computedAt: Date;
+};
+```
+
+Computed values such as access summaries, browse ranking, and Best Next Step must identify themselves as Yale Research derivations.
+They must not be presented as direct quotations from a source.
+
+### `review_decisions`
+
+`ReviewDecision` records manual merge, rejection, approval, lock, suppression, and identity-resolution actions.
+Manual review must not erase the original claims or snapshots.
+Public copy may say that a record was reviewed, while reviewer identity and internal notes remain protected.
+
+### Public attribution behavior
+
+The public UI should reveal enough attribution to establish trust without turning every card into an audit log.
+
+- Descriptions link to the official research source.
+- Leadership links to the official Yale person profile.
+- Access evidence may show a short redacted excerpt, source, and observation date.
+- Best Next Step includes a concise explanation of why it was selected.
+- Posted opportunities link to the official posting and deadline source.
+- Computed conclusions are labeled as Yale Research summaries derived from the displayed evidence.
+
+When credible sources conflict, the product should show uncertainty or route the record to review.
+It must not silently choose the most optimistic interpretation.
+
+## Scraper Refactor
+
+The scraper system remains evidence-first.
+The refactor changes subject selection and output contracts rather than allowing source adapters to write final conclusions.
+
+### Target pipeline
+
+```text
+Work planner
+  -> guarded fetch and cache
+  -> SourceDocument
+  -> stable EvidenceClaim rows
+  -> identity and claim validation
+  -> domain materializers
+  -> bounded discovery projection
+  -> Meilisearch sync
+  -> visibility gate
+  -> public REST DTOs
+```
+
+### Professor and identity sources
+
+Professor-profile ingestion should become official-link discovery, identity resolution, and link-health validation.
+It should not mirror full biographies, publication lists, citation metrics, or contact details.
+
+Roster, directory, entity-page, and official-profile sources may emit:
+
+- person name;
+- official Yale profile URL;
+- verified ORCID when present;
+- role or affiliation evidence;
+- source-backed relationship evidence.
+
+Ambiguous name matches must enter review.
+External identifiers alone must not create Yale people.
+
+### Research and access sources
+
+Research-home, department, program, and undergraduate-access scrapers remain central to the product.
+They may emit claims about:
+
+- durable research entities;
+- descriptions, topics, and methods;
+- organizational and entity relationships;
+- named leadership;
+- undergraduate participation;
+- official applications;
+- timing, eligibility, and constraints;
+- reviewed public action routes.
+
+Discovery-only sources must not manufacture undergraduate-access claims.
+Research activity, grants, and identifiers must not be treated as access evidence.
+
+### Observation compatibility
+
+The current `Observation` model uses runtime entity names and Mongoose field names.
+The target `EvidenceClaim` contract uses stable subjects and domain predicates.
+
+The migration may temporarily dual-emit `Observation` and `EvidenceClaim` rows.
+No scraper should switch to claim-only writes until the corresponding materializer and reconciliation report are available.
+Dual-write duration should be bounded by an explicit cutover phase.
+
+## Search and Read Projections
+
+Meilisearch remains the search engine.
+The `researchentities` index should be rebuilt from canonical research entities, role assignments, organization references, access summaries, and bounded discovery projections.
+
+The target search document may include:
+
+- entity name and type;
+- lead display names;
+- organization labels;
+- topics and methods;
+- concise source-backed description;
+- access state and evidence strength;
+- active-opportunity state;
+- planning facets;
+- browse rank and visibility state.
+
+The target index must not depend on a paper corpus.
+Any paper count, paper result, or publication-derived ranking behavior must be removed or replaced before paper collections are retired.
+
+MongoDB remains the source of truth.
+Meilisearch documents are rebuildable projections.
+
+## REST and GraphQL Boundary
+
+This refactor does not adopt GraphQL.
+The graph-shaped domain makes a future GraphQL read layer easier, but the data model and API protocol remain separate decisions.
+
+REST remains appropriate for the current bounded student experiences:
+
+- research search;
+- research detail;
+- opportunity detail;
+- saved research plans;
+- admin review workflows.
+
+Services should expose reusable domain loaders and projection functions so a future GraphQL layer could call the same logic.
+Public REST DTOs should remain purpose-built, bounded, contact-safe, and visibility-aware.
+
+GraphQL should be reconsidered only if clients need materially different combinations of the graph or operator tools require frequent ad hoc traversal.
+A future GraphQL layer would require field-level authorization, query-cost limits, batching, persisted-query or caching policy, and strict protection against arbitrary evidence traversal.
+Meilisearch would continue to power search even if GraphQL were introduced.
+
+## Current-to-Target Mapping
+
+| Current shape | Target | Migration intent |
+| --- | --- | --- |
+| Auth, student state, and faculty profile fields on `User` | `Account`, `StudentProfile`, `ResearchPlan`, optional `Person` | Split private account state from public research identity |
+| `FacultyMember` plus professor-shaped `User` | `Person` | Deterministically merge accepted identities and quarantine conflicts |
+| `ResearchGroupMember` with dual entity and person references | `RoleAssignment` | Rewrite references to one entity ID and one person ID |
+| `ResearchEntity` registered from `researchGroupSchema` | Clean `ResearchEntity` schema | Cut reads to canonical fields, then remove legacy fields |
+| `ResearchGroup` and `researchGroupId` residue | `ResearchEntity` and `researchEntityId` | Remove compatibility references after verified parity |
+| `Listing` | `EntryPathway` plus `PostedOpportunity` | Preserve real postings and remove legacy listing ownership fields |
+| `Fellowship` | `ResearchEntity`, `EntryPathway`, `PostedOpportunity`, or formalization summary | Classify by behavior rather than by legacy collection |
+| `acceptingUndergrads` and openness caches | `AccessSignal` plus computed access summary | Remove binary and duplicated access state |
+| Official person profile treated as contact | `Person.officialProfile` | Keep navigation separate from permission to contact |
+| `User.publications`, `Paper`, `PaperAuthor`, and scholarly sidecars | No target collection | Remove reads, stop ingestion, archive, then drop |
+| ORCID works ingestion | `Person.identifiers.orcid` | Retain identity and outbound link only |
+| Field-name-based `Observation` | Predicate-based `EvidenceClaim` | Dual-emit temporarily, reconcile, then cut over |
+| Mixed saved-plan maps on `User` | `ResearchPlan` | Migrate one plan per account and target |
+
+## Migration Strategy
+
+The refactor must use vertical cutovers rather than a flag-day rewrite.
+Each phase must remove a compatibility read before the corresponding legacy storage is dropped.
+
+### Phase 0: resolve integration state and measure production
+
+- Resolve the existing merge conflicts before implementation changes begin.
+- Inventory collection counts, schema versions, field distributions, and reference integrity.
+- Identify actual read paths, index use, and query cost.
+- Record data collisions and unresolved identity conflicts.
+- Produce recoverable export or Atlas restore instructions before destructive cleanup.
+
+Exit condition: reviewed inventory, ownership map, and rollback plan.
+
+### Phase 1: introduce versioned canonical schemas
+
+- Add `schemaVersion` to new canonical documents.
+- Add MongoDB validators initially in migration-safe mode.
+- Introduce domain loaders and bounded DTO projections.
+- Add target collections without removing current readers.
+
+Exit condition: new collections and readers can coexist safely with current runtime data.
+
+### Phase 2: split account and person identity
+
+- Create canonical people from accepted Yale-confirmed identity evidence.
+- Link accounts to people when a deterministic match exists.
+- Quarantine same-name, conflicting-email, and conflicting-identifier cases.
+- Introduce role assignments with canonical entity and person references.
+- Switch public leadership and search-name projections to canonical roles.
+
+Exit condition: student-facing research reads no longer require `FacultyMember` or professor-profile fields on `User`.
+
+### Phase 3: retire professor and publication mirrors
+
+- Switch professor navigation to verified official Yale profile URLs.
+- Expose ORCID only as an optional outbound identity link.
+- Remove professor and research-detail publication sections and compatibility DTO fields.
+- Disable paper, preprint, ORCID-works, and bibliographic hydration scrapers.
+- Remove paper-quality and authorship gates after replacement launch criteria are documented.
+- Archive the existing scholarly corpus before dropping collections.
+
+Exit condition: no runtime read, write, audit, search, or public payload depends on paper data.
+
+### Phase 4: clean research and access records
+
+- Declare the clean ResearchEntity schema directly.
+- Move canonical organization, topic, and method references into place.
+- Remove legacy access booleans and openness caches after search and DTO cutover.
+- Finish classification of listings and fellowships.
+- Migrate private saved planning into `ResearchPlan`.
+
+Exit condition: canonical entity, access, opportunity, and planning reads require no legacy adapters.
+
+### Phase 5: migrate evidence claims and projections
+
+- Introduce stable claim predicates and source-document identity.
+- Dual-emit observations and evidence claims for bounded source groups.
+- Reconcile materialized outputs between old and new pipelines.
+- Cut materializers to evidence claims.
+- Rebuild bounded entity discovery projections and Meilisearch.
+
+Exit condition: integrity, visibility, attribution, and search gates pass without field-name-based observation readers.
+
+### Phase 6: remove compatibility storage
+
+- Stop dual writes.
+- Verify no code or index references legacy fields and collections.
+- Run reference, orphan, uniqueness, visibility, and source-attribution audits.
+- Drop or archive legacy collections only after reviewed parity and rollback evidence.
+- Tighten MongoDB validation after all surviving documents conform.
+
+Exit condition: one canonical read and write path exists for each target concept.
+
+## Verification Gates
+
+The migration is not complete merely because documents were copied.
+Each vertical cutover should verify:
+
+- source and target record counts with explained differences;
+- no unresolved orphan references;
+- no dual person or entity identities in public DTOs;
+- no public contact information leakage;
+- source attribution for every material access claim;
+- deterministic handling of source conflicts;
+- official-profile link validity and graceful failure behavior;
+- search relevance and result parity for representative student queries;
+- correct visibility filtering;
+- bounded detail payload sizes;
+- private research-plan isolation;
+- no paper or publication dependency after the scholarly cutover;
+- rollback readiness before any collection drop.
+
+Focused tests and audit scripts should be added alongside each phase.
+Graphify output should be refreshed only through the repository's dedicated maintenance workflow after the implementation settles.
+
+## Non-Goals
+
+This refactor does not:
+
+- adopt GraphQL;
+- create a public people directory;
+- create an internal professor-profile product;
+- create a publication search product;
+- infer undergraduate access from research activity;
+- expose scraped contact information;
+- treat course credit or ordinary fellowship funding as an entry pathway;
+- require every Yale researcher to have a public `Person` record;
+- specify production deletion commands before inventory and rollback review.
+
+## Deferred Decisions
+
+Grant and external funding-award persistence is not redesigned by this document.
+Grant data must not be used as undergraduate-access evidence, and its long-term storage should be justified by a separate product and query requirement before the final cleanup phase.
+
+Exact evidence-snapshot retention windows remain environment and source-policy decisions.
+They must be set after production volume, sensitivity, audit value, and restoration requirements are measured.
+
+The model permits non-faculty people when they are necessary to explain research leadership or supervision.
+The detailed public-visibility policy for staff, postdoctoral researchers, graduate students, and undergraduates remains subject to source quality and privacy review.
+
+## Implementation Notes
+
+The current runtime contains compatibility behavior that contradicts parts of this target by design.
+Implementation work must update code, migrations, tests, launch gates, search settings, and durable docs together.
+
+Likely implementation areas include:
+
+- `server/src/models/`;
+- `server/src/services/researchGroupService.ts`;
+- `server/src/services/profileService.ts`;
+- `server/src/services/researchEntitySearchIndexService.ts`;
+- `server/src/scrapers/entityMaterializer.ts`;
+- `server/src/scrapers/accessMaterializer.ts`;
+- paper and person source scrapers under `server/src/scrapers/sources/`;
+- public research and profile DTOs;
+- `/research`, research detail, account planning, and admin review clients;
+- data migrations and integrity audits;
+- `docs/research-model.md`;
+- `docs/research-data-pipeline.md`;
+- `docs/product-context.md`;
+- `docs/decisions.md`;
+- scraper and architecture skills.
+
+After the existing merge is resolved, this document should be linked from the canonical research-model documentation.
+When the migration is complete, the stable decisions should be folded into [`research-model.md`](./research-model.md), and this document should either become the concise historical decision record or be removed to avoid maintaining duplicate truth.

--- a/docs/research-model.md
+++ b/docs/research-model.md
@@ -1,5 +1,8 @@
 # Research Model
 
+The current runtime model is documented here.
+The accepted target model, phased migration boundaries, and Phase 0 inventory runbook are documented in [`research-model-refactor.md`](./research-model-refactor.md) and [`research-model-refactor-phase0.md`](./research-model-refactor-phase0.md).
+
 ## Current Implementation Context
 
 The current codebase still has some legacy-named files and client components, but

--- a/docs/tasks/priority-roadmap.md
+++ b/docs/tasks/priority-roadmap.md
@@ -1,6 +1,6 @@
 # Priority Roadmap
 
-Last updated: 2026-07-21
+Last updated: 2026-07-25
 
 This is the single task source of truth for Yale Research.
 Keep it operational and compact.
@@ -48,6 +48,7 @@ Active themes:
 | P1       | Add URL-backed search state and evidence facets.                                 | Query and filters survive reload/share/back navigation, and facets use evidence/product-model concepts instead of legacy acceptance labels.                             |
 | P2       | Add a minimal E2E smoke in CI or scheduled Beta checks.                          | Browse -> search -> detail -> save is exercised outside manual-only scripts.                                                                                            |
 | P2       | Reduce frontend and API payload weight.                                          | Student routes are split out of the admin bundle path and browse cards use a smaller DTO.                                                                               |
+| P2       | Complete research-model refactor Phase 0.                                        | Beta and production-copy inventories, the phase ownership map, and rollback prerequisites are reviewed under the [Phase 0 runbook](../research-model-refactor-phase0.md). |
 | P2       | Move gate scorecards off fixed `/tmp` paths.                                     | Operator Board scorecards survive deploys/restarts through a durable store or explicitly documented external artifact path.                                             |
 | P2       | Continue surface-area deletion.                                                  | Unused indexes, old listing-era paths, unused deps, and obsolete docs are removed when touched.                                                                         |
 

--- a/server/package.json
+++ b/server/package.json
@@ -38,6 +38,7 @@
     "meili:seed": "yarn meili:rebuild-research-entities --clear --confirm-meili-rebuild && yarn meili:rebuild-pathways --clear --confirm-meili-rebuild",
     "research-entity:audit-rename": "tsx src/scripts/auditResearchEntityRename.ts",
     "research-entity:coverage-audit": "tsx src/scripts/researchEntityCoverageAudit.ts",
+    "model-refactor:inventory": "tsx src/scripts/researchModelInventory.ts",
     "accepted-inputs": "tsx src/scripts/acceptedInputs.ts",
     "beta:data-quality": "tsx src/scripts/betaDataQuality.ts",
     "beta:seed-environment": "tsx src/scripts/betaSeedEnvironment.ts",

--- a/server/package.json
+++ b/server/package.json
@@ -104,6 +104,7 @@
     "express": "^4.22.2",
     "express-rate-limit": "^8.5.2",
     "meilisearch": "^0.57.0",
+    "mongodb": "~6.20.0",
     "mongoose": "^8.9.5",
     "passport": "^0.7.0",
     "passport-cas": "git+https://github.com/coursetable/passport-cas#79612f1",

--- a/server/src/db/connections.ts
+++ b/server/src/db/connections.ts
@@ -76,13 +76,16 @@ export function triggerReconnect(): void {
   })();
 }
 
-export async function initializeConnections(): Promise<void> {
+export async function initializeConnections(
+  options: { infoLog?: (...values: unknown[]) => void } = {},
+): Promise<void> {
   const mode = getApiMode();
+  const infoLog = options.infoLog ?? ((...values: unknown[]) => console.log(...values));
 
   // Surface connection lifecycle so Render logs show exactly when the driver
   // loses or regains the server — makes the next incident much easier to trace.
   mongoose.connection.on('disconnected', () => console.error('MongoDB: disconnected'));
-  mongoose.connection.on('reconnected', () => console.log('MongoDB: reconnected'));
+  mongoose.connection.on('reconnected', () => infoLog('MongoDB: reconnected'));
   mongoose.connection.on('error', (err: Error) =>
     console.error('MongoDB: error', err?.message ?? err),
   );
@@ -100,10 +103,10 @@ export async function initializeConnections(): Promise<void> {
 
     await mongoose.connect(primaryUrl, mongoOptions);
     productionConnection = mongoose.connection;
-    console.log('Connected to primary database (default) 🚀');
+    infoLog('Connected to primary database (default) 🚀');
 
     migrationConnection = await mongoose.createConnection(migrationUrl, mongoOptions).asPromise();
-    console.log('Connected to migration database (listings) 🔄');
+    infoLog('Connected to migration database (listings) 🔄');
 
     MigrationListing = migrationConnection.model('Listing', listingSchema, 'listings');
   } else {
@@ -112,7 +115,7 @@ export async function initializeConnections(): Promise<void> {
       throw new Error('MONGODBURL is required');
     }
     await mongoose.connect(url, mongoOptions);
-    console.log(`Connected to database 🚀`);
+    infoLog('Connected to database 🚀');
   }
 }
 

--- a/server/src/db/connections.ts
+++ b/server/src/db/connections.ts
@@ -76,16 +76,13 @@ export function triggerReconnect(): void {
   })();
 }
 
-export async function initializeConnections(
-  options: { infoLog?: (...values: unknown[]) => void } = {},
-): Promise<void> {
+export async function initializeConnections(): Promise<void> {
   const mode = getApiMode();
-  const infoLog = options.infoLog ?? ((...values: unknown[]) => console.log(...values));
 
   // Surface connection lifecycle so Render logs show exactly when the driver
   // loses or regains the server — makes the next incident much easier to trace.
   mongoose.connection.on('disconnected', () => console.error('MongoDB: disconnected'));
-  mongoose.connection.on('reconnected', () => infoLog('MongoDB: reconnected'));
+  mongoose.connection.on('reconnected', () => console.log('MongoDB: reconnected'));
   mongoose.connection.on('error', (err: Error) =>
     console.error('MongoDB: error', err?.message ?? err),
   );
@@ -103,10 +100,10 @@ export async function initializeConnections(
 
     await mongoose.connect(primaryUrl, mongoOptions);
     productionConnection = mongoose.connection;
-    infoLog('Connected to primary database (default) 🚀');
+    console.log('Connected to primary database (default) 🚀');
 
     migrationConnection = await mongoose.createConnection(migrationUrl, mongoOptions).asPromise();
-    infoLog('Connected to migration database (listings) 🔄');
+    console.log('Connected to migration database (listings) 🔄');
 
     MigrationListing = migrationConnection.model('Listing', listingSchema, 'listings');
   } else {
@@ -115,7 +112,7 @@ export async function initializeConnections(
       throw new Error('MONGODBURL is required');
     }
     await mongoose.connect(url, mongoOptions);
-    infoLog('Connected to database 🚀');
+    console.log(`Connected to database 🚀`);
   }
 }
 

--- a/server/src/scripts/__tests__/researchModelInventory.test.ts
+++ b/server/src/scripts/__tests__/researchModelInventory.test.ts
@@ -1,0 +1,65 @@
+import type { Db } from 'mongodb';
+import { describe, expect, it } from 'vitest';
+import { checkReferenceEdge } from '../researchModelInventory';
+import { REFERENCE_EDGES } from '../researchModelInventoryCore';
+
+function asyncCursor(rows: Record<string, unknown>[]) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const row of rows) {
+        yield row;
+      }
+    },
+  };
+}
+
+describe('checkReferenceEdge', () => {
+  const edge = REFERENCE_EDGES.find((candidate) => candidate.name === 'member_to_entity');
+
+  if (!edge) {
+    throw new Error('member_to_entity edge is required');
+  }
+
+  it('skips an edge when its source collection is missing', async () => {
+    const db = {
+      collection() {
+        throw new Error('missing source must not be queried');
+      },
+    } as unknown as Db;
+
+    await expect(checkReferenceEdge(db, edge, new Set(), 20)).resolves.toMatchObject({
+      status: 'source-missing',
+      checked: 0,
+      orphaned: 0,
+      sampleOrphanIds: [],
+    });
+  });
+
+  it('counts every non-null reference as orphaned when the target is missing', async () => {
+    const db = {
+      collection(name: string) {
+        if (name !== edge.fromCollection) {
+          throw new Error(`unexpected collection: ${name}`);
+        }
+        return {
+          find() {
+            return asyncCursor([
+              { _id: 'member-1', researchEntityId: 'entity-1' },
+              { _id: 'member-2', researchEntityId: null },
+              { _id: 'member-3', researchEntityId: 'entity-3' },
+            ]);
+          },
+        };
+      },
+    } as unknown as Db;
+
+    await expect(
+      checkReferenceEdge(db, edge, new Set([edge.fromCollection]), 1),
+    ).resolves.toMatchObject({
+      status: 'target-missing',
+      checked: 2,
+      orphaned: 2,
+      sampleOrphanIds: ['member-1'],
+    });
+  });
+});

--- a/server/src/scripts/__tests__/researchModelInventory.test.ts
+++ b/server/src/scripts/__tests__/researchModelInventory.test.ts
@@ -154,8 +154,8 @@ describe('gatherInventoryFacts', () => {
           throw new Error(`unexpected collection: ${name}`);
         }
         return {
-          async countDocuments(query: Record<string, unknown>) {
-            return Object.keys(query).length === 0 ? 4 : 0;
+          async countDocuments() {
+            throw new Error('census must not use countDocuments');
           },
           aggregate(pipeline: unknown) {
             aggregatePipelines.push(pipeline);
@@ -203,11 +203,13 @@ describe('gatherInventoryFacts', () => {
       { bsonType: 'null', value: null, count: 1 },
       { bsonType: 'missing', count: 1 },
     ]);
+    expect(
+      facts.census.find((fact) => fact.collection === 'research_entities')?.documentCount,
+    ).toBe(4);
   });
 
-  it('reuses census totals and aggregates all field probes once per collection', async () => {
+  it('derives census totals and aggregates all field probes once per collection', async () => {
     const liveCollections = [...new Set(RETIREMENT_FIELD_PROBES.map((probe) => probe.collection))];
-    const totalCountCalls = new Map<string, number>();
     const fieldAggregationCalls = new Map<string, number>();
     let activeFieldScans = 0;
     let peakFieldScans = 0;
@@ -222,19 +224,17 @@ describe('gatherInventoryFacts', () => {
       },
       collection(name: string) {
         return {
-          async countDocuments(query: Record<string, unknown>) {
-            if (Object.keys(query).length === 0) {
-              totalCountCalls.set(name, (totalCountCalls.get(name) ?? 0) + 1);
-              return 12;
-            }
-            throw new Error('field probes must not use countDocuments');
+          async countDocuments() {
+            throw new Error('inventory must not use countDocuments for tracked collections');
           },
           aggregate(pipeline: Array<{ $group?: Record<string, unknown> }>) {
             const group = pipeline[0]?.$group;
             const isFieldAggregation = group?._id === null;
             return {
               async toArray() {
-                if (!isFieldAggregation) return [];
+                if (!isFieldAggregation) {
+                  return [{ _id: { bsonType: 'missing' }, count: 12 }];
+                }
                 fieldAggregationCalls.set(name, (fieldAggregationCalls.get(name) ?? 0) + 1);
                 activeFieldScans += 1;
                 peakFieldScans = Math.max(peakFieldScans, activeFieldScans);
@@ -266,7 +266,6 @@ describe('gatherInventoryFacts', () => {
     expect(peakFieldScans).toBeGreaterThan(1);
     expect(peakFieldScans).toBeLessThanOrEqual(4);
     for (const collection of liveCollections) {
-      expect(totalCountCalls.get(collection)).toBe(1);
       expect(fieldAggregationCalls.get(collection)).toBe(1);
     }
     expect(facts.fieldPresence.every((fact) => fact.present === 3 && fact.total === 12)).toBe(true);

--- a/server/src/scripts/__tests__/researchModelInventory.test.ts
+++ b/server/src/scripts/__tests__/researchModelInventory.test.ts
@@ -1,4 +1,4 @@
-import type { Db } from 'mongodb';
+import { ObjectId, type Db } from 'mongodb';
 import { describe, expect, it, vi } from 'vitest';
 import {
   checkReferenceEdge,
@@ -156,7 +156,7 @@ describe('checkReferenceEdge', () => {
           return {
             find(query: Record<string, unknown>) {
               targetQueries.push(query);
-              const referenceIds = (query.$expr as { $in: [unknown, string[]] }).$in[1];
+              const referenceIds = (query._id as { $in: unknown[] }).$in;
               return asyncCursor(referenceIds.map((_id) => ({ _id })));
             },
           };
@@ -174,6 +174,53 @@ describe('checkReferenceEdge', () => {
       sampleOrphanIds: [],
     });
     expect(targetQueries).toHaveLength(2);
+    expect(targetQueries[0]).toEqual({
+      _id: {
+        $in: expect.arrayContaining(['entity-0', 'entity-999']),
+      },
+    });
+    expect(targetQueries[0]).not.toHaveProperty('$expr');
+  });
+
+  it('queries string and ObjectId reference representations through the _id index', async () => {
+    const objectIdReference = '507f1f77bcf86cd799439011';
+    let targetQuery: Record<string, unknown> | undefined;
+    const db = {
+      collection(name: string) {
+        if (name === edge.fromCollection) {
+          return {
+            find() {
+              return asyncCursor([
+                { _id: 'member-string', researchEntityId: 'string-id' },
+                { _id: 'member-object', researchEntityId: objectIdReference },
+              ]);
+            },
+          };
+        }
+        if (name === edge.toCollection) {
+          return {
+            find(query: Record<string, unknown>) {
+              targetQuery = query;
+              return asyncCursor([{ _id: 'string-id' }, { _id: new ObjectId(objectIdReference) }]);
+            },
+          };
+        }
+        throw new Error(`unexpected collection: ${name}`);
+      },
+    } as unknown as Db;
+
+    await expect(
+      checkReferenceEdge(db, edge, new Set([edge.fromCollection, edge.toCollection]), 20),
+    ).resolves.toMatchObject({
+      checked: 2,
+      orphaned: 0,
+    });
+    expect(targetQuery).toEqual({
+      _id: {
+        $in: ['string-id', objectIdReference, new ObjectId(objectIdReference)],
+      },
+    });
+    expect(targetQuery).not.toHaveProperty('$expr');
   });
 });
 

--- a/server/src/scripts/__tests__/researchModelInventory.test.ts
+++ b/server/src/scripts/__tests__/researchModelInventory.test.ts
@@ -463,6 +463,41 @@ describe('gatherInventoryFacts', () => {
 });
 
 describe('runResearchModelInventory', () => {
+  it('rejects a mislabeled configured target before connecting', async () => {
+    const client = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      db: vi.fn(),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await expect(
+      runResearchModelInventory(
+        { environment: 'beta', sampleLimit: 1 },
+        'mongodb://localhost:27017/Production',
+        client,
+      ),
+    ).rejects.toThrow('Inventory environment beta does not match MongoDB database Production');
+    expect(client.connect).not.toHaveBeenCalled();
+  });
+
+  it('rejects a connected database that differs from the configured target', async () => {
+    const db = { databaseName: 'Production' } as Db;
+    const client = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      db: vi.fn(() => db),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await expect(
+      runResearchModelInventory(
+        { environment: 'beta', sampleLimit: 1 },
+        'mongodb://localhost:27017/Beta',
+        client,
+      ),
+    ).rejects.toThrow('Inventory environment beta does not match MongoDB database Production');
+    expect(client.close).toHaveBeenCalledOnce();
+  });
+
   it('uses the supplied native client and closes it after gathering', async () => {
     const db = {
       databaseName: 'inventory-test',

--- a/server/src/scripts/__tests__/researchModelInventory.test.ts
+++ b/server/src/scripts/__tests__/researchModelInventory.test.ts
@@ -1,7 +1,11 @@
 import type { Db } from 'mongodb';
-import { describe, expect, it } from 'vitest';
-import { checkReferenceEdge } from '../researchModelInventory';
-import { REFERENCE_EDGES } from '../researchModelInventoryCore';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  checkReferenceEdge,
+  gatherInventoryFacts,
+  runResearchModelInventory,
+} from '../researchModelInventory';
+import { REFERENCE_EDGES, RETIREMENT_FIELD_PROBES } from '../researchModelInventoryCore';
 
 function asyncCursor(rows: Record<string, unknown>[]) {
   return {
@@ -61,5 +65,122 @@ describe('checkReferenceEdge', () => {
       orphaned: 2,
       sampleOrphanIds: ['member-1'],
     });
+  });
+});
+
+describe('gatherInventoryFacts', () => {
+  it('reuses census totals and bounds concurrent field scans', async () => {
+    const liveCollections = [...new Set(RETIREMENT_FIELD_PROBES.map((probe) => probe.collection))];
+    const totalCountCalls = new Map<string, number>();
+    let activeFieldScans = 0;
+    let peakFieldScans = 0;
+
+    const db = {
+      listCollections() {
+        return {
+          async toArray() {
+            return liveCollections.map((name) => ({ name }));
+          },
+        };
+      },
+      collection(name: string) {
+        return {
+          async countDocuments(query: Record<string, unknown>) {
+            if (Object.keys(query).length === 0) {
+              totalCountCalls.set(name, (totalCountCalls.get(name) ?? 0) + 1);
+              return 12;
+            }
+            activeFieldScans += 1;
+            peakFieldScans = Math.max(peakFieldScans, activeFieldScans);
+            await new Promise((resolve) => setTimeout(resolve, 1));
+            activeFieldScans -= 1;
+            return 3;
+          },
+          aggregate() {
+            return {
+              async toArray() {
+                return [];
+              },
+            };
+          },
+          find() {
+            return asyncCursor([]);
+          },
+        };
+      },
+    } as unknown as Db;
+
+    const facts = await gatherInventoryFacts(db, {
+      environment: 'test',
+      sampleLimit: 1,
+    });
+
+    expect(facts.fieldPresence).toHaveLength(RETIREMENT_FIELD_PROBES.length);
+    expect(peakFieldScans).toBeGreaterThan(1);
+    expect(peakFieldScans).toBeLessThanOrEqual(4);
+    for (const collection of liveCollections) {
+      expect(totalCountCalls.get(collection)).toBe(1);
+    }
+  });
+});
+
+describe('runResearchModelInventory', () => {
+  it('uses the supplied native client and closes it after gathering', async () => {
+    const db = {
+      databaseName: 'inventory-test',
+      listCollections() {
+        return {
+          async toArray() {
+            return [];
+          },
+        };
+      },
+      collection() {
+        throw new Error('absent collections must not be queried');
+      },
+    } as unknown as Db;
+    const client = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      db: vi.fn(() => db),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const output = await runResearchModelInventory(
+      { environment: 'test', sampleLimit: 1 },
+      'mongodb://localhost:27017/inventory-test',
+      client,
+    );
+
+    expect(client.connect).toHaveBeenCalledOnce();
+    expect(client.db).toHaveBeenCalledOnce();
+    expect(client.close).toHaveBeenCalledOnce();
+    expect(output.db).toBe('inventory-test');
+  });
+
+  it('closes the native client when gathering fails', async () => {
+    const db = {
+      databaseName: 'inventory-test',
+      listCollections() {
+        return {
+          async toArray() {
+            throw new Error('inventory failed');
+          },
+        };
+      },
+    } as unknown as Db;
+    const client = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      db: vi.fn(() => db),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await expect(
+      runResearchModelInventory(
+        { environment: 'test', sampleLimit: 1 },
+        'mongodb://localhost:27017/inventory-test',
+        client,
+      ),
+    ).rejects.toThrow('inventory failed');
+    expect(client.close).toHaveBeenCalledOnce();
   });
 });

--- a/server/src/scripts/__tests__/researchModelInventory.test.ts
+++ b/server/src/scripts/__tests__/researchModelInventory.test.ts
@@ -140,7 +140,7 @@ describe('checkReferenceEdge', () => {
 
 describe('gatherInventoryFacts', () => {
   it('preserves BSON types and distinguishes missing schema versions from null', async () => {
-    let aggregatePipeline: unknown;
+    const aggregatePipelines: unknown[] = [];
     const db = {
       listCollections() {
         return {
@@ -158,9 +158,13 @@ describe('gatherInventoryFacts', () => {
             return Object.keys(query).length === 0 ? 4 : 0;
           },
           aggregate(pipeline: unknown) {
-            aggregatePipeline = pipeline;
+            aggregatePipelines.push(pipeline);
+            const group = (pipeline as Array<{ $group?: { _id: unknown } }>)[0]?.$group;
             return {
               async toArray() {
+                if (group?._id === null) {
+                  return [{ _id: null }];
+                }
                 return [
                   { _id: { bsonType: 'int', value: 1 }, count: 1 },
                   { _id: { bsonType: 'string', value: '1' }, count: 1 },
@@ -179,7 +183,7 @@ describe('gatherInventoryFacts', () => {
       sampleLimit: 1,
     });
 
-    expect(aggregatePipeline).toEqual(
+    expect(aggregatePipelines).toContainEqual(
       expect.arrayContaining([
         expect.objectContaining({
           $group: expect.objectContaining({
@@ -201,9 +205,10 @@ describe('gatherInventoryFacts', () => {
     ]);
   });
 
-  it('reuses census totals and bounds concurrent field scans', async () => {
+  it('reuses census totals and aggregates all field probes once per collection', async () => {
     const liveCollections = [...new Set(RETIREMENT_FIELD_PROBES.map((probe) => probe.collection))];
     const totalCountCalls = new Map<string, number>();
+    const fieldAggregationCalls = new Map<string, number>();
     let activeFieldScans = 0;
     let peakFieldScans = 0;
 
@@ -222,16 +227,26 @@ describe('gatherInventoryFacts', () => {
               totalCountCalls.set(name, (totalCountCalls.get(name) ?? 0) + 1);
               return 12;
             }
-            activeFieldScans += 1;
-            peakFieldScans = Math.max(peakFieldScans, activeFieldScans);
-            await new Promise((resolve) => setTimeout(resolve, 1));
-            activeFieldScans -= 1;
-            return 3;
+            throw new Error('field probes must not use countDocuments');
           },
-          aggregate() {
+          aggregate(pipeline: Array<{ $group?: Record<string, unknown> }>) {
+            const group = pipeline[0]?.$group;
+            const isFieldAggregation = group?._id === null;
             return {
               async toArray() {
-                return [];
+                if (!isFieldAggregation) return [];
+                fieldAggregationCalls.set(name, (fieldAggregationCalls.get(name) ?? 0) + 1);
+                activeFieldScans += 1;
+                peakFieldScans = Math.max(peakFieldScans, activeFieldScans);
+                await new Promise((resolve) => setTimeout(resolve, 1));
+                activeFieldScans -= 1;
+                return [
+                  Object.fromEntries(
+                    Object.keys(group)
+                      .filter((key) => key !== '_id')
+                      .map((key) => [key, 3]),
+                  ),
+                ];
               },
             };
           },
@@ -252,15 +267,19 @@ describe('gatherInventoryFacts', () => {
     expect(peakFieldScans).toBeLessThanOrEqual(4);
     for (const collection of liveCollections) {
       expect(totalCountCalls.get(collection)).toBe(1);
+      expect(fieldAggregationCalls.get(collection)).toBe(1);
     }
+    expect(facts.fieldPresence.every((fact) => fact.present === 3 && fact.total === 12)).toBe(true);
   });
 
-  it('loads each target set and scans each source collection once', async () => {
+  it('scans sources before streaming each referenced target collection once', async () => {
     const liveCollections = [
       ...new Set(REFERENCE_EDGES.flatMap((edge) => [edge.fromCollection, edge.toCollection])),
     ];
     const targetScans = new Map<string, number>();
     const sourceScans = new Map<string, number>();
+    let sourceScansComplete = false;
+    const expectedSourceScans = new Set(REFERENCE_EDGES.map((edge) => edge.fromCollection)).size;
 
     const db = {
       listCollections() {
@@ -283,9 +302,21 @@ describe('gatherInventoryFacts', () => {
             };
           },
           find(_query: Record<string, unknown>, options: { projection: Record<string, 1> }) {
-            const calls = Object.keys(options.projection).length === 1 ? targetScans : sourceScans;
-            calls.set(name, (calls.get(name) ?? 0) + 1);
-            return asyncCursor([]);
+            if (Object.keys(options.projection).length === 1) {
+              expect(sourceScansComplete).toBe(true);
+              targetScans.set(name, (targetScans.get(name) ?? 0) + 1);
+              return asyncCursor([{ _id: name }, { _id: `${name}-unreferenced` }]);
+            }
+
+            sourceScans.set(name, (sourceScans.get(name) ?? 0) + 1);
+            sourceScansComplete = sourceScans.size === expectedSourceScans;
+            const sourceDocument: Record<string, unknown> = { _id: `${name}-source` };
+            for (const edge of REFERENCE_EDGES.filter(
+              (candidate) => candidate.fromCollection === name,
+            )) {
+              sourceDocument[edge.localField] = edge.toCollection;
+            }
+            return asyncCursor([sourceDocument]);
           },
         };
       },
@@ -302,6 +333,56 @@ describe('gatherInventoryFacts', () => {
     for (const collection of new Set(REFERENCE_EDGES.map((edge) => edge.fromCollection))) {
       expect(sourceScans.get(collection)).toBe(1);
     }
+  });
+
+  it('preserves document-level orphan counts while matching distinct string references', async () => {
+    const memberEdge = REFERENCE_EDGES.find(
+      (candidate) => candidate.name === 'member_to_entity',
+    );
+    if (!memberEdge) {
+      throw new Error('member reference edge fixture is required');
+    }
+    const targetId = {
+      toString() {
+        return 'entity-found';
+      },
+    };
+    const db = {
+      collection(name: string) {
+        if (name === memberEdge.fromCollection) {
+          return {
+            find() {
+              return asyncCursor([
+                { _id: 'member-1', researchEntityId: 'entity-found' },
+                { _id: 'member-2', researchEntityId: 'entity-missing' },
+                { _id: 'member-3', researchEntityId: 'entity-missing' },
+              ]);
+            },
+          };
+        }
+        if (name === memberEdge.toCollection) {
+          return {
+            find() {
+              return asyncCursor([{ _id: targetId }, { _id: 'unreferenced-target' }]);
+            },
+          };
+        }
+        throw new Error(`unexpected collection: ${name}`);
+      },
+    } as unknown as Db;
+
+    await expect(
+      checkReferenceEdge(
+        db,
+        memberEdge,
+        new Set([memberEdge.fromCollection, memberEdge.toCollection]),
+        2,
+      ),
+    ).resolves.toMatchObject({
+      checked: 3,
+      orphaned: 2,
+      sampleOrphanIds: ['member-2', 'member-3'],
+    });
   });
 
   it('checks all tracked fields from one source scan independently', async () => {

--- a/server/src/scripts/__tests__/researchModelInventory.test.ts
+++ b/server/src/scripts/__tests__/researchModelInventory.test.ts
@@ -136,6 +136,52 @@ describe('checkReferenceEdge', () => {
     });
     expect(sourceFilter).toEqual({});
   });
+
+  it('resolves high-cardinality references in bounded batches', async () => {
+    const sourceDocuments = Array.from({ length: 1_001 }, (_, index) => ({
+      _id: `member-${index}`,
+      researchEntityId: `entity-${index}`,
+    }));
+    const targetQueries: Record<string, unknown>[] = [];
+    const db = {
+      collection(name: string) {
+        if (name === edge.fromCollection) {
+          return {
+            find() {
+              return asyncCursor(sourceDocuments);
+            },
+          };
+        }
+        if (name === edge.toCollection) {
+          return {
+            find(query: Record<string, unknown>) {
+              targetQueries.push(query);
+              const referenceIds = (
+                query.$expr as { $in: [unknown, string[]] }
+              ).$in[1];
+              return asyncCursor(referenceIds.map((_id) => ({ _id })));
+            },
+          };
+        }
+        throw new Error(`unexpected collection: ${name}`);
+      },
+    } as unknown as Db;
+
+    await expect(
+      checkReferenceEdge(
+        db,
+        edge,
+        new Set([edge.fromCollection, edge.toCollection]),
+        20,
+      ),
+    ).resolves.toMatchObject({
+      status: 'checked',
+      checked: 1_001,
+      orphaned: 0,
+      sampleOrphanIds: [],
+    });
+    expect(targetQueries).toHaveLength(2);
+  });
 });
 
 describe('gatherInventoryFacts', () => {

--- a/server/src/scripts/__tests__/researchModelInventory.test.ts
+++ b/server/src/scripts/__tests__/researchModelInventory.test.ts
@@ -70,6 +70,30 @@ describe('checkReferenceEdge', () => {
     });
   });
 
+  it('keeps a missing target explicit when an optional edge has no references', async () => {
+    const db = {
+      collection(name: string) {
+        if (name !== edge.fromCollection) {
+          throw new Error(`unexpected collection: ${name}`);
+        }
+        return {
+          find() {
+            return asyncCursor([{ _id: 'member-1', researchEntityId: null }]);
+          },
+        };
+      },
+    } as unknown as Db;
+
+    await expect(
+      checkReferenceEdge(db, edge, new Set([edge.fromCollection]), 20),
+    ).resolves.toMatchObject({
+      status: 'target-missing',
+      checked: 0,
+      orphaned: 0,
+      sampleOrphanIds: [],
+    });
+  });
+
   it('reports missing required local references as integrity failures', async () => {
     let sourceFilter: Record<string, unknown> | undefined;
     const db = {
@@ -115,6 +139,68 @@ describe('checkReferenceEdge', () => {
 });
 
 describe('gatherInventoryFacts', () => {
+  it('preserves BSON types and distinguishes missing schema versions from null', async () => {
+    let aggregatePipeline: unknown;
+    const db = {
+      listCollections() {
+        return {
+          async toArray() {
+            return [{ name: 'research_entities' }];
+          },
+        };
+      },
+      collection(name: string) {
+        if (name !== 'research_entities') {
+          throw new Error(`unexpected collection: ${name}`);
+        }
+        return {
+          async countDocuments(query: Record<string, unknown>) {
+            return Object.keys(query).length === 0 ? 4 : 0;
+          },
+          aggregate(pipeline: unknown) {
+            aggregatePipeline = pipeline;
+            return {
+              async toArray() {
+                return [
+                  { _id: { bsonType: 'int', value: 1 }, count: 1 },
+                  { _id: { bsonType: 'string', value: '1' }, count: 1 },
+                  { _id: { bsonType: 'null', value: null }, count: 1 },
+                  { _id: { bsonType: 'missing' }, count: 1 },
+                ];
+              },
+            };
+          },
+        };
+      },
+    } as unknown as Db;
+
+    const facts = await gatherInventoryFacts(db, {
+      environment: 'test',
+      sampleLimit: 1,
+    });
+
+    expect(aggregatePipeline).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          $group: expect.objectContaining({
+            _id: {
+              bsonType: { $type: '$schemaVersion' },
+              value: '$schemaVersion',
+            },
+          }),
+        }),
+      ]),
+    );
+    expect(
+      facts.census.find((fact) => fact.collection === 'research_entities')?.schemaVersions,
+    ).toEqual([
+      { bsonType: 'int', value: 1, count: 1 },
+      { bsonType: 'string', value: '1', count: 1 },
+      { bsonType: 'null', value: null, count: 1 },
+      { bsonType: 'missing', count: 1 },
+    ]);
+  });
+
   it('reuses census totals and bounds concurrent field scans', async () => {
     const liveCollections = [...new Set(RETIREMENT_FIELD_PROBES.map((probe) => probe.collection))];
     const totalCountCalls = new Map<string, number>();
@@ -167,6 +253,134 @@ describe('gatherInventoryFacts', () => {
     for (const collection of liveCollections) {
       expect(totalCountCalls.get(collection)).toBe(1);
     }
+  });
+
+  it('loads each target set and scans each source collection once', async () => {
+    const liveCollections = [
+      ...new Set(REFERENCE_EDGES.flatMap((edge) => [edge.fromCollection, edge.toCollection])),
+    ];
+    const targetScans = new Map<string, number>();
+    const sourceScans = new Map<string, number>();
+
+    const db = {
+      listCollections() {
+        return {
+          async toArray() {
+            return liveCollections.map((name) => ({ name }));
+          },
+        };
+      },
+      collection(name: string) {
+        return {
+          async countDocuments(query: Record<string, unknown>) {
+            return Object.keys(query).length === 0 ? 1 : 0;
+          },
+          aggregate() {
+            return {
+              async toArray() {
+                return [];
+              },
+            };
+          },
+          find(_query: Record<string, unknown>, options: { projection: Record<string, 1> }) {
+            const calls = Object.keys(options.projection).length === 1 ? targetScans : sourceScans;
+            calls.set(name, (calls.get(name) ?? 0) + 1);
+            return asyncCursor([]);
+          },
+        };
+      },
+    } as unknown as Db;
+
+    await gatherInventoryFacts(db, {
+      environment: 'test',
+      sampleLimit: 1,
+    });
+
+    for (const collection of new Set(REFERENCE_EDGES.map((edge) => edge.toCollection))) {
+      expect(targetScans.get(collection)).toBe(1);
+    }
+    for (const collection of new Set(REFERENCE_EDGES.map((edge) => edge.fromCollection))) {
+      expect(sourceScans.get(collection)).toBe(1);
+    }
+  });
+
+  it('checks all tracked fields from one source scan independently', async () => {
+    const liveCollections = [
+      'access_signals',
+      'entry_pathways',
+      'observations',
+      'research_entities',
+    ];
+    const targetDocuments: Record<string, Record<string, unknown>[]> = {
+      entry_pathways: [{ _id: 'pathway-1' }],
+      observations: [{ _id: 'observation-1' }],
+      research_entities: [{ _id: 'entity-1' }],
+    };
+
+    const db = {
+      listCollections() {
+        return {
+          async toArray() {
+            return liveCollections.map((name) => ({ name }));
+          },
+        };
+      },
+      collection(name: string) {
+        return {
+          async countDocuments(query: Record<string, unknown>) {
+            return Object.keys(query).length === 0 ? 1 : 0;
+          },
+          aggregate() {
+            return {
+              async toArray() {
+                return [];
+              },
+            };
+          },
+          find(_query: Record<string, unknown>, options: { projection: Record<string, 1> }) {
+            if (Object.keys(options.projection).length === 1) {
+              return asyncCursor(targetDocuments[name] ?? []);
+            }
+            if (name === 'access_signals') {
+              return asyncCursor([
+                {
+                  _id: 'signal-1',
+                  researchEntityId: 'entity-1',
+                  entryPathwayId: 'pathway-1',
+                  sourceEvidenceId: 'observation-1',
+                  observationId: 'observation-missing',
+                },
+              ]);
+            }
+            return asyncCursor([]);
+          },
+        };
+      },
+    } as unknown as Db;
+
+    const facts = await gatherInventoryFacts(db, {
+      environment: 'test',
+      sampleLimit: 1,
+    });
+    const byName = new Map(facts.referenceIntegrity.map((fact) => [fact.name, fact]));
+
+    expect(byName.get('access_signal_to_entity')).toMatchObject({
+      checked: 1,
+      orphaned: 0,
+    });
+    expect(byName.get('access_signal_to_pathway')).toMatchObject({
+      checked: 1,
+      orphaned: 0,
+    });
+    expect(byName.get('access_signal_to_source_evidence')).toMatchObject({
+      checked: 1,
+      orphaned: 0,
+    });
+    expect(byName.get('access_signal_to_observation')).toMatchObject({
+      checked: 1,
+      orphaned: 1,
+      sampleOrphanIds: ['signal-1'],
+    });
   });
 });
 

--- a/server/src/scripts/__tests__/researchModelInventory.test.ts
+++ b/server/src/scripts/__tests__/researchModelInventory.test.ts
@@ -335,9 +335,7 @@ describe('gatherInventoryFacts', () => {
   });
 
   it('preserves document-level orphan counts while matching distinct string references', async () => {
-    const memberEdge = REFERENCE_EDGES.find(
-      (candidate) => candidate.name === 'member_to_entity',
-    );
+    const memberEdge = REFERENCE_EDGES.find((candidate) => candidate.name === 'member_to_entity');
     if (!memberEdge) {
       throw new Error('member reference edge fixture is required');
     }

--- a/server/src/scripts/__tests__/researchModelInventory.test.ts
+++ b/server/src/scripts/__tests__/researchModelInventory.test.ts
@@ -156,9 +156,7 @@ describe('checkReferenceEdge', () => {
           return {
             find(query: Record<string, unknown>) {
               targetQueries.push(query);
-              const referenceIds = (
-                query.$expr as { $in: [unknown, string[]] }
-              ).$in[1];
+              const referenceIds = (query.$expr as { $in: [unknown, string[]] }).$in[1];
               return asyncCursor(referenceIds.map((_id) => ({ _id })));
             },
           };
@@ -168,12 +166,7 @@ describe('checkReferenceEdge', () => {
     } as unknown as Db;
 
     await expect(
-      checkReferenceEdge(
-        db,
-        edge,
-        new Set([edge.fromCollection, edge.toCollection]),
-        20,
-      ),
+      checkReferenceEdge(db, edge, new Set([edge.fromCollection, edge.toCollection]), 20),
     ).resolves.toMatchObject({
       status: 'checked',
       checked: 1_001,
@@ -317,15 +310,12 @@ describe('gatherInventoryFacts', () => {
     expect(facts.fieldPresence.every((fact) => fact.present === 3 && fact.total === 12)).toBe(true);
   });
 
-  it('scans sources before streaming each referenced target collection once', async () => {
+  it('scans each source once and resolves each populated edge batch', async () => {
     const liveCollections = [
       ...new Set(REFERENCE_EDGES.flatMap((edge) => [edge.fromCollection, edge.toCollection])),
     ];
     const targetScans = new Map<string, number>();
     const sourceScans = new Map<string, number>();
-    let sourceScansComplete = false;
-    const expectedSourceScans = new Set(REFERENCE_EDGES.map((edge) => edge.fromCollection)).size;
-
     const db = {
       listCollections() {
         return {
@@ -348,13 +338,11 @@ describe('gatherInventoryFacts', () => {
           },
           find(_query: Record<string, unknown>, options: { projection: Record<string, 1> }) {
             if (Object.keys(options.projection).length === 1) {
-              expect(sourceScansComplete).toBe(true);
               targetScans.set(name, (targetScans.get(name) ?? 0) + 1);
               return asyncCursor([{ _id: name }, { _id: `${name}-unreferenced` }]);
             }
 
             sourceScans.set(name, (sourceScans.get(name) ?? 0) + 1);
-            sourceScansComplete = sourceScans.size === expectedSourceScans;
             const sourceDocument: Record<string, unknown> = { _id: `${name}-source` };
             for (const edge of REFERENCE_EDGES.filter(
               (candidate) => candidate.fromCollection === name,
@@ -373,7 +361,9 @@ describe('gatherInventoryFacts', () => {
     });
 
     for (const collection of new Set(REFERENCE_EDGES.map((edge) => edge.toCollection))) {
-      expect(targetScans.get(collection)).toBe(1);
+      expect(targetScans.get(collection)).toBe(
+        REFERENCE_EDGES.filter((edge) => edge.toCollection === collection).length,
+      );
     }
     for (const collection of new Set(REFERENCE_EDGES.map((edge) => edge.fromCollection))) {
       expect(sourceScans.get(collection)).toBe(1);

--- a/server/src/scripts/__tests__/researchModelInventory.test.ts
+++ b/server/src/scripts/__tests__/researchModelInventory.test.ts
@@ -19,9 +19,12 @@ function asyncCursor(rows: Record<string, unknown>[]) {
 
 describe('checkReferenceEdge', () => {
   const edge = REFERENCE_EDGES.find((candidate) => candidate.name === 'member_to_entity');
+  const requiredEdge = REFERENCE_EDGES.find(
+    (candidate) => candidate.name === 'entry_pathway_to_entity',
+  );
 
-  if (!edge) {
-    throw new Error('member_to_entity edge is required');
+  if (!edge || !requiredEdge) {
+    throw new Error('reference edge fixtures are required');
   }
 
   it('skips an edge when its source collection is missing', async () => {
@@ -65,6 +68,49 @@ describe('checkReferenceEdge', () => {
       orphaned: 2,
       sampleOrphanIds: ['member-1'],
     });
+  });
+
+  it('reports missing required local references as integrity failures', async () => {
+    let sourceFilter: Record<string, unknown> | undefined;
+    const db = {
+      collection(name: string) {
+        if (name === requiredEdge.toCollection) {
+          return {
+            find() {
+              return asyncCursor([{ _id: 'entity-1' }]);
+            },
+          };
+        }
+        if (name === requiredEdge.fromCollection) {
+          return {
+            find(query: Record<string, unknown>) {
+              sourceFilter = query;
+              return asyncCursor([
+                { _id: 'pathway-1' },
+                { _id: 'pathway-2', researchEntityId: null },
+                { _id: 'pathway-3', researchEntityId: 'entity-1' },
+              ]);
+            },
+          };
+        }
+        throw new Error(`unexpected collection: ${name}`);
+      },
+    } as unknown as Db;
+
+    await expect(
+      checkReferenceEdge(
+        db,
+        requiredEdge,
+        new Set([requiredEdge.fromCollection, requiredEdge.toCollection]),
+        20,
+      ),
+    ).resolves.toMatchObject({
+      status: 'checked',
+      checked: 3,
+      orphaned: 2,
+      sampleOrphanIds: ['pathway-1', 'pathway-2'],
+    });
+    expect(sourceFilter).toEqual({});
   });
 });
 

--- a/server/src/scripts/__tests__/researchModelInventoryCore.test.ts
+++ b/server/src/scripts/__tests__/researchModelInventoryCore.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest';
+import {
+  INVENTORY_COLLECTIONS,
+  REFERENCE_EDGES,
+  RETIREMENT_FIELD_PROBES,
+  buildResearchModelInventoryOutput,
+  buildResearchModelInventoryReport,
+  findUnclassifiedCollections,
+  parseResearchModelInventoryArgs,
+  type InventoryFacts,
+} from '../researchModelInventoryCore';
+
+function emptyFacts(): InventoryFacts {
+  return {
+    liveCollections: [],
+    census: [],
+    fieldPresence: [],
+    referenceIntegrity: [],
+  };
+}
+
+describe('INVENTORY_COLLECTIONS', () => {
+  it('has unique physical collection names', () => {
+    const names = INVENTORY_COLLECTIONS.map((spec) => spec.collection);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('marks every scholarly collection for phase 3 retirement', () => {
+    const scholarly = INVENTORY_COLLECTIONS.filter((spec) => spec.group === 'scholarly-retire');
+    expect(scholarly.length).toBeGreaterThan(0);
+    for (const spec of scholarly) {
+      expect(spec.phase).toBe(3);
+    }
+  });
+
+  it('flags the hard-pivot collections as expected-gone residue', () => {
+    const residue = INVENTORY_COLLECTIONS.filter((spec) => spec.expectPresent === false);
+    expect(residue.map((spec) => spec.collection)).toContain('research_groups');
+    expect(residue.map((spec) => spec.collection)).toContain('applications');
+  });
+});
+
+describe('findUnclassifiedCollections', () => {
+  it('returns live collections not in the spec, excluding system collections', () => {
+    const live = ['research_entities', 'system.indexes', 'mystery_collection', '__prewarm'];
+    expect(findUnclassifiedCollections(live)).toEqual(['mystery_collection']);
+  });
+
+  it('returns empty when all live collections are classified', () => {
+    const live = INVENTORY_COLLECTIONS.map((spec) => spec.collection);
+    expect(findUnclassifiedCollections(live)).toEqual([]);
+  });
+});
+
+describe('buildResearchModelInventoryReport', () => {
+  it('marks a spec collection absent when it is not live', () => {
+    const report = buildResearchModelInventoryReport(emptyFacts());
+    const entities = report.collections.find((row) => row.collection === 'research_entities');
+    expect(entities?.present).toBe(false);
+    expect(entities?.documentCount).toBe(0);
+    expect(report.summary.collectionsPresent).toBe(0);
+    expect(report.summary.totalDocuments).toBe(0);
+  });
+
+  it('reports legacy residue only when an expected-gone collection holds documents', () => {
+    const withResidue = buildResearchModelInventoryReport({
+      ...emptyFacts(),
+      liveCollections: ['research_groups', 'applications'],
+      census: [
+        { collection: 'research_groups', present: true, documentCount: 12, schemaVersions: [] },
+        { collection: 'applications', present: true, documentCount: 0, schemaVersions: [] },
+      ],
+    });
+    // research_groups has documents -> residue; applications is empty -> not residue.
+    expect(withResidue.summary.legacyResidueCollections).toEqual(['research_groups']);
+    const appsRow = withResidue.collections.find((row) => row.collection === 'applications');
+    expect(appsRow?.residue).toBe(false);
+  });
+
+  it('computes retirement-field prevalence and counts fields still present', () => {
+    const report = buildResearchModelInventoryReport({
+      ...emptyFacts(),
+      liveCollections: ['research_entities'],
+      fieldPresence: [
+        { collection: 'research_entities', field: 'acceptingUndergrads', present: 40, total: 200 },
+        { collection: 'research_entities', field: 'kind', present: 0, total: 200 },
+      ],
+    });
+    const accepting = report.retirementFields.find((row) => row.field === 'acceptingUndergrads');
+    expect(accepting?.prevalence).toBe(0.2);
+    // Only fields with present > 0 count toward "still present".
+    expect(report.summary.retirementFieldsStillPresent).toBe(1);
+  });
+
+  it('flags reference edges with orphans and keeps clean edges clean', () => {
+    const report = buildResearchModelInventoryReport({
+      ...emptyFacts(),
+      liveCollections: ['research_entity_members', 'research_entities', 'users'],
+      referenceIntegrity: [
+        {
+          name: 'member_to_entity',
+          fromCollection: 'research_entity_members',
+          toCollection: 'research_entities',
+          checked: 100,
+          orphaned: 5,
+          sampleOrphanIds: ['a', 'b'],
+        },
+        {
+          name: 'member_to_user',
+          fromCollection: 'research_entity_members',
+          toCollection: 'users',
+          checked: 100,
+          orphaned: 0,
+          sampleOrphanIds: [],
+        },
+      ],
+    });
+    const memberToEntity = report.referenceIntegrity.find((row) => row.name === 'member_to_entity');
+    expect(memberToEntity?.clean).toBe(false);
+    expect(memberToEntity?.orphanRate).toBe(0.05);
+    const memberToUser = report.referenceIntegrity.find((row) => row.name === 'member_to_user');
+    expect(memberToUser?.clean).toBe(true);
+    expect(report.summary.referenceEdgesWithOrphans).toBe(1);
+    expect(report.summary.totalOrphans).toBe(5);
+  });
+
+  it('covers every declared reference edge in the report even with no facts', () => {
+    const report = buildResearchModelInventoryReport(emptyFacts());
+    expect(report.referenceIntegrity).toHaveLength(REFERENCE_EDGES.length);
+    expect(report.retirementFields).toHaveLength(RETIREMENT_FIELD_PROBES.length);
+    expect(report.summary.referenceEdgesChecked).toBe(REFERENCE_EDGES.length);
+  });
+
+  it('surfaces unclassified live collections in the summary', () => {
+    const report = buildResearchModelInventoryReport({
+      ...emptyFacts(),
+      liveCollections: ['research_entities', 'surprise_collection'],
+    });
+    expect(report.summary.unclassifiedCollections).toEqual(['surprise_collection']);
+  });
+});
+
+describe('parseResearchModelInventoryArgs', () => {
+  it('defaults the sample limit and leaves output undefined', () => {
+    const args = parseResearchModelInventoryArgs([]);
+    expect(args.sampleLimit).toBe(20);
+    expect(args.output).toBeUndefined();
+  });
+
+  it('parses sample limit and output path', () => {
+    const args = parseResearchModelInventoryArgs(['--sample-limit', '5', '--output', '/tmp/x.json']);
+    expect(args.sampleLimit).toBe(5);
+    expect(args.output).toBe('/tmp/x.json');
+  });
+
+  it('rejects a negative sample limit', () => {
+    expect(() => parseResearchModelInventoryArgs(['--sample-limit', '-1'])).toThrow();
+  });
+
+  it('rejects unknown arguments', () => {
+    expect(() => parseResearchModelInventoryArgs(['--nope'])).toThrow('Unknown argument: --nope');
+  });
+});
+
+describe('buildResearchModelInventoryOutput', () => {
+  it('wraps the report with metadata and a stable generatedAt', () => {
+    const report = buildResearchModelInventoryReport(emptyFacts());
+    const output = buildResearchModelInventoryOutput(report, {
+      environment: 'beta',
+      db: 'ylabs-beta',
+      generatedAt: '2026-07-24T00:00:00.000Z',
+      options: { sampleLimit: 20 },
+    });
+    expect(output.generatedAt).toBe('2026-07-24T00:00:00.000Z');
+    expect(output.environment).toBe('beta');
+    expect(output.db).toBe('ylabs-beta');
+    expect(output.options.sampleLimit).toBe(20);
+    expect(output.summary.collectionsClassified).toBe(INVENTORY_COLLECTIONS.length);
+  });
+
+  it('omits environment and db when not provided', () => {
+    const report = buildResearchModelInventoryReport(emptyFacts());
+    const output = buildResearchModelInventoryOutput(report, { options: { sampleLimit: 20 } });
+    expect('environment' in output).toBe(false);
+    expect('db' in output).toBe(false);
+    expect(typeof output.generatedAt).toBe('string');
+  });
+});

--- a/server/src/scripts/__tests__/researchModelInventoryCore.test.ts
+++ b/server/src/scripts/__tests__/researchModelInventoryCore.test.ts
@@ -55,6 +55,10 @@ describe('inventory coverage', () => {
     expect(REFERENCE_EDGES.map((edge) => `${edge.fromCollection}.${edge.localField}`)).toEqual(
       expect.arrayContaining([
         'research_entity_members.facultyMemberId',
+        'users.facultyMemberId',
+        'users.studentProfileId',
+        'faculty_members.userId',
+        'student_profiles.userId',
         'access_signals.entryPathwayId',
         'contact_routes.entryPathwayId',
         'posted_opportunities.researchEntityId',
@@ -65,6 +69,7 @@ describe('inventory coverage', () => {
   it('includes current private-record reference edges', () => {
     expect(REFERENCE_EDGES.map((edge) => `${edge.fromCollection}.${edge.localField}`)).toEqual(
       expect.arrayContaining([
+        'student_applications.listingObjectId',
         'student_applications.postedOpportunityId',
         'student_applications.researchEntityId',
         'student_applications.studentUserId',
@@ -78,6 +83,18 @@ describe('inventory coverage', () => {
         'student_engagement_events.researchEntityId',
       ]),
     );
+  });
+
+  it('records current schema requiredness for every reference edge', () => {
+    expect(REFERENCE_EDGES.every((edge) => typeof edge.required === 'boolean')).toBe(true);
+    expect(
+      REFERENCE_EDGES.find((edge) => edge.name === 'entry_pathway_to_entity'),
+    ).toMatchObject({
+      required: true,
+    });
+    expect(REFERENCE_EDGES.find((edge) => edge.name === 'member_to_entity')).toMatchObject({
+      required: false,
+    });
   });
 
   it('includes current compatibility and professor-mirror retirement fields', () => {
@@ -185,6 +202,8 @@ describe('buildResearchModelInventoryReport', () => {
     const memberToEntity = report.referenceIntegrity.find((row) => row.name === 'member_to_entity');
     expect(memberToEntity?.clean).toBe(false);
     expect(memberToEntity?.orphanRate).toBe(0.05);
+    expect(memberToEntity?.localField).toBe('researchEntityId');
+    expect(memberToEntity?.required).toBe(false);
     const memberToUser = report.referenceIntegrity.find((row) => row.name === 'member_to_user');
     expect(memberToUser?.clean).toBe(true);
     expect(report.summary.referenceEdgesWithOrphans).toBe(1);

--- a/server/src/scripts/__tests__/researchModelInventoryCore.test.ts
+++ b/server/src/scripts/__tests__/researchModelInventoryCore.test.ts
@@ -51,6 +51,11 @@ describe('INVENTORY_COLLECTIONS', () => {
 });
 
 describe('inventory coverage', () => {
+  it('has unique reference edge names', () => {
+    const names = REFERENCE_EDGES.map((edge) => edge.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
   it('includes current canonical and dual-truth reference edges', () => {
     expect(REFERENCE_EDGES.map((edge) => `${edge.fromCollection}.${edge.localField}`)).toEqual(
       expect.arrayContaining([
@@ -60,8 +65,15 @@ describe('inventory coverage', () => {
         'faculty_members.userId',
         'student_profiles.userId',
         'access_signals.entryPathwayId',
+        'access_signals.sourceEvidenceId',
+        'access_signals.observationId',
         'contact_routes.entryPathwayId',
+        'contact_routes.personId',
+        'contact_routes.sourceEvidenceId',
         'posted_opportunities.researchEntityId',
+        'posted_opportunities.listingId',
+        'listings.researchEntityId',
+        'observations.sourceId',
       ]),
     );
   });
@@ -87,9 +99,7 @@ describe('inventory coverage', () => {
 
   it('records current schema requiredness for every reference edge', () => {
     expect(REFERENCE_EDGES.every((edge) => typeof edge.required === 'boolean')).toBe(true);
-    expect(
-      REFERENCE_EDGES.find((edge) => edge.name === 'entry_pathway_to_entity'),
-    ).toMatchObject({
+    expect(REFERENCE_EDGES.find((edge) => edge.name === 'entry_pathway_to_entity')).toMatchObject({
       required: true,
     });
     expect(REFERENCE_EDGES.find((edge) => edge.name === 'member_to_entity')).toMatchObject({
@@ -117,6 +127,15 @@ describe('inventory coverage', () => {
         'faculty_members.googleScholarId',
         'faculty_members.openAlexId',
         'faculty_members.semanticScholarId',
+        'research_entities.opennessSignals',
+        'research_entities.opennessStatusCache',
+        'research_entities.opennessExplanationCache',
+        'research_entities.opennessComputedAt',
+        'research_entities.opennessLastSignalAt',
+        'research_entities.recentPaperCount',
+        'research_entities.lastPaperAtCache',
+        'research_entities.activePaperCount2yCache',
+        'research_entities.featuredPaperIds',
       ]),
     );
   });
@@ -271,6 +290,41 @@ describe('buildResearchModelInventoryReport', () => {
     expect(report.summary.referenceEdgesChecked).toBe(1);
     expect(report.summary.referenceEdgesWithOrphans).toBe(1);
     expect(report.summary.totalOrphans).toBe(3);
+  });
+
+  it('keeps a missing unused target explicit without creating a blocker', () => {
+    const report = buildResearchModelInventoryReport({
+      ...emptyFacts(),
+      referenceIntegrity: [
+        {
+          name: 'student_application_to_listing',
+          fromCollection: 'student_applications',
+          toCollection: 'listings',
+          status: 'target-missing',
+          checked: 0,
+          orphaned: 0,
+          sampleOrphanIds: [],
+        },
+      ],
+    });
+    const edge = report.referenceIntegrity.find(
+      (row) => row.name === 'student_application_to_listing',
+    );
+    expect(edge).toMatchObject({
+      status: 'target-missing',
+      clean: null,
+      checked: 0,
+      orphaned: 0,
+    });
+    expect(report.summary.referenceEdgesChecked).toBe(1);
+    expect(report.summary.referenceEdgesWithOrphans).toBe(0);
+  });
+
+  it('states that orphan and field coverage is curated', () => {
+    const report = buildResearchModelInventoryReport(emptyFacts());
+    expect(report.summary.coverageScope).toContain('Curated refactor-relevant');
+    expect(report.summary.coverageScope).toContain('only tracked edges');
+    expect(report.summary.coverageScope).toContain('not an exhaustive');
   });
 
   it('surfaces unclassified live collections in the summary', () => {

--- a/server/src/scripts/__tests__/researchModelInventoryCore.test.ts
+++ b/server/src/scripts/__tests__/researchModelInventoryCore.test.ts
@@ -153,6 +153,7 @@ describe('inventory coverage', () => {
         'users.orcidWorksSyncedAt',
         'users.europePmcWorksSyncedAt',
         'users.pubmedWorksSyncedAt',
+        'faculty_members.orcidId',
         'faculty_members.googleScholarId',
         'faculty_members.openAlexId',
         'faculty_members.semanticScholarId',
@@ -170,11 +171,28 @@ describe('inventory coverage', () => {
     expect(RETIREMENT_FIELD_PROBES.filter((probe) => probe.field === 'googleScholarId')).toEqual([
       expect.objectContaining({
         collection: 'users',
-        target: 'Person.outboundProfiles.googleScholar, then remove legacy field',
+        target: 'Verified PersonProfileLink kind GOOGLE_SCHOLAR, then remove legacy field',
       }),
       expect.objectContaining({
         collection: 'faculty_members',
-        target: 'Person.outboundProfiles.googleScholar, then remove legacy field',
+        target: 'Verified PersonProfileLink kind GOOGLE_SCHOLAR, then remove legacy field',
+      }),
+    ]);
+    expect(RETIREMENT_FIELD_PROBES.filter((probe) => /orcid/i.test(probe.field))).toEqual([
+      expect.objectContaining({
+        collection: 'users',
+        field: 'orcid',
+        target: 'Person.identifiers.orcid plus verified PersonProfileLink kind ORCID',
+      }),
+      expect.objectContaining({
+        collection: 'users',
+        field: 'orcidWorksSyncedAt',
+        target: 'Remove with publication mirrors',
+      }),
+      expect.objectContaining({
+        collection: 'faculty_members',
+        field: 'orcidId',
+        target: 'Person.identifiers.orcid plus verified PersonProfileLink kind ORCID',
       }),
     ]);
   });

--- a/server/src/scripts/__tests__/researchModelInventoryCore.test.ts
+++ b/server/src/scripts/__tests__/researchModelInventoryCore.test.ts
@@ -62,6 +62,24 @@ describe('inventory coverage', () => {
     );
   });
 
+  it('includes current private-record reference edges', () => {
+    expect(REFERENCE_EDGES.map((edge) => `${edge.fromCollection}.${edge.localField}`)).toEqual(
+      expect.arrayContaining([
+        'student_applications.postedOpportunityId',
+        'student_applications.researchEntityId',
+        'student_applications.studentUserId',
+        'student_applications.studentProfileId',
+        'student_trackings.studentProfileId',
+        'student_trackings.researchEntityId',
+        'student_outreaches.studentProfileId',
+        'student_outreaches.researchEntityId',
+        'student_outreaches.trackingId',
+        'student_engagement_events.studentProfileId',
+        'student_engagement_events.researchEntityId',
+      ]),
+    );
+  });
+
   it('includes current compatibility and professor-mirror retirement fields', () => {
     expect(RETIREMENT_FIELD_PROBES.map((probe) => `${probe.collection}.${probe.field}`)).toEqual(
       expect.arrayContaining([
@@ -73,6 +91,15 @@ describe('inventory coverage', () => {
         'users.googleScholarId',
         'users.openAlexId',
         'users.semanticScholarId',
+        'users.facultyMemberId',
+        'users.googleScholarMetricsUpdatedAt',
+        'users.openAlexWorksSyncedAt',
+        'users.orcidWorksSyncedAt',
+        'users.europePmcWorksSyncedAt',
+        'users.pubmedWorksSyncedAt',
+        'faculty_members.googleScholarId',
+        'faculty_members.openAlexId',
+        'faculty_members.semanticScholarId',
       ]),
     );
   });

--- a/server/src/scripts/__tests__/researchModelInventoryCore.test.ts
+++ b/server/src/scripts/__tests__/researchModelInventoryCore.test.ts
@@ -38,6 +38,44 @@ describe('INVENTORY_COLLECTIONS', () => {
     expect(residue.map((spec) => spec.collection)).toContain('research_groups');
     expect(residue.map((spec) => spec.collection)).toContain('applications');
   });
+
+  it('classifies retained private student applications', () => {
+    expect(
+      INVENTORY_COLLECTIONS.find((spec) => spec.collection === 'student_applications'),
+    ).toMatchObject({
+      group: 'private',
+      phase: 4,
+      target: 'Private student application records (retained, normalized references)',
+    });
+  });
+});
+
+describe('inventory coverage', () => {
+  it('includes current canonical and dual-truth reference edges', () => {
+    expect(REFERENCE_EDGES.map((edge) => `${edge.fromCollection}.${edge.localField}`)).toEqual(
+      expect.arrayContaining([
+        'research_entity_members.facultyMemberId',
+        'access_signals.entryPathwayId',
+        'contact_routes.entryPathwayId',
+        'posted_opportunities.researchEntityId',
+      ]),
+    );
+  });
+
+  it('includes current compatibility and professor-mirror retirement fields', () => {
+    expect(RETIREMENT_FIELD_PROBES.map((probe) => `${probe.collection}.${probe.field}`)).toEqual(
+      expect.arrayContaining([
+        'listings.researchGroupId',
+        'student_trackings.researchGroupId',
+        'student_outreaches.researchGroupId',
+        'student_engagement_events.researchGroupId',
+        'users.hIndex',
+        'users.googleScholarId',
+        'users.openAlexId',
+        'users.semanticScholarId',
+      ]),
+    );
+  });
 });
 
 describe('findUnclassifiedCollections', () => {
@@ -101,6 +139,7 @@ describe('buildResearchModelInventoryReport', () => {
           name: 'member_to_entity',
           fromCollection: 'research_entity_members',
           toCollection: 'research_entities',
+          status: 'checked',
           checked: 100,
           orphaned: 5,
           sampleOrphanIds: ['a', 'b'],
@@ -109,6 +148,7 @@ describe('buildResearchModelInventoryReport', () => {
           name: 'member_to_user',
           fromCollection: 'research_entity_members',
           toCollection: 'users',
+          status: 'checked',
           checked: 100,
           orphaned: 0,
           sampleOrphanIds: [],
@@ -128,7 +168,63 @@ describe('buildResearchModelInventoryReport', () => {
     const report = buildResearchModelInventoryReport(emptyFacts());
     expect(report.referenceIntegrity).toHaveLength(REFERENCE_EDGES.length);
     expect(report.retirementFields).toHaveLength(RETIREMENT_FIELD_PROBES.length);
-    expect(report.summary.referenceEdgesChecked).toBe(REFERENCE_EDGES.length);
+    expect(report.referenceIntegrity.every((row) => row.status === 'not-gathered')).toBe(true);
+    expect(report.referenceIntegrity.every((row) => row.clean === null)).toBe(true);
+    expect(report.summary.referenceEdgesChecked).toBe(0);
+    expect(report.summary.referenceEdgesSkipped).toBe(REFERENCE_EDGES.length);
+  });
+
+  it('marks a missing source collection as skipped and indeterminate', () => {
+    const report = buildResearchModelInventoryReport({
+      ...emptyFacts(),
+      referenceIntegrity: [
+        {
+          name: 'member_to_entity',
+          fromCollection: 'research_entity_members',
+          toCollection: 'research_entities',
+          status: 'source-missing',
+          checked: 0,
+          orphaned: 0,
+          sampleOrphanIds: [],
+        },
+      ],
+    });
+    const edge = report.referenceIntegrity.find((row) => row.name === 'member_to_entity');
+    expect(edge).toMatchObject({
+      status: 'source-missing',
+      clean: null,
+      checked: 0,
+      orphaned: 0,
+    });
+    expect(report.summary.referenceEdgesChecked).toBe(0);
+    expect(report.summary.referenceEdgesSkipped).toBe(REFERENCE_EDGES.length);
+  });
+
+  it('reports references to a missing target as checked orphans', () => {
+    const report = buildResearchModelInventoryReport({
+      ...emptyFacts(),
+      referenceIntegrity: [
+        {
+          name: 'member_to_entity',
+          fromCollection: 'research_entity_members',
+          toCollection: 'research_entities',
+          status: 'target-missing',
+          checked: 3,
+          orphaned: 3,
+          sampleOrphanIds: ['member-1'],
+        },
+      ],
+    });
+    const edge = report.referenceIntegrity.find((row) => row.name === 'member_to_entity');
+    expect(edge).toMatchObject({
+      status: 'target-missing',
+      clean: false,
+      checked: 3,
+      orphaned: 3,
+    });
+    expect(report.summary.referenceEdgesChecked).toBe(1);
+    expect(report.summary.referenceEdgesWithOrphans).toBe(1);
+    expect(report.summary.totalOrphans).toBe(3);
   });
 
   it('surfaces unclassified live collections in the summary', () => {
@@ -141,24 +237,44 @@ describe('buildResearchModelInventoryReport', () => {
 });
 
 describe('parseResearchModelInventoryArgs', () => {
-  it('defaults the sample limit and leaves output undefined', () => {
-    const args = parseResearchModelInventoryArgs([]);
+  it('requires an explicit environment and defaults other options', () => {
+    const args = parseResearchModelInventoryArgs(['--environment', 'beta']);
+    expect(args.environment).toBe('beta');
     expect(args.sampleLimit).toBe(20);
     expect(args.output).toBeUndefined();
   });
 
   it('parses sample limit and output path', () => {
-    const args = parseResearchModelInventoryArgs(['--sample-limit', '5', '--output', '/tmp/x.json']);
+    const args = parseResearchModelInventoryArgs([
+      '--environment',
+      'production-copy',
+      '--sample-limit',
+      '5',
+      '--output',
+      '/tmp/x.json',
+    ]);
+    expect(args.environment).toBe('production-copy');
     expect(args.sampleLimit).toBe(5);
     expect(args.output).toBe('/tmp/x.json');
   });
 
   it('rejects a negative sample limit', () => {
-    expect(() => parseResearchModelInventoryArgs(['--sample-limit', '-1'])).toThrow();
+    expect(() =>
+      parseResearchModelInventoryArgs(['--environment', 'beta', '--sample-limit', '-1']),
+    ).toThrow();
+  });
+
+  it('rejects missing and invalid environments', () => {
+    expect(() => parseResearchModelInventoryArgs([])).toThrow('--environment is required');
+    expect(() => parseResearchModelInventoryArgs(['--environment', 'staging'])).toThrow(
+      '--environment requires',
+    );
   });
 
   it('rejects unknown arguments', () => {
-    expect(() => parseResearchModelInventoryArgs(['--nope'])).toThrow('Unknown argument: --nope');
+    expect(() => parseResearchModelInventoryArgs(['--environment', 'beta', '--nope'])).toThrow(
+      'Unknown argument: --nope',
+    );
   });
 });
 
@@ -168,21 +284,27 @@ describe('buildResearchModelInventoryOutput', () => {
     const output = buildResearchModelInventoryOutput(report, {
       environment: 'beta',
       db: 'ylabs-beta',
+      target: 'example.mongodb.net/ylabs-beta',
       generatedAt: '2026-07-24T00:00:00.000Z',
-      options: { sampleLimit: 20 },
+      options: { environment: 'beta', sampleLimit: 20 },
     });
     expect(output.generatedAt).toBe('2026-07-24T00:00:00.000Z');
     expect(output.environment).toBe('beta');
     expect(output.db).toBe('ylabs-beta');
+    expect(output.target).toBe('example.mongodb.net/ylabs-beta');
     expect(output.options.sampleLimit).toBe(20);
     expect(output.summary.collectionsClassified).toBe(INVENTORY_COLLECTIONS.length);
   });
 
-  it('omits environment and db when not provided', () => {
+  it('omits optional database metadata when not provided', () => {
     const report = buildResearchModelInventoryReport(emptyFacts());
-    const output = buildResearchModelInventoryOutput(report, { options: { sampleLimit: 20 } });
-    expect('environment' in output).toBe(false);
+    const output = buildResearchModelInventoryOutput(report, {
+      environment: 'test',
+      options: { environment: 'test', sampleLimit: 20 },
+    });
+    expect(output.environment).toBe('test');
     expect('db' in output).toBe(false);
+    expect('target' in output).toBe(false);
     expect(typeof output.generatedAt).toBe('string');
   });
 });

--- a/server/src/scripts/__tests__/researchModelInventoryCore.test.ts
+++ b/server/src/scripts/__tests__/researchModelInventoryCore.test.ts
@@ -144,7 +144,7 @@ describe('inventory coverage', () => {
 describe('findUnclassifiedCollections', () => {
   it('returns live collections not in the spec, excluding system collections', () => {
     const live = ['research_entities', 'system.indexes', 'mystery_collection', '__prewarm'];
-    expect(findUnclassifiedCollections(live)).toEqual(['mystery_collection']);
+    expect(findUnclassifiedCollections(live)).toEqual(['__prewarm', 'mystery_collection']);
   });
 
   it('returns empty when all live collections are classified', () => {

--- a/server/src/scripts/__tests__/researchModelInventoryCore.test.ts
+++ b/server/src/scripts/__tests__/researchModelInventoryCore.test.ts
@@ -3,12 +3,41 @@ import {
   INVENTORY_COLLECTIONS,
   REFERENCE_EDGES,
   RETIREMENT_FIELD_PROBES,
+  assertInventoryEnvironmentMatchesDatabase,
   buildResearchModelInventoryOutput,
   buildResearchModelInventoryReport,
   findUnclassifiedCollections,
   parseResearchModelInventoryArgs,
   type InventoryFacts,
 } from '../researchModelInventoryCore';
+
+describe('assertInventoryEnvironmentMatchesDatabase', () => {
+  it.each([
+    ['development', 'Development'],
+    ['beta', 'Beta'],
+    ['production-copy', 'ProductionCopy'],
+    ['production-copy', 'production-copy'],
+    ['production', 'Production'],
+    ['test', 'Test'],
+    ['test', 'inventory-test'],
+  ] as const)('accepts %s inventory evidence for %s', (environment, databaseName) => {
+    expect(() =>
+      assertInventoryEnvironmentMatchesDatabase(environment, databaseName),
+    ).not.toThrow();
+  });
+
+  it.each([
+    ['beta', 'Production'],
+    ['production', 'Beta'],
+    ['production-copy', 'Production'],
+    ['development', 'inventory-test'],
+    ['test', 'Beta'],
+  ] as const)('rejects %s inventory evidence for %s', (environment, databaseName) => {
+    expect(() => assertInventoryEnvironmentMatchesDatabase(environment, databaseName)).toThrow(
+      `Inventory environment ${environment} does not match MongoDB database ${databaseName}`,
+    );
+  });
+});
 
 function emptyFacts(): InventoryFacts {
   return {
@@ -138,6 +167,16 @@ describe('inventory coverage', () => {
         'research_entities.featuredPaperIds',
       ]),
     );
+    expect(RETIREMENT_FIELD_PROBES.filter((probe) => probe.field === 'googleScholarId')).toEqual([
+      expect.objectContaining({
+        collection: 'users',
+        target: 'Person.outboundProfiles.googleScholar, then remove legacy field',
+      }),
+      expect.objectContaining({
+        collection: 'faculty_members',
+        target: 'Person.outboundProfiles.googleScholar, then remove legacy field',
+      }),
+    ]);
   });
 });
 

--- a/server/src/scripts/researchModelInventory.ts
+++ b/server/src/scripts/researchModelInventory.ts
@@ -83,12 +83,27 @@ async function censusCollection(
   const documentCount = await coll.countDocuments({});
   const grouped = await coll
     .aggregate<{
-      _id: unknown;
+      _id: {
+        bsonType: string;
+        value?: unknown;
+      };
       count: number;
-    }>([{ $group: { _id: '$schemaVersion', count: { $sum: 1 } } }, { $sort: { count: -1 } }])
+    }>([
+      {
+        $group: {
+          _id: {
+            bsonType: { $type: '$schemaVersion' },
+            value: '$schemaVersion',
+          },
+          count: { $sum: 1 },
+        },
+      },
+      { $sort: { count: -1, '_id.bsonType': 1 } },
+    ])
     .toArray();
   const schemaVersions: SchemaVersionBucket[] = grouped.map((row) => ({
-    version: row._id === null || row._id === undefined ? 'unset' : String(row._id),
+    bsonType: row._id.bsonType,
+    ...(row._id.bsonType === 'missing' ? {} : { value: row._id.value }),
     count: row.count,
   }));
   return { collection, present: true, documentCount, schemaVersions };
@@ -110,17 +125,13 @@ async function probeFieldPresence(
 }
 
 /**
- * Type-agnostic orphan check: build the set of target ids as strings, then scan
- * the referencing collection. This stays correct whether references are stored
- * as ObjectId or string, unlike a `$lookup` keyed on `_id`.
+ * Type-agnostic orphan checks compare string forms so references stored as
+ * ObjectId or string are handled consistently.
  */
-export async function checkReferenceEdge(
-  db: Db,
-  edge: (typeof REFERENCE_EDGES)[number],
-  presentCollections: Set<string>,
-  sampleLimit: number,
-): Promise<ReferenceIntegrityFact> {
-  const base: ReferenceIntegrityFact = {
+type InventoryReferenceEdge = (typeof REFERENCE_EDGES)[number];
+
+function emptyReferenceFact(edge: InventoryReferenceEdge): ReferenceIntegrityFact {
+  return {
     name: edge.name,
     fromCollection: edge.fromCollection,
     toCollection: edge.toCollection,
@@ -129,53 +140,127 @@ export async function checkReferenceEdge(
     orphaned: 0,
     sampleOrphanIds: [],
   };
-  if (!presentCollections.has(edge.fromCollection)) {
-    return { ...base, status: 'source-missing' };
-  }
+}
 
+async function loadTargetIds(db: Db, collection: string): Promise<Set<string>> {
   const targetIds = new Set<string>();
-  const targetPresent = presentCollections.has(edge.toCollection);
-  if (targetPresent) {
-    const targetCursor = db.collection(edge.toCollection).find({}, { projection: { _id: 1 } });
-    for await (const doc of targetCursor) {
-      targetIds.add(String(doc._id));
-    }
+  const targetCursor = db.collection(collection).find({}, { projection: { _id: 1 } });
+  for await (const doc of targetCursor) {
+    targetIds.add(String(doc._id));
+  }
+  return targetIds;
+}
+
+async function gatherReferenceIntegrityFacts(
+  db: Db,
+  edges: InventoryReferenceEdge[],
+  presentCollections: Set<string>,
+  sampleLimit: number,
+): Promise<ReferenceIntegrityFact[]> {
+  const targetCollections = [
+    ...new Set(
+      edges
+        .filter((edge) => presentCollections.has(edge.fromCollection))
+        .map((edge) => edge.toCollection)
+        .filter((collection) => presentCollections.has(collection)),
+    ),
+  ];
+  const targetEntries = await mapWithConcurrency(
+    targetCollections,
+    COLLECTION_SCAN_CONCURRENCY,
+    async (collection) => [collection, await loadTargetIds(db, collection)] as const,
+  );
+  const targetIdsByCollection = new Map(targetEntries);
+
+  const edgesBySource = new Map<string, InventoryReferenceEdge[]>();
+  for (const edge of edges) {
+    const sourceEdges = edgesBySource.get(edge.fromCollection) ?? [];
+    sourceEdges.push(edge);
+    edgesBySource.set(edge.fromCollection, sourceEdges);
   }
 
-  let checked = 0;
-  let orphaned = 0;
-  const sampleOrphanIds: string[] = [];
-  const sourceFilter = edge.required ? {} : { [edge.localField]: { $ne: null } };
-  const fromCursor = db
-    .collection(edge.fromCollection)
-    .find(sourceFilter, { projection: { [edge.localField]: 1 } });
-  for await (const doc of fromCursor) {
-    const ref = (doc as Record<string, unknown>)[edge.localField];
-    if (ref === null || ref === undefined) {
-      if (!edge.required) continue;
-      checked += 1;
-      orphaned += 1;
-      if (sampleOrphanIds.length < sampleLimit) {
-        sampleOrphanIds.push(String(doc._id));
+  const sourceGroups = await mapWithConcurrency(
+    [...edgesBySource.entries()],
+    COLLECTION_SCAN_CONCURRENCY,
+    async ([sourceCollection, sourceEdges]) => {
+      if (!presentCollections.has(sourceCollection)) {
+        return sourceEdges.map((edge) => ({
+          ...emptyReferenceFact(edge),
+          status: 'source-missing' as const,
+        }));
       }
-      continue;
-    }
-    checked += 1;
-    if (!targetIds.has(String(ref))) {
-      orphaned += 1;
-      if (sampleOrphanIds.length < sampleLimit) {
-        sampleOrphanIds.push(String(doc._id));
-      }
-    }
-  }
 
-  return {
-    ...base,
-    status: targetPresent ? 'checked' : 'target-missing',
-    checked,
-    orphaned,
-    sampleOrphanIds,
-  };
+      const factsByName = new Map(
+        sourceEdges.map((edge) => {
+          const targetPresent = presentCollections.has(edge.toCollection);
+          return [
+            edge.name,
+            {
+              ...emptyReferenceFact(edge),
+              status: targetPresent ? ('checked' as const) : ('target-missing' as const),
+            },
+          ];
+        }),
+      );
+      const projection: Record<string, 1> = { _id: 1 };
+      for (const edge of sourceEdges) {
+        projection[edge.localField] = 1;
+      }
+
+      const sourceCursor = db.collection(sourceCollection).find({}, { projection });
+      for await (const doc of sourceCursor) {
+        for (const edge of sourceEdges) {
+          const fact = factsByName.get(edge.name);
+          if (!fact) continue;
+          const ref = (doc as Record<string, unknown>)[edge.localField];
+          if (ref === null || ref === undefined) {
+            if (!edge.required) continue;
+            fact.checked += 1;
+            fact.orphaned += 1;
+            if (fact.sampleOrphanIds.length < sampleLimit) {
+              fact.sampleOrphanIds.push(String(doc._id));
+            }
+            continue;
+          }
+
+          fact.checked += 1;
+          const targetIds = targetIdsByCollection.get(edge.toCollection);
+          if (!targetIds?.has(String(ref))) {
+            fact.orphaned += 1;
+            if (fact.sampleOrphanIds.length < sampleLimit) {
+              fact.sampleOrphanIds.push(String(doc._id));
+            }
+          }
+        }
+      }
+
+      return sourceEdges.map((edge) => {
+        const fact = factsByName.get(edge.name);
+        if (!fact) {
+          throw new Error(`Missing reference fact for ${edge.name}`);
+        }
+        return fact;
+      });
+    },
+  );
+  const factsByName = new Map(sourceGroups.flat().map((fact) => [fact.name, fact]));
+  return edges.map((edge) => {
+    const fact = factsByName.get(edge.name);
+    if (!fact) {
+      throw new Error(`Missing reference fact for ${edge.name}`);
+    }
+    return fact;
+  });
+}
+
+export async function checkReferenceEdge(
+  db: Db,
+  edge: InventoryReferenceEdge,
+  presentCollections: Set<string>,
+  sampleLimit: number,
+): Promise<ReferenceIntegrityFact> {
+  const [fact] = await gatherReferenceIntegrityFacts(db, [edge], presentCollections, sampleLimit);
+  return fact;
 }
 
 export async function gatherInventoryFacts(
@@ -219,10 +304,12 @@ export async function gatherInventoryFacts(
   );
   const fieldPresence = fieldPresenceGroups.flat();
 
-  const referenceIntegrity: ReferenceIntegrityFact[] = [];
-  for (const edge of REFERENCE_EDGES) {
-    referenceIntegrity.push(await checkReferenceEdge(db, edge, liveSet, args.sampleLimit));
-  }
+  const referenceIntegrity = await gatherReferenceIntegrityFacts(
+    db,
+    REFERENCE_EDGES,
+    liveSet,
+    args.sampleLimit,
+  );
 
   return { liveCollections, census, fieldPresence, referenceIntegrity };
 }

--- a/server/src/scripts/researchModelInventory.ts
+++ b/server/src/scripts/researchModelInventory.ts
@@ -80,7 +80,6 @@ async function censusCollection(
     return { collection, present: false, documentCount: 0, schemaVersions: [] };
   }
   const coll = db.collection(collection);
-  const documentCount = await coll.countDocuments({});
   const grouped = await coll
     .aggregate<{
       _id: {
@@ -106,6 +105,7 @@ async function censusCollection(
     ...(row._id.bsonType === 'missing' ? {} : { value: row._id.value }),
     count: row.count,
   }));
+  const documentCount = schemaVersions.reduce((total, bucket) => total + bucket.count, 0);
   return { collection, present: true, documentCount, schemaVersions };
 }
 

--- a/server/src/scripts/researchModelInventory.ts
+++ b/server/src/scripts/researchModelInventory.ts
@@ -256,10 +256,7 @@ async function gatherReferenceIntegrityFacts(
           state.fact.checked += 1;
           const referenceId = String(ref);
           state.referencedIds.add(referenceId);
-          state.referenceCounts.set(
-            referenceId,
-            (state.referenceCounts.get(referenceId) ?? 0) + 1,
-          );
+          state.referenceCounts.set(referenceId, (state.referenceCounts.get(referenceId) ?? 0) + 1);
           const samples = state.samplesByReference.get(referenceId) ?? [];
           if (samples.length < sampleLimit) {
             samples.push({

--- a/server/src/scripts/researchModelInventory.ts
+++ b/server/src/scripts/researchModelInventory.ts
@@ -270,12 +270,14 @@ async function gatherReferenceIntegrityFacts(
             let foundIds = new Set<string>();
             if (presentCollections.has(edge.toCollection)) {
               const referenceIds = [...new Set(pending.map((item) => item.referenceId))];
-              const targetCursor = db.collection<{ _id: string | ObjectId }>(edge.toCollection).find(
-                {
-                  _id: { $in: referenceIdCandidates(referenceIds) },
-                },
-                { projection: { _id: 1 } },
-              );
+              const targetCursor = db
+                .collection<{ _id: string | ObjectId }>(edge.toCollection)
+                .find(
+                  {
+                    _id: { $in: referenceIdCandidates(referenceIds) },
+                  },
+                  { projection: { _id: 1 } },
+                );
               foundIds = new Set<string>();
               for await (const target of targetCursor) {
                 foundIds.add(String(target._id));

--- a/server/src/scripts/researchModelInventory.ts
+++ b/server/src/scripts/researchModelInventory.ts
@@ -14,9 +14,7 @@ import dotenv from 'dotenv';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import mongoose from 'mongoose';
-import type { Db } from 'mongodb';
-import { initializeConnections } from '../db/connections';
+import { MongoClient, type Db } from 'mongodb';
 import { summarizeMongoUrl } from '../scrapers/scraperEnvironment';
 import { resolveSafeJsonReportOutputPath } from './scriptWriteGuards';
 import { sanitizeLogValue } from '../utils/logSanitizer';
@@ -39,6 +37,35 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 
+const COLLECTION_SCAN_CONCURRENCY = 4;
+
+interface InventoryMongoClient {
+  connect(): Promise<unknown>;
+  db(): Db;
+  close(): Promise<void>;
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await mapper(items[index], index);
+    }
+  }
+
+  const workerCount = Math.min(concurrency, items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
+}
+
 async function listLiveCollections(db: Db): Promise<string[]> {
   const collections = await db.listCollections({}, { nameOnly: true }).toArray();
   return collections.map((entry) => entry.name).sort();
@@ -55,10 +82,10 @@ async function censusCollection(
   const coll = db.collection(collection);
   const documentCount = await coll.countDocuments({});
   const grouped = await coll
-    .aggregate<{ _id: unknown; count: number }>([
-      { $group: { _id: '$schemaVersion', count: { $sum: 1 } } },
-      { $sort: { count: -1 } },
-    ])
+    .aggregate<{
+      _id: unknown;
+      count: number;
+    }>([{ $group: { _id: '$schemaVersion', count: { $sum: 1 } } }, { $sort: { count: -1 } }])
     .toArray();
   const schemaVersions: SchemaVersionBucket[] = grouped.map((row) => ({
     version: row._id === null || row._id === undefined ? 'unset' : String(row._id),
@@ -72,15 +99,13 @@ async function probeFieldPresence(
   collection: string,
   field: string,
   present: boolean,
+  total: number,
 ): Promise<FieldPresenceFact> {
   if (!present) {
     return { collection, field, present: 0, total: 0 };
   }
   const coll = db.collection(collection);
-  const [total, withField] = await Promise.all([
-    coll.countDocuments({}),
-    coll.countDocuments({ [field]: { $exists: true } }),
-  ]);
+  const withField = await coll.countDocuments({ [field]: { $exists: true } });
   return { collection, field, present: withField, total };
 }
 
@@ -111,9 +136,7 @@ export async function checkReferenceEdge(
   const targetIds = new Set<string>();
   const targetPresent = presentCollections.has(edge.toCollection);
   if (targetPresent) {
-    const targetCursor = db
-      .collection(edge.toCollection)
-      .find({}, { projection: { _id: 1 } });
+    const targetCursor = db.collection(edge.toCollection).find({}, { projection: { _id: 1 } });
     for await (const doc of targetCursor) {
       targetIds.add(String(doc._id));
     }
@@ -146,24 +169,46 @@ export async function checkReferenceEdge(
   };
 }
 
-async function gatherInventoryFacts(
+export async function gatherInventoryFacts(
   db: Db,
   args: ResearchModelInventoryArgs,
 ): Promise<InventoryFacts> {
   const liveCollections = await listLiveCollections(db);
   const liveSet = new Set(liveCollections);
 
-  const census = await Promise.all(
-    INVENTORY_COLLECTIONS.map((spec) =>
-      censusCollection(db, spec.collection, liveSet.has(spec.collection)),
-    ),
+  const census = await mapWithConcurrency(
+    INVENTORY_COLLECTIONS,
+    COLLECTION_SCAN_CONCURRENCY,
+    (spec) => censusCollection(db, spec.collection, liveSet.has(spec.collection)),
   );
 
-  const fieldPresence = await Promise.all(
-    RETIREMENT_FIELD_PROBES.map((probe) =>
-      probeFieldPresence(db, probe.collection, probe.field, liveSet.has(probe.collection)),
-    ),
+  const censusByCollection = new Map(census.map((fact) => [fact.collection, fact]));
+  const probesByCollection = new Map<string, typeof RETIREMENT_FIELD_PROBES>();
+  for (const probe of RETIREMENT_FIELD_PROBES) {
+    const probes = probesByCollection.get(probe.collection) ?? [];
+    probes.push(probe);
+    probesByCollection.set(probe.collection, probes);
+  }
+
+  const fieldPresenceGroups = await mapWithConcurrency(
+    [...probesByCollection.entries()],
+    COLLECTION_SCAN_CONCURRENCY,
+    async ([collection, probes]) => {
+      const collectionPresent = liveSet.has(collection);
+      const censusFact = censusByCollection.get(collection);
+      const total =
+        censusFact?.documentCount ??
+        (collectionPresent ? await db.collection(collection).countDocuments({}) : 0);
+      const facts: FieldPresenceFact[] = [];
+      for (const probe of probes) {
+        facts.push(
+          await probeFieldPresence(db, probe.collection, probe.field, collectionPresent, total),
+        );
+      }
+      return facts;
+    },
   );
+  const fieldPresence = fieldPresenceGroups.flat();
 
   const referenceIntegrity: ReferenceIntegrityFact[] = [];
   for (const edge of REFERENCE_EDGES) {
@@ -171,6 +216,27 @@ async function gatherInventoryFacts(
   }
 
   return { liveCollections, census, fieldPresence, referenceIntegrity };
+}
+
+export async function runResearchModelInventory(
+  args: ResearchModelInventoryArgs,
+  mongoUrl: string,
+  client: InventoryMongoClient = new MongoClient(mongoUrl),
+): Promise<ReturnType<typeof buildResearchModelInventoryOutput>> {
+  try {
+    await client.connect();
+    const db = client.db();
+    const facts = await gatherInventoryFacts(db, args);
+    const report = buildResearchModelInventoryReport(facts);
+    return buildResearchModelInventoryOutput(report, {
+      environment: args.environment,
+      db: db.databaseName,
+      target: summarizeMongoUrl(mongoUrl),
+      options: args,
+    });
+  } finally {
+    await client.close();
+  }
 }
 
 export function writeResearchModelInventoryOutput(
@@ -189,23 +255,12 @@ async function main(): Promise<void> {
     resolveSafeJsonReportOutputPath(args.output);
   }
 
-  await initializeConnections({
-    infoLog: (...values) => console.error(...values),
-  });
-  const db = mongoose.connection.db;
-  if (!db) {
-    throw new Error('MongoDB connection is not available');
+  const mongoUrl = process.env.MONGODBURL;
+  if (!mongoUrl) {
+    throw new Error('MONGODBURL is required');
   }
 
-  const facts = await gatherInventoryFacts(db, args);
-  const report = buildResearchModelInventoryReport(facts);
-  const output = buildResearchModelInventoryOutput(report, {
-    environment: args.environment,
-    db: db.databaseName || mongoose.connection.name,
-    target: summarizeMongoUrl(process.env.MONGODBURL),
-    options: args,
-  });
-
+  const output = await runResearchModelInventory(args, mongoUrl);
   console.log(JSON.stringify(output, null, 2));
   writeResearchModelInventoryOutput(output, args.output);
 }
@@ -215,12 +270,8 @@ const isDirectRun = process.argv[1]
   : false;
 
 if (isDirectRun) {
-  main()
-    .catch((error) => {
-      console.error(sanitizeLogValue(error));
-      process.exitCode = 1;
-    })
-    .finally(async () => {
-      await mongoose.disconnect();
-    });
+  main().catch((error) => {
+    console.error(sanitizeLogValue(error));
+    process.exitCode = 1;
+  });
 }

--- a/server/src/scripts/researchModelInventory.ts
+++ b/server/src/scripts/researchModelInventory.ts
@@ -1,0 +1,213 @@
+/**
+ * Research-model refactor Phase 0 inventory (read-only).
+ *
+ * Produces the collection census, retirement-field prevalence, and
+ * reference-integrity picture that Phase 0 of `docs/research-model-refactor.md`
+ * requires before any target collection is written or any legacy storage is
+ * dropped. Writes nothing to the database.
+ *
+ * Usage:
+ *   yarn --cwd server model-refactor:inventory
+ *   yarn --cwd server model-refactor:inventory --output /tmp/inventory.json
+ */
+import dotenv from 'dotenv';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import mongoose from 'mongoose';
+import type { Db } from 'mongodb';
+import { initializeConnections } from '../db/connections';
+import { resolveScraperEnvironment, summarizeMongoUrl } from '../scrapers/scraperEnvironment';
+import { resolveSafeJsonReportOutputPath } from './scriptWriteGuards';
+import { sanitizeLogValue } from '../utils/logSanitizer';
+import {
+  INVENTORY_COLLECTIONS,
+  REFERENCE_EDGES,
+  RETIREMENT_FIELD_PROBES,
+  buildResearchModelInventoryOutput,
+  buildResearchModelInventoryReport,
+  parseResearchModelInventoryArgs,
+  type CollectionCensusFact,
+  type FieldPresenceFact,
+  type InventoryFacts,
+  type ReferenceIntegrityFact,
+  type ResearchModelInventoryArgs,
+  type SchemaVersionBucket,
+} from './researchModelInventoryCore';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+dotenv.config({ path: path.resolve(__dirname, '../../.env') });
+
+async function listLiveCollections(db: Db): Promise<string[]> {
+  const collections = await db.listCollections({}, { nameOnly: true }).toArray();
+  return collections.map((entry) => entry.name).sort();
+}
+
+async function censusCollection(
+  db: Db,
+  collection: string,
+  present: boolean,
+): Promise<CollectionCensusFact> {
+  if (!present) {
+    return { collection, present: false, documentCount: 0, schemaVersions: [] };
+  }
+  const coll = db.collection(collection);
+  const documentCount = await coll.countDocuments({});
+  const grouped = await coll
+    .aggregate<{ _id: unknown; count: number }>([
+      { $group: { _id: '$schemaVersion', count: { $sum: 1 } } },
+      { $sort: { count: -1 } },
+    ])
+    .toArray();
+  const schemaVersions: SchemaVersionBucket[] = grouped.map((row) => ({
+    version: row._id === null || row._id === undefined ? 'unset' : String(row._id),
+    count: row.count,
+  }));
+  return { collection, present: true, documentCount, schemaVersions };
+}
+
+async function probeFieldPresence(
+  db: Db,
+  collection: string,
+  field: string,
+  present: boolean,
+): Promise<FieldPresenceFact> {
+  if (!present) {
+    return { collection, field, present: 0, total: 0 };
+  }
+  const coll = db.collection(collection);
+  const [total, withField] = await Promise.all([
+    coll.countDocuments({}),
+    coll.countDocuments({ [field]: { $exists: true } }),
+  ]);
+  return { collection, field, present: withField, total };
+}
+
+/**
+ * Type-agnostic orphan check: build the set of target ids as strings, then scan
+ * the referencing collection. This stays correct whether references are stored
+ * as ObjectId or string, unlike a `$lookup` keyed on `_id`.
+ */
+async function checkReferenceEdge(
+  db: Db,
+  edge: (typeof REFERENCE_EDGES)[number],
+  presentCollections: Set<string>,
+  sampleLimit: number,
+): Promise<ReferenceIntegrityFact> {
+  const base: ReferenceIntegrityFact = {
+    name: edge.name,
+    fromCollection: edge.fromCollection,
+    toCollection: edge.toCollection,
+    checked: 0,
+    orphaned: 0,
+    sampleOrphanIds: [],
+  };
+  if (!presentCollections.has(edge.fromCollection) || !presentCollections.has(edge.toCollection)) {
+    return base;
+  }
+
+  const targetIds = new Set<string>();
+  const targetCursor = db
+    .collection(edge.toCollection)
+    .find({}, { projection: { _id: 1 } });
+  for await (const doc of targetCursor) {
+    targetIds.add(String(doc._id));
+  }
+
+  let checked = 0;
+  let orphaned = 0;
+  const sampleOrphanIds: string[] = [];
+  const fromCursor = db
+    .collection(edge.fromCollection)
+    .find({ [edge.localField]: { $ne: null } }, { projection: { [edge.localField]: 1 } });
+  for await (const doc of fromCursor) {
+    const ref = (doc as Record<string, unknown>)[edge.localField];
+    if (ref === null || ref === undefined) continue;
+    checked += 1;
+    if (!targetIds.has(String(ref))) {
+      orphaned += 1;
+      if (sampleOrphanIds.length < sampleLimit) {
+        sampleOrphanIds.push(String(doc._id));
+      }
+    }
+  }
+
+  return { ...base, checked, orphaned, sampleOrphanIds };
+}
+
+async function gatherInventoryFacts(
+  db: Db,
+  args: ResearchModelInventoryArgs,
+): Promise<InventoryFacts> {
+  const liveCollections = await listLiveCollections(db);
+  const liveSet = new Set(liveCollections);
+
+  const census = await Promise.all(
+    INVENTORY_COLLECTIONS.map((spec) =>
+      censusCollection(db, spec.collection, liveSet.has(spec.collection)),
+    ),
+  );
+
+  const fieldPresence = await Promise.all(
+    RETIREMENT_FIELD_PROBES.map((probe) =>
+      probeFieldPresence(db, probe.collection, probe.field, liveSet.has(probe.collection)),
+    ),
+  );
+
+  const referenceIntegrity: ReferenceIntegrityFact[] = [];
+  for (const edge of REFERENCE_EDGES) {
+    referenceIntegrity.push(await checkReferenceEdge(db, edge, liveSet, args.sampleLimit));
+  }
+
+  return { liveCollections, census, fieldPresence, referenceIntegrity };
+}
+
+export function writeResearchModelInventoryOutput(
+  output: object,
+  target: string | undefined,
+): void {
+  if (!target) return;
+  const safeOutput = resolveSafeJsonReportOutputPath(target);
+  fs.writeFileSync(safeOutput, `${JSON.stringify(output, null, 2)}\n`);
+}
+
+async function main(): Promise<void> {
+  const args = parseResearchModelInventoryArgs(process.argv.slice(2));
+  // Validate the output path before touching the database so a bad flag fails fast.
+  if (args.output) {
+    resolveSafeJsonReportOutputPath(args.output);
+  }
+
+  await initializeConnections();
+  const db = mongoose.connection.db;
+  if (!db) {
+    throw new Error('MongoDB connection is not available');
+  }
+
+  const facts = await gatherInventoryFacts(db, args);
+  const report = buildResearchModelInventoryReport(facts);
+  const output = buildResearchModelInventoryOutput(report, {
+    environment: resolveScraperEnvironment(process.env),
+    db: db.databaseName || mongoose.connection.name || summarizeMongoUrl(process.env.MONGODBURL),
+    options: args,
+  });
+
+  console.log(JSON.stringify(output, null, 2));
+  writeResearchModelInventoryOutput(output, args.output);
+}
+
+const isDirectRun = process.argv[1]
+  ? fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+  : false;
+
+if (isDirectRun) {
+  main()
+    .catch((error) => {
+      console.error(sanitizeLogValue(error));
+      process.exitCode = 1;
+    })
+    .finally(async () => {
+      await mongoose.disconnect();
+    });
+}

--- a/server/src/scripts/researchModelInventory.ts
+++ b/server/src/scripts/researchModelInventory.ts
@@ -39,6 +39,7 @@ const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 
 const COLLECTION_SCAN_CONCURRENCY = 4;
+const REFERENCE_SCAN_BATCH_SIZE = 1_000;
 
 interface InventoryMongoClient {
   connect(): Promise<unknown>;
@@ -162,19 +163,14 @@ function emptyReferenceFact(edge: InventoryReferenceEdge): ReferenceIntegrityFac
   };
 }
 
-interface OrphanSampleCandidate {
-  sourceOrder: number;
-  sourceId: string;
-}
-
 interface ReferenceScanState {
   edge: InventoryReferenceEdge;
   fact: ReferenceIntegrityFact;
-  referencedIds: Set<string>;
-  foundIds: Set<string>;
-  referenceCounts: Map<string, number>;
-  samplesByReference: Map<string, OrphanSampleCandidate[]>;
-  missingRequiredSamples: OrphanSampleCandidate[];
+}
+
+interface PendingReference {
+  referenceId: string;
+  sourceId: string;
 }
 
 async function gatherReferenceIntegrityFacts(
@@ -201,11 +197,6 @@ async function gatherReferenceIntegrityFacts(
             ...emptyReferenceFact(edge),
             status: 'source-missing',
           },
-          referencedIds: new Set(),
-          foundIds: new Set(),
-          referenceCounts: new Map(),
-          samplesByReference: new Map(),
-          missingRequiredSamples: [],
         }));
       }
 
@@ -220,11 +211,6 @@ async function gatherReferenceIntegrityFacts(
                 ...emptyReferenceFact(edge),
                 status: targetPresent ? ('checked' as const) : ('target-missing' as const),
               },
-              referencedIds: new Set<string>(),
-              foundIds: new Set<string>(),
-              referenceCounts: new Map<string, number>(),
-              samplesByReference: new Map<string, OrphanSampleCandidate[]>(),
-              missingRequiredSamples: [],
             },
           ];
         }),
@@ -235,40 +221,78 @@ async function gatherReferenceIntegrityFacts(
       }
 
       const sourceCursor = db.collection(sourceCollection).find({}, { projection });
-      let sourceOrder = 0;
-      for await (const doc of sourceCursor) {
-        for (const edge of sourceEdges) {
-          const state = statesByName.get(edge.name);
-          if (!state) continue;
-          const ref = (doc as Record<string, unknown>)[edge.localField];
-          if (ref === null || ref === undefined) {
-            if (!edge.required) continue;
-            state.fact.checked += 1;
-            state.fact.orphaned += 1;
-            if (state.missingRequiredSamples.length < sampleLimit) {
-              state.missingRequiredSamples.push({
-                sourceOrder,
-                sourceId: String(doc._id),
-              });
-            }
-            continue;
-          }
+      let batch: Record<string, unknown>[] = [];
 
-          state.fact.checked += 1;
-          const referenceId = String(ref);
-          state.referencedIds.add(referenceId);
-          state.referenceCounts.set(referenceId, (state.referenceCounts.get(referenceId) ?? 0) + 1);
-          const samples = state.samplesByReference.get(referenceId) ?? [];
-          if (samples.length < sampleLimit) {
-            samples.push({
-              sourceOrder,
+      async function processBatch(): Promise<void> {
+        const pendingByEdge = new Map<string, PendingReference[]>();
+
+        for (const doc of batch) {
+          for (const edge of sourceEdges) {
+            const state = statesByName.get(edge.name);
+            if (!state) continue;
+            const ref = doc[edge.localField];
+            if (ref === null || ref === undefined) {
+              if (!edge.required) continue;
+              state.fact.checked += 1;
+              state.fact.orphaned += 1;
+              if (state.fact.sampleOrphanIds.length < sampleLimit) {
+                state.fact.sampleOrphanIds.push(String(doc._id));
+              }
+              continue;
+            }
+
+            state.fact.checked += 1;
+            const pending = pendingByEdge.get(edge.name) ?? [];
+            pending.push({
+              referenceId: String(ref),
               sourceId: String(doc._id),
             });
-            state.samplesByReference.set(referenceId, samples);
+            pendingByEdge.set(edge.name, pending);
           }
         }
-        sourceOrder += 1;
+
+        await Promise.all(
+          sourceEdges.map(async (edge) => {
+            const state = statesByName.get(edge.name);
+            const pending = pendingByEdge.get(edge.name) ?? [];
+            if (!state || pending.length === 0) return;
+
+            let foundIds = new Set<string>();
+            if (presentCollections.has(edge.toCollection)) {
+              const referenceIds = [...new Set(pending.map((item) => item.referenceId))];
+              const targetCursor = db.collection(edge.toCollection).find(
+                {
+                  $expr: {
+                    $in: [{ $toString: '$_id' }, referenceIds],
+                  },
+                },
+                { projection: { _id: 1 } },
+              );
+              foundIds = new Set<string>();
+              for await (const target of targetCursor) {
+                foundIds.add(String(target._id));
+              }
+            }
+
+            for (const item of pending) {
+              if (foundIds.has(item.referenceId)) continue;
+              state.fact.orphaned += 1;
+              if (state.fact.sampleOrphanIds.length < sampleLimit) {
+                state.fact.sampleOrphanIds.push(item.sourceId);
+              }
+            }
+          }),
+        );
       }
+
+      for await (const doc of sourceCursor) {
+        batch.push(doc as Record<string, unknown>);
+        if (batch.length === REFERENCE_SCAN_BATCH_SIZE) {
+          await processBatch();
+          batch = [];
+        }
+      }
+      if (batch.length > 0) await processBatch();
 
       return sourceEdges.map((edge) => {
         const state = statesByName.get(edge.name);
@@ -280,49 +304,6 @@ async function gatherReferenceIntegrityFacts(
     },
   );
   const states = sourceStateGroups.flat();
-
-  const statesByTarget = new Map<string, ReferenceScanState[]>();
-  for (const state of states) {
-    if (
-      state.fact.status !== 'checked' ||
-      state.referencedIds.size === 0 ||
-      !presentCollections.has(state.edge.toCollection)
-    ) {
-      continue;
-    }
-    const targetStates = statesByTarget.get(state.edge.toCollection) ?? [];
-    targetStates.push(state);
-    statesByTarget.set(state.edge.toCollection, targetStates);
-  }
-
-  await mapWithConcurrency(
-    [...statesByTarget.entries()],
-    COLLECTION_SCAN_CONCURRENCY,
-    async ([targetCollection, targetStates]) => {
-      const targetCursor = db.collection(targetCollection).find({}, { projection: { _id: 1 } });
-      for await (const doc of targetCursor) {
-        const targetId = String(doc._id);
-        for (const state of targetStates) {
-          if (state.referencedIds.has(targetId)) {
-            state.foundIds.add(targetId);
-          }
-        }
-      }
-    },
-  );
-
-  for (const state of states) {
-    const orphanSamples = [...state.missingRequiredSamples];
-    for (const referenceId of state.referencedIds) {
-      if (state.foundIds.has(referenceId)) continue;
-      state.fact.orphaned += state.referenceCounts.get(referenceId) ?? 0;
-      orphanSamples.push(...(state.samplesByReference.get(referenceId) ?? []));
-    }
-    state.fact.sampleOrphanIds = orphanSamples
-      .sort((left, right) => left.sourceOrder - right.sourceOrder)
-      .slice(0, sampleLimit)
-      .map((sample) => sample.sourceId);
-  }
 
   const factsByName = new Map(states.map((state) => [state.fact.name, state.fact]));
   return edges.map((edge) => {

--- a/server/src/scripts/researchModelInventory.ts
+++ b/server/src/scripts/researchModelInventory.ts
@@ -7,8 +7,8 @@
  * dropped. Writes nothing to the database.
  *
  * Usage:
- *   yarn --cwd server model-refactor:inventory
- *   yarn --cwd server model-refactor:inventory --output /tmp/inventory.json
+ *   yarn --cwd server model-refactor:inventory --environment beta
+ *   yarn --cwd server model-refactor:inventory --environment beta --output /tmp/inventory.json
  */
 import dotenv from 'dotenv';
 import fs from 'fs';
@@ -17,7 +17,7 @@ import { fileURLToPath } from 'url';
 import mongoose from 'mongoose';
 import type { Db } from 'mongodb';
 import { initializeConnections } from '../db/connections';
-import { resolveScraperEnvironment, summarizeMongoUrl } from '../scrapers/scraperEnvironment';
+import { summarizeMongoUrl } from '../scrapers/scraperEnvironment';
 import { resolveSafeJsonReportOutputPath } from './scriptWriteGuards';
 import { sanitizeLogValue } from '../utils/logSanitizer';
 import {
@@ -89,7 +89,7 @@ async function probeFieldPresence(
  * the referencing collection. This stays correct whether references are stored
  * as ObjectId or string, unlike a `$lookup` keyed on `_id`.
  */
-async function checkReferenceEdge(
+export async function checkReferenceEdge(
   db: Db,
   edge: (typeof REFERENCE_EDGES)[number],
   presentCollections: Set<string>,
@@ -99,20 +99,24 @@ async function checkReferenceEdge(
     name: edge.name,
     fromCollection: edge.fromCollection,
     toCollection: edge.toCollection,
+    status: 'checked',
     checked: 0,
     orphaned: 0,
     sampleOrphanIds: [],
   };
-  if (!presentCollections.has(edge.fromCollection) || !presentCollections.has(edge.toCollection)) {
-    return base;
+  if (!presentCollections.has(edge.fromCollection)) {
+    return { ...base, status: 'source-missing' };
   }
 
   const targetIds = new Set<string>();
-  const targetCursor = db
-    .collection(edge.toCollection)
-    .find({}, { projection: { _id: 1 } });
-  for await (const doc of targetCursor) {
-    targetIds.add(String(doc._id));
+  const targetPresent = presentCollections.has(edge.toCollection);
+  if (targetPresent) {
+    const targetCursor = db
+      .collection(edge.toCollection)
+      .find({}, { projection: { _id: 1 } });
+    for await (const doc of targetCursor) {
+      targetIds.add(String(doc._id));
+    }
   }
 
   let checked = 0;
@@ -133,7 +137,13 @@ async function checkReferenceEdge(
     }
   }
 
-  return { ...base, checked, orphaned, sampleOrphanIds };
+  return {
+    ...base,
+    status: targetPresent ? 'checked' : 'target-missing',
+    checked,
+    orphaned,
+    sampleOrphanIds,
+  };
 }
 
 async function gatherInventoryFacts(
@@ -179,7 +189,9 @@ async function main(): Promise<void> {
     resolveSafeJsonReportOutputPath(args.output);
   }
 
-  await initializeConnections();
+  await initializeConnections({
+    infoLog: (...values) => console.error(...values),
+  });
   const db = mongoose.connection.db;
   if (!db) {
     throw new Error('MongoDB connection is not available');
@@ -188,8 +200,9 @@ async function main(): Promise<void> {
   const facts = await gatherInventoryFacts(db, args);
   const report = buildResearchModelInventoryReport(facts);
   const output = buildResearchModelInventoryOutput(report, {
-    environment: resolveScraperEnvironment(process.env),
-    db: db.databaseName || mongoose.connection.name || summarizeMongoUrl(process.env.MONGODBURL),
+    environment: args.environment,
+    db: db.databaseName || mongoose.connection.name,
+    target: summarizeMongoUrl(process.env.MONGODBURL),
     options: args,
   });
 

--- a/server/src/scripts/researchModelInventory.ts
+++ b/server/src/scripts/researchModelInventory.ts
@@ -14,7 +14,7 @@ import dotenv from 'dotenv';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { MongoClient, type Db } from 'mongodb';
+import { MongoClient, ObjectId, type Db } from 'mongodb';
 import { summarizeMongoUrl } from '../scrapers/scraperEnvironment';
 import { resolveSafeJsonReportOutputPath } from './scriptWriteGuards';
 import { sanitizeLogValue } from '../utils/logSanitizer';
@@ -173,6 +173,16 @@ interface PendingReference {
   sourceId: string;
 }
 
+function referenceIdCandidates(referenceIds: string[]): (string | ObjectId)[] {
+  const candidates: (string | ObjectId)[] = [...referenceIds];
+  for (const referenceId of referenceIds) {
+    if (ObjectId.isValid(referenceId)) {
+      candidates.push(new ObjectId(referenceId));
+    }
+  }
+  return candidates;
+}
+
 async function gatherReferenceIntegrityFacts(
   db: Db,
   edges: InventoryReferenceEdge[],
@@ -260,11 +270,9 @@ async function gatherReferenceIntegrityFacts(
             let foundIds = new Set<string>();
             if (presentCollections.has(edge.toCollection)) {
               const referenceIds = [...new Set(pending.map((item) => item.referenceId))];
-              const targetCursor = db.collection(edge.toCollection).find(
+              const targetCursor = db.collection<{ _id: string | ObjectId }>(edge.toCollection).find(
                 {
-                  $expr: {
-                    $in: [{ $toString: '$_id' }, referenceIds],
-                  },
+                  _id: { $in: referenceIdCandidates(referenceIds) },
                 },
                 { projection: { _id: 1 } },
               );

--- a/server/src/scripts/researchModelInventory.ts
+++ b/server/src/scripts/researchModelInventory.ts
@@ -145,12 +145,21 @@ export async function checkReferenceEdge(
   let checked = 0;
   let orphaned = 0;
   const sampleOrphanIds: string[] = [];
+  const sourceFilter = edge.required ? {} : { [edge.localField]: { $ne: null } };
   const fromCursor = db
     .collection(edge.fromCollection)
-    .find({ [edge.localField]: { $ne: null } }, { projection: { [edge.localField]: 1 } });
+    .find(sourceFilter, { projection: { [edge.localField]: 1 } });
   for await (const doc of fromCursor) {
     const ref = (doc as Record<string, unknown>)[edge.localField];
-    if (ref === null || ref === undefined) continue;
+    if (ref === null || ref === undefined) {
+      if (!edge.required) continue;
+      checked += 1;
+      orphaned += 1;
+      if (sampleOrphanIds.length < sampleLimit) {
+        sampleOrphanIds.push(String(doc._id));
+      }
+      continue;
+    }
     checked += 1;
     if (!targetIds.has(String(ref))) {
       orphaned += 1;

--- a/server/src/scripts/researchModelInventory.ts
+++ b/server/src/scripts/researchModelInventory.ts
@@ -109,19 +109,38 @@ async function censusCollection(
   return { collection, present: true, documentCount, schemaVersions };
 }
 
-async function probeFieldPresence(
+async function probeCollectionFieldPresence(
   db: Db,
   collection: string,
-  field: string,
+  fields: string[],
   present: boolean,
   total: number,
-): Promise<FieldPresenceFact> {
+): Promise<FieldPresenceFact[]> {
   if (!present) {
-    return { collection, field, present: 0, total: 0 };
+    return fields.map((field) => ({ collection, field, present: 0, total: 0 }));
   }
-  const coll = db.collection(collection);
-  const withField = await coll.countDocuments({ [field]: { $exists: true } });
-  return { collection, field, present: withField, total };
+
+  const counters = Object.fromEntries(
+    fields.map((field, index) => [
+      `field_${index}`,
+      {
+        $sum: {
+          $cond: [{ $ne: [{ $type: `$${field}` }, 'missing'] }, 1, 0],
+        },
+      },
+    ]),
+  );
+  const [counts = {}] = await db
+    .collection(collection)
+    .aggregate<Record<string, number>>([{ $group: { _id: null, ...counters } }])
+    .toArray();
+
+  return fields.map((field, index) => ({
+    collection,
+    field,
+    present: counts[`field_${index}`] ?? 0,
+    total,
+  }));
 }
 
 /**
@@ -142,13 +161,19 @@ function emptyReferenceFact(edge: InventoryReferenceEdge): ReferenceIntegrityFac
   };
 }
 
-async function loadTargetIds(db: Db, collection: string): Promise<Set<string>> {
-  const targetIds = new Set<string>();
-  const targetCursor = db.collection(collection).find({}, { projection: { _id: 1 } });
-  for await (const doc of targetCursor) {
-    targetIds.add(String(doc._id));
-  }
-  return targetIds;
+interface OrphanSampleCandidate {
+  sourceOrder: number;
+  sourceId: string;
+}
+
+interface ReferenceScanState {
+  edge: InventoryReferenceEdge;
+  fact: ReferenceIntegrityFact;
+  referencedIds: Set<string>;
+  foundIds: Set<string>;
+  referenceCounts: Map<string, number>;
+  samplesByReference: Map<string, OrphanSampleCandidate[]>;
+  missingRequiredSamples: OrphanSampleCandidate[];
 }
 
 async function gatherReferenceIntegrityFacts(
@@ -157,21 +182,6 @@ async function gatherReferenceIntegrityFacts(
   presentCollections: Set<string>,
   sampleLimit: number,
 ): Promise<ReferenceIntegrityFact[]> {
-  const targetCollections = [
-    ...new Set(
-      edges
-        .filter((edge) => presentCollections.has(edge.fromCollection))
-        .map((edge) => edge.toCollection)
-        .filter((collection) => presentCollections.has(collection)),
-    ),
-  ];
-  const targetEntries = await mapWithConcurrency(
-    targetCollections,
-    COLLECTION_SCAN_CONCURRENCY,
-    async (collection) => [collection, await loadTargetIds(db, collection)] as const,
-  );
-  const targetIdsByCollection = new Map(targetEntries);
-
   const edgesBySource = new Map<string, InventoryReferenceEdge[]>();
   for (const edge of edges) {
     const sourceEdges = edgesBySource.get(edge.fromCollection) ?? [];
@@ -179,25 +189,41 @@ async function gatherReferenceIntegrityFacts(
     edgesBySource.set(edge.fromCollection, sourceEdges);
   }
 
-  const sourceGroups = await mapWithConcurrency(
+  const sourceStateGroups = await mapWithConcurrency(
     [...edgesBySource.entries()],
     COLLECTION_SCAN_CONCURRENCY,
     async ([sourceCollection, sourceEdges]) => {
       if (!presentCollections.has(sourceCollection)) {
-        return sourceEdges.map((edge) => ({
-          ...emptyReferenceFact(edge),
-          status: 'source-missing' as const,
+        return sourceEdges.map<ReferenceScanState>((edge) => ({
+          edge,
+          fact: {
+            ...emptyReferenceFact(edge),
+            status: 'source-missing',
+          },
+          referencedIds: new Set(),
+          foundIds: new Set(),
+          referenceCounts: new Map(),
+          samplesByReference: new Map(),
+          missingRequiredSamples: [],
         }));
       }
 
-      const factsByName = new Map(
-        sourceEdges.map((edge) => {
+      const statesByName = new Map<string, ReferenceScanState>(
+        sourceEdges.map((edge): [string, ReferenceScanState] => {
           const targetPresent = presentCollections.has(edge.toCollection);
           return [
             edge.name,
             {
-              ...emptyReferenceFact(edge),
-              status: targetPresent ? ('checked' as const) : ('target-missing' as const),
+              edge,
+              fact: {
+                ...emptyReferenceFact(edge),
+                status: targetPresent ? ('checked' as const) : ('target-missing' as const),
+              },
+              referencedIds: new Set<string>(),
+              foundIds: new Set<string>(),
+              referenceCounts: new Map<string, number>(),
+              samplesByReference: new Map<string, OrphanSampleCandidate[]>(),
+              missingRequiredSamples: [],
             },
           ];
         }),
@@ -208,42 +234,99 @@ async function gatherReferenceIntegrityFacts(
       }
 
       const sourceCursor = db.collection(sourceCollection).find({}, { projection });
+      let sourceOrder = 0;
       for await (const doc of sourceCursor) {
         for (const edge of sourceEdges) {
-          const fact = factsByName.get(edge.name);
-          if (!fact) continue;
+          const state = statesByName.get(edge.name);
+          if (!state) continue;
           const ref = (doc as Record<string, unknown>)[edge.localField];
           if (ref === null || ref === undefined) {
             if (!edge.required) continue;
-            fact.checked += 1;
-            fact.orphaned += 1;
-            if (fact.sampleOrphanIds.length < sampleLimit) {
-              fact.sampleOrphanIds.push(String(doc._id));
+            state.fact.checked += 1;
+            state.fact.orphaned += 1;
+            if (state.missingRequiredSamples.length < sampleLimit) {
+              state.missingRequiredSamples.push({
+                sourceOrder,
+                sourceId: String(doc._id),
+              });
             }
             continue;
           }
 
-          fact.checked += 1;
-          const targetIds = targetIdsByCollection.get(edge.toCollection);
-          if (!targetIds?.has(String(ref))) {
-            fact.orphaned += 1;
-            if (fact.sampleOrphanIds.length < sampleLimit) {
-              fact.sampleOrphanIds.push(String(doc._id));
-            }
+          state.fact.checked += 1;
+          const referenceId = String(ref);
+          state.referencedIds.add(referenceId);
+          state.referenceCounts.set(
+            referenceId,
+            (state.referenceCounts.get(referenceId) ?? 0) + 1,
+          );
+          const samples = state.samplesByReference.get(referenceId) ?? [];
+          if (samples.length < sampleLimit) {
+            samples.push({
+              sourceOrder,
+              sourceId: String(doc._id),
+            });
+            state.samplesByReference.set(referenceId, samples);
           }
         }
+        sourceOrder += 1;
       }
 
       return sourceEdges.map((edge) => {
-        const fact = factsByName.get(edge.name);
-        if (!fact) {
-          throw new Error(`Missing reference fact for ${edge.name}`);
+        const state = statesByName.get(edge.name);
+        if (!state) {
+          throw new Error(`Missing reference state for ${edge.name}`);
         }
-        return fact;
+        return state;
       });
     },
   );
-  const factsByName = new Map(sourceGroups.flat().map((fact) => [fact.name, fact]));
+  const states = sourceStateGroups.flat();
+
+  const statesByTarget = new Map<string, ReferenceScanState[]>();
+  for (const state of states) {
+    if (
+      state.fact.status !== 'checked' ||
+      state.referencedIds.size === 0 ||
+      !presentCollections.has(state.edge.toCollection)
+    ) {
+      continue;
+    }
+    const targetStates = statesByTarget.get(state.edge.toCollection) ?? [];
+    targetStates.push(state);
+    statesByTarget.set(state.edge.toCollection, targetStates);
+  }
+
+  await mapWithConcurrency(
+    [...statesByTarget.entries()],
+    COLLECTION_SCAN_CONCURRENCY,
+    async ([targetCollection, targetStates]) => {
+      const targetCursor = db.collection(targetCollection).find({}, { projection: { _id: 1 } });
+      for await (const doc of targetCursor) {
+        const targetId = String(doc._id);
+        for (const state of targetStates) {
+          if (state.referencedIds.has(targetId)) {
+            state.foundIds.add(targetId);
+          }
+        }
+      }
+    },
+  );
+
+  for (const state of states) {
+    const orphanSamples = [...state.missingRequiredSamples];
+    for (const referenceId of state.referencedIds) {
+      if (state.foundIds.has(referenceId)) continue;
+      state.fact.orphaned += state.referenceCounts.get(referenceId) ?? 0;
+      orphanSamples.push(...(state.samplesByReference.get(referenceId) ?? []));
+    }
+    state.fact.sampleOrphanIds = orphanSamples
+      .sort((left, right) => left.sourceOrder - right.sourceOrder)
+      .slice(0, sampleLimit)
+      .map((sample) => sample.sourceId);
+  }
+
+  const factsByName = new Map(states.map((state) => [state.fact.name, state.fact]));
   return edges.map((edge) => {
     const fact = factsByName.get(edge.name);
     if (!fact) {
@@ -293,13 +376,13 @@ export async function gatherInventoryFacts(
       const total =
         censusFact?.documentCount ??
         (collectionPresent ? await db.collection(collection).countDocuments({}) : 0);
-      const facts: FieldPresenceFact[] = [];
-      for (const probe of probes) {
-        facts.push(
-          await probeFieldPresence(db, probe.collection, probe.field, collectionPresent, total),
-        );
-      }
-      return facts;
+      return probeCollectionFieldPresence(
+        db,
+        collection,
+        probes.map((probe) => probe.field),
+        collectionPresent,
+        total,
+      );
     },
   );
   const fieldPresence = fieldPresenceGroups.flat();

--- a/server/src/scripts/researchModelInventory.ts
+++ b/server/src/scripts/researchModelInventory.ts
@@ -22,6 +22,7 @@ import {
   INVENTORY_COLLECTIONS,
   REFERENCE_EDGES,
   RETIREMENT_FIELD_PROBES,
+  assertInventoryEnvironmentMatchesDatabase,
   buildResearchModelInventoryOutput,
   buildResearchModelInventoryReport,
   parseResearchModelInventoryArgs,
@@ -399,9 +400,15 @@ export async function runResearchModelInventory(
   mongoUrl: string,
   client: InventoryMongoClient = new MongoClient(mongoUrl),
 ): Promise<ReturnType<typeof buildResearchModelInventoryOutput>> {
+  const configuredDatabaseName = decodeURIComponent(
+    new URL(mongoUrl).pathname.slice(1).split('/')[0],
+  );
+  assertInventoryEnvironmentMatchesDatabase(args.environment, configuredDatabaseName);
+
   try {
     await client.connect();
     const db = client.db();
+    assertInventoryEnvironmentMatchesDatabase(args.environment, db.databaseName);
     const facts = await gatherInventoryFacts(db, args);
     const report = buildResearchModelInventoryReport(facts);
     return buildResearchModelInventoryOutput(report, {

--- a/server/src/scripts/researchModelInventoryCore.ts
+++ b/server/src/scripts/researchModelInventoryCore.ts
@@ -47,6 +47,7 @@ export interface ReferenceEdge {
   fromCollection: string;
   localField: string;
   toCollection: string;
+  required: boolean;
   meaning: string;
 }
 
@@ -493,6 +494,7 @@ export const REFERENCE_EDGES: ReferenceEdge[] = [
     fromCollection: 'research_entity_members',
     localField: 'researchEntityId',
     toCollection: 'research_entities',
+    required: false,
     meaning: 'Membership rows must resolve to a research entity',
   },
   {
@@ -500,6 +502,7 @@ export const REFERENCE_EDGES: ReferenceEdge[] = [
     fromCollection: 'research_entity_members',
     localField: 'userId',
     toCollection: 'users',
+    required: false,
     meaning: 'Membership user refs must resolve to a user',
   },
   {
@@ -507,13 +510,47 @@ export const REFERENCE_EDGES: ReferenceEdge[] = [
     fromCollection: 'research_entity_members',
     localField: 'facultyMemberId',
     toCollection: 'faculty_members',
+    required: false,
     meaning: 'Membership faculty refs must resolve to a faculty member',
+  },
+  {
+    name: 'user_to_faculty',
+    fromCollection: 'users',
+    localField: 'facultyMemberId',
+    toCollection: 'faculty_members',
+    required: false,
+    meaning: 'User faculty refs must resolve to a faculty member',
+  },
+  {
+    name: 'user_to_student_profile',
+    fromCollection: 'users',
+    localField: 'studentProfileId',
+    toCollection: 'student_profiles',
+    required: false,
+    meaning: 'User student-profile refs must resolve to a student profile',
+  },
+  {
+    name: 'faculty_to_user',
+    fromCollection: 'faculty_members',
+    localField: 'userId',
+    toCollection: 'users',
+    required: false,
+    meaning: 'Faculty user refs must resolve to a user',
+  },
+  {
+    name: 'student_profile_to_user',
+    fromCollection: 'student_profiles',
+    localField: 'userId',
+    toCollection: 'users',
+    required: true,
+    meaning: 'Student profiles must resolve to a user',
   },
   {
     name: 'access_signal_to_entity',
     fromCollection: 'access_signals',
     localField: 'researchEntityId',
     toCollection: 'research_entities',
+    required: true,
     meaning: 'Access signals must resolve to a research entity',
   },
   {
@@ -521,6 +558,7 @@ export const REFERENCE_EDGES: ReferenceEdge[] = [
     fromCollection: 'access_signals',
     localField: 'entryPathwayId',
     toCollection: 'entry_pathways',
+    required: false,
     meaning: 'Access signal pathway refs must resolve to an entry pathway',
   },
   {
@@ -528,6 +566,7 @@ export const REFERENCE_EDGES: ReferenceEdge[] = [
     fromCollection: 'entry_pathways',
     localField: 'researchEntityId',
     toCollection: 'research_entities',
+    required: true,
     meaning: 'Entry pathways must resolve to a research entity',
   },
   {
@@ -535,6 +574,7 @@ export const REFERENCE_EDGES: ReferenceEdge[] = [
     fromCollection: 'contact_routes',
     localField: 'researchEntityId',
     toCollection: 'research_entities',
+    required: true,
     meaning: 'Contact routes must resolve to a research entity',
   },
   {
@@ -542,6 +582,7 @@ export const REFERENCE_EDGES: ReferenceEdge[] = [
     fromCollection: 'contact_routes',
     localField: 'entryPathwayId',
     toCollection: 'entry_pathways',
+    required: false,
     meaning: 'Contact route pathway refs must resolve to an entry pathway',
   },
   {
@@ -549,6 +590,7 @@ export const REFERENCE_EDGES: ReferenceEdge[] = [
     fromCollection: 'posted_opportunities',
     localField: 'entryPathwayId',
     toCollection: 'entry_pathways',
+    required: true,
     meaning: 'Posted opportunities must resolve to an entry pathway',
   },
   {
@@ -556,6 +598,7 @@ export const REFERENCE_EDGES: ReferenceEdge[] = [
     fromCollection: 'posted_opportunities',
     localField: 'researchEntityId',
     toCollection: 'research_entities',
+    required: false,
     meaning: 'Posted opportunity entity refs must resolve to a research entity',
   },
   {
@@ -563,6 +606,7 @@ export const REFERENCE_EDGES: ReferenceEdge[] = [
     fromCollection: 'research_entity_relationships',
     localField: 'sourceResearchEntityId',
     toCollection: 'research_entities',
+    required: true,
     meaning: 'Relationship source must resolve to a research entity',
   },
   {
@@ -570,13 +614,23 @@ export const REFERENCE_EDGES: ReferenceEdge[] = [
     fromCollection: 'research_entity_relationships',
     localField: 'targetResearchEntityId',
     toCollection: 'research_entities',
+    required: true,
     meaning: 'Relationship target must resolve to a research entity',
+  },
+  {
+    name: 'student_application_to_listing',
+    fromCollection: 'student_applications',
+    localField: 'listingObjectId',
+    toCollection: 'listings',
+    required: false,
+    meaning: 'Student application listing refs must resolve to a listing',
   },
   {
     name: 'student_application_to_opportunity',
     fromCollection: 'student_applications',
     localField: 'postedOpportunityId',
     toCollection: 'posted_opportunities',
+    required: false,
     meaning: 'Student application opportunity refs must resolve to a posted opportunity',
   },
   {
@@ -584,6 +638,7 @@ export const REFERENCE_EDGES: ReferenceEdge[] = [
     fromCollection: 'student_applications',
     localField: 'researchEntityId',
     toCollection: 'research_entities',
+    required: false,
     meaning: 'Student application entity refs must resolve to a research entity',
   },
   {
@@ -591,6 +646,7 @@ export const REFERENCE_EDGES: ReferenceEdge[] = [
     fromCollection: 'student_applications',
     localField: 'studentUserId',
     toCollection: 'users',
+    required: false,
     meaning: 'Student application user refs must resolve to a user',
   },
   {
@@ -598,6 +654,7 @@ export const REFERENCE_EDGES: ReferenceEdge[] = [
     fromCollection: 'student_applications',
     localField: 'studentProfileId',
     toCollection: 'student_profiles',
+    required: false,
     meaning: 'Student application profile refs must resolve to a student profile',
   },
   {
@@ -605,6 +662,7 @@ export const REFERENCE_EDGES: ReferenceEdge[] = [
     fromCollection: 'student_trackings',
     localField: 'studentProfileId',
     toCollection: 'student_profiles',
+    required: true,
     meaning: 'Student tracking profile refs must resolve to a student profile',
   },
   {
@@ -612,6 +670,7 @@ export const REFERENCE_EDGES: ReferenceEdge[] = [
     fromCollection: 'student_trackings',
     localField: 'researchEntityId',
     toCollection: 'research_entities',
+    required: true,
     meaning: 'Student tracking entity refs must resolve to a research entity',
   },
   {
@@ -619,6 +678,7 @@ export const REFERENCE_EDGES: ReferenceEdge[] = [
     fromCollection: 'student_outreaches',
     localField: 'studentProfileId',
     toCollection: 'student_profiles',
+    required: true,
     meaning: 'Student outreach profile refs must resolve to a student profile',
   },
   {
@@ -626,6 +686,7 @@ export const REFERENCE_EDGES: ReferenceEdge[] = [
     fromCollection: 'student_outreaches',
     localField: 'researchEntityId',
     toCollection: 'research_entities',
+    required: true,
     meaning: 'Student outreach entity refs must resolve to a research entity',
   },
   {
@@ -633,6 +694,7 @@ export const REFERENCE_EDGES: ReferenceEdge[] = [
     fromCollection: 'student_outreaches',
     localField: 'trackingId',
     toCollection: 'student_trackings',
+    required: true,
     meaning: 'Student outreach tracking refs must resolve to a student tracking record',
   },
   {
@@ -640,6 +702,7 @@ export const REFERENCE_EDGES: ReferenceEdge[] = [
     fromCollection: 'student_engagement_events',
     localField: 'studentProfileId',
     toCollection: 'student_profiles',
+    required: false,
     meaning: 'Student engagement profile refs must resolve to a student profile',
   },
   {
@@ -647,6 +710,7 @@ export const REFERENCE_EDGES: ReferenceEdge[] = [
     fromCollection: 'student_engagement_events',
     localField: 'researchEntityId',
     toCollection: 'research_entities',
+    required: true,
     meaning: 'Student engagement entity refs must resolve to a research entity',
   },
 ];
@@ -722,6 +786,8 @@ export interface RetirementFieldRow {
 
 export interface ReferenceIntegrityRow extends Omit<ReferenceIntegrityFact, 'status'> {
   status: ReferenceIntegrityFact['status'] | 'not-gathered';
+  localField: string;
+  required: boolean;
   meaning: string;
   orphanRate: number;
   clean: boolean | null;
@@ -821,6 +887,8 @@ export function buildResearchModelInventoryReport(
       fromCollection: edge.fromCollection,
       toCollection: edge.toCollection,
       status,
+      localField: edge.localField,
+      required: edge.required,
       meaning: edge.meaning,
       checked,
       orphaned,

--- a/server/src/scripts/researchModelInventoryCore.ts
+++ b/server/src/scripts/researchModelInventoryCore.ts
@@ -59,82 +59,596 @@ export type InventoryEnvironment =
 
 /** Refactor-relevant collections, keyed by physical name. */
 export const INVENTORY_COLLECTIONS: CollectionSpec[] = [
-  { collection: 'users', model: 'User', group: 'dual-truth', phase: 2, target: 'Account + Person (+ StudentProfile, ResearchPlan)' },
-  { collection: 'faculty_members', model: 'FacultyMember', group: 'dual-truth', phase: 2, target: 'Person (deterministic merge, quarantine conflicts)' },
-  { collection: 'research_entity_members', model: 'ResearchGroupMember', group: 'dual-truth', phase: 2, target: 'RoleAssignment (one entity id, one person id)' },
-  { collection: 'research_entities', model: 'ResearchEntity', group: 'canonical-domain', phase: 4, target: 'Clean ResearchEntity schema + bounded discovery projection' },
-  { collection: 'research_entity_relationships', model: 'ResearchEntityRelationship', group: 'canonical-domain', phase: 4, target: 'EntityRelationship' },
-  { collection: 'entry_pathways', model: 'EntryPathway', group: 'canonical-domain', phase: 4, target: 'EntryPathway (retained)' },
-  { collection: 'posted_opportunities', model: 'PostedOpportunity', group: 'canonical-domain', phase: 4, target: 'PostedOpportunity (retained)' },
-  { collection: 'access_signals', model: 'AccessSignal', group: 'canonical-domain', phase: 4, target: 'AccessSignal (retained)' },
-  { collection: 'contact_routes', model: 'ContactRoute', group: 'canonical-domain', phase: 4, target: 'ContactRoute (retained)' },
-  { collection: 'admin_grants', model: 'AdminGrant', group: 'canonical-domain', phase: null, target: 'AdminGrant (admin authority)' },
-  { collection: 'listings', model: 'Listing', group: 'legacy-residue', phase: 4, target: 'EntryPathway + PostedOpportunity' },
-  { collection: 'fellowships', model: 'Fellowship', group: 'legacy-residue', phase: 4, target: 'Classify: entity / pathway / posting / formalization' },
-  { collection: 'departments', model: 'Department', group: 'reference-data', phase: 4, target: 'OrgUnit' },
-  { collection: 'research_areas', model: 'ResearchArea', group: 'reference-data', phase: 4, target: 'TaxonomyTerm' },
-  { collection: 'grants', model: 'Grant', group: 'reference-data', phase: null, target: 'Deferred; never undergraduate-access evidence' },
-  { collection: 'papers', model: 'Paper', group: 'scholarly-retire', phase: 3, target: 'No target collection' },
-  { collection: 'paper_authors', model: 'PaperAuthor', group: 'scholarly-retire', phase: 3, target: 'No target collection' },
-  { collection: 'research_scholarly_links', model: 'ResearchScholarlyLink', group: 'scholarly-retire', phase: 3, target: 'Crux: bare outbound link vs curated activity surface' },
-  { collection: 'research_scholarly_attributions', model: 'ResearchScholarlyAttribution', group: 'scholarly-retire', phase: 3, target: 'No target collection' },
-  { collection: 'observations', model: 'Observation', group: 'evidence', phase: 5, target: 'EvidenceClaim (+ SourceDocument)' },
-  { collection: 'sources', model: 'Source', group: 'evidence', phase: 5, target: 'Source + SourceDocument' },
-  { collection: 'student_profiles', model: 'StudentProfile', group: 'private', phase: 4, target: 'StudentProfile (retained)' },
-  { collection: 'student_applications', model: 'StudentApplication', group: 'private', phase: 4, target: 'Private student application records (retained, normalized references)' },
-  { collection: 'student_trackings', model: 'StudentTracking', group: 'private', phase: 4, target: 'ResearchPlan' },
-  { collection: 'student_outreaches', model: 'StudentOutreach', group: 'private', phase: null, target: 'Private outreach state' },
-  { collection: 'student_engagement_events', model: 'StudentEngagementEvent', group: 'private', phase: null, target: 'EngagementEvent (append-only analytics)' },
+  {
+    collection: 'users',
+    model: 'User',
+    group: 'dual-truth',
+    phase: 2,
+    target: 'Account + Person (+ StudentProfile, ResearchPlan)',
+  },
+  {
+    collection: 'faculty_members',
+    model: 'FacultyMember',
+    group: 'dual-truth',
+    phase: 2,
+    target: 'Person (deterministic merge, quarantine conflicts)',
+  },
+  {
+    collection: 'research_entity_members',
+    model: 'ResearchGroupMember',
+    group: 'dual-truth',
+    phase: 2,
+    target: 'RoleAssignment (one entity id, one person id)',
+  },
+  {
+    collection: 'research_entities',
+    model: 'ResearchEntity',
+    group: 'canonical-domain',
+    phase: 4,
+    target: 'Clean ResearchEntity schema + bounded discovery projection',
+  },
+  {
+    collection: 'research_entity_relationships',
+    model: 'ResearchEntityRelationship',
+    group: 'canonical-domain',
+    phase: 4,
+    target: 'EntityRelationship',
+  },
+  {
+    collection: 'entry_pathways',
+    model: 'EntryPathway',
+    group: 'canonical-domain',
+    phase: 4,
+    target: 'EntryPathway (retained)',
+  },
+  {
+    collection: 'posted_opportunities',
+    model: 'PostedOpportunity',
+    group: 'canonical-domain',
+    phase: 4,
+    target: 'PostedOpportunity (retained)',
+  },
+  {
+    collection: 'access_signals',
+    model: 'AccessSignal',
+    group: 'canonical-domain',
+    phase: 4,
+    target: 'AccessSignal (retained)',
+  },
+  {
+    collection: 'contact_routes',
+    model: 'ContactRoute',
+    group: 'canonical-domain',
+    phase: 4,
+    target: 'ContactRoute (retained)',
+  },
+  {
+    collection: 'admin_grants',
+    model: 'AdminGrant',
+    group: 'canonical-domain',
+    phase: null,
+    target: 'AdminGrant (admin authority)',
+  },
+  {
+    collection: 'listings',
+    model: 'Listing',
+    group: 'legacy-residue',
+    phase: 4,
+    target: 'EntryPathway + PostedOpportunity',
+  },
+  {
+    collection: 'fellowships',
+    model: 'Fellowship',
+    group: 'legacy-residue',
+    phase: 4,
+    target: 'Classify: entity / pathway / posting / formalization',
+  },
+  {
+    collection: 'departments',
+    model: 'Department',
+    group: 'reference-data',
+    phase: 4,
+    target: 'OrgUnit',
+  },
+  {
+    collection: 'research_areas',
+    model: 'ResearchArea',
+    group: 'reference-data',
+    phase: 4,
+    target: 'TaxonomyTerm',
+  },
+  {
+    collection: 'grants',
+    model: 'Grant',
+    group: 'reference-data',
+    phase: null,
+    target: 'Deferred; never undergraduate-access evidence',
+  },
+  {
+    collection: 'papers',
+    model: 'Paper',
+    group: 'scholarly-retire',
+    phase: 3,
+    target: 'No target collection',
+  },
+  {
+    collection: 'paper_authors',
+    model: 'PaperAuthor',
+    group: 'scholarly-retire',
+    phase: 3,
+    target: 'No target collection',
+  },
+  {
+    collection: 'research_scholarly_links',
+    model: 'ResearchScholarlyLink',
+    group: 'scholarly-retire',
+    phase: 3,
+    target: 'Crux: bare outbound link vs curated activity surface',
+  },
+  {
+    collection: 'research_scholarly_attributions',
+    model: 'ResearchScholarlyAttribution',
+    group: 'scholarly-retire',
+    phase: 3,
+    target: 'No target collection',
+  },
+  {
+    collection: 'observations',
+    model: 'Observation',
+    group: 'evidence',
+    phase: 5,
+    target: 'EvidenceClaim (+ SourceDocument)',
+  },
+  {
+    collection: 'sources',
+    model: 'Source',
+    group: 'evidence',
+    phase: 5,
+    target: 'Source + SourceDocument',
+  },
+  {
+    collection: 'student_profiles',
+    model: 'StudentProfile',
+    group: 'private',
+    phase: 4,
+    target: 'StudentProfile (retained)',
+  },
+  {
+    collection: 'student_applications',
+    model: 'StudentApplication',
+    group: 'private',
+    phase: 4,
+    target: 'Private student application records (retained, normalized references)',
+  },
+  {
+    collection: 'student_trackings',
+    model: 'StudentTracking',
+    group: 'private',
+    phase: 4,
+    target: 'ResearchPlan',
+  },
+  {
+    collection: 'student_outreaches',
+    model: 'StudentOutreach',
+    group: 'private',
+    phase: null,
+    target: 'Private outreach state',
+  },
+  {
+    collection: 'student_engagement_events',
+    model: 'StudentEngagementEvent',
+    group: 'private',
+    phase: null,
+    target: 'EngagementEvent (append-only analytics)',
+  },
   // Expected already retired by the earlier hard-pivot; presence is residue.
-  { collection: 'research_groups', model: 'ResearchGroup', group: 'legacy-residue', phase: 0, target: 'research_entities (should be dropped)', expectPresent: false },
-  { collection: 'research_group_members', model: 'ResearchGroupMember (legacy)', group: 'legacy-residue', phase: 0, target: 'research_entity_members (should be dropped)', expectPresent: false },
-  { collection: 'research_group_stats', model: 'ResearchGroupStats', group: 'legacy-residue', phase: 0, target: 'None (should be dropped)', expectPresent: false },
-  { collection: 'paper_group_links', model: 'PaperGroupLink', group: 'legacy-residue', phase: 0, target: 'None (should be dropped)', expectPresent: false },
-  { collection: 'applications', model: 'Application', group: 'legacy-residue', phase: 0, target: 'student_applications (should be dropped)', expectPresent: false },
+  {
+    collection: 'research_groups',
+    model: 'ResearchGroup',
+    group: 'legacy-residue',
+    phase: 0,
+    target: 'research_entities (should be dropped)',
+    expectPresent: false,
+  },
+  {
+    collection: 'research_group_members',
+    model: 'ResearchGroupMember (legacy)',
+    group: 'legacy-residue',
+    phase: 0,
+    target: 'research_entity_members (should be dropped)',
+    expectPresent: false,
+  },
+  {
+    collection: 'research_group_stats',
+    model: 'ResearchGroupStats',
+    group: 'legacy-residue',
+    phase: 0,
+    target: 'None (should be dropped)',
+    expectPresent: false,
+  },
+  {
+    collection: 'paper_group_links',
+    model: 'PaperGroupLink',
+    group: 'legacy-residue',
+    phase: 0,
+    target: 'None (should be dropped)',
+    expectPresent: false,
+  },
+  {
+    collection: 'applications',
+    model: 'Application',
+    group: 'legacy-residue',
+    phase: 0,
+    target: 'student_applications (should be dropped)',
+    expectPresent: false,
+  },
 ];
 
 /** Legacy fields whose lingering prevalence gates their retirement phase. */
 export const RETIREMENT_FIELD_PROBES: FieldProbe[] = [
-  { collection: 'research_entities', field: 'kind', meaning: 'Legacy type field superseded by entityType', target: 'Retire after read cutover' },
-  { collection: 'research_entities', field: 'acceptingUndergrads', meaning: 'Binary access cache', target: 'AccessSignal + computed access summary' },
-  { collection: 'research_entities', field: 'openness', meaning: 'Openness cache', target: 'AccessSignal + computed access summary' },
-  { collection: 'research_entities', field: 'acceptanceConfidence', meaning: 'Openness confidence cache', target: 'AccessSignal + computed access summary' },
-  { collection: 'research_entities', field: 'shortDescription', meaning: 'Duplicate description field', target: 'Single description' },
-  { collection: 'research_entities', field: 'fullDescription', meaning: 'Duplicate description field', target: 'Single description' },
-  { collection: 'research_entity_members', field: 'researchGroupId', meaning: 'Legacy entity reference', target: 'RoleAssignment.target.id' },
-  { collection: 'research_entity_members', field: 'researchEntityId', meaning: 'Canonical entity reference', target: 'RoleAssignment.target.id' },
-  { collection: 'research_entity_members', field: 'userId', meaning: 'User person reference', target: 'RoleAssignment.personId' },
-  { collection: 'research_entity_members', field: 'facultyMemberId', meaning: 'FacultyMember person reference', target: 'RoleAssignment.personId' },
-  { collection: 'users', field: 'publications', meaning: 'Embedded publication array', target: 'Removed (link to official profile / ORCID)' },
-  { collection: 'users', field: 'favPathways', meaning: 'Legacy saved-pathway array', target: 'ResearchPlan' },
-  { collection: 'users', field: 'savedPathwayPlans', meaning: 'Legacy saved-pathway plan map', target: 'ResearchPlan' },
-  { collection: 'users', field: 'savedResearchEntities', meaning: 'Saved-entity array', target: 'ResearchPlan' },
-  { collection: 'users', field: 'savedResearchEntityPlans', meaning: 'Saved-entity plan map', target: 'ResearchPlan' },
-  { collection: 'users', field: 'orcid', meaning: 'External researcher identifier', target: 'Person.identifiers.orcid' },
-  { collection: 'users', field: 'hIndex', meaning: 'Mirrored citation metric', target: 'Remove with professor-profile mirrors' },
-  { collection: 'users', field: 'googleScholarId', meaning: 'Mirrored scholarly identifier', target: 'Remove with professor-profile mirrors' },
-  { collection: 'users', field: 'openAlexId', meaning: 'Mirrored scholarly identifier', target: 'Remove with professor-profile mirrors' },
-  { collection: 'users', field: 'semanticScholarId', meaning: 'Mirrored scholarly identifier', target: 'Remove with professor-profile mirrors' },
-  { collection: 'listings', field: 'researchGroupId', meaning: 'Legacy entity reference', target: 'researchEntityId before Listing retirement' },
-  { collection: 'student_trackings', field: 'researchGroupId', meaning: 'Legacy entity reference', target: 'researchEntityId' },
-  { collection: 'student_outreaches', field: 'researchGroupId', meaning: 'Legacy entity reference', target: 'researchEntityId' },
-  { collection: 'student_engagement_events', field: 'researchGroupId', meaning: 'Legacy entity reference', target: 'researchEntityId' },
+  {
+    collection: 'research_entities',
+    field: 'kind',
+    meaning: 'Legacy type field superseded by entityType',
+    target: 'Retire after read cutover',
+  },
+  {
+    collection: 'research_entities',
+    field: 'acceptingUndergrads',
+    meaning: 'Binary access cache',
+    target: 'AccessSignal + computed access summary',
+  },
+  {
+    collection: 'research_entities',
+    field: 'openness',
+    meaning: 'Openness cache',
+    target: 'AccessSignal + computed access summary',
+  },
+  {
+    collection: 'research_entities',
+    field: 'acceptanceConfidence',
+    meaning: 'Openness confidence cache',
+    target: 'AccessSignal + computed access summary',
+  },
+  {
+    collection: 'research_entities',
+    field: 'shortDescription',
+    meaning: 'Duplicate description field',
+    target: 'Single description',
+  },
+  {
+    collection: 'research_entities',
+    field: 'fullDescription',
+    meaning: 'Duplicate description field',
+    target: 'Single description',
+  },
+  {
+    collection: 'research_entity_members',
+    field: 'researchGroupId',
+    meaning: 'Legacy entity reference',
+    target: 'RoleAssignment.target.id',
+  },
+  {
+    collection: 'research_entity_members',
+    field: 'researchEntityId',
+    meaning: 'Canonical entity reference',
+    target: 'RoleAssignment.target.id',
+  },
+  {
+    collection: 'research_entity_members',
+    field: 'userId',
+    meaning: 'User person reference',
+    target: 'RoleAssignment.personId',
+  },
+  {
+    collection: 'research_entity_members',
+    field: 'facultyMemberId',
+    meaning: 'FacultyMember person reference',
+    target: 'RoleAssignment.personId',
+  },
+  {
+    collection: 'users',
+    field: 'publications',
+    meaning: 'Embedded publication array',
+    target: 'Removed (link to official profile / ORCID)',
+  },
+  {
+    collection: 'users',
+    field: 'favPathways',
+    meaning: 'Legacy saved-pathway array',
+    target: 'ResearchPlan',
+  },
+  {
+    collection: 'users',
+    field: 'savedPathwayPlans',
+    meaning: 'Legacy saved-pathway plan map',
+    target: 'ResearchPlan',
+  },
+  {
+    collection: 'users',
+    field: 'savedResearchEntities',
+    meaning: 'Saved-entity array',
+    target: 'ResearchPlan',
+  },
+  {
+    collection: 'users',
+    field: 'savedResearchEntityPlans',
+    meaning: 'Saved-entity plan map',
+    target: 'ResearchPlan',
+  },
+  {
+    collection: 'users',
+    field: 'orcid',
+    meaning: 'External researcher identifier',
+    target: 'Person.identifiers.orcid',
+  },
+  {
+    collection: 'users',
+    field: 'facultyMemberId',
+    meaning: 'Faculty identity reference',
+    target: 'Account.personId',
+  },
+  {
+    collection: 'users',
+    field: 'hIndex',
+    meaning: 'Mirrored citation metric',
+    target: 'Remove with professor-profile mirrors',
+  },
+  {
+    collection: 'users',
+    field: 'googleScholarId',
+    meaning: 'Mirrored scholarly identifier',
+    target: 'Remove with professor-profile mirrors',
+  },
+  {
+    collection: 'users',
+    field: 'openAlexId',
+    meaning: 'Mirrored scholarly identifier',
+    target: 'Remove with professor-profile mirrors',
+  },
+  {
+    collection: 'users',
+    field: 'semanticScholarId',
+    meaning: 'Mirrored scholarly identifier',
+    target: 'Remove with professor-profile mirrors',
+  },
+  {
+    collection: 'users',
+    field: 'googleScholarMetricsUpdatedAt',
+    meaning: 'Scholarly synchronization timestamp',
+    target: 'Remove with professor-profile mirrors',
+  },
+  {
+    collection: 'users',
+    field: 'openAlexWorksSyncedAt',
+    meaning: 'Scholarly synchronization timestamp',
+    target: 'Remove with publication mirrors',
+  },
+  {
+    collection: 'users',
+    field: 'orcidWorksSyncedAt',
+    meaning: 'Scholarly synchronization timestamp',
+    target: 'Remove with publication mirrors',
+  },
+  {
+    collection: 'users',
+    field: 'europePmcWorksSyncedAt',
+    meaning: 'Scholarly synchronization timestamp',
+    target: 'Remove with publication mirrors',
+  },
+  {
+    collection: 'users',
+    field: 'pubmedWorksSyncedAt',
+    meaning: 'Scholarly synchronization timestamp',
+    target: 'Remove with publication mirrors',
+  },
+  {
+    collection: 'faculty_members',
+    field: 'googleScholarId',
+    meaning: 'Mirrored scholarly identifier',
+    target: 'Remove with professor-profile mirrors',
+  },
+  {
+    collection: 'faculty_members',
+    field: 'openAlexId',
+    meaning: 'Mirrored scholarly identifier',
+    target: 'Remove with professor-profile mirrors',
+  },
+  {
+    collection: 'faculty_members',
+    field: 'semanticScholarId',
+    meaning: 'Mirrored scholarly identifier',
+    target: 'Remove with professor-profile mirrors',
+  },
+  {
+    collection: 'listings',
+    field: 'researchGroupId',
+    meaning: 'Legacy entity reference',
+    target: 'researchEntityId before Listing retirement',
+  },
+  {
+    collection: 'student_trackings',
+    field: 'researchGroupId',
+    meaning: 'Legacy entity reference',
+    target: 'researchEntityId',
+  },
+  {
+    collection: 'student_outreaches',
+    field: 'researchGroupId',
+    meaning: 'Legacy entity reference',
+    target: 'researchEntityId',
+  },
+  {
+    collection: 'student_engagement_events',
+    field: 'researchGroupId',
+    meaning: 'Legacy entity reference',
+    target: 'researchEntityId',
+  },
 ];
 
 /** Reference edges whose orphans block clean cutover. */
 export const REFERENCE_EDGES: ReferenceEdge[] = [
-  { name: 'member_to_entity', fromCollection: 'research_entity_members', localField: 'researchEntityId', toCollection: 'research_entities', meaning: 'Membership rows must resolve to a research entity' },
-  { name: 'member_to_user', fromCollection: 'research_entity_members', localField: 'userId', toCollection: 'users', meaning: 'Membership user refs must resolve to a user' },
-  { name: 'member_to_faculty', fromCollection: 'research_entity_members', localField: 'facultyMemberId', toCollection: 'faculty_members', meaning: 'Membership faculty refs must resolve to a faculty member' },
-  { name: 'access_signal_to_entity', fromCollection: 'access_signals', localField: 'researchEntityId', toCollection: 'research_entities', meaning: 'Access signals must resolve to a research entity' },
-  { name: 'access_signal_to_pathway', fromCollection: 'access_signals', localField: 'entryPathwayId', toCollection: 'entry_pathways', meaning: 'Access signal pathway refs must resolve to an entry pathway' },
-  { name: 'entry_pathway_to_entity', fromCollection: 'entry_pathways', localField: 'researchEntityId', toCollection: 'research_entities', meaning: 'Entry pathways must resolve to a research entity' },
-  { name: 'contact_route_to_entity', fromCollection: 'contact_routes', localField: 'researchEntityId', toCollection: 'research_entities', meaning: 'Contact routes must resolve to a research entity' },
-  { name: 'contact_route_to_pathway', fromCollection: 'contact_routes', localField: 'entryPathwayId', toCollection: 'entry_pathways', meaning: 'Contact route pathway refs must resolve to an entry pathway' },
-  { name: 'posted_opportunity_to_pathway', fromCollection: 'posted_opportunities', localField: 'entryPathwayId', toCollection: 'entry_pathways', meaning: 'Posted opportunities must resolve to an entry pathway' },
-  { name: 'posted_opportunity_to_entity', fromCollection: 'posted_opportunities', localField: 'researchEntityId', toCollection: 'research_entities', meaning: 'Posted opportunity entity refs must resolve to a research entity' },
-  { name: 'relationship_source_to_entity', fromCollection: 'research_entity_relationships', localField: 'sourceResearchEntityId', toCollection: 'research_entities', meaning: 'Relationship source must resolve to a research entity' },
-  { name: 'relationship_target_to_entity', fromCollection: 'research_entity_relationships', localField: 'targetResearchEntityId', toCollection: 'research_entities', meaning: 'Relationship target must resolve to a research entity' },
+  {
+    name: 'member_to_entity',
+    fromCollection: 'research_entity_members',
+    localField: 'researchEntityId',
+    toCollection: 'research_entities',
+    meaning: 'Membership rows must resolve to a research entity',
+  },
+  {
+    name: 'member_to_user',
+    fromCollection: 'research_entity_members',
+    localField: 'userId',
+    toCollection: 'users',
+    meaning: 'Membership user refs must resolve to a user',
+  },
+  {
+    name: 'member_to_faculty',
+    fromCollection: 'research_entity_members',
+    localField: 'facultyMemberId',
+    toCollection: 'faculty_members',
+    meaning: 'Membership faculty refs must resolve to a faculty member',
+  },
+  {
+    name: 'access_signal_to_entity',
+    fromCollection: 'access_signals',
+    localField: 'researchEntityId',
+    toCollection: 'research_entities',
+    meaning: 'Access signals must resolve to a research entity',
+  },
+  {
+    name: 'access_signal_to_pathway',
+    fromCollection: 'access_signals',
+    localField: 'entryPathwayId',
+    toCollection: 'entry_pathways',
+    meaning: 'Access signal pathway refs must resolve to an entry pathway',
+  },
+  {
+    name: 'entry_pathway_to_entity',
+    fromCollection: 'entry_pathways',
+    localField: 'researchEntityId',
+    toCollection: 'research_entities',
+    meaning: 'Entry pathways must resolve to a research entity',
+  },
+  {
+    name: 'contact_route_to_entity',
+    fromCollection: 'contact_routes',
+    localField: 'researchEntityId',
+    toCollection: 'research_entities',
+    meaning: 'Contact routes must resolve to a research entity',
+  },
+  {
+    name: 'contact_route_to_pathway',
+    fromCollection: 'contact_routes',
+    localField: 'entryPathwayId',
+    toCollection: 'entry_pathways',
+    meaning: 'Contact route pathway refs must resolve to an entry pathway',
+  },
+  {
+    name: 'posted_opportunity_to_pathway',
+    fromCollection: 'posted_opportunities',
+    localField: 'entryPathwayId',
+    toCollection: 'entry_pathways',
+    meaning: 'Posted opportunities must resolve to an entry pathway',
+  },
+  {
+    name: 'posted_opportunity_to_entity',
+    fromCollection: 'posted_opportunities',
+    localField: 'researchEntityId',
+    toCollection: 'research_entities',
+    meaning: 'Posted opportunity entity refs must resolve to a research entity',
+  },
+  {
+    name: 'relationship_source_to_entity',
+    fromCollection: 'research_entity_relationships',
+    localField: 'sourceResearchEntityId',
+    toCollection: 'research_entities',
+    meaning: 'Relationship source must resolve to a research entity',
+  },
+  {
+    name: 'relationship_target_to_entity',
+    fromCollection: 'research_entity_relationships',
+    localField: 'targetResearchEntityId',
+    toCollection: 'research_entities',
+    meaning: 'Relationship target must resolve to a research entity',
+  },
+  {
+    name: 'student_application_to_opportunity',
+    fromCollection: 'student_applications',
+    localField: 'postedOpportunityId',
+    toCollection: 'posted_opportunities',
+    meaning: 'Student application opportunity refs must resolve to a posted opportunity',
+  },
+  {
+    name: 'student_application_to_entity',
+    fromCollection: 'student_applications',
+    localField: 'researchEntityId',
+    toCollection: 'research_entities',
+    meaning: 'Student application entity refs must resolve to a research entity',
+  },
+  {
+    name: 'student_application_to_user',
+    fromCollection: 'student_applications',
+    localField: 'studentUserId',
+    toCollection: 'users',
+    meaning: 'Student application user refs must resolve to a user',
+  },
+  {
+    name: 'student_application_to_profile',
+    fromCollection: 'student_applications',
+    localField: 'studentProfileId',
+    toCollection: 'student_profiles',
+    meaning: 'Student application profile refs must resolve to a student profile',
+  },
+  {
+    name: 'student_tracking_to_profile',
+    fromCollection: 'student_trackings',
+    localField: 'studentProfileId',
+    toCollection: 'student_profiles',
+    meaning: 'Student tracking profile refs must resolve to a student profile',
+  },
+  {
+    name: 'student_tracking_to_entity',
+    fromCollection: 'student_trackings',
+    localField: 'researchEntityId',
+    toCollection: 'research_entities',
+    meaning: 'Student tracking entity refs must resolve to a research entity',
+  },
+  {
+    name: 'student_outreach_to_profile',
+    fromCollection: 'student_outreaches',
+    localField: 'studentProfileId',
+    toCollection: 'student_profiles',
+    meaning: 'Student outreach profile refs must resolve to a student profile',
+  },
+  {
+    name: 'student_outreach_to_entity',
+    fromCollection: 'student_outreaches',
+    localField: 'researchEntityId',
+    toCollection: 'research_entities',
+    meaning: 'Student outreach entity refs must resolve to a research entity',
+  },
+  {
+    name: 'student_outreach_to_tracking',
+    fromCollection: 'student_outreaches',
+    localField: 'trackingId',
+    toCollection: 'student_trackings',
+    meaning: 'Student outreach tracking refs must resolve to a student tracking record',
+  },
+  {
+    name: 'student_engagement_to_profile',
+    fromCollection: 'student_engagement_events',
+    localField: 'studentProfileId',
+    toCollection: 'student_profiles',
+    meaning: 'Student engagement profile refs must resolve to a student profile',
+  },
+  {
+    name: 'student_engagement_to_entity',
+    fromCollection: 'student_engagement_events',
+    localField: 'researchEntityId',
+    toCollection: 'research_entities',
+    meaning: 'Student engagement entity refs must resolve to a research entity',
+  },
 ];
 
 const SYSTEM_COLLECTION_PATTERN = /^(system\.|__)/;
@@ -262,9 +776,7 @@ export function buildResearchModelInventoryReport(
   const fieldFactByKey = new Map(
     facts.fieldPresence.map((row) => [`${row.collection}.${row.field}`, row]),
   );
-  const referenceFactByName = new Map(
-    facts.referenceIntegrity.map((row) => [row.name, row]),
-  );
+  const referenceFactByName = new Map(facts.referenceIntegrity.map((row) => [row.name, row]));
 
   const collections: CollectionReportRow[] = specs.map((spec) => {
     const census = censusByCollection.get(spec.collection);
@@ -314,12 +826,7 @@ export function buildResearchModelInventoryReport(
       orphaned,
       sampleOrphanIds: fact?.sampleOrphanIds ?? [],
       orphanRate: ratio(orphaned, checked),
-      clean:
-        status === 'checked'
-          ? orphaned === 0
-          : status === 'target-missing'
-            ? false
-            : null,
+      clean: status === 'checked' ? orphaned === 0 : status === 'target-missing' ? false : null,
     };
   });
 
@@ -359,9 +866,7 @@ export interface ResearchModelInventoryArgs {
   output?: string;
 }
 
-export function parseResearchModelInventoryArgs(
-  argv: string[],
-): ResearchModelInventoryArgs {
+export function parseResearchModelInventoryArgs(argv: string[]): ResearchModelInventoryArgs {
   let environment: InventoryEnvironment | undefined;
   let sampleLimit = 20;
   let output: string | undefined;
@@ -371,11 +876,11 @@ export function parseResearchModelInventoryArgs(
     if (arg === '--environment') {
       const raw = argv[i + 1];
       if (
-        raw !== 'development'
-        && raw !== 'beta'
-        && raw !== 'production-copy'
-        && raw !== 'production'
-        && raw !== 'test'
+        raw !== 'development' &&
+        raw !== 'beta' &&
+        raw !== 'production-copy' &&
+        raw !== 'production' &&
+        raw !== 'test'
       ) {
         throw new Error(
           '--environment requires development, beta, production-copy, production, or test',

--- a/server/src/scripts/researchModelInventoryCore.ts
+++ b/server/src/scripts/researchModelInventoryCore.ts
@@ -58,6 +58,34 @@ export type InventoryEnvironment =
   | 'production'
   | 'test';
 
+const INVENTORY_DATABASE_NAMES: Record<
+  Exclude<InventoryEnvironment, 'test'>,
+  ReadonlySet<string>
+> = {
+  development: new Set(['development']),
+  beta: new Set(['beta']),
+  'production-copy': new Set(['productioncopy']),
+  production: new Set(['production']),
+};
+
+export function assertInventoryEnvironmentMatchesDatabase(
+  environment: InventoryEnvironment,
+  databaseName: string,
+): void {
+  const lowerDatabaseName = databaseName.trim().toLowerCase();
+  const normalizedDatabaseName = lowerDatabaseName.replace(/[-_]/g, '');
+  const matches =
+    environment === 'test'
+      ? lowerDatabaseName === 'test' || /[-_]test$/.test(lowerDatabaseName)
+      : INVENTORY_DATABASE_NAMES[environment].has(normalizedDatabaseName);
+
+  if (!matches) {
+    throw new Error(
+      `Inventory environment ${environment} does not match MongoDB database ${databaseName || '(missing)'}`,
+    );
+  }
+}
+
 /** Refactor-relevant collections, keyed by physical name. */
 export const INVENTORY_COLLECTIONS: CollectionSpec[] = [
   {
@@ -452,8 +480,8 @@ export const RETIREMENT_FIELD_PROBES: FieldProbe[] = [
   {
     collection: 'users',
     field: 'googleScholarId',
-    meaning: 'Mirrored scholarly identifier',
-    target: 'Remove with professor-profile mirrors',
+    meaning: 'Legacy Google Scholar profile identifier',
+    target: 'Person.outboundProfiles.googleScholar, then remove legacy field',
   },
   {
     collection: 'users',
@@ -500,8 +528,8 @@ export const RETIREMENT_FIELD_PROBES: FieldProbe[] = [
   {
     collection: 'faculty_members',
     field: 'googleScholarId',
-    meaning: 'Mirrored scholarly identifier',
-    target: 'Remove with professor-profile mirrors',
+    meaning: 'Legacy Google Scholar profile identifier',
+    target: 'Person.outboundProfiles.googleScholar, then remove legacy field',
   },
   {
     collection: 'faculty_members',

--- a/server/src/scripts/researchModelInventoryCore.ts
+++ b/server/src/scripts/researchModelInventoryCore.ts
@@ -50,6 +50,13 @@ export interface ReferenceEdge {
   meaning: string;
 }
 
+export type InventoryEnvironment =
+  | 'development'
+  | 'beta'
+  | 'production-copy'
+  | 'production'
+  | 'test';
+
 /** Refactor-relevant collections, keyed by physical name. */
 export const INVENTORY_COLLECTIONS: CollectionSpec[] = [
   { collection: 'users', model: 'User', group: 'dual-truth', phase: 2, target: 'Account + Person (+ StudentProfile, ResearchPlan)' },
@@ -74,6 +81,7 @@ export const INVENTORY_COLLECTIONS: CollectionSpec[] = [
   { collection: 'observations', model: 'Observation', group: 'evidence', phase: 5, target: 'EvidenceClaim (+ SourceDocument)' },
   { collection: 'sources', model: 'Source', group: 'evidence', phase: 5, target: 'Source + SourceDocument' },
   { collection: 'student_profiles', model: 'StudentProfile', group: 'private', phase: 4, target: 'StudentProfile (retained)' },
+  { collection: 'student_applications', model: 'StudentApplication', group: 'private', phase: 4, target: 'Private student application records (retained, normalized references)' },
   { collection: 'student_trackings', model: 'StudentTracking', group: 'private', phase: 4, target: 'ResearchPlan' },
   { collection: 'student_outreaches', model: 'StudentOutreach', group: 'private', phase: null, target: 'Private outreach state' },
   { collection: 'student_engagement_events', model: 'StudentEngagementEvent', group: 'private', phase: null, target: 'EngagementEvent (append-only analytics)' },
@@ -103,16 +111,28 @@ export const RETIREMENT_FIELD_PROBES: FieldProbe[] = [
   { collection: 'users', field: 'savedResearchEntities', meaning: 'Saved-entity array', target: 'ResearchPlan' },
   { collection: 'users', field: 'savedResearchEntityPlans', meaning: 'Saved-entity plan map', target: 'ResearchPlan' },
   { collection: 'users', field: 'orcid', meaning: 'External researcher identifier', target: 'Person.identifiers.orcid' },
+  { collection: 'users', field: 'hIndex', meaning: 'Mirrored citation metric', target: 'Remove with professor-profile mirrors' },
+  { collection: 'users', field: 'googleScholarId', meaning: 'Mirrored scholarly identifier', target: 'Remove with professor-profile mirrors' },
+  { collection: 'users', field: 'openAlexId', meaning: 'Mirrored scholarly identifier', target: 'Remove with professor-profile mirrors' },
+  { collection: 'users', field: 'semanticScholarId', meaning: 'Mirrored scholarly identifier', target: 'Remove with professor-profile mirrors' },
+  { collection: 'listings', field: 'researchGroupId', meaning: 'Legacy entity reference', target: 'researchEntityId before Listing retirement' },
+  { collection: 'student_trackings', field: 'researchGroupId', meaning: 'Legacy entity reference', target: 'researchEntityId' },
+  { collection: 'student_outreaches', field: 'researchGroupId', meaning: 'Legacy entity reference', target: 'researchEntityId' },
+  { collection: 'student_engagement_events', field: 'researchGroupId', meaning: 'Legacy entity reference', target: 'researchEntityId' },
 ];
 
 /** Reference edges whose orphans block clean cutover. */
 export const REFERENCE_EDGES: ReferenceEdge[] = [
   { name: 'member_to_entity', fromCollection: 'research_entity_members', localField: 'researchEntityId', toCollection: 'research_entities', meaning: 'Membership rows must resolve to a research entity' },
   { name: 'member_to_user', fromCollection: 'research_entity_members', localField: 'userId', toCollection: 'users', meaning: 'Membership user refs must resolve to a user' },
+  { name: 'member_to_faculty', fromCollection: 'research_entity_members', localField: 'facultyMemberId', toCollection: 'faculty_members', meaning: 'Membership faculty refs must resolve to a faculty member' },
   { name: 'access_signal_to_entity', fromCollection: 'access_signals', localField: 'researchEntityId', toCollection: 'research_entities', meaning: 'Access signals must resolve to a research entity' },
+  { name: 'access_signal_to_pathway', fromCollection: 'access_signals', localField: 'entryPathwayId', toCollection: 'entry_pathways', meaning: 'Access signal pathway refs must resolve to an entry pathway' },
   { name: 'entry_pathway_to_entity', fromCollection: 'entry_pathways', localField: 'researchEntityId', toCollection: 'research_entities', meaning: 'Entry pathways must resolve to a research entity' },
   { name: 'contact_route_to_entity', fromCollection: 'contact_routes', localField: 'researchEntityId', toCollection: 'research_entities', meaning: 'Contact routes must resolve to a research entity' },
+  { name: 'contact_route_to_pathway', fromCollection: 'contact_routes', localField: 'entryPathwayId', toCollection: 'entry_pathways', meaning: 'Contact route pathway refs must resolve to an entry pathway' },
   { name: 'posted_opportunity_to_pathway', fromCollection: 'posted_opportunities', localField: 'entryPathwayId', toCollection: 'entry_pathways', meaning: 'Posted opportunities must resolve to an entry pathway' },
+  { name: 'posted_opportunity_to_entity', fromCollection: 'posted_opportunities', localField: 'researchEntityId', toCollection: 'research_entities', meaning: 'Posted opportunity entity refs must resolve to a research entity' },
   { name: 'relationship_source_to_entity', fromCollection: 'research_entity_relationships', localField: 'sourceResearchEntityId', toCollection: 'research_entities', meaning: 'Relationship source must resolve to a research entity' },
   { name: 'relationship_target_to_entity', fromCollection: 'research_entity_relationships', localField: 'targetResearchEntityId', toCollection: 'research_entities', meaning: 'Relationship target must resolve to a research entity' },
 ];
@@ -146,6 +166,7 @@ export interface ReferenceIntegrityFact {
   name: string;
   fromCollection: string;
   toCollection: string;
+  status: 'checked' | 'target-missing' | 'source-missing';
   checked: number;
   orphaned: number;
   sampleOrphanIds: string[];
@@ -185,10 +206,11 @@ export interface RetirementFieldRow {
   prevalence: number;
 }
 
-export interface ReferenceIntegrityRow extends ReferenceIntegrityFact {
+export interface ReferenceIntegrityRow extends Omit<ReferenceIntegrityFact, 'status'> {
+  status: ReferenceIntegrityFact['status'] | 'not-gathered';
   meaning: string;
   orphanRate: number;
-  clean: boolean;
+  clean: boolean | null;
 }
 
 export interface InventorySummary {
@@ -199,6 +221,7 @@ export interface InventorySummary {
   totalDocuments: number;
   retirementFieldsStillPresent: number;
   referenceEdgesChecked: number;
+  referenceEdgesSkipped: number;
   referenceEdgesWithOrphans: number;
   totalOrphans: number;
 }
@@ -278,18 +301,25 @@ export function buildResearchModelInventoryReport(
 
   const referenceIntegrity: ReferenceIntegrityRow[] = referenceEdges.map((edge) => {
     const fact = referenceFactByName.get(edge.name);
+    const status = fact?.status ?? 'not-gathered';
     const checked = fact?.checked ?? 0;
     const orphaned = fact?.orphaned ?? 0;
     return {
       name: edge.name,
       fromCollection: edge.fromCollection,
       toCollection: edge.toCollection,
+      status,
       meaning: edge.meaning,
       checked,
       orphaned,
       sampleOrphanIds: fact?.sampleOrphanIds ?? [],
       orphanRate: ratio(orphaned, checked),
-      clean: orphaned === 0,
+      clean:
+        status === 'checked'
+          ? orphaned === 0
+          : status === 'target-missing'
+            ? false
+            : null,
     };
   });
 
@@ -304,8 +334,13 @@ export function buildResearchModelInventoryReport(
     unclassifiedCollections: findUnclassifiedCollections(facts.liveCollections, specs),
     totalDocuments: collections.reduce((sum, row) => sum + row.documentCount, 0),
     retirementFieldsStillPresent: retirementFields.filter((row) => row.present > 0).length,
-    referenceEdgesChecked: referenceIntegrity.length,
-    referenceEdgesWithOrphans: referenceIntegrity.filter((row) => !row.clean).length,
+    referenceEdgesChecked: referenceIntegrity.filter(
+      (row) => row.status === 'checked' || row.status === 'target-missing',
+    ).length,
+    referenceEdgesSkipped: referenceIntegrity.filter(
+      (row) => row.status === 'source-missing' || row.status === 'not-gathered',
+    ).length,
+    referenceEdgesWithOrphans: referenceIntegrity.filter((row) => row.orphaned > 0).length,
     totalOrphans: referenceIntegrity.reduce((sum, row) => sum + row.orphaned, 0),
   };
 
@@ -317,6 +352,7 @@ export function buildResearchModelInventoryReport(
 // ---------------------------------------------------------------------------
 
 export interface ResearchModelInventoryArgs {
+  environment: InventoryEnvironment;
   /** Max orphan sample ids retained per reference edge. */
   sampleLimit: number;
   /** Optional .json report output path (guarded to tmp roots). */
@@ -326,12 +362,28 @@ export interface ResearchModelInventoryArgs {
 export function parseResearchModelInventoryArgs(
   argv: string[],
 ): ResearchModelInventoryArgs {
+  let environment: InventoryEnvironment | undefined;
   let sampleLimit = 20;
   let output: string | undefined;
 
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
-    if (arg === '--sample-limit') {
+    if (arg === '--environment') {
+      const raw = argv[i + 1];
+      if (
+        raw !== 'development'
+        && raw !== 'beta'
+        && raw !== 'production-copy'
+        && raw !== 'production'
+        && raw !== 'test'
+      ) {
+        throw new Error(
+          '--environment requires development, beta, production-copy, production, or test',
+        );
+      }
+      environment = raw;
+      i += 1;
+    } else if (arg === '--sample-limit') {
       const raw = argv[i + 1];
       const parsed = Number(raw);
       if (!Number.isFinite(parsed) || parsed < 0) {
@@ -340,34 +392,45 @@ export function parseResearchModelInventoryArgs(
       sampleLimit = Math.floor(parsed);
       i += 1;
     } else if (arg === '--output') {
-      output = argv[i + 1];
+      const raw = argv[i + 1];
+      if (!raw) {
+        throw new Error('--output requires a path');
+      }
+      output = raw;
       i += 1;
     } else {
       throw new Error(`Unknown argument: ${arg}`);
     }
   }
 
-  return { sampleLimit, output };
+  if (!environment) {
+    throw new Error('--environment is required');
+  }
+
+  return { environment, sampleLimit, output };
 }
 
 export function buildResearchModelInventoryOutput(
   report: InventoryReport,
   metadata: {
-    environment?: string;
+    environment: InventoryEnvironment;
     db?: string;
+    target?: string;
     generatedAt?: string;
     options: ResearchModelInventoryArgs;
   },
 ): InventoryReport & {
   generatedAt: string;
-  environment?: string;
+  environment: InventoryEnvironment;
   db?: string;
+  target?: string;
   options: ResearchModelInventoryArgs;
 } {
   return {
     generatedAt: metadata.generatedAt ?? new Date().toISOString(),
-    ...(metadata.environment ? { environment: metadata.environment } : {}),
+    environment: metadata.environment,
     ...(metadata.db ? { db: metadata.db } : {}),
+    ...(metadata.target ? { target: metadata.target } : {}),
     ...report,
     options: metadata.options,
   };

--- a/server/src/scripts/researchModelInventoryCore.ts
+++ b/server/src/scripts/researchModelInventoryCore.ts
@@ -463,13 +463,13 @@ export const RETIREMENT_FIELD_PROBES: FieldProbe[] = [
     collection: 'users',
     field: 'orcid',
     meaning: 'External researcher identifier',
-    target: 'Person.identifiers.orcid',
+    target: 'Person.identifiers.orcid plus verified PersonProfileLink kind ORCID',
   },
   {
     collection: 'users',
     field: 'facultyMemberId',
     meaning: 'Faculty identity reference',
-    target: 'Account.personId',
+    target: 'Person.accountId after identity reconciliation',
   },
   {
     collection: 'users',
@@ -481,7 +481,7 @@ export const RETIREMENT_FIELD_PROBES: FieldProbe[] = [
     collection: 'users',
     field: 'googleScholarId',
     meaning: 'Legacy Google Scholar profile identifier',
-    target: 'Person.outboundProfiles.googleScholar, then remove legacy field',
+    target: 'Verified PersonProfileLink kind GOOGLE_SCHOLAR, then remove legacy field',
   },
   {
     collection: 'users',
@@ -527,9 +527,15 @@ export const RETIREMENT_FIELD_PROBES: FieldProbe[] = [
   },
   {
     collection: 'faculty_members',
+    field: 'orcidId',
+    meaning: 'External researcher identifier',
+    target: 'Person.identifiers.orcid plus verified PersonProfileLink kind ORCID',
+  },
+  {
+    collection: 'faculty_members',
     field: 'googleScholarId',
     meaning: 'Legacy Google Scholar profile identifier',
-    target: 'Person.outboundProfiles.googleScholar, then remove legacy field',
+    target: 'Verified PersonProfileLink kind GOOGLE_SCHOLAR, then remove legacy field',
   },
   {
     collection: 'faculty_members',

--- a/server/src/scripts/researchModelInventoryCore.ts
+++ b/server/src/scripts/researchModelInventoryCore.ts
@@ -1,0 +1,374 @@
+/**
+ * Pure logic for the research-model refactor Phase 0 inventory.
+ *
+ * The runner (`researchModelInventory.ts`) gathers raw facts from MongoDB and
+ * hands them to `buildResearchModelInventoryReport`, which classifies every
+ * collection against the target model in `docs/research-model-refactor.md`,
+ * flags legacy residue and retirement-field prevalence, and summarizes
+ * reference-integrity orphans. Keeping the shaping here means it can be unit
+ * tested without a database, matching the other audit scripts in this folder.
+ */
+
+export type InventoryGroup =
+  | 'canonical-domain'
+  | 'dual-truth'
+  | 'legacy-residue'
+  | 'scholarly-retire'
+  | 'evidence'
+  | 'private'
+  | 'reference-data';
+
+export interface CollectionSpec {
+  /** Physical MongoDB collection name. */
+  collection: string;
+  /** Logical Mongoose model name for readability. */
+  model: string;
+  group: InventoryGroup;
+  /** Where this concept goes in the target model. */
+  target: string;
+  /** Owning migration phase from the refactor doc (or null when deferred). */
+  phase: number | null;
+  /**
+   * When false, the collection is expected to already be gone; its presence
+   * with documents is flagged as unresolved legacy residue.
+   */
+  expectPresent?: boolean;
+}
+
+export interface FieldProbe {
+  collection: string;
+  field: string;
+  meaning: string;
+  target: string;
+}
+
+export interface ReferenceEdge {
+  name: string;
+  fromCollection: string;
+  localField: string;
+  toCollection: string;
+  meaning: string;
+}
+
+/** Refactor-relevant collections, keyed by physical name. */
+export const INVENTORY_COLLECTIONS: CollectionSpec[] = [
+  { collection: 'users', model: 'User', group: 'dual-truth', phase: 2, target: 'Account + Person (+ StudentProfile, ResearchPlan)' },
+  { collection: 'faculty_members', model: 'FacultyMember', group: 'dual-truth', phase: 2, target: 'Person (deterministic merge, quarantine conflicts)' },
+  { collection: 'research_entity_members', model: 'ResearchGroupMember', group: 'dual-truth', phase: 2, target: 'RoleAssignment (one entity id, one person id)' },
+  { collection: 'research_entities', model: 'ResearchEntity', group: 'canonical-domain', phase: 4, target: 'Clean ResearchEntity schema + bounded discovery projection' },
+  { collection: 'research_entity_relationships', model: 'ResearchEntityRelationship', group: 'canonical-domain', phase: 4, target: 'EntityRelationship' },
+  { collection: 'entry_pathways', model: 'EntryPathway', group: 'canonical-domain', phase: 4, target: 'EntryPathway (retained)' },
+  { collection: 'posted_opportunities', model: 'PostedOpportunity', group: 'canonical-domain', phase: 4, target: 'PostedOpportunity (retained)' },
+  { collection: 'access_signals', model: 'AccessSignal', group: 'canonical-domain', phase: 4, target: 'AccessSignal (retained)' },
+  { collection: 'contact_routes', model: 'ContactRoute', group: 'canonical-domain', phase: 4, target: 'ContactRoute (retained)' },
+  { collection: 'admin_grants', model: 'AdminGrant', group: 'canonical-domain', phase: null, target: 'AdminGrant (admin authority)' },
+  { collection: 'listings', model: 'Listing', group: 'legacy-residue', phase: 4, target: 'EntryPathway + PostedOpportunity' },
+  { collection: 'fellowships', model: 'Fellowship', group: 'legacy-residue', phase: 4, target: 'Classify: entity / pathway / posting / formalization' },
+  { collection: 'departments', model: 'Department', group: 'reference-data', phase: 4, target: 'OrgUnit' },
+  { collection: 'research_areas', model: 'ResearchArea', group: 'reference-data', phase: 4, target: 'TaxonomyTerm' },
+  { collection: 'grants', model: 'Grant', group: 'reference-data', phase: null, target: 'Deferred; never undergraduate-access evidence' },
+  { collection: 'papers', model: 'Paper', group: 'scholarly-retire', phase: 3, target: 'No target collection' },
+  { collection: 'paper_authors', model: 'PaperAuthor', group: 'scholarly-retire', phase: 3, target: 'No target collection' },
+  { collection: 'research_scholarly_links', model: 'ResearchScholarlyLink', group: 'scholarly-retire', phase: 3, target: 'Crux: bare outbound link vs curated activity surface' },
+  { collection: 'research_scholarly_attributions', model: 'ResearchScholarlyAttribution', group: 'scholarly-retire', phase: 3, target: 'No target collection' },
+  { collection: 'observations', model: 'Observation', group: 'evidence', phase: 5, target: 'EvidenceClaim (+ SourceDocument)' },
+  { collection: 'sources', model: 'Source', group: 'evidence', phase: 5, target: 'Source + SourceDocument' },
+  { collection: 'student_profiles', model: 'StudentProfile', group: 'private', phase: 4, target: 'StudentProfile (retained)' },
+  { collection: 'student_trackings', model: 'StudentTracking', group: 'private', phase: 4, target: 'ResearchPlan' },
+  { collection: 'student_outreaches', model: 'StudentOutreach', group: 'private', phase: null, target: 'Private outreach state' },
+  { collection: 'student_engagement_events', model: 'StudentEngagementEvent', group: 'private', phase: null, target: 'EngagementEvent (append-only analytics)' },
+  // Expected already retired by the earlier hard-pivot; presence is residue.
+  { collection: 'research_groups', model: 'ResearchGroup', group: 'legacy-residue', phase: 0, target: 'research_entities (should be dropped)', expectPresent: false },
+  { collection: 'research_group_members', model: 'ResearchGroupMember (legacy)', group: 'legacy-residue', phase: 0, target: 'research_entity_members (should be dropped)', expectPresent: false },
+  { collection: 'research_group_stats', model: 'ResearchGroupStats', group: 'legacy-residue', phase: 0, target: 'None (should be dropped)', expectPresent: false },
+  { collection: 'paper_group_links', model: 'PaperGroupLink', group: 'legacy-residue', phase: 0, target: 'None (should be dropped)', expectPresent: false },
+  { collection: 'applications', model: 'Application', group: 'legacy-residue', phase: 0, target: 'student_applications (should be dropped)', expectPresent: false },
+];
+
+/** Legacy fields whose lingering prevalence gates their retirement phase. */
+export const RETIREMENT_FIELD_PROBES: FieldProbe[] = [
+  { collection: 'research_entities', field: 'kind', meaning: 'Legacy type field superseded by entityType', target: 'Retire after read cutover' },
+  { collection: 'research_entities', field: 'acceptingUndergrads', meaning: 'Binary access cache', target: 'AccessSignal + computed access summary' },
+  { collection: 'research_entities', field: 'openness', meaning: 'Openness cache', target: 'AccessSignal + computed access summary' },
+  { collection: 'research_entities', field: 'acceptanceConfidence', meaning: 'Openness confidence cache', target: 'AccessSignal + computed access summary' },
+  { collection: 'research_entities', field: 'shortDescription', meaning: 'Duplicate description field', target: 'Single description' },
+  { collection: 'research_entities', field: 'fullDescription', meaning: 'Duplicate description field', target: 'Single description' },
+  { collection: 'research_entity_members', field: 'researchGroupId', meaning: 'Legacy entity reference', target: 'RoleAssignment.target.id' },
+  { collection: 'research_entity_members', field: 'researchEntityId', meaning: 'Canonical entity reference', target: 'RoleAssignment.target.id' },
+  { collection: 'research_entity_members', field: 'userId', meaning: 'User person reference', target: 'RoleAssignment.personId' },
+  { collection: 'research_entity_members', field: 'facultyMemberId', meaning: 'FacultyMember person reference', target: 'RoleAssignment.personId' },
+  { collection: 'users', field: 'publications', meaning: 'Embedded publication array', target: 'Removed (link to official profile / ORCID)' },
+  { collection: 'users', field: 'favPathways', meaning: 'Legacy saved-pathway array', target: 'ResearchPlan' },
+  { collection: 'users', field: 'savedPathwayPlans', meaning: 'Legacy saved-pathway plan map', target: 'ResearchPlan' },
+  { collection: 'users', field: 'savedResearchEntities', meaning: 'Saved-entity array', target: 'ResearchPlan' },
+  { collection: 'users', field: 'savedResearchEntityPlans', meaning: 'Saved-entity plan map', target: 'ResearchPlan' },
+  { collection: 'users', field: 'orcid', meaning: 'External researcher identifier', target: 'Person.identifiers.orcid' },
+];
+
+/** Reference edges whose orphans block clean cutover. */
+export const REFERENCE_EDGES: ReferenceEdge[] = [
+  { name: 'member_to_entity', fromCollection: 'research_entity_members', localField: 'researchEntityId', toCollection: 'research_entities', meaning: 'Membership rows must resolve to a research entity' },
+  { name: 'member_to_user', fromCollection: 'research_entity_members', localField: 'userId', toCollection: 'users', meaning: 'Membership user refs must resolve to a user' },
+  { name: 'access_signal_to_entity', fromCollection: 'access_signals', localField: 'researchEntityId', toCollection: 'research_entities', meaning: 'Access signals must resolve to a research entity' },
+  { name: 'entry_pathway_to_entity', fromCollection: 'entry_pathways', localField: 'researchEntityId', toCollection: 'research_entities', meaning: 'Entry pathways must resolve to a research entity' },
+  { name: 'contact_route_to_entity', fromCollection: 'contact_routes', localField: 'researchEntityId', toCollection: 'research_entities', meaning: 'Contact routes must resolve to a research entity' },
+  { name: 'posted_opportunity_to_pathway', fromCollection: 'posted_opportunities', localField: 'entryPathwayId', toCollection: 'entry_pathways', meaning: 'Posted opportunities must resolve to an entry pathway' },
+  { name: 'relationship_source_to_entity', fromCollection: 'research_entity_relationships', localField: 'sourceResearchEntityId', toCollection: 'research_entities', meaning: 'Relationship source must resolve to a research entity' },
+  { name: 'relationship_target_to_entity', fromCollection: 'research_entity_relationships', localField: 'targetResearchEntityId', toCollection: 'research_entities', meaning: 'Relationship target must resolve to a research entity' },
+];
+
+const SYSTEM_COLLECTION_PATTERN = /^(system\.|__)/;
+
+// ---------------------------------------------------------------------------
+// Facts gathered by the runner
+// ---------------------------------------------------------------------------
+
+export interface SchemaVersionBucket {
+  version: string;
+  count: number;
+}
+
+export interface CollectionCensusFact {
+  collection: string;
+  present: boolean;
+  documentCount: number;
+  schemaVersions: SchemaVersionBucket[];
+}
+
+export interface FieldPresenceFact {
+  collection: string;
+  field: string;
+  present: number;
+  total: number;
+}
+
+export interface ReferenceIntegrityFact {
+  name: string;
+  fromCollection: string;
+  toCollection: string;
+  checked: number;
+  orphaned: number;
+  sampleOrphanIds: string[];
+}
+
+export interface InventoryFacts {
+  liveCollections: string[];
+  census: CollectionCensusFact[];
+  fieldPresence: FieldPresenceFact[];
+  referenceIntegrity: ReferenceIntegrityFact[];
+}
+
+// ---------------------------------------------------------------------------
+// Report shape
+// ---------------------------------------------------------------------------
+
+export interface CollectionReportRow {
+  collection: string;
+  model: string;
+  group: InventoryGroup;
+  phase: number | null;
+  target: string;
+  present: boolean;
+  documentCount: number;
+  schemaVersions: SchemaVersionBucket[];
+  /** Legacy collection expected gone but still holding documents. */
+  residue: boolean;
+}
+
+export interface RetirementFieldRow {
+  collection: string;
+  field: string;
+  meaning: string;
+  target: string;
+  present: number;
+  total: number;
+  prevalence: number;
+}
+
+export interface ReferenceIntegrityRow extends ReferenceIntegrityFact {
+  meaning: string;
+  orphanRate: number;
+  clean: boolean;
+}
+
+export interface InventorySummary {
+  collectionsClassified: number;
+  collectionsPresent: number;
+  legacyResidueCollections: string[];
+  unclassifiedCollections: string[];
+  totalDocuments: number;
+  retirementFieldsStillPresent: number;
+  referenceEdgesChecked: number;
+  referenceEdgesWithOrphans: number;
+  totalOrphans: number;
+}
+
+export interface InventoryReport {
+  summary: InventorySummary;
+  collections: CollectionReportRow[];
+  retirementFields: RetirementFieldRow[];
+  referenceIntegrity: ReferenceIntegrityRow[];
+}
+
+function ratio(part: number, whole: number): number {
+  if (whole <= 0) return 0;
+  return Math.round((part / whole) * 10000) / 10000;
+}
+
+/**
+ * Any live collection that is not classified and not a Mongo system collection.
+ * Surfacing these prevents a silent migration blind spot.
+ */
+export function findUnclassifiedCollections(
+  liveCollections: string[],
+  specs: CollectionSpec[] = INVENTORY_COLLECTIONS,
+): string[] {
+  const known = new Set(specs.map((spec) => spec.collection));
+  return liveCollections
+    .filter((name) => !known.has(name) && !SYSTEM_COLLECTION_PATTERN.test(name))
+    .sort();
+}
+
+export function buildResearchModelInventoryReport(
+  facts: InventoryFacts,
+  specs: CollectionSpec[] = INVENTORY_COLLECTIONS,
+  fieldProbes: FieldProbe[] = RETIREMENT_FIELD_PROBES,
+  referenceEdges: ReferenceEdge[] = REFERENCE_EDGES,
+): InventoryReport {
+  const censusByCollection = new Map(facts.census.map((row) => [row.collection, row]));
+  const fieldFactByKey = new Map(
+    facts.fieldPresence.map((row) => [`${row.collection}.${row.field}`, row]),
+  );
+  const referenceFactByName = new Map(
+    facts.referenceIntegrity.map((row) => [row.name, row]),
+  );
+
+  const collections: CollectionReportRow[] = specs.map((spec) => {
+    const census = censusByCollection.get(spec.collection);
+    const present = census?.present ?? false;
+    const documentCount = census?.documentCount ?? 0;
+    const residue = spec.expectPresent === false && present && documentCount > 0;
+    return {
+      collection: spec.collection,
+      model: spec.model,
+      group: spec.group,
+      phase: spec.phase,
+      target: spec.target,
+      present,
+      documentCount,
+      schemaVersions: census?.schemaVersions ?? [],
+      residue,
+    };
+  });
+
+  const retirementFields: RetirementFieldRow[] = fieldProbes.map((probe) => {
+    const fact = fieldFactByKey.get(`${probe.collection}.${probe.field}`);
+    const present = fact?.present ?? 0;
+    const total = fact?.total ?? 0;
+    return {
+      collection: probe.collection,
+      field: probe.field,
+      meaning: probe.meaning,
+      target: probe.target,
+      present,
+      total,
+      prevalence: ratio(present, total),
+    };
+  });
+
+  const referenceIntegrity: ReferenceIntegrityRow[] = referenceEdges.map((edge) => {
+    const fact = referenceFactByName.get(edge.name);
+    const checked = fact?.checked ?? 0;
+    const orphaned = fact?.orphaned ?? 0;
+    return {
+      name: edge.name,
+      fromCollection: edge.fromCollection,
+      toCollection: edge.toCollection,
+      meaning: edge.meaning,
+      checked,
+      orphaned,
+      sampleOrphanIds: fact?.sampleOrphanIds ?? [],
+      orphanRate: ratio(orphaned, checked),
+      clean: orphaned === 0,
+    };
+  });
+
+  const legacyResidueCollections = collections
+    .filter((row) => row.residue)
+    .map((row) => row.collection);
+
+  const summary: InventorySummary = {
+    collectionsClassified: specs.length,
+    collectionsPresent: collections.filter((row) => row.present).length,
+    legacyResidueCollections,
+    unclassifiedCollections: findUnclassifiedCollections(facts.liveCollections, specs),
+    totalDocuments: collections.reduce((sum, row) => sum + row.documentCount, 0),
+    retirementFieldsStillPresent: retirementFields.filter((row) => row.present > 0).length,
+    referenceEdgesChecked: referenceIntegrity.length,
+    referenceEdgesWithOrphans: referenceIntegrity.filter((row) => !row.clean).length,
+    totalOrphans: referenceIntegrity.reduce((sum, row) => sum + row.orphaned, 0),
+  };
+
+  return { summary, collections, retirementFields, referenceIntegrity };
+}
+
+// ---------------------------------------------------------------------------
+// CLI args + output envelope
+// ---------------------------------------------------------------------------
+
+export interface ResearchModelInventoryArgs {
+  /** Max orphan sample ids retained per reference edge. */
+  sampleLimit: number;
+  /** Optional .json report output path (guarded to tmp roots). */
+  output?: string;
+}
+
+export function parseResearchModelInventoryArgs(
+  argv: string[],
+): ResearchModelInventoryArgs {
+  let sampleLimit = 20;
+  let output: string | undefined;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--sample-limit') {
+      const raw = argv[i + 1];
+      const parsed = Number(raw);
+      if (!Number.isFinite(parsed) || parsed < 0) {
+        throw new Error('--sample-limit requires a non-negative number');
+      }
+      sampleLimit = Math.floor(parsed);
+      i += 1;
+    } else if (arg === '--output') {
+      output = argv[i + 1];
+      i += 1;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return { sampleLimit, output };
+}
+
+export function buildResearchModelInventoryOutput(
+  report: InventoryReport,
+  metadata: {
+    environment?: string;
+    db?: string;
+    generatedAt?: string;
+    options: ResearchModelInventoryArgs;
+  },
+): InventoryReport & {
+  generatedAt: string;
+  environment?: string;
+  db?: string;
+  options: ResearchModelInventoryArgs;
+} {
+  return {
+    generatedAt: metadata.generatedAt ?? new Date().toISOString(),
+    ...(metadata.environment ? { environment: metadata.environment } : {}),
+    ...(metadata.db ? { db: metadata.db } : {}),
+    ...report,
+    options: metadata.options,
+  };
+}

--- a/server/src/scripts/researchModelInventoryCore.ts
+++ b/server/src/scripts/researchModelInventoryCore.ts
@@ -825,7 +825,7 @@ export const REFERENCE_EDGES: ReferenceEdge[] = [
   },
 ];
 
-const SYSTEM_COLLECTION_PATTERN = /^(system\.|__)/;
+const SYSTEM_COLLECTION_PATTERN = /^system\./;
 
 // ---------------------------------------------------------------------------
 // Facts gathered by the runner

--- a/server/src/scripts/researchModelInventoryCore.ts
+++ b/server/src/scripts/researchModelInventoryCore.ts
@@ -313,6 +313,60 @@ export const RETIREMENT_FIELD_PROBES: FieldProbe[] = [
   },
   {
     collection: 'research_entities',
+    field: 'opennessSignals',
+    meaning: 'Embedded openness evidence',
+    target: 'AccessSignal',
+  },
+  {
+    collection: 'research_entities',
+    field: 'opennessStatusCache',
+    meaning: 'Derived openness status cache',
+    target: 'Computed access summary',
+  },
+  {
+    collection: 'research_entities',
+    field: 'opennessExplanationCache',
+    meaning: 'Derived openness explanation cache',
+    target: 'Computed access summary',
+  },
+  {
+    collection: 'research_entities',
+    field: 'opennessComputedAt',
+    meaning: 'Derived openness computation timestamp',
+    target: 'Computed access summary',
+  },
+  {
+    collection: 'research_entities',
+    field: 'opennessLastSignalAt',
+    meaning: 'Derived openness evidence timestamp',
+    target: 'AccessSignal',
+  },
+  {
+    collection: 'research_entities',
+    field: 'recentPaperCount',
+    meaning: 'Paper-derived activity count',
+    target: 'Remove with scholarly mirrors',
+  },
+  {
+    collection: 'research_entities',
+    field: 'lastPaperAtCache',
+    meaning: 'Paper-derived activity timestamp',
+    target: 'Remove with scholarly mirrors',
+  },
+  {
+    collection: 'research_entities',
+    field: 'activePaperCount2yCache',
+    meaning: 'Paper-derived recent activity count',
+    target: 'Remove with scholarly mirrors',
+  },
+  {
+    collection: 'research_entities',
+    field: 'featuredPaperIds',
+    meaning: 'Curated paper references',
+    target: 'Remove with scholarly collections',
+  },
+  {
+    collection: 'research_entities',
     field: 'shortDescription',
     meaning: 'Duplicate description field',
     target: 'Single description',
@@ -562,6 +616,22 @@ export const REFERENCE_EDGES: ReferenceEdge[] = [
     meaning: 'Access signal pathway refs must resolve to an entry pathway',
   },
   {
+    name: 'access_signal_to_source_evidence',
+    fromCollection: 'access_signals',
+    localField: 'sourceEvidenceId',
+    toCollection: 'observations',
+    required: false,
+    meaning: 'Access signal source-evidence refs must resolve to an observation',
+  },
+  {
+    name: 'access_signal_to_observation',
+    fromCollection: 'access_signals',
+    localField: 'observationId',
+    toCollection: 'observations',
+    required: false,
+    meaning: 'Access signal observation refs must resolve to an observation',
+  },
+  {
     name: 'entry_pathway_to_entity',
     fromCollection: 'entry_pathways',
     localField: 'researchEntityId',
@@ -586,6 +656,22 @@ export const REFERENCE_EDGES: ReferenceEdge[] = [
     meaning: 'Contact route pathway refs must resolve to an entry pathway',
   },
   {
+    name: 'contact_route_to_person',
+    fromCollection: 'contact_routes',
+    localField: 'personId',
+    toCollection: 'users',
+    required: false,
+    meaning: 'Contact route person refs must resolve to a user',
+  },
+  {
+    name: 'contact_route_to_source_evidence',
+    fromCollection: 'contact_routes',
+    localField: 'sourceEvidenceId',
+    toCollection: 'observations',
+    required: false,
+    meaning: 'Contact route source-evidence refs must resolve to an observation',
+  },
+  {
     name: 'posted_opportunity_to_pathway',
     fromCollection: 'posted_opportunities',
     localField: 'entryPathwayId',
@@ -600,6 +686,22 @@ export const REFERENCE_EDGES: ReferenceEdge[] = [
     toCollection: 'research_entities',
     required: false,
     meaning: 'Posted opportunity entity refs must resolve to a research entity',
+  },
+  {
+    name: 'posted_opportunity_to_listing',
+    fromCollection: 'posted_opportunities',
+    localField: 'listingId',
+    toCollection: 'listings',
+    required: false,
+    meaning: 'Posted opportunity listing refs must resolve to a listing',
+  },
+  {
+    name: 'listing_to_entity',
+    fromCollection: 'listings',
+    localField: 'researchEntityId',
+    toCollection: 'research_entities',
+    required: false,
+    meaning: 'Listing entity refs must resolve to a research entity',
   },
   {
     name: 'relationship_source_to_entity',
@@ -713,6 +815,14 @@ export const REFERENCE_EDGES: ReferenceEdge[] = [
     required: true,
     meaning: 'Student engagement entity refs must resolve to a research entity',
   },
+  {
+    name: 'observation_to_source',
+    fromCollection: 'observations',
+    localField: 'sourceId',
+    toCollection: 'sources',
+    required: true,
+    meaning: 'Observations must resolve to a source',
+  },
 ];
 
 const SYSTEM_COLLECTION_PATTERN = /^(system\.|__)/;
@@ -722,7 +832,8 @@ const SYSTEM_COLLECTION_PATTERN = /^(system\.|__)/;
 // ---------------------------------------------------------------------------
 
 export interface SchemaVersionBucket {
-  version: string;
+  bsonType: string;
+  value?: unknown;
   count: number;
 }
 
@@ -794,6 +905,7 @@ export interface ReferenceIntegrityRow extends Omit<ReferenceIntegrityFact, 'sta
 }
 
 export interface InventorySummary {
+  coverageScope: string;
   collectionsClassified: number;
   collectionsPresent: number;
   legacyResidueCollections: string[];
@@ -894,7 +1006,12 @@ export function buildResearchModelInventoryReport(
       orphaned,
       sampleOrphanIds: fact?.sampleOrphanIds ?? [],
       orphanRate: ratio(orphaned, checked),
-      clean: status === 'checked' ? orphaned === 0 : status === 'target-missing' ? false : null,
+      clean:
+        status === 'checked'
+          ? orphaned === 0
+          : status === 'target-missing' && checked > 0
+            ? false
+            : null,
     };
   });
 
@@ -903,6 +1020,8 @@ export function buildResearchModelInventoryReport(
     .map((row) => row.collection);
 
   const summary: InventorySummary = {
+    coverageScope:
+      'Curated refactor-relevant collections, fields, and scalar reference edges; totalOrphans counts only tracked edges and is not an exhaustive referential-integrity proof.',
     collectionsClassified: specs.length,
     collectionsPresent: collections.filter((row) => row.present).length,
     legacyResidueCollections,

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -3781,6 +3781,7 @@ __metadata:
     express: "npm:^4.22.2"
     express-rate-limit: "npm:^8.5.2"
     meilisearch: "npm:^0.57.0"
+    mongodb: "npm:~6.20.0"
     mongoose: "npm:^8.9.5"
     passport: "npm:^0.7.0"
     passport-cas: "git+https://github.com/coursetable/passport-cas#79612f1"

--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -66,6 +66,7 @@ Models are Mongoose schemas with indexes.
 | `yarn --cwd server test`          | Server Vitest suite.                                           |
 | `yarn --cwd server scrape <cmd>`  | Scraper CLI.                                                   |
 | `yarn --cwd server gates:refresh` | Regenerate canonical gate scorecards.                          |
+| `yarn --cwd server model-refactor:inventory --environment <env>` | Run the read-only research-model Phase 0 inventory. |
 
 Migration scripts run from `data-migration/` with `npx tsx --transpile-only <script>.ts`.
 

--- a/skills/product-model/SKILL.md
+++ b/skills/product-model/SKILL.md
@@ -60,4 +60,4 @@ Prefer official and public URLs.
 Redact scraped emails from public payloads.
 - Prefer first-class collections over embedding pathways, signals, or routes inside `ResearchEntity`.
 
-See `docs/research-model.md` for full schema and migration guidance.
+See `docs/research-model.md` for the current runtime model and `docs/research-model-refactor.md` for the accepted target and phased migration.

--- a/skills/search-data/SKILL.md
+++ b/skills/search-data/SKILL.md
@@ -40,12 +40,13 @@ Rebuild scripts do full repopulation.
 The `researchentities` index prioritizes name, professor, research-area, keyword, and `studentSearchTerms` attributes before summary or description text.
 Its settings also include curated synonyms and typo guards for short aliases such as `ai`, `ml`, `nlp`, and `cv`, so rebuild or sync the index after changing alias or relevance settings.
 
-## Rebuild commands
+## Data commands
 
 | Command                                                 | Effect                                                               |
 | ------------------------------------------------------- | -------------------------------------------------------------------- |
 | `yarn --cwd server meili:rebuild-research-entities`     | Rebuild the ResearchEntity index.                                    |
 | `yarn --cwd server meili:rebuild-pathways`              | Rebuild the Pathway index.                                           |
+| `yarn --cwd server model-refactor:inventory --environment <env>` | Inventory refactor-relevant MongoDB state without writes. |
 | `yarn --cwd server research-entity:migrate`             | Run the ResearchEntity physical migration.                           |
 | `yarn --cwd server research-homes:backfill-browse-rank` | Recompute `browseRankScore`; apply requires `--confirm-browse-rank`. |
 


### PR DESCRIPTION
## Intent

Kick off the research-model refactor (docs/research-model-refactor.md, tracked in epic #203 and phase issues #204-210) by landing Phase 0 inventory tooling, targeting beta. Phase 0 was chosen deliberately as the safe, read-only, additive starting point: it measures current MongoDB state and writes nothing, so it cannot regress runtime behavior. This change adds: (1) researchModelInventoryCore.ts, a data-driven spec mapping every refactor-relevant collection, retirement-field probe, and reference edge to the target model, plus pure report shaping (classification, legacy-residue detection, orphan summary), fully unit tested (17 tests); (2) researchModelInventory.ts, a read-only runner that gathers the census, retirement-field prevalence, and type-agnostic reference-integrity orphans and emits a guarded JSON report; (3) a model-refactor:inventory yarn script and a Phase 0 runbook. It also brings the refactor design doc itself onto the branch so the runbook and issues are self-consistent. Deliberate decisions a diff reviewer would not know: the runner follows the repo's established audit-script pattern (Core pure-logic + thin DB runner) and is validated via Core unit tests because there is no DB/creds in the worktree and there is no in-memory Mongo in the test suite - actually running it against beta is the Phase 0 measurement step the user performs later. The reference check processes bounded source batches and queries both ObjectId and string target IDs through the indexed `_id` field, preserving mixed-type correctness without retaining production-scale ID sets. Three pre-existing tsc errors in ../data-migration (dotenv resolution) are unrelated to this change and present on clean beta.

## What Changed

- Add a guarded, read-only MongoDB inventory command that reports collection census data, schema-version distribution, legacy-field prevalence, and tracked reference-integrity gaps.
- Define and test the refactor’s machine-readable collection, retirement-field, and reference-edge coverage with bounded, type-aware scans.
- Document the accepted target research model, phased migration plan, and Phase 0 inventory, export, and rollback runbook.

## Risk Assessment

✅ Low: The additive inventory tooling is read-only, well-bounded, and its report semantics, schema-backed coverage, operational safeguards, tests, and runbook are internally consistent.

## Testing

After inspecting the exact base-to-target change, I ran the focused inventory tests and full server suite, exercised the complete gather-and-report flow against a representative injected MongoDB adapter, validated the resulting reviewer-visible JSON, and checked the real CLI’s required-environment and safe-output guards. Everything passed, the adapter observed only read operations and client shutdown, and the report correctly exposed legacy residue, mixed-ID integrity, required-reference failures, and an unclassified double-underscore collection. A live beta census was not attempted because this isolated worktree has no MongoDB configuration and the runbook deliberately reserves that measurement for the later operator step; this is a CLI-only change, so JSON evidence is the appropriate artifact rather than a UI screenshot.

<details>
<summary>Evidence: Representative Phase 0 inventory report</summary>

```text
{
  "generatedAt": "2026-07-25T06:00:32.172Z",
  "environment": "test",
  "db": "phase0_evidence",
  "target": "readonly.example.test/phase0_evidence",
  "summary": {
    "coverageScope": "Curated refactor-relevant collections, fields, and scalar reference edges; totalOrphans counts only tracked edges and is not an exhaustive referential-integrity proof.",
    "collectionsClassified": 31,
    "collectionsPresent": 4,
    "legacyResidueCollections": [
      "research_groups"
    ],
    "unclassifiedCollections": [
      "unmapped__shadow"
    ],
    "totalDocuments": 7,
    "retirementFieldsStillPresent": 2,
    "referenceEdgesChecked": 4,
    "referenceEdgesSkipped": 31,
    "referenceEdgesWithOrphans": 2,
    "totalOrphans": 2
  },
  "collections": [
    {
      "collection": "users",
      "model": "User",
      "group": "dual-truth",
      "phase": 2,
      "target": "Account + Person (+ StudentProfile, ResearchPlan)",
      "present": false,
      "documentCount": 0,
      "schemaVersions": [],
      "residue": false
    },
    {
      "collection": "faculty_members",
      "model": "FacultyMember",
      "group": "dual-truth",
      "phase": 2,
      "target": "Person (deterministic merge, quarantine conflicts)",
      "present": false,
      "documentCount": 0,
      "schemaVersions": [],
      "residue": false
    },
    {
      "collection": "research_entity_members",
      "model": "ResearchGroupMember",
      "group": "dual-truth",
      "phase": 2,
      "target": "RoleAssignment (one entity id, one person id)",
      "present": true,
      "documentCount": 2,
      "schemaVersions": [
        {
          "bsonType": "int",
          "value": 1,
          "count": 2
        }
      ],
      "residue": false
    },
    {
      "collection": "research_entities",
      "model": "ResearchEntity",
      "group": "canonical-domain",
      "phase": 4,
      "target": "Clean ResearchEntity schema + bounded discovery projection",
      "present": true,
      "documentCount": 2,
      "schemaVersions": [
        {
          "bsonType": "int",
          "value": 1,
          "count": 1
        },
        {
          "bsonType": "null",
          "value": null,
          "count": 1
        }
      ],
      "residue": false
    },
    {
      "collection": "research_entity_relationships",
      "model": "ResearchEntityRelationship",
      "group": "canonical-domain",
      "phase": 4,
      "target": "EntityRelationship",
      "present": false,
      "documentCount": 0,
      "schemaVersions": [],
      "residue": false
    },
    {
      "collection": "entry_pathways",
      "model": "EntryPathway",
      "group": "canonical-domain",
      "phase": 4,
      "target": "EntryPathway (retained)",
      "present": true,
      "documentCount": 2,
      "schemaVersions": [
        {
          "bsonType": "int",
          "value": 1,
          "count": 2
        }
      ],
      "residue": false
    },
    {
      "collection": "posted_opportunities",
      "model": "PostedOpportunity",
      "group": "canonical-domain",
      "phase": 4,
      "target": "PostedOpportunity (retained)",
      "present": false,
      "documentCount": 0,
      "schemaVersions": [],
      "residue": false
    },
    {
      "collection": "access_signals",
      "model": "AccessSignal",
      "group": "canonical-domain",
      "phase": 4,
      "target": "AccessSignal (retained)",
      "present": false,
      "documentCount": 0,
      "schemaVersions": [],
      "residue": false
    },
    {
      "collection": "contact_routes",
      "model": "ContactRoute",
      "group": "canonical-domain",
      "phase": 4,
      "target": "ContactRoute (retained)",
      "present": false,
      "documentCount": 0,
      "schemaVersions": [],
      "residue": false
    },
    {
      "collection": "admin_grants",
      "model": "AdminGrant",
      "group": "canonical-domain",
      "phase": null,
      "target": "AdminGrant (admin authority)",
      "present": false,
      "documentCount": 0,
      "schemaVersions": [],
      "residue": false
    },
    {
      "collection": "listings",
      "model": "Listing",
      "group": "legacy-residue",
      "phase": 4,
      "target": "EntryPathway + PostedOpportunity",
      "present": false,
      "documentCount": 0,
      "schemaVersions": [],
      "residue": false
    },
    {
      "collection": "fellowships",
      "model": "Fellowship",
      "group": "legacy-residue",
      "phase": 4,
      "target": "Classify: entity / pathway / posting / formalization",
      "present": false,
      "documentCount": 0,
      "schemaVersions": [],
      "residue": false
    },
    {
      "collection": "departments",
      "model": "Department",
      "group": "reference-data",
      "phase": 4,
      "target": "OrgUnit",
      "present": false,
      "documentCount": 0,
      "schemaVersions": [],
      "residue": false
    },
    {
      "collection": "research_areas",
      "model": "ResearchArea",
      "group": "reference-data",
      "phase": 4,
      "target": "TaxonomyTerm",
      "present": false,
      "documentCount": 0,
      "schemaVersions": [],
      "residue": false
    },
    {
      "collection": "grants",
      "model": "Grant",
      "group": "reference-data",
      "phase": null,
      "target": "Deferred; never undergraduate-access evidence",
      "present": false,
      "documentCount": 0,
      "schemaVersions": [],
      "residue": false
    },
    {
      "collection": "papers",
      "model": "Paper",
      "group": "scholarly-retire",
      "phase": 3,
      "target": "No target collection",
      "present": false,
      "documentCount": 0,
      "schemaVersions": [],
      "residue": false
    },
    {
      "collection": "paper_authors",
      "model": "PaperAuthor",
      "group": "scholarly-retire",
      "phase": 3,
      "target": "No target collection",
      "present": false,
      "documentCount": 0,
      "schemaVersions": [],
      "residue": false
    },
    {
      "collection": "research_scholarly_links",
      "model": "ResearchScholarlyLink",
      "group": "scholarly-retire",
      "phase": 3,
      "target": "Crux: bare outbound link vs curated activity surface",
      "present": false,
      "documentCount": 0,
      "schemaVersions": [],
      "residue": false
    },
    {
      "collection": "research_scholarly_attributions",
      "model": "ResearchScholarlyAttribution",
      "group": "scholarly-retire",
      "phase": 3,
      "target": "No target collection",
      "present": false,
      "documentCount": 0,
      "schemaVersions": [],
      "residue": false
    },
    {
      "collection": "observations",
      "model": "Observation",
      "group": "evidence",
      "phase": 5,
      "target": "EvidenceClaim (+ SourceDocument)",
      "present": false,
      "documentCount": 0,
      "schemaVersions": [],
      "residue": false
    },
    {
      "collection": "sources",
      "model": "Source",
      "group": "evidence",
      "phase": 5,
      "target": "Source + SourceDocument",
      "present": false,
      "documentCount": 0,
      "schemaVersions": [],
      "residue": false
    },
    {
      "collection": "student_profiles",
      "model": "StudentProfile",
      "group": "private",
      "phase": 4,
      "target": "StudentProfile (retained)",
      "present": false,
      "documentCount": 0,
      "schemaVersions": [],
      "residue": false
    },
    {
      "collection": "student_applications",
      "model": "StudentApplication",
      "group": "private",
      "phase": 4,
      "target": "Private student application records (retained, normalized references)",
      "present": false,
      "documentCount": 0,
      "schemaVersions": [],
      "residue": false
    },
    {
      "collection": "student_trackings",
      "model": "StudentTracking",
      "group": "private",
      "phase": 4,
      "target": "ResearchPlan",
      "present": false,
      "documentCount": 0,
      "schemaVersions": [],
      "residue": false
    },
    {
      "collection": "student_outreaches",
      "model": "StudentOutreach",
      "group": "private",
      "phase": null,
      "target": "P

... [19229 bytes truncated] ...

    "checked": 0,
      "orphaned": 0,
      "sampleOrphanIds": [],
      "orphanRate": 0,
      "clean": null
    },
    {
      "name": "posted_opportunity_to_entity",
      "fromCollection": "posted_opportunities",
      "toCollection": "research_entities",
      "status": "source-missing",
      "localField": "researchEntityId",
      "required": false,
      "meaning": "Posted opportunity entity refs must resolve to a research entity",
      "checked": 0,
      "orphaned": 0,
      "sampleOrphanIds": [],
      "orphanRate": 0,
      "clean": null
    },
    {
      "name": "posted_opportunity_to_listing",
      "fromCollection": "posted_opportunities",
      "toCollection": "listings",
      "status": "source-missing",
      "localField": "listingId",
      "required": false,
      "meaning": "Posted opportunity listing refs must resolve to a listing",
      "checked": 0,
      "orphaned": 0,
      "sampleOrphanIds": [],
      "orphanRate": 0,
      "clean": null
    },
    {
      "name": "listing_to_entity",
      "fromCollection": "listings",
      "toCollection": "research_entities",
      "status": "source-missing",
      "localField": "researchEntityId",
      "required": false,
      "meaning": "Listing entity refs must resolve to a research entity",
      "checked": 0,
      "orphaned": 0,
      "sampleOrphanIds": [],
      "orphanRate": 0,
      "clean": null
    },
    {
      "name": "relationship_source_to_entity",
      "fromCollection": "research_entity_relationships",
      "toCollection": "research_entities",
      "status": "source-missing",
      "localField": "sourceResearchEntityId",
      "required": true,
      "meaning": "Relationship source must resolve to a research entity",
      "checked": 0,
      "orphaned": 0,
      "sampleOrphanIds": [],
      "orphanRate": 0,
      "clean": null
    },
    {
      "name": "relationship_target_to_entity",
      "fromCollection": "research_entity_relationships",
      "toCollection": "research_entities",
      "status": "source-missing",
      "localField": "targetResearchEntityId",
      "required": true,
      "meaning": "Relationship target must resolve to a research entity",
      "checked": 0,
      "orphaned": 0,
      "sampleOrphanIds": [],
      "orphanRate": 0,
      "clean": null
    },
    {
      "name": "student_application_to_listing",
      "fromCollection": "student_applications",
      "toCollection": "listings",
      "status": "source-missing",
      "localField": "listingObjectId",
      "required": false,
      "meaning": "Student application listing refs must resolve to a listing",
      "checked": 0,
      "orphaned": 0,
      "sampleOrphanIds": [],
      "orphanRate": 0,
      "clean": null
    },
    {
      "name": "student_application_to_opportunity",
      "fromCollection": "student_applications",
      "toCollection": "posted_opportunities",
      "status": "source-missing",
      "localField": "postedOpportunityId",
      "required": false,
      "meaning": "Student application opportunity refs must resolve to a posted opportunity",
      "checked": 0,
      "orphaned": 0,
      "sampleOrphanIds": [],
      "orphanRate": 0,
      "clean": null
    },
    {
      "name": "student_application_to_entity",
      "fromCollection": "student_applications",
      "toCollection": "research_entities",
      "status": "source-missing",
      "localField": "researchEntityId",
      "required": false,
      "meaning": "Student application entity refs must resolve to a research entity",
      "checked": 0,
      "orphaned": 0,
      "sampleOrphanIds": [],
      "orphanRate": 0,
      "clean": null
    },
    {
      "name": "student_application_to_user",
      "fromCollection": "student_applications",
      "toCollection": "users",
      "status": "source-missing",
      "localField": "studentUserId",
      "required": false,
      "meaning": "Student application user refs must resolve to a user",
      "checked": 0,
      "orphaned": 0,
      "sampleOrphanIds": [],
      "orphanRate": 0,
      "clean": null
    },
    {
      "name": "student_application_to_profile",
      "fromCollection": "student_applications",
      "toCollection": "student_profiles",
      "status": "source-missing",
      "localField": "studentProfileId",
      "required": false,
      "meaning": "Student application profile refs must resolve to a student profile",
      "checked": 0,
      "orphaned": 0,
      "sampleOrphanIds": [],
      "orphanRate": 0,
      "clean": null
    },
    {
      "name": "student_tracking_to_profile",
      "fromCollection": "student_trackings",
      "toCollection": "student_profiles",
      "status": "source-missing",
      "localField": "studentProfileId",
      "required": true,
      "meaning": "Student tracking profile refs must resolve to a student profile",
      "checked": 0,
      "orphaned": 0,
      "sampleOrphanIds": [],
      "orphanRate": 0,
      "clean": null
    },
    {
      "name": "student_tracking_to_entity",
      "fromCollection": "student_trackings",
      "toCollection": "research_entities",
      "status": "source-missing",
      "localField": "researchEntityId",
      "required": true,
      "meaning": "Student tracking entity refs must resolve to a research entity",
      "checked": 0,
      "orphaned": 0,
      "sampleOrphanIds": [],
      "orphanRate": 0,
      "clean": null
    },
    {
      "name": "student_outreach_to_profile",
      "fromCollection": "student_outreaches",
      "toCollection": "student_profiles",
      "status": "source-missing",
      "localField": "studentProfileId",
      "required": true,
      "meaning": "Student outreach profile refs must resolve to a student profile",
      "checked": 0,
      "orphaned": 0,
      "sampleOrphanIds": [],
      "orphanRate": 0,
      "clean": null
    },
    {
      "name": "student_outreach_to_entity",
      "fromCollection": "student_outreaches",
      "toCollection": "research_entities",
      "status": "source-missing",
      "localField": "researchEntityId",
      "required": true,
      "meaning": "Student outreach entity refs must resolve to a research entity",
      "checked": 0,
      "orphaned": 0,
      "sampleOrphanIds": [],
      "orphanRate": 0,
      "clean": null
    },
    {
      "name": "student_outreach_to_tracking",
      "fromCollection": "student_outreaches",
      "toCollection": "student_trackings",
      "status": "source-missing",
      "localField": "trackingId",
      "required": true,
      "meaning": "Student outreach tracking refs must resolve to a student tracking record",
      "checked": 0,
      "orphaned": 0,
      "sampleOrphanIds": [],
      "orphanRate": 0,
      "clean": null
    },
    {
      "name": "student_engagement_to_profile",
      "fromCollection": "student_engagement_events",
      "toCollection": "student_profiles",
      "status": "source-missing",
      "localField": "studentProfileId",
      "required": false,
      "meaning": "Student engagement profile refs must resolve to a student profile",
      "checked": 0,
      "orphaned": 0,
      "sampleOrphanIds": [],
      "orphanRate": 0,
      "clean": null
    },
    {
      "name": "student_engagement_to_entity",
      "fromCollection": "student_engagement_events",
      "toCollection": "research_entities",
      "status": "source-missing",
      "localField": "researchEntityId",
      "required": true,
      "meaning": "Student engagement entity refs must resolve to a research entity",
      "checked": 0,
      "orphaned": 0,
      "sampleOrphanIds": [],
      "orphanRate": 0,
      "clean": null
    },
    {
      "name": "observation_to_source",
      "fromCollection": "observations",
      "toCollection": "sources",
      "status": "source-missing",
      "localField": "sourceId",
      "required": true,
      "meaning": "Observations must resolve to a source",
      "checked": 0,
      "orphaned": 0,
      "sampleOrphanIds": [],
      "orphanRate": 0,
      "clean": null
    }
  ],
  "options": {
    "environment": "test",
    "sampleLimit": 5,
    "output": "/tmp/no-mistakes-evidence/01KYBP70753YDW1PGB5B7882T2/phase0-inventory-report.json"
  }
}
```
</details>
<details>
<summary>Evidence: Read-only operation trace and report highlights</summary>

```text
{
  "scenario": "Representative Phase 0 read-only inventory run with canonical data, legacy residue, mixed reference types, an orphan, a missing required reference, and an unclassified double-underscore collection.",
  "reportPath": "/tmp/no-mistakes-evidence/01KYBP70753YDW1PGB5B7882T2/phase0-inventory-report.json",
  "safety": {
    "clientClosed": true,
    "databaseOperations": [
      "client.connect",
      "client.db",
      "listCollections",
      "aggregate:census:research_entity_members",
      "aggregate:census:research_entities",
      "aggregate:census:entry_pathways",
      "aggregate:census:research_groups",
      "aggregate:field-presence:research_entities",
      "aggregate:field-presence:research_entity_members",
      "find:source-refs:research_entity_members",
      "find:source-refs:entry_pathways",
      "find:target-ids:research_entities",
      "client.close"
    ],
    "writeOperationsObserved": []
  },
  "observedReport": {
    "environment": "test",
    "db": "phase0_evidence",
    "target": "readonly.example.test/phase0_evidence",
    "summary": {
      "coverageScope": "Curated refactor-relevant collections, fields, and scalar reference edges; totalOrphans counts only tracked edges and is not an exhaustive referential-integrity proof.",
      "collectionsClassified": 31,
      "collectionsPresent": 4,
      "legacyResidueCollections": [
        "research_groups"
      ],
      "unclassifiedCollections": [
        "unmapped__shadow"
      ],
      "totalDocuments": 7,
      "retirementFieldsStillPresent": 2,
      "referenceEdgesChecked": 4,
      "referenceEdgesSkipped": 31,
      "referenceEdgesWithOrphans": 2,
      "totalOrphans": 2
    },
    "retirementField": {
      "collection": "research_entities",
      "field": "acceptingUndergrads",
      "meaning": "Binary access cache",
      "target": "AccessSignal + computed access summary",
      "present": 1,
      "total": 2,
      "prevalence": 0.5
    },
    "memberReference": {
      "name": "member_to_entity",
      "fromCollection": "research_entity_members",
      "toCollection": "research_entities",
      "status": "checked",
      "localField": "researchEntityId",
      "required": false,
      "meaning": "Membership rows must resolve to a research entity",
      "checked": 2,
      "orphaned": 1,
      "sampleOrphanIds": [
        "member-orphan"
      ],
      "orphanRate": 0.5,
      "clean": false
    },
    "requiredPathwayReference": {
      "name": "entry_pathway_to_entity",
      "fromCollection": "entry_pathways",
      "toCollection": "research_entities",
      "status": "checked",
      "localField": "researchEntityId",
      "required": true,
      "meaning": "Entry pathways must resolve to a research entity",
      "checked": 2,
      "orphaned": 1,
      "sampleOrphanIds": [
        "pathway-missing-required-ref"
      ],
      "orphanRate": 0.5,
      "clean": false
    }
  }
}
```
</details>
<details>
<summary>Evidence: Real CLI guard behavior</summary>

```text
Missing `--environment` and an unsafe `--output ./should-not-write.json` were both rejected with exit code 1; no unsafe file was created.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 6 issues found → auto-fixed (7) ✅</summary>

- 🚨 `server/src/scripts/researchModelInventory.ts:106` - When either collection is absent, this returns an all-zero fact. Report shaping then marks the edge `clean: true` and counts it as checked. A present source with a missing target should report its references as orphaned, while a missing source should be explicitly skipped or indeterminate.
- ⚠️ `server/src/scripts/researchModelInventoryCore.ts:109` - The edge inventory omits migration-relevant references already present in current schemas, including `research_entity_members.facultyMemberId`, `access_signals.entryPathwayId`, `contact_routes.entryPathwayId`, and `posted_opportunities.researchEntityId`. Consequently, `totalOrphans` can report zero while known canonical or dual-truth references are orphaned. Add these edges or clearly scope the summary so it cannot imply complete integrity.
- ⚠️ `server/src/scripts/researchModelInventoryCore.ts:85` - The spec maps legacy `applications` to `student_applications` but never classifies the existing `student_applications` collection itself. Its documents therefore appear only as unclassified and are excluded from census totals and schema-version distribution. Decide its target-model ownership and phase, then add it to the collection spec.
- ⚠️ `server/src/scripts/researchModelInventoryCore.ts:88` - The retirement probes omit compatibility fields explicitly slated for removal, including `researchGroupId` on listings, student trackings, outreaches, and engagement events, plus professor-mirror fields such as `hIndex`, `googleScholarId`, `openAlexId`, and `semanticScholarId` on users. The headline can therefore report no retirement fields remaining while these fields persist. Add probes for the documented retirement contract.
- ⚠️ `server/src/scripts/researchModelInventory.ts:191` - The runbook tells operators to select an environment only through `MONGODBURL`, but this metadata defaults to `development` unless `SCRAPER_ENV`, `APP_ENV`, or `NODE_ENV` is separately set. The `db` field normally records only the database name, so a saved beta or production-copy artifact can be mislabeled. Require or validate explicit environment metadata and retain a sanitized host/database target.
- ⚠️ `server/src/scripts/researchModelInventory.ts:182` - `initializeConnections()` writes its connection message to stdout before the JSON report is printed, so the documented stdout mode is not valid JSON and cannot be redirected directly into `jq` or a report file. Route connection diagnostics to stderr or isolate the report output stream.

🔧 Fix: Correct research model inventory integrity reporting
4 issues (1 error, 3 warnings) still open:
- 🚨 `server/src/scripts/researchModelInventory.ts:192` - `initializeConnections()` violates the runner&#39;s read-only contract. Importing it registers `Listing`, while Mongoose defaults `autoCreate` and `autoIndex` to true, so connecting can create `listings` or build indexes before the census. In `productionMigration` mode it also opens and initializes a secondary connection that this runner neither inventories nor closes. Use a dedicated native connection, or explicitly disable model creation/indexing and close every connection.
- ⚠️ `server/src/scripts/researchModelInventoryCore.ts:137` - The reference inventory still omits schema-backed references on retained private records, including `student_applications.postedOpportunityId`, `researchEntityId`, `studentUserId`, and `studentProfileId`, plus required entity/profile/tracking references on student trackings, outreaches, and engagement events. Broken private-data references can therefore coexist with `totalOrphans: 0`; add these edges.
- ⚠️ `server/src/scripts/researchModelInventoryCore.ts:117` - Retirement coverage remains incomplete for current fields unambiguously affected by Phases 2 and 3, including `users.facultyMemberId`, the scholarly synchronization timestamps on `users`, and `faculty_members.googleScholarId`, `openAlexId`, and `semanticScholarId`. Consequently, `retirementFieldsStillPresent` can understate identity and publication-mirror residue.
- ⚠️ `server/src/scripts/researchModelInventory.ts:162` - Each field probe independently runs a total count and an existence count under an unbounded `Promise.all`. The current list issues 20 concurrent counts against `users`, including ten identical total counts, after census already counted that collection. Group probes by collection, reuse totals, and bound concurrency to avoid unnecessary database load.

🔧 Fix: Harden research inventory isolation and reference coverage
4 issues (1 error, 3 warnings) still open:
- 🚨 `server/src/scripts/researchModelInventory.ts:150` - Required local references are silently excluded by the `$ne: null` source query. A collection can contain documents missing required fields such as `entry_pathways.researchEntityId` or `student_outreaches.trackingId` yet report `checked: 0`, `orphaned: 0`, and `clean: true`. Add required/optional metadata to each edge and report missing required references as integrity failures while continuing to skip absent optional references.
- ⚠️ `server/src/scripts/researchModelInventoryCore.ts:490` - Reference coverage still omits current scalar links central to the refactor, including `users.facultyMemberId`, `users.studentProfileId`, `faculty_members.userId`, `student_profiles.userId`, and `student_applications.listingObjectId`. Broken identity, profile, or listing-migration links can therefore coexist with `totalOrphans: 0`; add the schema-backed edges.
- ⚠️ `server/src/scripts/researchModelInventory.ts:83` - The report combines independent live reads without snapshot semantics or a quiescence requirement. Concurrent writes can make schema-version buckets disagree with `documentCount`, or change targets between target-ID and source scans and produce false clean/orphan results. Decide whether migration evidence must use a declared immutable copy or point-in-time MongoDB reads, and enforce that choice.
- ⚠️ `server/src/scripts/researchModelInventory.ts:17` - The new direct `mongodb` import is not declared in `server/package.json`; it currently works only because Mongoose&#39;s private driver dependency is hoisted. A dependency-layout or Mongoose upgrade can break the inventory command or unexpectedly change its driver version. Add `mongodb` as a direct server dependency and update the server lockfile.

🔧 Fix: Harden required-reference inventory integrity and coverage
5 warnings still open:
- ⚠️ `server/src/scripts/researchModelInventoryCore.ts:897` - A missing target always produces `clean: false`, even when an optional edge has no references. After `listings` is retired, for example, `student_applications.listingObjectId` can report `checked: 0`, `orphaned: 0`, but remain a permanent false blocker. Treat a fully scanned target-missing edge with zero references as clean, or distinguish this state explicitly.
- ⚠️ `server/src/scripts/researchModelInventoryCore.ts:490` - The edge inventory still omits migration-relevant scalar references present in current schemas, including `observations.sourceId`, access/contact observation references, `contact_routes.personId`, `posted_opportunities.listingId`, and `listings.researchEntityId`. Consequently, `totalOrphans: 0` does not establish source-attribution or listing/access integrity. Add these edges or explicitly narrow the summary&#39;s claim.
- ⚠️ `server/src/scripts/researchModelInventoryCore.ts:288` - Retirement coverage omits fields explicitly excluded by the target model, including the embedded `opennessSignals` and related openness caches, plus paper-derived entity fields such as `recentPaperCount`, `lastPaperAtCache`, `activePaperCount2yCache`, and `featuredPaperIds`. The headline can therefore understate remaining Phase 3 and Phase 4 residue.
- ⚠️ `server/src/scripts/researchModelInventory.ts:136` - Each edge rebuilds its target-ID set, so the current inventory reads all `research_entities` IDs eleven times, `student_profiles` five times, and also rescans source collections once per field. Cache target sets and group source fields by collection to avoid dozens of redundant full scans during a production inventory.
- ⚠️ `server/src/scripts/researchModelInventory.ts:90` - Stringifying schema-version keys makes numeric `1` and string `&#34;1&#34;` indistinguishable, while MongoDB grouping already combines missing and explicit-null values. This obscures precisely the invalid type/null drift the version census should surface. Preserve BSON type information and distinguish missing from null in the aggregation.

🔧 Fix: Harden research inventory coverage and scan efficiency
2 warnings still open:
- ⚠️ `server/src/scripts/researchModelInventory.ts:168` - All target ID sets are materialized and retained before source scanning. Since `observations` can approach the repository&#39;s 5 GB Atlas limit, converting every observation ID to a retained string set can exhaust process memory. Preserve type-agnostic comparison by scanning sources first and retaining only referenced IDs, or process target/source groups incrementally.
- ⚠️ `server/src/scripts/researchModelInventory.ts:297` - Probe grouping only controls scheduling: every probe still executes a separate `$exists` count, producing 42 collection scans, including 15 over `research_entities` and 16 over `users`. Calculate all field counts with one projected cursor or aggregation per collection to reduce production database load.

🔧 Fix: Bound inventory memory and consolidate field scans
1 warning still open:
- ⚠️ `server/src/scripts/researchModelInventory.ts:83` - `censusCollection` runs `countDocuments({})` before an aggregation that already counts every document by schema-version bucket. This adds a redundant collection-wide operation for every present collection, including large `observations`, and can make `documentCount` disagree with the bucket sum during concurrent writes. Derive `documentCount` by summing the aggregation results.

🔧 Fix: Derive census totals from schema-version buckets
1 warning still open:
- ⚠️ `server/src/scripts/researchModelInventoryCore.ts:828` - The unclassified-collection filter suppresses every `__*` collection, although MongoDB system collections use the `system.` prefix and the repository defines no `__` convention. A temporary migration, backup, or refactor collection with that prefix would disappear from the Phase 0 inventory. Restrict the exclusion to known system collections unless ignoring all `__*` collections is an explicit requirement.

🔧 Fix: Surface double-underscore collections in inventory
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `yarn --cwd server test src/scripts/__tests__/researchModelInventoryCore.test.ts src/scripts/__tests__/researchModelInventory.test.ts`
- `yarn --cwd server test`
- `yarn --cwd server tsx /tmp/no-mistakes-evidence/01KYBP70753YDW1PGB5B7882T2/inventory-e2e-evidence.mts "$PWD" /tmp/no-mistakes-evidence/01KYBP70753YDW1PGB5B7882T2`
- <code>Validated the generated JSON using `node --input-type=module -e ...`, asserting classification, legacy residue, double-underscore collection discovery, orphan reporting, required-reference reporting, client closure, and zero write operations</code>
- `env -u MONGODBURL yarn --cwd server model-refactor:inventory`
- <code>`env -u MONGODBURL yarn --cwd server model-refactor:inventory --environment test --output ./should-not-write.json` and verified no output file was created</code>
- `git status --short --untracked-files=all`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

