### PR TITLE
feat(server): add canonical identity and reference schemas

### DIFF
--- a/docs/research-model-refactor.md
+++ b/docs/research-model-refactor.md
@@ -1,6 +1,6 @@
 # Research Model Refactor
 
-Status: accepted product and architecture direction, implementation pending
+Status: accepted product and architecture direction, implementation in progress
 
 Decision date: 2026-07-24
 
@@ -205,6 +205,20 @@ Suggested fields include:
 Search-specific synonyms may extend this vocabulary in Meilisearch.
 They must not silently create new canonical taxonomy terms.
 
+#### Phase 1 identity and reference schema boundary
+
+The versioned `Account`, `Person`, `RoleAssignment`, `OrgUnit`, and `TaxonomyTerm` schemas are registered in `server/src/models/` with explicit `accounts`, `people`, `role_assignments`, `org_units`, and `taxonomy_terms` collection names.
+They currently coexist empty with legacy runtime collections and have no application readers, writers, routes, migrations, startup hooks, or Meilisearch projections.
+
+`Account` contains CAS identity and lifecycle state but no person pointer or role array.
+`AdminGrant` remains the source of admin authority, research roles belong to `RoleAssignment`, and `Person.accountId` is the only optional account-person relationship.
+`Person.profileLinks` permits at most one verified outbound link for each of the five accepted kinds, with Google Scholar and ORCID restricted to scholarly-purpose links and kind-specific canonical URLs.
+An ORCID identifier may remain non-public until its outbound profile link is reviewed, but any stored ORCID profile link must match the person's canonical ORCID identifier.
+
+`RoleAssignment` stores dated person-to-target relationships and permits repeated historical terms.
+`OrgUnit` and `TaxonomyTerm` are new canonical reference identities, but this phase does not copy from or cut readers over from `Department` or `ResearchArea`.
+Taxonomy uniqueness is scoped by term kind and the normalized canonical label.
+
 ### `research_entities`
 
 `ResearchEntity` remains the central browseable concept.
@@ -253,9 +267,10 @@ Full roles, pathways, signals, routes, and evidence remain first-class records.
 
 Legacy fields such as `kind`, duplicate description fields, `acceptingUndergrads`, `openness`, `acceptanceConfidence`, embedded openness signals, and legacy research-group references must be retired after canonical reads cut over.
 
-### `entity_relationships`
+### `research_entity_relationships`
 
-`EntityRelationship` represents source-backed relationships between research entities.
+`ResearchEntityRelationship` represents source-backed relationships between research entities.
+The existing model and `research_entity_relationships` physical collection remain canonical rather than being duplicated under a renamed model.
 Examples include affiliation, hosting, membership, umbrella structure, and succession.
 
 Relationships remain first-class because they are many-to-many, independently evidenced, and queried in both directions.

--- a/server/src/models/__tests__/canonicalIdentityModels.test.ts
+++ b/server/src/models/__tests__/canonicalIdentityModels.test.ts
@@ -319,7 +319,7 @@ describe('canonical identity and reference models', () => {
         endedAt: new Date('2026-07-03T00:00:00.000Z'),
       }).validateSync()?.errors.endedAt,
     ).toBeTruthy();
-    expect(validRoleAssignment({ state: 'HISTORICAL' }).validateSync()?.errors.state).toBeTruthy();
+    expect(validRoleAssignment({ state: 'HISTORICAL' }).validateSync()).toBeUndefined();
     expect(
       validRoleAssignment({
         evidenceClaimIds: [duplicateEvidenceId, duplicateEvidenceId],

--- a/server/src/models/__tests__/canonicalIdentityModels.test.ts
+++ b/server/src/models/__tests__/canonicalIdentityModels.test.ts
@@ -90,7 +90,7 @@ const validProfileLinks = [
   {
     kind: 'ORCID',
     purpose: 'SCHOLARLY',
-    url: 'https://orcid.org/0000-0002-1825-0097',
+    url: 'https://orcid.org/9999-9999-9999-9994',
     verifiedAt,
     healthStatus: 'HEALTHY',
   },
@@ -191,7 +191,7 @@ describe('canonical identity and reference models', () => {
 
   it('accepts one verified profile link of every supported kind', () => {
     const person = validPerson({
-      identifiers: { orcid: '0000-0002-1825-0097' },
+      identifiers: { orcid: '9999-9999-9999-9994' },
       profileLinks: validProfileLinks,
     });
 
@@ -231,7 +231,7 @@ describe('canonical identity and reference models', () => {
     ['YALE_OFFICIAL', 'PRIMARY_IDENTITY', 'https://example.org/profile/person'],
     ['GOOGLE_SCHOLAR', 'SCHOLARLY', 'https://example.org/citations?user=abcdefghijkl'],
     ['GOOGLE_SCHOLAR', 'SCHOLARLY', 'http://scholar.google.com/citations?user=abcdefghijkl'],
-    ['ORCID', 'SCHOLARLY', 'https://orcid.org/0000-0002-1825-0098'],
+    ['ORCID', 'SCHOLARLY', 'https://orcid.org/9999-9999-9999-9995'],
   ])('rejects an invalid verified %s URL', (kind, purpose, url) => {
     const person = validPerson({
       profileLinks: [{ kind, purpose, url, verifiedAt }],
@@ -268,7 +268,7 @@ describe('canonical identity and reference models', () => {
 
   it('requires an ORCID profile URL to match the canonical identifier', () => {
     const person = validPerson({
-      identifiers: { orcid: '0000-0003-1419-2405' },
+      identifiers: { orcid: '1234-5678-9012-3451' },
       profileLinks: [validProfileLinks[4]],
     });
 
@@ -277,7 +277,7 @@ describe('canonical identity and reference models', () => {
 
   it('allows a valid ORCID identifier to remain private until a profile link is reviewed', () => {
     const person = validPerson({
-      identifiers: { orcid: '0000-0002-1825-0097' },
+      identifiers: { orcid: '9999-9999-9999-9994' },
     });
 
     expect(person.validateSync()).toBeUndefined();
@@ -288,7 +288,7 @@ describe('canonical identity and reference models', () => {
       validPerson({ displayName: 'x'.repeat(241) }).validateSync()?.errors.displayName,
     ).toBeTruthy();
     expect(
-      validPerson({ identifiers: { orcid: '0000-0002-1825-0098' } }).validateSync()?.errors[
+      validPerson({ identifiers: { orcid: '9999-9999-9999-9995' } }).validateSync()?.errors[
         'identifiers.orcid'
       ],
     ).toBeTruthy();

--- a/server/src/models/__tests__/canonicalIdentityModels.test.ts
+++ b/server/src/models/__tests__/canonicalIdentityModels.test.ts
@@ -1,0 +1,466 @@
+import mongoose from 'mongoose';
+import { describe, expect, it } from 'vitest';
+import { Account, accountSchema } from '../account';
+import { OrgUnit } from '../orgUnit';
+import { Person, personProfileLinkSchema } from '../person';
+import { ResearchEntityRelationship } from '../researchEntityRelationship';
+import { RoleAssignment } from '../roleAssignment';
+import { TaxonomyTerm } from '../taxonomyTerm';
+import * as modelExports from '../index';
+
+const objectId = () => new mongoose.Types.ObjectId();
+
+function validAccount(overrides: Record<string, unknown> = {}) {
+  return new Account({
+    netid: 'fixture1',
+    email: 'fixture1@yale.edu',
+    ...overrides,
+  });
+}
+
+function validPerson(overrides: Record<string, unknown> = {}) {
+  return new Person({
+    displayName: 'Fixture Person',
+    ...overrides,
+  });
+}
+
+function validRoleAssignment(overrides: Record<string, unknown> = {}) {
+  return new RoleAssignment({
+    personId: objectId(),
+    target: {
+      kind: 'RESEARCH_ENTITY',
+      id: objectId(),
+    },
+    role: 'PI',
+    confidence: 0.9,
+    ...overrides,
+  });
+}
+
+function validOrgUnit(overrides: Record<string, unknown> = {}) {
+  return new OrgUnit({
+    slug: 'computer-science',
+    name: 'Computer Science',
+    kind: 'DEPARTMENT',
+    ...overrides,
+  });
+}
+
+function validTaxonomyTerm(overrides: Record<string, unknown> = {}) {
+  return new TaxonomyTerm({
+    kind: 'METHOD',
+    label: 'Machine Learning',
+    normalizedLabel: 'machine learning',
+    ...overrides,
+  });
+}
+
+const verifiedAt = new Date('2026-07-01T00:00:00.000Z');
+
+const validProfileLinks = [
+  {
+    kind: 'YALE_OFFICIAL',
+    purpose: 'PRIMARY_IDENTITY',
+    url: 'https://medicine.yale.edu/profile/fixture-person',
+    verifiedAt,
+    healthStatus: 'HEALTHY',
+  },
+  {
+    kind: 'LAB_ABOUT',
+    purpose: 'PRIMARY_IDENTITY',
+    url: 'https://example.edu/lab/people/fixture-person',
+    verifiedAt,
+    healthStatus: 'HEALTHY',
+  },
+  {
+    kind: 'PERSONAL_ACADEMIC',
+    purpose: 'PRIMARY_IDENTITY',
+    url: 'https://fixture.example.org',
+    verifiedAt,
+    healthStatus: 'UNKNOWN',
+  },
+  {
+    kind: 'GOOGLE_SCHOLAR',
+    purpose: 'SCHOLARLY',
+    url: 'https://scholar.google.com/citations?user=abcdefghijkl',
+    verifiedAt,
+    healthStatus: 'HEALTHY',
+  },
+  {
+    kind: 'ORCID',
+    purpose: 'SCHOLARLY',
+    url: 'https://orcid.org/0000-0002-1825-0097',
+    verifiedAt,
+    healthStatus: 'HEALTHY',
+  },
+];
+
+describe('canonical identity and reference models', () => {
+  it('registers explicit canonical model and collection names', () => {
+    expect([
+      [Account.modelName, Account.collection.name],
+      [Person.modelName, Person.collection.name],
+      [RoleAssignment.modelName, RoleAssignment.collection.name],
+      [OrgUnit.modelName, OrgUnit.collection.name],
+      [TaxonomyTerm.modelName, TaxonomyTerm.collection.name],
+    ]).toEqual([
+      ['Account', 'accounts'],
+      ['Person', 'people'],
+      ['RoleAssignment', 'role_assignments'],
+      ['OrgUnit', 'org_units'],
+      ['TaxonomyTerm', 'taxonomy_terms'],
+    ]);
+  });
+
+  it('defaults every new canonical document to its collection schema version', () => {
+    const documents = [
+      validAccount(),
+      validPerson(),
+      validRoleAssignment(),
+      validOrgUnit(),
+      validTaxonomyTerm(),
+    ];
+
+    for (const document of documents) {
+      expect(document.schemaVersion).toBe(1);
+      expect(document.validateSync()).toBeUndefined();
+    }
+  });
+
+  it('keeps the account-person relationship only on Person.accountId', () => {
+    expect(accountSchema.path('personId')).toBeUndefined();
+    expect(accountSchema.path('roles')).toBeUndefined();
+    expect(Person.schema.path('accountId')?.options.ref).toBe('Account');
+
+    const accountIndex = Person.schema
+      .indexes()
+      .find(([fields]) => fields.accountId === 1 && Object.keys(fields).length === 1);
+    expect(accountIndex?.[1]).toMatchObject({ unique: true, sparse: true });
+    expect(
+      Person.schema
+        .indexes()
+        .some(([fields, options]) => fields.displayName === 1 && options.unique),
+    ).toBe(false);
+  });
+
+  it('keeps Person role-neutral and free of professor-profile mirrors and copied contact data', () => {
+    const forbiddenFields = [
+      'role',
+      'personType',
+      'netid',
+      'roles',
+      'userType',
+      'lastLoginAt',
+      'bio',
+      'email',
+      'phone',
+      'website',
+      'imageUrl',
+      'departments',
+      'college',
+      'major',
+      'title',
+      'unit',
+      'physicalLocation',
+      'mailingAddress',
+      'publications',
+      'hIndex',
+      'citationCount',
+      'researchInterests',
+      'topics',
+      'googleScholarId',
+      'openAlexId',
+      'semanticScholarId',
+    ];
+
+    for (const field of forbiddenFields) {
+      expect(Person.schema.path(field)).toBeUndefined();
+    }
+  });
+
+  it('keeps the reviewed profile-link contract bounded to public outbound-link fields', () => {
+    expect(Object.keys(personProfileLinkSchema.paths).sort()).toEqual([
+      'healthStatus',
+      'kind',
+      'purpose',
+      'url',
+      'verifiedAt',
+    ]);
+  });
+
+  it('accepts one verified profile link of every supported kind', () => {
+    const person = validPerson({
+      identifiers: { orcid: '0000-0002-1825-0097' },
+      profileLinks: validProfileLinks,
+    });
+
+    expect(person.validateSync()).toBeUndefined();
+  });
+
+  it('rejects duplicate profile-link kinds', () => {
+    const person = validPerson({
+      profileLinks: [validProfileLinks[0], { ...validProfileLinks[0] }],
+    });
+
+    expect(person.validateSync()?.errors.profileLinks).toBeTruthy();
+  });
+
+  it('rejects more than five profile links', () => {
+    const person = validPerson({
+      profileLinks: [...validProfileLinks, { ...validProfileLinks[0] }],
+    });
+
+    expect(person.validateSync()?.errors.profileLinks).toBeTruthy();
+  });
+
+  it('rejects profile-link kinds paired with the wrong purpose', () => {
+    const person = validPerson({
+      profileLinks: [
+        {
+          ...validProfileLinks[3],
+          purpose: 'PRIMARY_IDENTITY',
+        },
+      ],
+    });
+
+    expect(person.validateSync()?.errors['profileLinks.0.purpose']).toBeTruthy();
+  });
+
+  it.each([
+    ['YALE_OFFICIAL', 'PRIMARY_IDENTITY', 'https://example.org/profile/person'],
+    ['GOOGLE_SCHOLAR', 'SCHOLARLY', 'https://example.org/citations?user=abcdefghijkl'],
+    ['GOOGLE_SCHOLAR', 'SCHOLARLY', 'http://scholar.google.com/citations?user=abcdefghijkl'],
+    ['ORCID', 'SCHOLARLY', 'https://orcid.org/0000-0002-1825-0098'],
+  ])('rejects an invalid verified %s URL', (kind, purpose, url) => {
+    const person = validPerson({
+      profileLinks: [{ kind, purpose, url, verifiedAt }],
+    });
+
+    expect(person.validateSync()?.errors['profileLinks.0.url']).toBeTruthy();
+  });
+
+  it('requires a verification timestamp for every profile link', () => {
+    const person = validPerson({
+      profileLinks: [
+        {
+          ...validProfileLinks[0],
+          verifiedAt: undefined,
+        },
+      ],
+    });
+
+    expect(person.validateSync()?.errors['profileLinks.0.verifiedAt']).toBeTruthy();
+  });
+
+  it('rejects a profile link with a future verification timestamp', () => {
+    const person = validPerson({
+      profileLinks: [
+        {
+          ...validProfileLinks[0],
+          verifiedAt: new Date('2999-01-01T00:00:00.000Z'),
+        },
+      ],
+    });
+
+    expect(person.validateSync()?.errors['profileLinks.0.verifiedAt']).toBeTruthy();
+  });
+
+  it('requires an ORCID profile URL to match the canonical identifier', () => {
+    const person = validPerson({
+      identifiers: { orcid: '0000-0003-1419-2405' },
+      profileLinks: [validProfileLinks[4]],
+    });
+
+    expect(person.validateSync()?.errors.profileLinks).toBeTruthy();
+  });
+
+  it('allows a valid ORCID identifier to remain private until a profile link is reviewed', () => {
+    const person = validPerson({
+      identifiers: { orcid: '0000-0002-1825-0097' },
+    });
+
+    expect(person.validateSync()).toBeUndefined();
+  });
+
+  it('rejects unbounded identity text and invalid ORCID identifiers', () => {
+    expect(
+      validPerson({ displayName: 'x'.repeat(241) }).validateSync()?.errors.displayName,
+    ).toBeTruthy();
+    expect(
+      validPerson({ identifiers: { orcid: '0000-0002-1825-0098' } }).validateSync()?.errors[
+        'identifiers.orcid'
+      ],
+    ).toBeTruthy();
+  });
+
+  it('normalizes account identity without creating competing authorization roles', () => {
+    const account = validAccount({
+      netid: ' FIXTURE2 ',
+      email: ' FIXTURE2@YALE.EDU ',
+    });
+
+    expect(account.netid).toBe('fixture2');
+    expect(account.email).toBe('fixture2@yale.edu');
+    expect(account.validateSync()).toBeUndefined();
+    expect(validAccount({ status: 'ADMIN' }).validateSync()?.errors.status).toBeTruthy();
+  });
+
+  it('validates role assignment confidence, lifecycle dates, and bounded evidence references', () => {
+    const startedAt = new Date('2026-07-02T00:00:00.000Z');
+    const endedAt = new Date('2026-07-01T00:00:00.000Z');
+    const duplicateEvidenceId = objectId();
+
+    expect(validRoleAssignment({ confidence: 1.1 }).validateSync()?.errors.confidence).toBeTruthy();
+    expect(validRoleAssignment({ startedAt, endedAt }).validateSync()?.errors.endedAt).toBeTruthy();
+    expect(
+      validRoleAssignment({
+        state: 'CURRENT',
+        endedAt: new Date('2026-07-03T00:00:00.000Z'),
+      }).validateSync()?.errors.endedAt,
+    ).toBeTruthy();
+    expect(validRoleAssignment({ state: 'HISTORICAL' }).validateSync()?.errors.state).toBeTruthy();
+    expect(
+      validRoleAssignment({
+        evidenceClaimIds: [duplicateEvidenceId, duplicateEvidenceId],
+      }).validateSync()?.errors.evidenceClaimIds,
+    ).toBeTruthy();
+    expect(
+      validRoleAssignment({
+        evidenceClaimIds: Array.from({ length: 101 }, objectId),
+      }).validateSync()?.errors.evidenceClaimIds,
+    ).toBeTruthy();
+  });
+
+  it('indexes role assignments by person, target, state, and lifecycle', () => {
+    expect(RoleAssignment.schema.indexes()).toContainEqual([
+      {
+        personId: 1,
+        state: 1,
+        archived: 1,
+      },
+      expect.any(Object),
+    ]);
+    expect(RoleAssignment.schema.indexes()).toContainEqual([
+      {
+        'target.kind': 1,
+        'target.id': 1,
+        state: 1,
+        archived: 1,
+      },
+      expect.any(Object),
+    ]);
+    expect(RoleAssignment.schema.path('role')).toBeTruthy();
+    expect(Person.schema.path('role')).toBeUndefined();
+  });
+
+  it('allows repeated historical terms instead of treating a role as permanent person identity', () => {
+    const personId = objectId();
+    const targetId = objectId();
+    const firstTerm = validRoleAssignment({
+      personId,
+      target: { kind: 'RESEARCH_ENTITY', id: targetId },
+      state: 'HISTORICAL',
+      startedAt: new Date('2020-01-01T00:00:00.000Z'),
+      endedAt: new Date('2021-01-01T00:00:00.000Z'),
+    });
+    const secondTerm = validRoleAssignment({
+      personId,
+      target: { kind: 'RESEARCH_ENTITY', id: targetId },
+      state: 'HISTORICAL',
+      startedAt: new Date('2022-01-01T00:00:00.000Z'),
+      endedAt: new Date('2023-01-01T00:00:00.000Z'),
+    });
+
+    expect(firstTerm.validateSync()).toBeUndefined();
+    expect(secondTerm.validateSync()).toBeUndefined();
+    expect(RoleAssignment.schema.indexes().some(([, options]) => options.unique)).toBe(false);
+  });
+
+  it('enforces bounded, case-insensitively unique OrgUnit aliases', () => {
+    expect(
+      validOrgUnit({ aliases: ['Yale CS', ' yale cs '] }).validateSync()?.errors.aliases,
+    ).toBeTruthy();
+    expect(
+      validOrgUnit({
+        aliases: Array.from({ length: 21 }, (_, index) => `Alias ${index}`),
+      }).validateSync()?.errors.aliases,
+    ).toBeTruthy();
+  });
+
+  it('enforces bounded, case-insensitively unique TaxonomyTerm aliases', () => {
+    expect(
+      validTaxonomyTerm({
+        aliases: ['Machine Intelligence', 'machine intelligence'],
+      }).validateSync()?.errors.aliases,
+    ).toBeTruthy();
+    expect(
+      validTaxonomyTerm({
+        aliases: Array.from({ length: 31 }, (_, index) => `Alias ${index}`),
+      }).validateSync()?.errors.aliases,
+    ).toBeTruthy();
+  });
+
+  it('uses kind plus normalized label as the TaxonomyTerm uniqueness boundary', () => {
+    expect(TaxonomyTerm.schema.indexes()).toContainEqual([
+      {
+        kind: 1,
+        normalizedLabel: 1,
+      },
+      expect.objectContaining({ unique: true }),
+    ]);
+    expect(validTaxonomyTerm({ normalizedLabel: ' MACHINE LEARNING ' }).normalizedLabel).toBe(
+      'machine learning',
+    );
+    expect(
+      validTaxonomyTerm({ normalizedLabel: 'deep learning' }).validateSync()?.errors
+        .normalizedLabel,
+    ).toBeTruthy();
+    expect(validTaxonomyTerm({ normalizedLabel: undefined }).normalizedLabel).toBe(
+      'machine learning',
+    );
+    expect(
+      validTaxonomyTerm({ aliases: [' machine   learning '] }).validateSync()?.errors.aliases,
+    ).toBeTruthy();
+  });
+
+  it('registers canonical identity indexes without requiring collection creation', () => {
+    expect(Account.schema.indexes()).toContainEqual([
+      { netid: 1 },
+      expect.objectContaining({ unique: true }),
+    ]);
+    expect(OrgUnit.schema.indexes()).toContainEqual([
+      { slug: 1 },
+      expect.objectContaining({ unique: true }),
+    ]);
+    expect(Person.schema.indexes()).toContainEqual([
+      { 'identifiers.orcid': 1 },
+      expect.objectContaining({ unique: true, sparse: true }),
+    ]);
+  });
+
+  it('rejects self-parenting canonical reference records', () => {
+    const orgUnit = validOrgUnit();
+    orgUnit.parentOrgUnitId = orgUnit._id;
+    expect(orgUnit.validateSync()?.errors.parentOrgUnitId).toBeTruthy();
+
+    const taxonomyTerm = validTaxonomyTerm();
+    taxonomyTerm.parentTermId = taxonomyTerm._id;
+    expect(taxonomyTerm.validateSync()?.errors.parentTermId).toBeTruthy();
+  });
+
+  it('reuses the existing ResearchEntityRelationship model and physical collection', () => {
+    expect(ResearchEntityRelationship.modelName).toBe('ResearchEntityRelationship');
+    expect(ResearchEntityRelationship.collection.name).toBe('research_entity_relationships');
+    expect(mongoose.models.EntityRelationship).toBeUndefined();
+  });
+
+  it('exports all canonical models from the model barrel without collisions', () => {
+    expect(modelExports.Account).toBe(Account);
+    expect(modelExports.Person).toBe(Person);
+    expect(modelExports.RoleAssignment).toBe(RoleAssignment);
+    expect(modelExports.OrgUnit).toBe(OrgUnit);
+    expect(modelExports.TaxonomyTerm).toBe(TaxonomyTerm);
+    expect(modelExports.ResearchEntityRelationship).toBe(ResearchEntityRelationship);
+  });
+});

--- a/server/src/models/__tests__/mongoNamingConventions.test.ts
+++ b/server/src/models/__tests__/mongoNamingConventions.test.ts
@@ -1,5 +1,6 @@
 import type mongoose from 'mongoose';
 import { describe, expect, it } from 'vitest';
+import { Account } from '../account';
 import { AccessSignal } from '../accessSignal';
 import { AdminGrant } from '../adminGrant';
 import { AnalyticsEvent } from '../analytics';
@@ -11,12 +12,15 @@ import { Fellowship } from '../fellowship';
 import { Grant } from '../grant';
 import { Listing } from '../listing';
 import { Observation } from '../observation';
+import { OrgUnit } from '../orgUnit';
 import { Paper } from '../paper';
 import { PaperAuthor } from '../paperAuthor';
 import { PostedOpportunity } from '../postedOpportunity';
+import { Person } from '../person';
 import { ResearchArea } from '../researchArea';
 import { ResearchEntity } from '../researchEntity';
 import { ResearchGroupMember } from '../researchGroupMember';
+import { RoleAssignment } from '../roleAssignment';
 import { ScrapeRun } from '../scrapeRun';
 import { ScrapeSnapshot } from '../scrapeSnapshot';
 import { Source } from '../source';
@@ -25,9 +29,11 @@ import { StudentEngagementEvent } from '../studentEngagementEvent';
 import { StudentOutreach } from '../studentOutreach';
 import { StudentProfile } from '../studentProfile';
 import { StudentTracking } from '../studentTracking';
+import { TaxonomyTerm } from '../taxonomyTerm';
 import { User } from '../user';
 
 const models: Array<[mongoose.Model<any>, string]> = [
+  [Account, 'accounts'],
   [AccessSignal, 'access_signals'],
   [AdminGrant, 'admin_grants'],
   [AnalyticsEvent, 'analytics_events'],
@@ -39,12 +45,15 @@ const models: Array<[mongoose.Model<any>, string]> = [
   [Grant, 'grants'],
   [Listing, 'listings'],
   [Observation, 'observations'],
+  [OrgUnit, 'org_units'],
   [Paper, 'papers'],
   [PaperAuthor, 'paper_authors'],
   [PostedOpportunity, 'posted_opportunities'],
+  [Person, 'people'],
   [ResearchArea, 'research_areas'],
   [ResearchEntity, 'research_entities'],
   [ResearchGroupMember, 'research_entity_members'],
+  [RoleAssignment, 'role_assignments'],
   [ScrapeRun, 'scrape_runs'],
   [ScrapeSnapshot, 'scrape_snapshots'],
   [Source, 'sources'],
@@ -53,6 +62,7 @@ const models: Array<[mongoose.Model<any>, string]> = [
   [StudentOutreach, 'student_outreaches'],
   [StudentProfile, 'student_profiles'],
   [StudentTracking, 'student_trackings'],
+  [TaxonomyTerm, 'taxonomy_terms'],
   [User, 'users'],
 ];
 
@@ -72,7 +82,8 @@ describe('Mongo naming conventions', () => {
   it('uses lowercase plural snake_case Mongo collection names', () => {
     for (const [model, collectionName] of models) {
       expect(model.collection.name).toBe(collectionName);
-      expect(collectionName).toMatch(/^[a-z][a-z0-9]*(?:_[a-z0-9]+)*s$/);
+      expect(collectionName).toMatch(/^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$/);
+      expect(collectionName === 'people' || collectionName.endsWith('s')).toBe(true);
     }
   });
 

--- a/server/src/models/account.ts
+++ b/server/src/models/account.ts
@@ -1,0 +1,65 @@
+import mongoose from 'mongoose';
+import {
+  canonicalSchemaVersionField,
+  defineCanonicalSchemaVersion,
+} from './canonicalSchemaVersion';
+
+export const accountSchemaVersion = defineCanonicalSchemaVersion({ currentVersion: 1 });
+
+export const accountStatuses = ['ACTIVE', 'DISABLED', 'UNKNOWN'] as const;
+export type AccountStatus = (typeof accountStatuses)[number];
+
+export interface AccountRecord {
+  schemaVersion: number;
+  netid: string;
+  email: string;
+  status: AccountStatus;
+  lastLoginAt?: Date;
+  archived: boolean;
+}
+
+export const accountSchema = new mongoose.Schema<AccountRecord>(
+  {
+    schemaVersion: canonicalSchemaVersionField(accountSchemaVersion),
+    netid: {
+      type: String,
+      required: true,
+      unique: true,
+      trim: true,
+      lowercase: true,
+      minlength: 2,
+      maxlength: 64,
+      match: /^[a-z0-9][a-z0-9._-]*$/,
+    },
+    email: {
+      type: String,
+      required: true,
+      trim: true,
+      lowercase: true,
+      maxlength: 254,
+      match: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+    },
+    status: {
+      type: String,
+      enum: [...accountStatuses],
+      default: 'ACTIVE',
+    },
+    lastLoginAt: {
+      type: Date,
+      required: false,
+    },
+    archived: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+accountSchema.index({ email: 1 });
+accountSchema.index({ status: 1, archived: 1 });
+
+export const Account =
+  mongoose.models.Account || mongoose.model<AccountRecord>('Account', accountSchema, 'accounts');

--- a/server/src/models/index.ts
+++ b/server/src/models/index.ts
@@ -39,3 +39,8 @@ export * from './researchAccessTypes';
 export * from './sourceCoverageTypes';
 export * from './modelPrimitives';
 export * from './canonicalSchemaVersion';
+export * from './account';
+export * from './person';
+export * from './roleAssignment';
+export * from './orgUnit';
+export * from './taxonomyTerm';

--- a/server/src/models/orgUnit.ts
+++ b/server/src/models/orgUnit.ts
@@ -1,0 +1,105 @@
+import mongoose from 'mongoose';
+import {
+  canonicalSchemaVersionField,
+  defineCanonicalSchemaVersion,
+} from './canonicalSchemaVersion';
+
+export const orgUnitSchemaVersion = defineCanonicalSchemaVersion({ currentVersion: 1 });
+
+export const orgUnitKinds = ['SCHOOL', 'DEPARTMENT', 'DIVISION', 'OFFICE'] as const;
+export type OrgUnitKind = (typeof orgUnitKinds)[number];
+
+export const orgUnitStatuses = ['ACTIVE', 'INACTIVE', 'UNKNOWN'] as const;
+export type OrgUnitStatus = (typeof orgUnitStatuses)[number];
+
+export interface OrgUnitRecord {
+  schemaVersion: number;
+  slug: string;
+  name: string;
+  kind: OrgUnitKind;
+  aliases: string[];
+  parentOrgUnitId?: mongoose.Types.ObjectId;
+  status: OrgUnitStatus;
+  archived: boolean;
+}
+
+const MAX_ORG_UNIT_ALIASES = 20;
+
+function hasBoundedUniqueAliases(values: readonly string[]): boolean {
+  const normalized = values.map((value) => value.trim().toLocaleLowerCase());
+  return values.length <= MAX_ORG_UNIT_ALIASES && new Set(normalized).size === values.length;
+}
+
+export const orgUnitSchema = new mongoose.Schema<OrgUnitRecord>(
+  {
+    schemaVersion: canonicalSchemaVersionField(orgUnitSchemaVersion),
+    slug: {
+      type: String,
+      required: true,
+      unique: true,
+      trim: true,
+      lowercase: true,
+      maxlength: 160,
+      match: /^[a-z0-9]+(?:-[a-z0-9]+)*$/,
+    },
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+      minlength: 1,
+      maxlength: 240,
+    },
+    kind: {
+      type: String,
+      enum: [...orgUnitKinds],
+      required: true,
+    },
+    aliases: {
+      type: [
+        {
+          type: String,
+          trim: true,
+          minlength: 1,
+          maxlength: 240,
+        },
+      ],
+      default: [],
+      validate: {
+        validator: hasBoundedUniqueAliases,
+        message: `aliases must contain at most ${MAX_ORG_UNIT_ALIASES} unique labels.`,
+      },
+    },
+    parentOrgUnitId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'OrgUnit',
+      required: false,
+      validate: {
+        validator: function (
+          this: { _id: mongoose.Types.ObjectId },
+          value?: mongoose.Types.ObjectId,
+        ) {
+          return value === undefined || !value.equals(this._id);
+        },
+        message: 'parentOrgUnitId cannot reference the same OrgUnit.',
+      },
+    },
+    status: {
+      type: String,
+      enum: [...orgUnitStatuses],
+      default: 'UNKNOWN',
+    },
+    archived: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+orgUnitSchema.index({ parentOrgUnitId: 1, kind: 1, status: 1, archived: 1 });
+orgUnitSchema.index({ kind: 1, name: 1 });
+
+export const OrgUnit =
+  mongoose.models.OrgUnit || mongoose.model<OrgUnitRecord>('OrgUnit', orgUnitSchema, 'org_units');

--- a/server/src/models/person.ts
+++ b/server/src/models/person.ts
@@ -1,0 +1,257 @@
+import mongoose from 'mongoose';
+import {
+  canonicalSchemaVersionField,
+  defineCanonicalSchemaVersion,
+} from './canonicalSchemaVersion';
+
+export const personSchemaVersion = defineCanonicalSchemaVersion({ currentVersion: 1 });
+
+export const personProfileLinkKinds = [
+  'YALE_OFFICIAL',
+  'LAB_ABOUT',
+  'PERSONAL_ACADEMIC',
+  'GOOGLE_SCHOLAR',
+  'ORCID',
+] as const;
+export type PersonProfileLinkKind = (typeof personProfileLinkKinds)[number];
+
+export const personProfileLinkPurposes = ['PRIMARY_IDENTITY', 'SCHOLARLY'] as const;
+export type PersonProfileLinkPurpose = (typeof personProfileLinkPurposes)[number];
+
+export const personProfileLinkHealthStatuses = ['HEALTHY', 'UNAVAILABLE', 'UNKNOWN'] as const;
+export type PersonProfileLinkHealthStatus = (typeof personProfileLinkHealthStatuses)[number];
+
+export interface PersonProfileLink {
+  kind: PersonProfileLinkKind;
+  purpose: PersonProfileLinkPurpose;
+  url: string;
+  verifiedAt: Date;
+  healthStatus: PersonProfileLinkHealthStatus;
+}
+
+export const personStatuses = ['ACTIVE', 'DEPARTED', 'UNKNOWN'] as const;
+export type PersonStatus = (typeof personStatuses)[number];
+
+export interface PersonIdentifiers {
+  orcid?: string;
+}
+
+export interface PersonRecord {
+  schemaVersion: number;
+  displayName: string;
+  accountId?: mongoose.Types.ObjectId;
+  profileLinks: PersonProfileLink[];
+  identifiers?: PersonIdentifiers;
+  status: PersonStatus;
+  archived: boolean;
+}
+
+const PROFILE_LINK_PURPOSE_BY_KIND: Record<PersonProfileLinkKind, PersonProfileLinkPurpose> = {
+  YALE_OFFICIAL: 'PRIMARY_IDENTITY',
+  LAB_ABOUT: 'PRIMARY_IDENTITY',
+  PERSONAL_ACADEMIC: 'PRIMARY_IDENTITY',
+  GOOGLE_SCHOLAR: 'SCHOLARLY',
+  ORCID: 'SCHOLARLY',
+};
+
+const ORCID_PATTERN = /^\d{4}-\d{4}-\d{4}-\d{3}[\dX]$/;
+
+export function isValidOrcid(value: string): boolean {
+  const normalized = value.trim().toUpperCase();
+  if (!ORCID_PATTERN.test(normalized)) return false;
+
+  const characters = normalized.replaceAll('-', '');
+  let total = 0;
+  for (const character of characters.slice(0, 15)) {
+    total = (total + Number(character)) * 2;
+  }
+  const checksumValue = (12 - (total % 11)) % 11;
+  const checksum = checksumValue === 10 ? 'X' : String(checksumValue);
+  return characters.at(-1) === checksum;
+}
+
+function parseHttpsUrl(value: string): URL | undefined {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'https:' ? url : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function orcidFromUrl(url: URL): string | undefined {
+  if (url.hostname !== 'orcid.org' || url.search || url.hash) return undefined;
+  const match = /^\/(\d{4}-\d{4}-\d{4}-\d{3}[\dX])\/?$/.exec(url.pathname.toUpperCase());
+  if (!match || !isValidOrcid(match[1])) return undefined;
+  return match[1];
+}
+
+function isVerifiedProfileUrl(kind: PersonProfileLinkKind, value: string): boolean {
+  const url = parseHttpsUrl(value);
+  if (!url || url.username || url.password) return false;
+
+  if (kind === 'YALE_OFFICIAL') {
+    return url.hostname === 'yale.edu' || url.hostname.endsWith('.yale.edu');
+  }
+  if (kind === 'GOOGLE_SCHOLAR') {
+    const scholarUserId = url.searchParams.get('user');
+    return (
+      url.hostname === 'scholar.google.com' &&
+      url.pathname === '/citations' &&
+      typeof scholarUserId === 'string' &&
+      /^[A-Za-z0-9_-]+$/.test(scholarUserId)
+    );
+  }
+  if (kind === 'ORCID') {
+    return orcidFromUrl(url) !== undefined;
+  }
+  return true;
+}
+
+export const personProfileLinkSchema = new mongoose.Schema<PersonProfileLink>(
+  {
+    kind: {
+      type: String,
+      enum: [...personProfileLinkKinds],
+      required: true,
+    },
+    purpose: {
+      type: String,
+      enum: [...personProfileLinkPurposes],
+      required: true,
+      validate: {
+        validator: function (
+          this: { kind?: PersonProfileLinkKind },
+          value: PersonProfileLinkPurpose,
+        ) {
+          return this.kind !== undefined && PROFILE_LINK_PURPOSE_BY_KIND[this.kind] === value;
+        },
+        message: 'Profile link purpose is incompatible with its kind.',
+      },
+    },
+    url: {
+      type: String,
+      required: true,
+      trim: true,
+      maxlength: 2048,
+      validate: {
+        validator: function (this: { kind?: PersonProfileLinkKind }, value: string) {
+          return this.kind !== undefined && isVerifiedProfileUrl(this.kind, value);
+        },
+        message: 'Profile link URL is not valid for its verified kind.',
+      },
+    },
+    verifiedAt: {
+      type: Date,
+      required: true,
+      validate: {
+        validator: (value: Date) => value <= new Date(),
+        message: 'verifiedAt cannot be in the future.',
+      },
+    },
+    healthStatus: {
+      type: String,
+      enum: [...personProfileLinkHealthStatuses],
+      default: 'UNKNOWN',
+    },
+  },
+  {
+    _id: false,
+  },
+);
+
+export const personIdentifiersSchema = new mongoose.Schema<PersonIdentifiers>(
+  {
+    orcid: {
+      type: String,
+      required: false,
+      trim: true,
+      uppercase: true,
+      validate: {
+        validator: isValidOrcid,
+        message: 'identifiers.orcid must be a valid ORCID identifier.',
+      },
+    },
+  },
+  {
+    _id: false,
+  },
+);
+
+function hasBoundedUniqueProfileKinds(values: readonly PersonProfileLink[]): boolean {
+  return (
+    values.length <= personProfileLinkKinds.length &&
+    new Set(values.map(({ kind }) => kind)).size === values.length
+  );
+}
+
+function orcidProfileMatchesIdentifier(
+  this: { identifiers?: { orcid?: string } },
+  values: readonly PersonProfileLink[],
+): boolean {
+  const link = values.find(({ kind }) => kind === 'ORCID');
+  if (!link) return true;
+
+  const url = parseHttpsUrl(link.url);
+  const profileOrcid = url ? orcidFromUrl(url) : undefined;
+  if (profileOrcid === undefined) return true;
+
+  return (
+    this.identifiers?.orcid !== undefined && profileOrcid === this.identifiers.orcid.toUpperCase()
+  );
+}
+
+export const personSchema = new mongoose.Schema<PersonRecord>(
+  {
+    schemaVersion: canonicalSchemaVersionField(personSchemaVersion),
+    displayName: {
+      type: String,
+      required: true,
+      trim: true,
+      minlength: 1,
+      maxlength: 240,
+    },
+    accountId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Account',
+      required: false,
+    },
+    profileLinks: {
+      type: [personProfileLinkSchema],
+      default: [],
+      validate: [
+        {
+          validator: hasBoundedUniqueProfileKinds,
+          message: 'profileLinks must contain at most one verified link per kind.',
+        },
+        {
+          validator: orcidProfileMatchesIdentifier,
+          message: 'An ORCID profile link must match identifiers.orcid.',
+        },
+      ],
+    },
+    identifiers: {
+      type: personIdentifiersSchema,
+      default: undefined,
+    },
+    status: {
+      type: String,
+      enum: [...personStatuses],
+      default: 'UNKNOWN',
+    },
+    archived: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+personSchema.index({ accountId: 1 }, { unique: true, sparse: true });
+personSchema.index({ 'identifiers.orcid': 1 }, { unique: true, sparse: true });
+personSchema.index({ displayName: 1, status: 1, archived: 1 });
+
+export const Person =
+  mongoose.models.Person || mongoose.model<PersonRecord>('Person', personSchema, 'people');

--- a/server/src/models/roleAssignment.ts
+++ b/server/src/models/roleAssignment.ts
@@ -1,0 +1,167 @@
+import mongoose from 'mongoose';
+import {
+  canonicalSchemaVersionField,
+  defineCanonicalSchemaVersion,
+} from './canonicalSchemaVersion';
+
+export const roleAssignmentSchemaVersion = defineCanonicalSchemaVersion({ currentVersion: 1 });
+
+export const roleAssignmentTargetKinds = ['RESEARCH_ENTITY', 'ORG_UNIT'] as const;
+export type RoleAssignmentTargetKind = (typeof roleAssignmentTargetKinds)[number];
+
+export const roleAssignmentRoles = [
+  'PI',
+  'CO_PI',
+  'DIRECTOR',
+  'CO_DIRECTOR',
+  'CORE_FACULTY',
+  'AFFILIATED',
+  'STAFF',
+  'POSTDOC',
+  'GRADUATE_STUDENT',
+  'UNDERGRADUATE',
+] as const;
+export type RoleAssignmentRole = (typeof roleAssignmentRoles)[number];
+
+export const roleAssignmentStates = ['CURRENT', 'HISTORICAL', 'UNKNOWN'] as const;
+export type RoleAssignmentState = (typeof roleAssignmentStates)[number];
+
+export const roleAssignmentReviewStatuses = ['UNREVIEWED', 'APPROVED', 'DISPUTED'] as const;
+export type RoleAssignmentReviewStatus = (typeof roleAssignmentReviewStatuses)[number];
+
+export interface RoleAssignmentTarget {
+  kind: RoleAssignmentTargetKind;
+  id: mongoose.Types.ObjectId;
+}
+
+export interface RoleAssignmentRecord {
+  schemaVersion: number;
+  personId: mongoose.Types.ObjectId;
+  target: RoleAssignmentTarget;
+  role: RoleAssignmentRole;
+  state: RoleAssignmentState;
+  startedAt?: Date;
+  endedAt?: Date;
+  evidenceClaimIds: mongoose.Types.ObjectId[];
+  confidence: number;
+  reviewStatus: RoleAssignmentReviewStatus;
+  archived: boolean;
+}
+
+const MAX_EVIDENCE_CLAIMS_PER_ROLE = 100;
+
+function hasBoundedUniqueObjectIds(values: readonly mongoose.Types.ObjectId[]): boolean {
+  return (
+    values.length <= MAX_EVIDENCE_CLAIMS_PER_ROLE &&
+    new Set(values.map((value) => value.toString())).size === values.length
+  );
+}
+
+export const roleAssignmentTargetSchema = new mongoose.Schema<RoleAssignmentTarget>(
+  {
+    kind: {
+      type: String,
+      enum: [...roleAssignmentTargetKinds],
+      required: true,
+    },
+    id: {
+      type: mongoose.Schema.Types.ObjectId,
+      required: true,
+    },
+  },
+  {
+    _id: false,
+  },
+);
+
+export const roleAssignmentSchema = new mongoose.Schema<RoleAssignmentRecord>(
+  {
+    schemaVersion: canonicalSchemaVersionField(roleAssignmentSchemaVersion),
+    personId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Person',
+      required: true,
+    },
+    target: {
+      type: roleAssignmentTargetSchema,
+      required: true,
+    },
+    role: {
+      type: String,
+      enum: [...roleAssignmentRoles],
+      required: true,
+    },
+    state: {
+      type: String,
+      enum: [...roleAssignmentStates],
+      default: 'UNKNOWN',
+      validate: {
+        validator: function (this: { endedAt?: Date }, value: RoleAssignmentState) {
+          return value !== 'HISTORICAL' || this.endedAt !== undefined;
+        },
+        message: 'HISTORICAL role assignments require endedAt.',
+      },
+    },
+    startedAt: {
+      type: Date,
+      required: false,
+    },
+    endedAt: {
+      type: Date,
+      required: false,
+      validate: {
+        validator: function (
+          this: { startedAt?: Date; state?: RoleAssignmentState },
+          value?: Date,
+        ) {
+          if (this.state === 'CURRENT' && value !== undefined) return false;
+          return value === undefined || this.startedAt === undefined || value >= this.startedAt;
+        },
+        message: 'endedAt must follow startedAt and cannot be set on a CURRENT role assignment.',
+      },
+    },
+    evidenceClaimIds: {
+      type: [
+        {
+          type: mongoose.Schema.Types.ObjectId,
+          ref: 'EvidenceClaim',
+        },
+      ],
+      default: [],
+      validate: {
+        validator: hasBoundedUniqueObjectIds,
+        message: `evidenceClaimIds must contain at most ${MAX_EVIDENCE_CLAIMS_PER_ROLE} unique ids.`,
+      },
+    },
+    confidence: {
+      type: Number,
+      required: true,
+      min: 0,
+      max: 1,
+    },
+    reviewStatus: {
+      type: String,
+      enum: [...roleAssignmentReviewStatuses],
+      default: 'UNREVIEWED',
+    },
+    archived: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+roleAssignmentSchema.index({ personId: 1, state: 1, archived: 1 });
+roleAssignmentSchema.index({
+  'target.kind': 1,
+  'target.id': 1,
+  state: 1,
+  archived: 1,
+});
+
+export const RoleAssignment =
+  mongoose.models.RoleAssignment ||
+  mongoose.model<RoleAssignmentRecord>('RoleAssignment', roleAssignmentSchema, 'role_assignments');

--- a/server/src/models/roleAssignment.ts
+++ b/server/src/models/roleAssignment.ts
@@ -95,12 +95,6 @@ export const roleAssignmentSchema = new mongoose.Schema<RoleAssignmentRecord>(
       type: String,
       enum: [...roleAssignmentStates],
       default: 'UNKNOWN',
-      validate: {
-        validator: function (this: { endedAt?: Date }, value: RoleAssignmentState) {
-          return value !== 'HISTORICAL' || this.endedAt !== undefined;
-        },
-        message: 'HISTORICAL role assignments require endedAt.',
-      },
     },
     startedAt: {
       type: Date,

--- a/server/src/models/taxonomyTerm.ts
+++ b/server/src/models/taxonomyTerm.ts
@@ -1,0 +1,135 @@
+import mongoose from 'mongoose';
+import {
+  canonicalSchemaVersionField,
+  defineCanonicalSchemaVersion,
+} from './canonicalSchemaVersion';
+
+export const taxonomyTermSchemaVersion = defineCanonicalSchemaVersion({ currentVersion: 1 });
+
+export const taxonomyTermKinds = ['TOPIC', 'METHOD'] as const;
+export type TaxonomyTermKind = (typeof taxonomyTermKinds)[number];
+
+export const taxonomyTermReviewStatuses = ['UNREVIEWED', 'APPROVED', 'DISPUTED'] as const;
+export type TaxonomyTermReviewStatus = (typeof taxonomyTermReviewStatuses)[number];
+
+export const taxonomyTermStatuses = ['ACTIVE', 'INACTIVE'] as const;
+export type TaxonomyTermStatus = (typeof taxonomyTermStatuses)[number];
+
+export interface TaxonomyTermRecord {
+  schemaVersion: number;
+  kind: TaxonomyTermKind;
+  label: string;
+  normalizedLabel: string;
+  aliases: string[];
+  parentTermId?: mongoose.Types.ObjectId;
+  reviewStatus: TaxonomyTermReviewStatus;
+  status: TaxonomyTermStatus;
+  archived: boolean;
+}
+
+const MAX_TAXONOMY_ALIASES = 30;
+
+export function normalizeTaxonomyLabel(value: string): string {
+  return value.normalize('NFKC').trim().toLocaleLowerCase().replace(/\s+/g, ' ');
+}
+
+function hasBoundedUniqueAliases(
+  this: { normalizedLabel?: string },
+  values: readonly string[],
+): boolean {
+  const normalized = values.map(normalizeTaxonomyLabel);
+  return (
+    values.length <= MAX_TAXONOMY_ALIASES &&
+    new Set(normalized).size === values.length &&
+    !normalized.includes(this.normalizedLabel ?? '')
+  );
+}
+
+export const taxonomyTermSchema = new mongoose.Schema<TaxonomyTermRecord>(
+  {
+    schemaVersion: canonicalSchemaVersionField(taxonomyTermSchemaVersion),
+    kind: {
+      type: String,
+      enum: [...taxonomyTermKinds],
+      required: true,
+    },
+    label: {
+      type: String,
+      required: true,
+      trim: true,
+      minlength: 1,
+      maxlength: 240,
+    },
+    normalizedLabel: {
+      type: String,
+      required: true,
+      trim: true,
+      lowercase: true,
+      minlength: 1,
+      maxlength: 240,
+      default: function (this: { label?: string }) {
+        return normalizeTaxonomyLabel(this.label ?? '');
+      },
+      set: normalizeTaxonomyLabel,
+      validate: {
+        validator: function (this: { label?: string }, value: string) {
+          return this.label !== undefined && value === normalizeTaxonomyLabel(this.label);
+        },
+        message: 'normalizedLabel must match the canonical label.',
+      },
+    },
+    aliases: {
+      type: [
+        {
+          type: String,
+          trim: true,
+          minlength: 1,
+          maxlength: 240,
+        },
+      ],
+      default: [],
+      validate: {
+        validator: hasBoundedUniqueAliases,
+        message: `aliases must contain at most ${MAX_TAXONOMY_ALIASES} unique labels.`,
+      },
+    },
+    parentTermId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'TaxonomyTerm',
+      required: false,
+      validate: {
+        validator: function (
+          this: { _id: mongoose.Types.ObjectId },
+          value?: mongoose.Types.ObjectId,
+        ) {
+          return value === undefined || !value.equals(this._id);
+        },
+        message: 'parentTermId cannot reference the same TaxonomyTerm.',
+      },
+    },
+    reviewStatus: {
+      type: String,
+      enum: [...taxonomyTermReviewStatuses],
+      default: 'UNREVIEWED',
+    },
+    status: {
+      type: String,
+      enum: [...taxonomyTermStatuses],
+      default: 'ACTIVE',
+    },
+    archived: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+taxonomyTermSchema.index({ kind: 1, normalizedLabel: 1 }, { unique: true });
+taxonomyTermSchema.index({ parentTermId: 1, kind: 1, status: 1, archived: 1 });
+
+export const TaxonomyTerm =
+  mongoose.models.TaxonomyTerm ||
+  mongoose.model<TaxonomyTermRecord>('TaxonomyTerm', taxonomyTermSchema, 'taxonomy_terms');

--- a/server/src/scripts/__tests__/researchModelInventoryCore.test.ts
+++ b/server/src/scripts/__tests__/researchModelInventoryCore.test.ts
@@ -54,6 +54,30 @@ describe('INVENTORY_COLLECTIONS', () => {
     expect(new Set(names).size).toBe(names.length);
   });
 
+  it('classifies every phase 1 canonical identity collection', () => {
+    expect(
+      INVENTORY_COLLECTIONS.filter((spec) => spec.phase === 1).map(
+        ({ collection, model, group, target }) => ({ collection, model, group, target }),
+      ),
+    ).toEqual([
+      { collection: 'accounts', model: 'Account', group: 'canonical-domain', target: 'Account' },
+      { collection: 'people', model: 'Person', group: 'canonical-domain', target: 'Person' },
+      {
+        collection: 'role_assignments',
+        model: 'RoleAssignment',
+        group: 'canonical-domain',
+        target: 'RoleAssignment',
+      },
+      { collection: 'org_units', model: 'OrgUnit', group: 'canonical-domain', target: 'OrgUnit' },
+      {
+        collection: 'taxonomy_terms',
+        model: 'TaxonomyTerm',
+        group: 'canonical-domain',
+        target: 'TaxonomyTerm',
+      },
+    ]);
+  });
+
   it('marks every scholarly collection for phase 3 retirement', () => {
     const scholarly = INVENTORY_COLLECTIONS.filter((spec) => spec.group === 'scholarly-retire');
     expect(scholarly.length).toBeGreaterThan(0);

--- a/server/src/scripts/__tests__/researchModelInventoryCore.test.ts
+++ b/server/src/scripts/__tests__/researchModelInventoryCore.test.ts
@@ -77,6 +77,15 @@ describe('INVENTORY_COLLECTIONS', () => {
       target: 'Private student application records (retained, normalized references)',
     });
   });
+
+  it('retains the existing ResearchEntityRelationship identity and collection', () => {
+    expect(
+      INVENTORY_COLLECTIONS.find((spec) => spec.collection === 'research_entity_relationships'),
+    ).toMatchObject({
+      model: 'ResearchEntityRelationship',
+      target: 'ResearchEntityRelationship (retained)',
+    });
+  });
 });
 
 describe('inventory coverage', () => {

--- a/server/src/scripts/researchModelInventoryCore.ts
+++ b/server/src/scripts/researchModelInventoryCore.ts
@@ -89,6 +89,41 @@ export function assertInventoryEnvironmentMatchesDatabase(
 /** Refactor-relevant collections, keyed by physical name. */
 export const INVENTORY_COLLECTIONS: CollectionSpec[] = [
   {
+    collection: 'accounts',
+    model: 'Account',
+    group: 'canonical-domain',
+    phase: 1,
+    target: 'Account',
+  },
+  {
+    collection: 'people',
+    model: 'Person',
+    group: 'canonical-domain',
+    phase: 1,
+    target: 'Person',
+  },
+  {
+    collection: 'role_assignments',
+    model: 'RoleAssignment',
+    group: 'canonical-domain',
+    phase: 1,
+    target: 'RoleAssignment',
+  },
+  {
+    collection: 'org_units',
+    model: 'OrgUnit',
+    group: 'canonical-domain',
+    phase: 1,
+    target: 'OrgUnit',
+  },
+  {
+    collection: 'taxonomy_terms',
+    model: 'TaxonomyTerm',
+    group: 'canonical-domain',
+    phase: 1,
+    target: 'TaxonomyTerm',
+  },
+  {
     collection: 'users',
     model: 'User',
     group: 'dual-truth',

--- a/server/src/scripts/researchModelInventoryCore.ts
+++ b/server/src/scripts/researchModelInventoryCore.ts
@@ -121,7 +121,7 @@ export const INVENTORY_COLLECTIONS: CollectionSpec[] = [
     model: 'ResearchEntityRelationship',
     group: 'canonical-domain',
     phase: 4,
-    target: 'EntityRelationship',
+    target: 'ResearchEntityRelationship (retained)',
   },
   {
     collection: 'entry_pathways',


### PR DESCRIPTION
## Intent

Finish the canonical research-model refactor safely after the merged contract foundation. For issue #214, add empty, versioned Account, Person, RoleAssignment, OrgUnit, and TaxonomyTerm schemas that coexist with Beta without runtime cutover. Keep Person role-neutral, store the optional account relationship only on Person.accountId, bound and verify profile links, preserve historical roles, reuse ResearchEntityRelationship, and add contract, naming, index, public-boundary, inventory, and durable documentation coverage. Do not add readers, writers, routes, migrations, startup hooks, ResearchEntity changes, or Meilisearch changes. Validate the branch, push it, and open a PR against Beta linked to #214, but do not merge it.

## What Changed

- Add versioned `Account`, `Person`, `RoleAssignment`, `OrgUnit`, and `TaxonomyTerm` models with explicit canonical collections, indexes, bounded fields, and validation.
- Keep identity and role boundaries migration-safe, including the one-way `Person.accountId` relationship, verified profile links, and historical role preservation without a Beta runtime cutover.
- Extend model contracts, naming checks, inventory coverage, and durable refactor documentation for the new canonical collections and retained `ResearchEntityRelationship`.

## Risk Assessment

✅ Low: The remediation fully closes both prior findings, and the complete base-to-HEAD change remains a bounded schema-only addition that conforms to the stated no-cutover constraints.

## Testing

After repairing the clean-worktree dependency setup, the targeted model, naming, inventory, and direct runtime contract checks all succeeded. The JSON artifact demonstrates the data contract; no visual evidence applies because the change intentionally adds no UI, routes, readers, or writers.

<details>
<summary>Evidence: Canonical identity runtime contract</summary>

```text
{
  "registeredCollections": [
    {
      "model": "Account",
      "collection": "accounts",
      "schemaVersion": 1,
      "valid": true
    },
    {
      "model": "Person",
      "collection": "people",
      "schemaVersion": 1,
      "valid": true
    },
    {
      "model": "RoleAssignment",
      "collection": "role_assignments",
      "schemaVersion": 1,
      "valid": true
    },
    {
      "model": "OrgUnit",
      "collection": "org_units",
      "schemaVersion": 1,
      "valid": true
    },
    {
      "model": "TaxonomyTerm",
      "collection": "taxonomy_terms",
      "schemaVersion": 1,
      "valid": true
    }
  ],
  "normalizedAccount": {
    "netid": "tester1",
    "email": "tester1@yale.edu",
    "hasPersonId": false
  },
  "personBoundary": {
    "accountRef": "Account",
    "roleFieldPresent": false,
    "profileLinkFields": [
      "healthStatus",
      "kind",
      "purpose",
      "url",
      "verifiedAt"
    ],
    "valid": true
  },
  "verifiedLinkRejection": {
    "url": "https://example.org/not-yale",
    "rejected": true
  },
  "historicalRole": {
    "state": "HISTORICAL",
    "startedAt": "2020-01-01T00:00:00.000Z",
    "endedAt": "2022-01-01T00:00:00.000Z",
    "valid": true
  },
  "relationshipReuse": {
    "model": "ResearchEntityRelationship",
    "collection": "research_entity_relationships",
    "competingModelRegistered": false
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `server/src/models/roleAssignment.ts:100` - The required &#34;preserve historical roles&#34; behavior is not fully supported: `state: &#39;HISTORICAL&#39;` is rejected unless `endedAt` is known. A former role whose source establishes that it is historical but provides no end date cannot be represented without falsely supplying a date or downgrading it to `UNKNOWN`. Please confirm whether historical roles with unknown end dates must be accepted, and if so remove this requirement while retaining the date-order validation.
- 🚨 `server/src/models/account.ts:65` - The required &#34;inventory coverage&#34; omits all five new physical collections. Once `accounts`, `people`, `role_assignments`, `org_units`, or `taxonomy_terms` exists, `findUnclassifiedCollections` will report it as unclassified and the inventory will not census its document count or schema versions. Add these canonical collections to `INVENTORY_COLLECTIONS` with their Phase 1 ownership, plus assertions covering them.

🔧 Fix: Preserve historical roles and inventory canonical collections
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`yarn install --immutable` in `server/` to repair missing local dependencies</code>
- `yarn test src/models/__tests__/canonicalIdentityModels.test.ts src/models/__tests__/mongoNamingConventions.test.ts src/scripts/__tests__/researchModelInventoryCore.test.ts`
- <code>Direct `yarn tsx -e ...` runtime check instantiating the five canonical models, validating accepted and rejected profile-link data, historical roles, relationship reuse, and model boundaries</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
