### PR TITLE
feat(models): add canonical evidence and planning schemas

### DIFF
--- a/docs/research-model.md
+++ b/docs/research-model.md
@@ -517,10 +517,14 @@ The existing `Source` and `StudentEngagementEvent` models remain the canonical s
 Notes, checklists, and deadlines are excluded from normal queries, and each export category requires an explicit opt-in preference.
 
 `SourceDocument` stores a source-scoped normalized document key, a content hash, bounded metadata, and an optional protected snapshot pointer.
+Its source metadata and snapshot pointer are excluded from normal queries.
+It may record credential-free HTTP(S) URLs, but storing a URL neither trusts nor fetches it.
+Any later outbound fetch from a stored URL must use [`server/src/utils/ssrfGuard.ts`](../server/src/utils/ssrfGuard.ts).
 It does not embed raw fetched content and it has no automatic TTL because retention decisions depend on source policy.
 
 `EvidenceClaim` accepts only predicates in the versioned registry in [`server/src/models/evidencePredicateRegistry.ts`](../server/src/models/evidencePredicateRegistry.ts).
 Claim values are bounded, excluded from normal queries, and `ADMIN_ONLY` unless a later reviewed workflow explicitly lowers sensitivity.
+Claims retain source evidence separately from the materialized domain records they may later support.
 
 `ReviewDecision` is an append-only audit record with a protected account reviewer.
 A later decision may point backward to one decision it supersedes, while the original decision remains unchanged.

--- a/docs/research-model.md
+++ b/docs/research-model.md
@@ -508,6 +508,26 @@ Validator plans must be deterministic, dry-run reviewable, and limited to an exp
 The pure planner in [`server/src/scripts/canonicalMongoValidatorsCore.ts`](../server/src/scripts/canonicalMongoValidatorsCore.ts) does not connect to MongoDB or apply commands.
 A later guarded operator command must compare current collection options, require explicit confirmation before writes, and never run during application startup.
 
+### Phase 1 evidence and planning schema foundation
+
+The versioned `ResearchPlan`, `SourceDocument`, `EvidenceClaim`, and `ReviewDecision` schemas establish storage contracts without adding runtime routes, scraper writers, materializers, Meilisearch documents, or migrations.
+The existing `Source` and `StudentEngagementEvent` models remain the canonical source registry and analytics event model.
+
+`ResearchPlan` is account-owned and private by default.
+Notes, checklists, and deadlines are excluded from normal queries, and each export category requires an explicit opt-in preference.
+
+`SourceDocument` stores a source-scoped normalized document key, a content hash, bounded metadata, and an optional protected snapshot pointer.
+It does not embed raw fetched content and it has no automatic TTL because retention decisions depend on source policy.
+
+`EvidenceClaim` accepts only predicates in the versioned registry in [`server/src/models/evidencePredicateRegistry.ts`](../server/src/models/evidencePredicateRegistry.ts).
+Claim values are bounded, excluded from normal queries, and `ADMIN_ONLY` unless a later reviewed workflow explicitly lowers sensitivity.
+
+`ReviewDecision` is an append-only audit record with a protected account reviewer.
+A later decision may point backward to one decision it supersedes, while the original decision remains unchanged.
+
+These collections may coexist empty with the current runtime.
+No current scraper or public read path should write or consume them until a later cutover phase adds reconciliation and explicit operational gates.
+
 Current physical strategy: hard-pivot to physical `research_entities` and canonical dependent collections. Development has copied and dropped `research_groups`, `research_group_members`, `research_group_stats`, `paper_group_links`, and leftover `applications` after verified parity. Runtime paper activity now uses `research_scholarly_links` and `research_scholarly_attributions`; empty stats and paper-entity-link collections are not part of the launch copy set.
 
 The remaining end-to-end work is tracked in [`docs/tasks/priority-roadmap.md`](./tasks/priority-roadmap.md), including Beta seed, Pathway Meili relevance review, source blocker resolution, production scraper rollout, opportunity detail polish, data-quality operations, post-Beta legacy cleanup, and saved/advising workflow expansion.

--- a/server/src/models/__tests__/canonicalEvidenceModels.test.ts
+++ b/server/src/models/__tests__/canonicalEvidenceModels.test.ts
@@ -1,0 +1,585 @@
+import mongoose from 'mongoose';
+import { describe, expect, it } from 'vitest';
+import {
+  EVIDENCE_CLAIM_SCHEMA_VERSION,
+  EvidenceClaim,
+  MAX_EVIDENCE_CLAIM_EXCERPT_LENGTH,
+  MAX_EVIDENCE_CLAIM_VALUE_COLLECTION_ITEMS,
+  MAX_EVIDENCE_CLAIM_VALUE_DEPTH,
+  MAX_EVIDENCE_CLAIM_VALUE_STRING_LENGTH,
+  evidenceClaimSchema,
+} from '../evidenceClaim';
+import {
+  EVIDENCE_PREDICATE_REGISTRY_VERSION,
+  evidenceClaimPredicates,
+  evidencePredicateRegistry,
+  evidencePredicateSupportsSubject,
+} from '../evidencePredicateRegistry';
+import {
+  MAX_RESEARCH_PLAN_CHECKLIST_ITEMS,
+  MAX_RESEARCH_PLAN_DEADLINES,
+  MAX_RESEARCH_PLAN_ITEM_TEXT_LENGTH,
+  MAX_RESEARCH_PLAN_NOTES_LENGTH,
+  RESEARCH_PLAN_SCHEMA_VERSION,
+  ResearchPlan,
+  researchPlanSchema,
+} from '../researchPlan';
+import {
+  MAX_REVIEW_DECISION_EVIDENCE_CLAIMS,
+  MAX_REVIEW_DECISION_FIELD_PATHS,
+  MAX_REVIEW_DECISION_FIELD_PATH_LENGTH,
+  MAX_REVIEW_DECISION_INTERNAL_NOTES_LENGTH,
+  MAX_REVIEW_DECISION_RATIONALE_LENGTH,
+  REVIEW_DECISION_SCHEMA_VERSION,
+  ReviewDecision,
+  reviewDecisionSchema,
+} from '../reviewDecision';
+import { Source } from '../source';
+import {
+  MAX_SOURCE_DOCUMENT_EXTERNAL_KEY_LENGTH,
+  MAX_SOURCE_DOCUMENT_METADATA_TEXT_LENGTH,
+  MAX_SOURCE_DOCUMENT_POINTER_LENGTH,
+  MAX_SOURCE_DOCUMENT_REDIRECTS,
+  SOURCE_DOCUMENT_SCHEMA_VERSION,
+  SourceDocument,
+  normalizeSourceDocumentKey,
+  sourceDocumentSchema,
+} from '../sourceDocument';
+import { StudentEngagementEvent } from '../studentEngagementEvent';
+import {
+  Source as BarrelSource,
+  StudentEngagementEvent as BarrelStudentEngagementEvent,
+} from '../index';
+
+const objectId = () => new mongoose.Types.ObjectId();
+const contentHash = 'a'.repeat(64);
+
+const validResearchPlan = () => ({
+  accountId: objectId(),
+  target: {
+    kind: 'RESEARCH_ENTITY',
+    id: objectId(),
+  },
+});
+
+const validSourceDocument = () => ({
+  sourceId: objectId(),
+  documentKey: 'official-profile:ada-lovelace',
+  canonicalUrl: 'https://example.yale.edu/profile/ada-lovelace',
+  retrievedAt: new Date('2026-07-25T12:00:00.000Z'),
+  contentHash,
+});
+
+const validEvidenceClaim = () => ({
+  subject: {
+    kind: 'PERSON',
+    id: objectId(),
+  },
+  predicate: 'PERSON_HAS_ORCID',
+  value: '0000-0000-0000-0000',
+  sourceDocumentId: objectId(),
+  observedAt: new Date('2026-07-25T12:00:00.000Z'),
+  confidence: 0.95,
+});
+
+const validReviewDecision = () => ({
+  target: {
+    kind: 'EVIDENCE_CLAIM',
+    id: objectId(),
+  },
+  decisionType: 'APPROVE',
+  rationale: 'The source and subject identity agree.',
+  reviewerAccountId: objectId(),
+});
+
+const indexKeys = (schema: mongoose.Schema): Record<string, number>[] =>
+  schema.indexes().map(([keys]) => keys as Record<string, number>);
+
+describe('canonical evidence, planning, and review models', () => {
+  it.each([
+    [ResearchPlan, 'ResearchPlan', 'research_plans'],
+    [SourceDocument, 'SourceDocument', 'source_documents'],
+    [EvidenceClaim, 'EvidenceClaim', 'evidence_claims'],
+    [ReviewDecision, 'ReviewDecision', 'review_decisions'],
+  ])('registers %s with an explicit physical collection', (model, modelName, collection) => {
+    expect(model.modelName).toBe(modelName);
+    expect(model.collection.name).toBe(collection);
+    expect(mongoose.models[modelName]).toBe(model);
+  });
+
+  it('keeps schema versions collection-specific and rejects unsupported versions', () => {
+    const fixtures = [
+      [ResearchPlan, validResearchPlan(), RESEARCH_PLAN_SCHEMA_VERSION],
+      [SourceDocument, validSourceDocument(), SOURCE_DOCUMENT_SCHEMA_VERSION],
+      [EvidenceClaim, validEvidenceClaim(), EVIDENCE_CLAIM_SCHEMA_VERSION],
+      [ReviewDecision, validReviewDecision(), REVIEW_DECISION_SCHEMA_VERSION],
+    ] as const;
+
+    for (const [Model, fixture, contract] of fixtures) {
+      const current = new Model(fixture);
+      expect(current.schemaVersion).toBe(contract.currentVersion);
+      expect(current.validateSync()).toBeUndefined();
+
+      const unsupported = new Model({ ...fixture, schemaVersion: 2 });
+      expect(unsupported.validateSync()?.errors.schemaVersion).toBeTruthy();
+    }
+  });
+
+  it('registers barrel exports without duplicating existing Source or engagement models', () => {
+    expect(BarrelSource).toBe(Source);
+    expect(BarrelStudentEngagementEvent).toBe(StudentEngagementEvent);
+    expect(Source.collection.name).toBe('sources');
+    expect(StudentEngagementEvent.collection.name).toBe('student_engagement_events');
+    expect(mongoose.modelNames().filter((name) => name === 'Source')).toHaveLength(1);
+    expect(mongoose.modelNames().filter((name) => name === 'StudentEngagementEvent')).toHaveLength(
+      1,
+    );
+  });
+
+  describe('ResearchPlan', () => {
+    it('requires account ownership and a typed target', () => {
+      const missingAccount = new ResearchPlan({
+        target: validResearchPlan().target,
+      });
+      const missingTarget = new ResearchPlan({
+        accountId: objectId(),
+      });
+      const invalidTargetKind = new ResearchPlan({
+        ...validResearchPlan(),
+        target: { kind: 'PAPER', id: objectId() },
+      });
+
+      expect(missingAccount.validateSync()?.errors.accountId).toBeTruthy();
+      expect(missingTarget.validateSync()?.errors.target).toBeTruthy();
+      expect(invalidTargetKind.validateSync()?.errors['target.kind']).toBeTruthy();
+      expect(researchPlanSchema.path('accountId').options.ref).toBe('Account');
+    });
+
+    it('keeps private plan content excluded and export opt-in by default', () => {
+      const plan = new ResearchPlan({
+        ...validResearchPlan(),
+        privateNotes: 'Do not export this note.',
+        checklist: [{ label: 'Read the official project page.' }],
+      });
+
+      expect(plan.exportPreferences).toMatchObject({
+        includePrivateNotes: false,
+        includeChecklist: false,
+        includeDeadlines: false,
+      });
+      expect(researchPlanSchema.path('privateNotes').options.select).toBe(false);
+      expect(researchPlanSchema.path('checklist').options.select).toBe(false);
+      expect(researchPlanSchema.path('deadlines').options.select).toBe(false);
+    });
+
+    it('bounds private notes and embedded checklist items', () => {
+      const longNotes = new ResearchPlan({
+        ...validResearchPlan(),
+        privateNotes: 'n'.repeat(MAX_RESEARCH_PLAN_NOTES_LENGTH + 1),
+      });
+      const largeChecklist = new ResearchPlan({
+        ...validResearchPlan(),
+        checklist: Array.from({ length: MAX_RESEARCH_PLAN_CHECKLIST_ITEMS + 1 }, (_, index) => ({
+          label: `Item ${index}`,
+        })),
+      });
+      const longChecklistLabel = new ResearchPlan({
+        ...validResearchPlan(),
+        checklist: [
+          {
+            label: 'l'.repeat(MAX_RESEARCH_PLAN_ITEM_TEXT_LENGTH + 1),
+          },
+        ],
+      });
+      const tooManyDeadlines = new ResearchPlan({
+        ...validResearchPlan(),
+        deadlines: Array.from({ length: MAX_RESEARCH_PLAN_DEADLINES + 1 }, (_, index) => ({
+          label: `Deadline ${index}`,
+          dueAt: new Date('2026-08-01T12:00:00.000Z'),
+        })),
+      });
+
+      expect(longNotes.validateSync()?.errors.privateNotes).toBeTruthy();
+      expect(largeChecklist.validateSync()?.errors.checklist).toBeTruthy();
+      expect(longChecklistLabel.validateSync()?.errors['checklist.0.label']).toBeTruthy();
+      expect(tooManyDeadlines.validateSync()?.errors.deadlines).toBeTruthy();
+    });
+
+    it('keeps checklist completion and completion timestamps coherent', () => {
+      const completedWithoutTimestamp = new ResearchPlan({
+        ...validResearchPlan(),
+        checklist: [{ label: 'Review the source.', completed: true }],
+      });
+      const incompleteWithTimestamp = new ResearchPlan({
+        ...validResearchPlan(),
+        checklist: [
+          {
+            label: 'Review the source.',
+            completed: false,
+            completedAt: new Date('2026-07-25T12:00:00.000Z'),
+          },
+        ],
+      });
+      const completed = new ResearchPlan({
+        ...validResearchPlan(),
+        checklist: [
+          {
+            label: 'Review the source.',
+            completed: true,
+            completedAt: new Date('2026-07-25T12:00:00.000Z'),
+          },
+        ],
+      });
+
+      expect(
+        completedWithoutTimestamp.validateSync()?.errors['checklist.0.completedAt'],
+      ).toBeTruthy();
+      expect(incompleteWithTimestamp.validateSync()?.errors['checklist.0.completed']).toBeTruthy();
+      expect(completed.validateSync()).toBeUndefined();
+    });
+
+    it('declares one plan per account and typed target', () => {
+      expect(researchPlanSchema.indexes()).toContainEqual([
+        { accountId: 1, 'target.kind': 1, 'target.id': 1 },
+        { unique: true, background: true },
+      ]);
+    });
+  });
+
+  describe('SourceDocument', () => {
+    it('requires a source-scoped stable identity and a URL or external resource key', () => {
+      const missingResource = new SourceDocument({
+        ...validSourceDocument(),
+        canonicalUrl: undefined,
+        externalResourceKey: undefined,
+      });
+      const externalResource = new SourceDocument({
+        ...validSourceDocument(),
+        canonicalUrl: undefined,
+        externalResourceKey: 'works/W123',
+      });
+      const missingDocumentKey = new SourceDocument({
+        ...validSourceDocument(),
+        documentKey: undefined,
+      });
+
+      expect(missingResource.validateSync()?.errors.canonicalUrl).toBeTruthy();
+      expect(missingResource.validateSync()?.errors.externalResourceKey).toBeTruthy();
+      expect(externalResource.validateSync()).toBeUndefined();
+      expect(missingDocumentKey.validateSync()?.errors.documentKey).toBeTruthy();
+      expect(sourceDocumentSchema.path('sourceId').options.ref).toBe('Source');
+      expect(normalizeSourceDocumentKey(' Official-Profile:ADA-Lovelace ')).toBe(
+        'official-profile:ada-lovelace',
+      );
+    });
+
+    it('protects snapshot pointers and metadata without embedding raw payloads', () => {
+      expect(sourceDocumentSchema.path('snapshotPointer').options.select).toBe(false);
+      expect(sourceDocumentSchema.path('metadata').options.select).toBe(false);
+      expect(sourceDocumentSchema.path('content')).toBeUndefined();
+      expect(sourceDocumentSchema.path('rawContent')).toBeUndefined();
+      expect(sourceDocumentSchema.path('snapshot')).toBeUndefined();
+    });
+
+    it('bounds protected source pointers, resource keys, and metadata text', () => {
+      const longPointer = new SourceDocument({
+        ...validSourceDocument(),
+        snapshotPointer: 'p'.repeat(MAX_SOURCE_DOCUMENT_POINTER_LENGTH + 1),
+      });
+      const longExternalKey = new SourceDocument({
+        ...validSourceDocument(),
+        canonicalUrl: undefined,
+        externalResourceKey: 'e'.repeat(MAX_SOURCE_DOCUMENT_EXTERNAL_KEY_LENGTH + 1),
+      });
+      const longMetadata = new SourceDocument({
+        ...validSourceDocument(),
+        metadata: {
+          title: 't'.repeat(MAX_SOURCE_DOCUMENT_METADATA_TEXT_LENGTH + 1),
+        },
+      });
+
+      expect(longPointer.validateSync()?.errors.snapshotPointer).toBeTruthy();
+      expect(longExternalKey.validateSync()?.errors.externalResourceKey).toBeTruthy();
+      expect(longMetadata.validateSync()?.errors['metadata.title']).toBeTruthy();
+    });
+
+    it('bounds redirects and rejects unsafe source URL shapes', () => {
+      const tooManyRedirects = new SourceDocument({
+        ...validSourceDocument(),
+        redirectChain: Array.from(
+          { length: MAX_SOURCE_DOCUMENT_REDIRECTS + 1 },
+          (_, index) => `https://example.yale.edu/redirect/${index}`,
+        ),
+      });
+      const nonHttpUrl = new SourceDocument({
+        ...validSourceDocument(),
+        canonicalUrl: 'file:///tmp/source.html',
+      });
+      const credentialedUrl = new SourceDocument({
+        ...validSourceDocument(),
+        canonicalUrl: 'https://student:secret@example.yale.edu/profile',
+      });
+      const malformedDocumentKey = new SourceDocument({
+        ...validSourceDocument(),
+        documentKey: 'unsafe key with spaces',
+      });
+      const normalizedDocumentKey = new SourceDocument({
+        ...validSourceDocument(),
+        documentKey: ' Official-Profile:ADA-Lovelace ',
+      });
+
+      expect(tooManyRedirects.validateSync()?.errors.redirectChain).toBeTruthy();
+      expect(nonHttpUrl.validateSync()?.errors.canonicalUrl).toBeTruthy();
+      expect(credentialedUrl.validateSync()?.errors.canonicalUrl).toBeTruthy();
+      expect(malformedDocumentKey.validateSync()?.errors.documentKey).toBeTruthy();
+      expect(normalizedDocumentKey.documentKey).toBe('official-profile:ada-lovelace');
+      expect(normalizedDocumentKey.validateSync()).toBeUndefined();
+    });
+
+    it('deduplicates identical source resource versions without a TTL index', () => {
+      expect(sourceDocumentSchema.indexes()).toContainEqual([
+        { sourceId: 1, documentKey: 1, contentHash: 1 },
+        { unique: true, background: true },
+      ]);
+      for (const [, options] of sourceDocumentSchema.indexes()) {
+        expect(options).not.toHaveProperty('expireAfterSeconds');
+      }
+    });
+  });
+
+  describe('EvidenceClaim', () => {
+    it('publishes the exact versioned predicate registry from the contract', () => {
+      expect(EVIDENCE_PREDICATE_REGISTRY_VERSION).toBe(1);
+      expect(evidenceClaimPredicates).toEqual([
+        'PERSON_HAS_OFFICIAL_PROFILE',
+        'PERSON_HAS_ORCID',
+        'PERSON_LEADS_ENTITY',
+        'ENTITY_HAS_DESCRIPTION',
+        'ENTITY_USES_METHOD',
+        'UNDERGRAD_PARTICIPATION_OBSERVED',
+        'OFFICIAL_APPLICATION_EXISTS',
+        'OPPORTUNITY_HAS_DEADLINE',
+        'DIRECT_CONTACT_NOT_PERMITTED',
+      ]);
+      expect(Object.isFrozen(evidencePredicateRegistry)).toBe(true);
+      expect(evidencePredicateSupportsSubject('PERSON_HAS_ORCID', 'PERSON')).toBe(true);
+      expect(evidencePredicateSupportsSubject('PERSON_HAS_ORCID', 'RESEARCH_ENTITY')).toBe(false);
+    });
+
+    it('requires a canonical id or stable key for the subject', () => {
+      const noIdentity = new EvidenceClaim({
+        ...validEvidenceClaim(),
+        subject: { kind: 'PERSON' },
+      });
+      const stableKey = new EvidenceClaim({
+        ...validEvidenceClaim(),
+        subject: { kind: 'PERSON', key: 'official-profile:ada-lovelace' },
+      });
+
+      expect(noIdentity.validateSync()?.errors.subject).toBeTruthy();
+      expect(stableKey.validateSync()).toBeUndefined();
+    });
+
+    it('rejects unknown predicates and predicates used on unsupported subjects', () => {
+      const unknown = new EvidenceClaim({
+        ...validEvidenceClaim(),
+        predicate: 'PERSON_HAS_PUBLICATIONS',
+      });
+      const unsupportedSubject = new EvidenceClaim({
+        ...validEvidenceClaim(),
+        subject: { kind: 'POSTED_OPPORTUNITY', id: objectId() },
+        predicate: 'PERSON_HAS_ORCID',
+      });
+      const unsupportedRegistryVersion = new EvidenceClaim({
+        ...validEvidenceClaim(),
+        predicateRegistryVersion: 2,
+      });
+
+      expect(unknown.validateSync()?.errors.predicate).toBeTruthy();
+      expect(unsupportedSubject.validateSync()?.errors.predicate).toBeTruthy();
+      expect(
+        unsupportedRegistryVersion.validateSync()?.errors.predicateRegistryVersion,
+      ).toBeTruthy();
+    });
+
+    it('bounds excerpts, strings, arrays, and nested mixed values', () => {
+      const longExcerpt = new EvidenceClaim({
+        ...validEvidenceClaim(),
+        excerpt: 'e'.repeat(MAX_EVIDENCE_CLAIM_EXCERPT_LENGTH + 1),
+      });
+      const longString = new EvidenceClaim({
+        ...validEvidenceClaim(),
+        value: 'v'.repeat(MAX_EVIDENCE_CLAIM_VALUE_STRING_LENGTH + 1),
+      });
+      const largeArray = new EvidenceClaim({
+        ...validEvidenceClaim(),
+        value: Array.from(
+          { length: MAX_EVIDENCE_CLAIM_VALUE_COLLECTION_ITEMS + 1 },
+          (_, index) => index,
+        ),
+      });
+      let nested: unknown = 'leaf';
+      for (let index = 0; index <= MAX_EVIDENCE_CLAIM_VALUE_DEPTH; index += 1) {
+        nested = { child: nested };
+      }
+      const deepValue = new EvidenceClaim({
+        ...validEvidenceClaim(),
+        value: nested,
+      });
+
+      expect(longExcerpt.validateSync()?.errors.excerpt).toBeTruthy();
+      expect(longString.validateSync()?.errors.value).toBeTruthy();
+      expect(largeArray.validateSync()?.errors.value).toBeTruthy();
+      expect(deepValue.validateSync()?.errors.value).toBeTruthy();
+    });
+
+    it('fails closed and requires coherent supersession state', () => {
+      const claim = new EvidenceClaim(validEvidenceClaim());
+      const missingReplacement = new EvidenceClaim({
+        ...validEvidenceClaim(),
+        status: 'SUPERSEDED',
+      });
+      const unexpectedReplacement = new EvidenceClaim({
+        ...validEvidenceClaim(),
+        status: 'ACTIVE',
+        supersededByClaimId: objectId(),
+      });
+      const validSupersession = new EvidenceClaim({
+        ...validEvidenceClaim(),
+        status: 'SUPERSEDED',
+        supersededByClaimId: objectId(),
+      });
+      const selfSupersession = new EvidenceClaim({
+        ...validEvidenceClaim(),
+        status: 'SUPERSEDED',
+      });
+      selfSupersession.supersededByClaimId = selfSupersession._id;
+
+      expect(claim.sensitivity).toBe('ADMIN_ONLY');
+      expect(evidenceClaimSchema.path('value').options.select).toBe(false);
+      expect(evidenceClaimSchema.path('excerpt').options.select).toBe(false);
+      expect(missingReplacement.validateSync()?.errors.status).toBeTruthy();
+      expect(unexpectedReplacement.validateSync()?.errors.status).toBeTruthy();
+      expect(selfSupersession.validateSync()?.errors.status).toBeTruthy();
+      expect(selfSupersession.validateSync()?.errors.supersededByClaimId).toBeTruthy();
+      expect(validSupersession.validateSync()).toBeUndefined();
+    });
+
+    it('keeps claim history non-unique', () => {
+      for (const [, options] of evidenceClaimSchema.indexes()) {
+        expect(options.unique).not.toBe(true);
+      }
+      expect(indexKeys(evidenceClaimSchema)).toContainEqual({
+        sourceDocumentId: 1,
+        observedAt: -1,
+      });
+    });
+  });
+
+  describe('ReviewDecision', () => {
+    it('requires an account reviewer and protects internal identity and notes', () => {
+      const missingReviewer = new ReviewDecision({
+        ...validReviewDecision(),
+        reviewerAccountId: undefined,
+      });
+
+      expect(missingReviewer.validateSync()?.errors.reviewerAccountId).toBeTruthy();
+      expect(reviewDecisionSchema.path('reviewerAccountId').options.ref).toBe('Account');
+      expect(reviewDecisionSchema.path('reviewerAccountId').options.select).toBe(false);
+      expect(reviewDecisionSchema.path('internalNotes').options.select).toBe(false);
+    });
+
+    it('requires coherent same-kind replacement targets for merge decisions', () => {
+      const missingReplacement = new ReviewDecision({
+        ...validReviewDecision(),
+        decisionType: 'MERGE',
+      });
+      const wrongKind = new ReviewDecision({
+        ...validReviewDecision(),
+        decisionType: 'MERGE',
+        replacementTarget: { kind: 'PERSON', id: objectId() },
+      });
+      const validMerge = new ReviewDecision({
+        ...validReviewDecision(),
+        decisionType: 'MERGE',
+        replacementTarget: { kind: 'EVIDENCE_CLAIM', id: objectId() },
+      });
+      const unexpectedReplacement = new ReviewDecision({
+        ...validReviewDecision(),
+        replacementTarget: { kind: 'EVIDENCE_CLAIM', id: objectId() },
+      });
+      const selfMergeFixture = validReviewDecision();
+      const selfMerge = new ReviewDecision({
+        ...selfMergeFixture,
+        decisionType: 'MERGE',
+        replacementTarget: selfMergeFixture.target,
+      });
+
+      expect(missingReplacement.validateSync()?.errors.decisionType).toBeTruthy();
+      expect(wrongKind.validateSync()?.errors.decisionType).toBeTruthy();
+      expect(selfMerge.validateSync()?.errors.decisionType).toBeTruthy();
+      expect(validMerge.validateSync()).toBeUndefined();
+      expect(unexpectedReplacement.validateSync()?.errors.decisionType).toBeTruthy();
+    });
+
+    it('bounds review notes and evidence arrays', () => {
+      const longNotes = new ReviewDecision({
+        ...validReviewDecision(),
+        internalNotes: 'n'.repeat(MAX_REVIEW_DECISION_INTERNAL_NOTES_LENGTH + 1),
+      });
+      const tooManyEvidenceClaims = new ReviewDecision({
+        ...validReviewDecision(),
+        evidenceClaimIds: Array.from({ length: MAX_REVIEW_DECISION_EVIDENCE_CLAIMS + 1 }, objectId),
+      });
+      const duplicateEvidenceClaimId = objectId();
+      const duplicateArrays = new ReviewDecision({
+        ...validReviewDecision(),
+        fieldPaths: ['status', 'status'],
+        evidenceClaimIds: [duplicateEvidenceClaimId, duplicateEvidenceClaimId],
+      });
+      const longRationale = new ReviewDecision({
+        ...validReviewDecision(),
+        rationale: 'r'.repeat(MAX_REVIEW_DECISION_RATIONALE_LENGTH + 1),
+      });
+      const longFieldPath = new ReviewDecision({
+        ...validReviewDecision(),
+        fieldPaths: [`target.${'f'.repeat(MAX_REVIEW_DECISION_FIELD_PATH_LENGTH + 1)}`],
+      });
+      const tooManyFieldPaths = new ReviewDecision({
+        ...validReviewDecision(),
+        fieldPaths: Array.from(
+          { length: MAX_REVIEW_DECISION_FIELD_PATHS + 1 },
+          (_, index) => `field.${index}`,
+        ),
+      });
+
+      expect(longNotes.validateSync()?.errors.internalNotes).toBeTruthy();
+      expect(longRationale.validateSync()?.errors.rationale).toBeTruthy();
+      expect(longFieldPath.validateSync()?.errors['fieldPaths.0']).toBeTruthy();
+      expect(tooManyFieldPaths.validateSync()?.errors.fieldPaths).toBeTruthy();
+      expect(tooManyEvidenceClaims.validateSync()?.errors.evidenceClaimIds).toBeTruthy();
+      expect(duplicateArrays.validateSync()?.errors.fieldPaths).toBeTruthy();
+      expect(duplicateArrays.validateSync()?.errors.evidenceClaimIds).toBeTruthy();
+    });
+
+    it('models append-only supersession as a backward pointer', () => {
+      const selfSupersession = new ReviewDecision(validReviewDecision());
+      selfSupersession.supersedesDecisionId = selfSupersession._id;
+
+      expect(reviewDecisionSchema.path('supersedesDecisionId').options.ref).toBe('ReviewDecision');
+      expect(reviewDecisionSchema.path('supersededByDecisionId')).toBeUndefined();
+      expect(reviewDecisionSchema.path('decisionType').options.immutable).toBe(true);
+      expect(reviewDecisionSchema.path('rationale').options.immutable).toBe(true);
+      expect(reviewDecisionSchema.path('updatedAt')).toBeUndefined();
+      expect(selfSupersession.validateSync()?.errors.supersedesDecisionId).toBeTruthy();
+      expect(reviewDecisionSchema.indexes()).toContainEqual([
+        { supersedesDecisionId: 1 },
+        {
+          unique: true,
+          partialFilterExpression: { supersedesDecisionId: { $type: 'objectId' } },
+          background: true,
+        },
+      ]);
+    });
+  });
+});

--- a/server/src/models/__tests__/mongoNamingConventions.test.ts
+++ b/server/src/models/__tests__/mongoNamingConventions.test.ts
@@ -7,6 +7,7 @@ import { AnalyticsEvent } from '../analytics';
 import { ContactRoute } from '../contactRoute';
 import { Department } from '../department';
 import { EntryPathway } from '../entryPathway';
+import { EvidenceClaim } from '../evidenceClaim';
 import { FacultyMember } from '../facultyMember';
 import { Fellowship } from '../fellowship';
 import { Grant } from '../grant';
@@ -21,9 +22,12 @@ import { ResearchArea } from '../researchArea';
 import { ResearchEntity } from '../researchEntity';
 import { ResearchGroupMember } from '../researchGroupMember';
 import { RoleAssignment } from '../roleAssignment';
+import { ResearchPlan } from '../researchPlan';
+import { ReviewDecision } from '../reviewDecision';
 import { ScrapeRun } from '../scrapeRun';
 import { ScrapeSnapshot } from '../scrapeSnapshot';
 import { Source } from '../source';
+import { SourceDocument } from '../sourceDocument';
 import { StudentApplication } from '../studentApplication';
 import { StudentEngagementEvent } from '../studentEngagementEvent';
 import { StudentOutreach } from '../studentOutreach';
@@ -40,6 +44,7 @@ const models: Array<[mongoose.Model<any>, string]> = [
   [ContactRoute, 'contact_routes'],
   [Department, 'departments'],
   [EntryPathway, 'entry_pathways'],
+  [EvidenceClaim, 'evidence_claims'],
   [FacultyMember, 'faculty_members'],
   [Fellowship, 'fellowships'],
   [Grant, 'grants'],
@@ -54,9 +59,12 @@ const models: Array<[mongoose.Model<any>, string]> = [
   [ResearchEntity, 'research_entities'],
   [ResearchGroupMember, 'research_entity_members'],
   [RoleAssignment, 'role_assignments'],
+  [ResearchPlan, 'research_plans'],
+  [ReviewDecision, 'review_decisions'],
   [ScrapeRun, 'scrape_runs'],
   [ScrapeSnapshot, 'scrape_snapshots'],
   [Source, 'sources'],
+  [SourceDocument, 'source_documents'],
   [StudentApplication, 'student_applications'],
   [StudentEngagementEvent, 'student_engagement_events'],
   [StudentOutreach, 'student_outreaches'],

--- a/server/src/models/evidenceClaim.ts
+++ b/server/src/models/evidenceClaim.ts
@@ -1,0 +1,228 @@
+import mongoose from 'mongoose';
+import {
+  canonicalSchemaVersionField,
+  defineCanonicalSchemaVersion,
+} from './canonicalSchemaVersion';
+import {
+  EVIDENCE_PREDICATE_REGISTRY_VERSION,
+  evidenceClaimPredicates,
+  evidenceClaimSubjectKinds,
+  evidencePredicateSupportsSubject,
+  isEvidenceClaimPredicate,
+  type EvidenceClaimSubjectKind,
+} from './evidencePredicateRegistry';
+
+export const EVIDENCE_CLAIM_SCHEMA_VERSION = defineCanonicalSchemaVersion({
+  currentVersion: 1,
+});
+
+export const evidenceClaimSensitivities = ['PUBLIC', 'AUTHENTICATED', 'ADMIN_ONLY'] as const;
+export const evidenceClaimStatuses = ['ACTIVE', 'SUPERSEDED', 'REJECTED', 'DISPUTED'] as const;
+
+export type EvidenceClaimSensitivity = (typeof evidenceClaimSensitivities)[number];
+export type EvidenceClaimStatus = (typeof evidenceClaimStatuses)[number];
+
+export const MAX_EVIDENCE_CLAIM_SUBJECT_KEY_LENGTH = 512;
+export const MAX_EVIDENCE_CLAIM_EXCERPT_LENGTH = 2_000;
+export const MAX_EVIDENCE_CLAIM_VALUE_STRING_LENGTH = 4_000;
+export const MAX_EVIDENCE_CLAIM_VALUE_COLLECTION_ITEMS = 50;
+export const MAX_EVIDENCE_CLAIM_VALUE_DEPTH = 6;
+export const MAX_EVIDENCE_CLAIM_VALUE_NODES = 250;
+export const MAX_EVIDENCE_CLAIM_OBJECT_KEY_LENGTH = 120;
+
+interface ValueValidationState {
+  nodes: number;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object') return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+export function isBoundedEvidenceClaimValue(
+  value: unknown,
+  depth = 0,
+  state: ValueValidationState = { nodes: 0 },
+): boolean {
+  state.nodes += 1;
+  if (state.nodes > MAX_EVIDENCE_CLAIM_VALUE_NODES || depth > MAX_EVIDENCE_CLAIM_VALUE_DEPTH) {
+    return false;
+  }
+  if (value === null || typeof value === 'boolean') return true;
+  if (typeof value === 'number') return Number.isFinite(value);
+  if (typeof value === 'string') return value.length <= MAX_EVIDENCE_CLAIM_VALUE_STRING_LENGTH;
+  if (value instanceof Date) return !Number.isNaN(value.getTime());
+  if (value instanceof mongoose.Types.ObjectId) return true;
+  if (Array.isArray(value)) {
+    return (
+      value.length <= MAX_EVIDENCE_CLAIM_VALUE_COLLECTION_ITEMS &&
+      value.every((item) => isBoundedEvidenceClaimValue(item, depth + 1, state))
+    );
+  }
+  if (!isPlainRecord(value)) return false;
+
+  const entries = Object.entries(value);
+  return (
+    entries.length <= MAX_EVIDENCE_CLAIM_VALUE_COLLECTION_ITEMS &&
+    entries.every(
+      ([key, item]) =>
+        key.length <= MAX_EVIDENCE_CLAIM_OBJECT_KEY_LENGTH &&
+        isBoundedEvidenceClaimValue(item, depth + 1, state),
+    )
+  );
+}
+
+const evidenceClaimSubjectSchema = new mongoose.Schema(
+  {
+    kind: {
+      type: String,
+      enum: [...evidenceClaimSubjectKinds],
+      required: true,
+    },
+    id: {
+      type: mongoose.Schema.Types.ObjectId,
+      required: false,
+    },
+    key: {
+      type: String,
+      trim: true,
+      maxlength: MAX_EVIDENCE_CLAIM_SUBJECT_KEY_LENGTH,
+      required: false,
+    },
+  },
+  { _id: false },
+);
+
+export const evidenceClaimSchema = new mongoose.Schema<Record<string, unknown>>(
+  {
+    schemaVersion: canonicalSchemaVersionField(EVIDENCE_CLAIM_SCHEMA_VERSION),
+    predicateRegistryVersion: {
+      type: Number,
+      enum: [EVIDENCE_PREDICATE_REGISTRY_VERSION],
+      default: EVIDENCE_PREDICATE_REGISTRY_VERSION,
+      required: true,
+    },
+    subject: {
+      type: evidenceClaimSubjectSchema,
+      required: true,
+      validate: {
+        validator: (subject: { id?: unknown; key?: string }) =>
+          Boolean(subject?.id || subject?.key?.trim()),
+        message: 'subject must identify a canonical id or stable key.',
+      },
+    },
+    predicate: {
+      type: String,
+      enum: [...evidenceClaimPredicates],
+      required: true,
+      validate: {
+        validator(this: { subject?: { kind?: EvidenceClaimSubjectKind } }, predicate: unknown) {
+          return (
+            isEvidenceClaimPredicate(predicate) &&
+            Boolean(this.subject?.kind) &&
+            evidencePredicateSupportsSubject(predicate, this.subject!.kind!)
+          );
+        },
+        message: 'predicate is not supported for the selected subject kind.',
+      },
+    },
+    value: {
+      type: mongoose.Schema.Types.Mixed,
+      required: true,
+      select: false,
+      validate: {
+        validator: (value: unknown) => isBoundedEvidenceClaimValue(value),
+        message: 'value exceeds the bounded EvidenceClaim value contract.',
+      },
+    },
+    excerpt: {
+      type: String,
+      default: '',
+      maxlength: MAX_EVIDENCE_CLAIM_EXCERPT_LENGTH,
+      select: false,
+    },
+    sourceDocumentId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'SourceDocument',
+      required: true,
+    },
+    observedAt: {
+      type: Date,
+      required: true,
+    },
+    confidence: {
+      type: Number,
+      min: 0,
+      max: 1,
+      required: true,
+    },
+    sensitivity: {
+      type: String,
+      enum: [...evidenceClaimSensitivities],
+      default: 'ADMIN_ONLY',
+      required: true,
+    },
+    status: {
+      type: String,
+      enum: [...evidenceClaimStatuses],
+      default: 'ACTIVE',
+      required: true,
+      validate: {
+        validator(
+          this: {
+            _id?: mongoose.Types.ObjectId;
+            supersededByClaimId?: mongoose.Types.ObjectId;
+          },
+          status: EvidenceClaimStatus,
+        ) {
+          if (status !== 'SUPERSEDED') return !this.supersededByClaimId;
+          if (!this.supersededByClaimId) return false;
+          return !this._id?.equals(this.supersededByClaimId);
+        },
+        message:
+          'supersededByClaimId must identify another claim and is allowed only for SUPERSEDED status.',
+      },
+    },
+    supersededByClaimId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'EvidenceClaim',
+      required: false,
+      validate: {
+        validator(
+          this: { _id?: mongoose.Types.ObjectId },
+          claimId: mongoose.Types.ObjectId | undefined,
+        ) {
+          return !claimId || !this._id?.equals(claimId);
+        },
+        message: 'An EvidenceClaim cannot supersede itself.',
+      },
+    },
+  },
+  {
+    timestamps: true,
+    collection: 'evidence_claims',
+  },
+);
+
+evidenceClaimSchema.index({
+  'subject.kind': 1,
+  'subject.id': 1,
+  predicate: 1,
+  status: 1,
+  observedAt: -1,
+});
+evidenceClaimSchema.index({
+  'subject.kind': 1,
+  'subject.key': 1,
+  predicate: 1,
+  status: 1,
+  observedAt: -1,
+});
+evidenceClaimSchema.index({ sourceDocumentId: 1, observedAt: -1 });
+evidenceClaimSchema.index({ predicate: 1, status: 1, observedAt: -1 });
+evidenceClaimSchema.index({ supersededByClaimId: 1 });
+
+export const EvidenceClaim =
+  mongoose.models.EvidenceClaim ||
+  mongoose.model('EvidenceClaim', evidenceClaimSchema, 'evidence_claims');

--- a/server/src/models/evidencePredicateRegistry.ts
+++ b/server/src/models/evidencePredicateRegistry.ts
@@ -1,0 +1,85 @@
+export const EVIDENCE_PREDICATE_REGISTRY_VERSION = 1 as const;
+
+export const evidenceClaimSubjectKinds = [
+  'PERSON',
+  'ROLE_ASSIGNMENT',
+  'RESEARCH_ENTITY',
+  'ENTITY_RELATIONSHIP',
+  'ENTRY_PATHWAY',
+  'POSTED_OPPORTUNITY',
+] as const;
+
+export type EvidenceClaimSubjectKind = (typeof evidenceClaimSubjectKinds)[number];
+
+export interface EvidencePredicateDefinition {
+  registryVersion: typeof EVIDENCE_PREDICATE_REGISTRY_VERSION;
+  allowedSubjectKinds: readonly EvidenceClaimSubjectKind[];
+  description: string;
+}
+
+function definePredicate(
+  allowedSubjectKinds: readonly EvidenceClaimSubjectKind[],
+  description: string,
+): EvidencePredicateDefinition {
+  return Object.freeze({
+    registryVersion: EVIDENCE_PREDICATE_REGISTRY_VERSION,
+    allowedSubjectKinds: Object.freeze([...allowedSubjectKinds]),
+    description,
+  });
+}
+
+export const evidencePredicateRegistry = Object.freeze({
+  PERSON_HAS_OFFICIAL_PROFILE: definePredicate(
+    ['PERSON'],
+    'A Yale-confirmed person has a source-backed official profile.',
+  ),
+  PERSON_HAS_ORCID: definePredicate(
+    ['PERSON'],
+    'A Yale-confirmed person has a source-backed ORCID identifier.',
+  ),
+  PERSON_LEADS_ENTITY: definePredicate(
+    ['PERSON', 'ROLE_ASSIGNMENT'],
+    'A person leads a research entity through an evidenced role.',
+  ),
+  ENTITY_HAS_DESCRIPTION: definePredicate(
+    ['RESEARCH_ENTITY'],
+    'A source provides descriptive research-home content.',
+  ),
+  ENTITY_USES_METHOD: definePredicate(
+    ['RESEARCH_ENTITY'],
+    'A source states that a research entity uses a method.',
+  ),
+  UNDERGRAD_PARTICIPATION_OBSERVED: definePredicate(
+    ['RESEARCH_ENTITY', 'ROLE_ASSIGNMENT'],
+    'A source records current or historical undergraduate participation.',
+  ),
+  OFFICIAL_APPLICATION_EXISTS: definePredicate(
+    ['RESEARCH_ENTITY', 'ENTRY_PATHWAY', 'POSTED_OPPORTUNITY'],
+    'A source identifies an official application route.',
+  ),
+  OPPORTUNITY_HAS_DEADLINE: definePredicate(
+    ['POSTED_OPPORTUNITY'],
+    'A source states a deadline for a posted opportunity.',
+  ),
+  DIRECT_CONTACT_NOT_PERMITTED: definePredicate(
+    ['PERSON', 'RESEARCH_ENTITY', 'ENTRY_PATHWAY'],
+    'A source explicitly states that direct contact is not permitted.',
+  ),
+});
+
+export type EvidenceClaimPredicate = keyof typeof evidencePredicateRegistry;
+
+export const evidenceClaimPredicates = Object.freeze(
+  Object.keys(evidencePredicateRegistry) as EvidenceClaimPredicate[],
+);
+
+export function isEvidenceClaimPredicate(value: unknown): value is EvidenceClaimPredicate {
+  return typeof value === 'string' && Object.hasOwn(evidencePredicateRegistry, value);
+}
+
+export function evidencePredicateSupportsSubject(
+  predicate: EvidenceClaimPredicate,
+  subjectKind: EvidenceClaimSubjectKind,
+): boolean {
+  return evidencePredicateRegistry[predicate].allowedSubjectKinds.includes(subjectKind);
+}

--- a/server/src/models/index.ts
+++ b/server/src/models/index.ts
@@ -44,3 +44,8 @@ export * from './person';
 export * from './roleAssignment';
 export * from './orgUnit';
 export * from './taxonomyTerm';
+export * from './evidencePredicateRegistry';
+export * from './sourceDocument';
+export * from './evidenceClaim';
+export * from './researchPlan';
+export * from './reviewDecision';

--- a/server/src/models/researchPlan.ts
+++ b/server/src/models/researchPlan.ts
@@ -1,0 +1,167 @@
+import mongoose from 'mongoose';
+import {
+  canonicalSchemaVersionField,
+  defineCanonicalSchemaVersion,
+} from './canonicalSchemaVersion';
+
+export const RESEARCH_PLAN_SCHEMA_VERSION = defineCanonicalSchemaVersion({
+  currentVersion: 1,
+});
+
+export const researchPlanTargetKinds = ['RESEARCH_ENTITY', 'PROGRAM'] as const;
+export const researchPlanStages = [
+  'SAVED',
+  'EXPLORING',
+  'PREPARING',
+  'CONTACTED',
+  'APPLIED',
+  'CLOSED',
+] as const;
+
+export type ResearchPlanTargetKind = (typeof researchPlanTargetKinds)[number];
+export type ResearchPlanStage = (typeof researchPlanStages)[number];
+
+export const MAX_RESEARCH_PLAN_NOTES_LENGTH = 8_000;
+export const MAX_RESEARCH_PLAN_CHECKLIST_ITEMS = 50;
+export const MAX_RESEARCH_PLAN_DEADLINES = 20;
+export const MAX_RESEARCH_PLAN_ITEM_TEXT_LENGTH = 240;
+
+const boundedArray = (maximum: number, label: string) => ({
+  validator: (values: unknown[]) => Array.isArray(values) && values.length <= maximum,
+  message: `${label} must contain at most ${maximum} items.`,
+});
+
+const researchPlanTargetSchema = new mongoose.Schema(
+  {
+    kind: {
+      type: String,
+      enum: [...researchPlanTargetKinds],
+      required: true,
+    },
+    id: {
+      type: mongoose.Schema.Types.ObjectId,
+      required: true,
+    },
+  },
+  { _id: false },
+);
+
+const researchPlanChecklistItemSchema = new mongoose.Schema(
+  {
+    label: {
+      type: String,
+      required: true,
+      trim: true,
+      maxlength: MAX_RESEARCH_PLAN_ITEM_TEXT_LENGTH,
+    },
+    completed: {
+      type: Boolean,
+      default: false,
+      validate: {
+        validator(this: { completedAt?: Date }, completed: boolean) {
+          return completed ? Boolean(this.completedAt) : !this.completedAt;
+        },
+        message:
+          'completed checklist items require completedAt, and incomplete items must omit it.',
+      },
+    },
+    completedAt: {
+      type: Date,
+      required(this: { completed?: boolean }) {
+        return this.completed === true;
+      },
+    },
+  },
+  { _id: true },
+);
+
+const researchPlanDeadlineSchema = new mongoose.Schema(
+  {
+    label: {
+      type: String,
+      required: true,
+      trim: true,
+      maxlength: MAX_RESEARCH_PLAN_ITEM_TEXT_LENGTH,
+    },
+    dueAt: {
+      type: Date,
+      required: true,
+    },
+    sourceDocumentId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'SourceDocument',
+      required: false,
+    },
+  },
+  { _id: true },
+);
+
+export const researchPlanSchema = new mongoose.Schema<Record<string, unknown>>(
+  {
+    schemaVersion: canonicalSchemaVersionField(RESEARCH_PLAN_SCHEMA_VERSION),
+    accountId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Account',
+      required: true,
+      immutable: true,
+    },
+    target: {
+      type: researchPlanTargetSchema,
+      required: true,
+    },
+    stage: {
+      type: String,
+      enum: [...researchPlanStages],
+      default: 'SAVED',
+      required: true,
+    },
+    privateNotes: {
+      type: String,
+      default: '',
+      maxlength: MAX_RESEARCH_PLAN_NOTES_LENGTH,
+      select: false,
+    },
+    checklist: {
+      type: [researchPlanChecklistItemSchema],
+      default: [],
+      select: false,
+      validate: boundedArray(MAX_RESEARCH_PLAN_CHECKLIST_ITEMS, 'checklist'),
+    },
+    deadlines: {
+      type: [researchPlanDeadlineSchema],
+      default: [],
+      select: false,
+      validate: boundedArray(MAX_RESEARCH_PLAN_DEADLINES, 'deadlines'),
+    },
+    exportPreferences: {
+      includePrivateNotes: {
+        type: Boolean,
+        default: false,
+      },
+      includeChecklist: {
+        type: Boolean,
+        default: false,
+      },
+      includeDeadlines: {
+        type: Boolean,
+        default: false,
+      },
+    },
+    archived: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  {
+    timestamps: true,
+    collection: 'research_plans',
+  },
+);
+
+researchPlanSchema.index({ accountId: 1, 'target.kind': 1, 'target.id': 1 }, { unique: true });
+researchPlanSchema.index({ accountId: 1, archived: 1, updatedAt: -1 });
+researchPlanSchema.index({ 'target.kind': 1, 'target.id': 1, archived: 1 });
+
+export const ResearchPlan =
+  mongoose.models.ResearchPlan ||
+  mongoose.model('ResearchPlan', researchPlanSchema, 'research_plans');

--- a/server/src/models/reviewDecision.ts
+++ b/server/src/models/reviewDecision.ts
@@ -1,0 +1,195 @@
+import mongoose from 'mongoose';
+import {
+  canonicalSchemaVersionField,
+  defineCanonicalSchemaVersion,
+} from './canonicalSchemaVersion';
+
+export const REVIEW_DECISION_SCHEMA_VERSION = defineCanonicalSchemaVersion({
+  currentVersion: 1,
+});
+
+export const reviewDecisionTargetKinds = [
+  'PERSON',
+  'ROLE_ASSIGNMENT',
+  'RESEARCH_ENTITY',
+  'ENTITY_RELATIONSHIP',
+  'ENTRY_PATHWAY',
+  'POSTED_OPPORTUNITY',
+  'SOURCE_DOCUMENT',
+  'EVIDENCE_CLAIM',
+] as const;
+export const reviewDecisionTypes = [
+  'APPROVE',
+  'REJECT',
+  'MERGE',
+  'LOCK',
+  'SUPPRESS',
+  'RESOLVE_IDENTITY',
+] as const;
+
+export type ReviewDecisionTargetKind = (typeof reviewDecisionTargetKinds)[number];
+export type ReviewDecisionType = (typeof reviewDecisionTypes)[number];
+
+export const MAX_REVIEW_DECISION_RATIONALE_LENGTH = 4_000;
+export const MAX_REVIEW_DECISION_INTERNAL_NOTES_LENGTH = 4_000;
+export const MAX_REVIEW_DECISION_FIELD_PATHS = 25;
+export const MAX_REVIEW_DECISION_FIELD_PATH_LENGTH = 160;
+export const MAX_REVIEW_DECISION_EVIDENCE_CLAIMS = 50;
+
+const boundedArray = (maximum: number, label: string) => ({
+  validator: (values: unknown[]) => Array.isArray(values) && values.length <= maximum,
+  message: `${label} must contain at most ${maximum} items.`,
+});
+
+const uniqueArray = (label: string) => ({
+  validator: (values: unknown[]) =>
+    Array.isArray(values) && new Set(values.map((value) => String(value))).size === values.length,
+  message: `${label} must not contain duplicate items.`,
+});
+
+const reviewDecisionTargetSchema = new mongoose.Schema(
+  {
+    kind: {
+      type: String,
+      enum: [...reviewDecisionTargetKinds],
+      required: true,
+    },
+    id: {
+      type: mongoose.Schema.Types.ObjectId,
+      required: true,
+    },
+  },
+  { _id: false },
+);
+
+export const reviewDecisionSchema = new mongoose.Schema<Record<string, unknown>>(
+  {
+    schemaVersion: canonicalSchemaVersionField(REVIEW_DECISION_SCHEMA_VERSION),
+    target: {
+      type: reviewDecisionTargetSchema,
+      required: true,
+      immutable: true,
+    },
+    decisionType: {
+      type: String,
+      enum: [...reviewDecisionTypes],
+      required: true,
+      immutable: true,
+      validate: {
+        validator(
+          this: {
+            target?: { kind?: ReviewDecisionTargetKind; id?: unknown };
+            replacementTarget?: { kind?: ReviewDecisionTargetKind; id?: unknown };
+          },
+          decisionType: ReviewDecisionType,
+        ) {
+          const needsReplacement = decisionType === 'MERGE' || decisionType === 'RESOLVE_IDENTITY';
+          if (!needsReplacement) return !this.replacementTarget?.id;
+          return (
+            Boolean(this.replacementTarget?.id) &&
+            this.replacementTarget?.kind === this.target?.kind &&
+            String(this.replacementTarget?.id) !== String(this.target?.id)
+          );
+        },
+        message:
+          'MERGE and RESOLVE_IDENTITY decisions require a different same-kind replacement target, which other decisions must omit.',
+      },
+    },
+    replacementTarget: {
+      type: reviewDecisionTargetSchema,
+      required: false,
+      immutable: true,
+    },
+    fieldPaths: {
+      type: [
+        {
+          type: String,
+          trim: true,
+          minlength: 1,
+          maxlength: MAX_REVIEW_DECISION_FIELD_PATH_LENGTH,
+        },
+      ],
+      default: [],
+      immutable: true,
+      validate: [
+        boundedArray(MAX_REVIEW_DECISION_FIELD_PATHS, 'fieldPaths'),
+        uniqueArray('fieldPaths'),
+      ],
+    },
+    rationale: {
+      type: String,
+      required: true,
+      trim: true,
+      maxlength: MAX_REVIEW_DECISION_RATIONALE_LENGTH,
+      immutable: true,
+    },
+    internalNotes: {
+      type: String,
+      default: '',
+      maxlength: MAX_REVIEW_DECISION_INTERNAL_NOTES_LENGTH,
+      select: false,
+      immutable: true,
+    },
+    evidenceClaimIds: {
+      type: [mongoose.Schema.Types.ObjectId],
+      ref: 'EvidenceClaim',
+      default: [],
+      immutable: true,
+      validate: [
+        boundedArray(MAX_REVIEW_DECISION_EVIDENCE_CLAIMS, 'evidenceClaimIds'),
+        uniqueArray('evidenceClaimIds'),
+      ],
+    },
+    reviewerAccountId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Account',
+      required: true,
+      select: false,
+      immutable: true,
+    },
+    decidedAt: {
+      type: Date,
+      default: () => new Date(),
+      required: true,
+      immutable: true,
+    },
+    supersedesDecisionId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'ReviewDecision',
+      required: false,
+      immutable: true,
+      validate: {
+        validator(
+          this: { _id?: mongoose.Types.ObjectId },
+          decisionId: mongoose.Types.ObjectId | undefined,
+        ) {
+          return !decisionId || !this._id?.equals(decisionId);
+        },
+        message: 'A ReviewDecision cannot supersede itself.',
+      },
+    },
+  },
+  {
+    timestamps: { createdAt: true, updatedAt: false },
+    collection: 'review_decisions',
+  },
+);
+
+reviewDecisionSchema.index({
+  'target.kind': 1,
+  'target.id': 1,
+  decidedAt: -1,
+});
+reviewDecisionSchema.index({ reviewerAccountId: 1, decidedAt: -1 });
+reviewDecisionSchema.index({ evidenceClaimIds: 1 });
+reviewDecisionSchema.index(
+  { supersedesDecisionId: 1 },
+  {
+    unique: true,
+    partialFilterExpression: { supersedesDecisionId: { $type: 'objectId' } },
+  },
+);
+
+export const ReviewDecision =
+  mongoose.models.ReviewDecision ||
+  mongoose.model('ReviewDecision', reviewDecisionSchema, 'review_decisions');

--- a/server/src/models/sourceDocument.ts
+++ b/server/src/models/sourceDocument.ts
@@ -1,0 +1,215 @@
+import mongoose from 'mongoose';
+import {
+  canonicalSchemaVersionField,
+  defineCanonicalSchemaVersion,
+} from './canonicalSchemaVersion';
+
+export const SOURCE_DOCUMENT_SCHEMA_VERSION = defineCanonicalSchemaVersion({
+  currentVersion: 1,
+});
+
+export const sourceDocumentHealthStatuses = [
+  'HEALTHY',
+  'REDIRECTED',
+  'UNAVAILABLE',
+  'UNKNOWN',
+] as const;
+export const sourceDocumentSensitivities = ['PUBLIC', 'AUTHENTICATED', 'ADMIN_ONLY'] as const;
+export const sourceDocumentRetentionClasses = [
+  'EPHEMERAL',
+  'STANDARD',
+  'AUDIT',
+  'RESTRICTED',
+] as const;
+
+export type SourceDocumentHealthStatus = (typeof sourceDocumentHealthStatuses)[number];
+export type SourceDocumentSensitivity = (typeof sourceDocumentSensitivities)[number];
+export type SourceDocumentRetentionClass = (typeof sourceDocumentRetentionClasses)[number];
+
+export const MAX_SOURCE_DOCUMENT_URL_LENGTH = 2_048;
+export const MAX_SOURCE_DOCUMENT_EXTERNAL_KEY_LENGTH = 512;
+export const MAX_SOURCE_DOCUMENT_KEY_LENGTH = 512;
+export const MAX_SOURCE_DOCUMENT_POINTER_LENGTH = 2_048;
+export const MAX_SOURCE_DOCUMENT_REDIRECTS = 10;
+export const MAX_SOURCE_DOCUMENT_METADATA_TEXT_LENGTH = 512;
+
+export function normalizeSourceDocumentKey(value: string): string {
+  return value.normalize('NFKC').trim().toLowerCase();
+}
+
+export function isNormalizedSourceDocumentKey(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value === normalizeSourceDocumentKey(value) &&
+    /^[a-z0-9][a-z0-9._:/@+-]*$/.test(value)
+  );
+}
+
+export function isSafeHttpUrl(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+
+  try {
+    const parsed = new URL(value);
+    return (
+      (parsed.protocol === 'http:' || parsed.protocol === 'https:') &&
+      Boolean(parsed.hostname) &&
+      !parsed.username &&
+      !parsed.password
+    );
+  } catch {
+    return false;
+  }
+}
+
+const sourceDocumentMetadataSchema = new mongoose.Schema(
+  {
+    title: {
+      type: String,
+      default: '',
+      maxlength: MAX_SOURCE_DOCUMENT_METADATA_TEXT_LENGTH,
+    },
+    mediaType: {
+      type: String,
+      default: '',
+      maxlength: 160,
+    },
+    language: {
+      type: String,
+      default: '',
+      maxlength: 32,
+    },
+    etag: {
+      type: String,
+      default: '',
+      maxlength: MAX_SOURCE_DOCUMENT_METADATA_TEXT_LENGTH,
+    },
+    lastModifiedAt: {
+      type: Date,
+      required: false,
+    },
+  },
+  { _id: false },
+);
+
+export const sourceDocumentSchema = new mongoose.Schema<Record<string, unknown>>(
+  {
+    schemaVersion: canonicalSchemaVersionField(SOURCE_DOCUMENT_SCHEMA_VERSION),
+    sourceId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Source',
+      required: true,
+    },
+    documentKey: {
+      type: String,
+      trim: true,
+      set: normalizeSourceDocumentKey,
+      maxlength: MAX_SOURCE_DOCUMENT_KEY_LENGTH,
+      required: true,
+      validate: {
+        validator: isNormalizedSourceDocumentKey,
+        message:
+          'documentKey must be a normalized lowercase source identity using safe ASCII separators.',
+      },
+    },
+    canonicalUrl: {
+      type: String,
+      trim: true,
+      maxlength: MAX_SOURCE_DOCUMENT_URL_LENGTH,
+      required(this: { externalResourceKey?: string }) {
+        return !this.externalResourceKey;
+      },
+      validate: {
+        validator: (value: string | undefined) => !value || isSafeHttpUrl(value),
+        message: 'canonicalUrl must be an HTTP(S) URL without embedded credentials.',
+      },
+    },
+    externalResourceKey: {
+      type: String,
+      trim: true,
+      maxlength: MAX_SOURCE_DOCUMENT_EXTERNAL_KEY_LENGTH,
+      required(this: { canonicalUrl?: string }) {
+        return !this.canonicalUrl;
+      },
+    },
+    retrievedAt: {
+      type: Date,
+      required: true,
+    },
+    contentHash: {
+      type: String,
+      required: true,
+      trim: true,
+      match: /^[a-f0-9]{64}$/i,
+    },
+    httpStatusCode: {
+      type: Number,
+      min: 100,
+      max: 599,
+      required: false,
+    },
+    healthStatus: {
+      type: String,
+      enum: [...sourceDocumentHealthStatuses],
+      default: 'UNKNOWN',
+      required: true,
+    },
+    snapshotPointer: {
+      type: String,
+      default: '',
+      maxlength: MAX_SOURCE_DOCUMENT_POINTER_LENGTH,
+      select: false,
+    },
+    sensitivity: {
+      type: String,
+      enum: [...sourceDocumentSensitivities],
+      default: 'ADMIN_ONLY',
+      required: true,
+    },
+    retentionClass: {
+      type: String,
+      enum: [...sourceDocumentRetentionClasses],
+      default: 'STANDARD',
+      required: true,
+    },
+    redirectChain: {
+      type: [
+        {
+          type: String,
+          maxlength: MAX_SOURCE_DOCUMENT_URL_LENGTH,
+          validate: {
+            validator: isSafeHttpUrl,
+            message: 'redirectChain entries must be HTTP(S) URLs without embedded credentials.',
+          },
+        },
+      ],
+      default: [],
+      validate: {
+        validator: (values: unknown[]) =>
+          Array.isArray(values) && values.length <= MAX_SOURCE_DOCUMENT_REDIRECTS,
+        message: `redirectChain must contain at most ${MAX_SOURCE_DOCUMENT_REDIRECTS} URLs.`,
+      },
+    },
+    metadata: {
+      type: sourceDocumentMetadataSchema,
+      default: () => ({}),
+      select: false,
+    },
+  },
+  {
+    timestamps: true,
+    collection: 'source_documents',
+  },
+);
+
+sourceDocumentSchema.index({ sourceId: 1, retrievedAt: -1 });
+sourceDocumentSchema.index({ sourceId: 1, documentKey: 1, contentHash: 1 }, { unique: true });
+sourceDocumentSchema.index({ sourceId: 1, documentKey: 1, retrievedAt: -1 });
+sourceDocumentSchema.index({ sourceId: 1, canonicalUrl: 1, retrievedAt: -1 });
+sourceDocumentSchema.index({ sourceId: 1, externalResourceKey: 1, retrievedAt: -1 });
+sourceDocumentSchema.index({ contentHash: 1 });
+sourceDocumentSchema.index({ retentionClass: 1, retrievedAt: 1 });
+
+export const SourceDocument =
+  mongoose.models.SourceDocument ||
+  mongoose.model('SourceDocument', sourceDocumentSchema, 'source_documents');


### PR DESCRIPTION
## Intent

Continue the canonical research-model refactor after merged identity schemas. For issue #215, add empty, versioned ResearchPlan, SourceDocument, EvidenceClaim, and ReviewDecision schemas that coexist with Beta without runtime cutover. Reuse existing Source and StudentEngagementEvent models, keep research plans private and account-owned, retain source evidence separately from materialized records, govern claims through the exact versioned predicate registry from issue #205, bound all mixed values and embedded arrays, fail closed on sensitivity, and keep reviewer identity, internal notes, evidence values, source metadata, and snapshot pointers protected. SourceDocument may store credential-free HTTP(S) URLs but does not trust or fetch them; any later outbound fetch must use the SSRF guard. Add contract, naming, schema-version, index, privacy-boundary, predicate-registry, and durable documentation coverage. Do not add scraper writers, materializer cutovers, routes, migrations, startup hooks, TTL indexes, raw snapshots, public DTOs, or Meilisearch changes. Validate the rebased branch, push it, and open a PR against Beta linked to #215, but do not merge it.

## What Changed

- Add versioned `ResearchPlan`, `SourceDocument`, `EvidenceClaim`, and `ReviewDecision` models and export them without introducing a runtime cutover.
- Enforce bounded values and arrays, protected sensitive fields, credential-free source URLs, private account ownership, and fail-closed claim sensitivity through a versioned predicate registry.
- Document the evidence and planning storage boundaries and add contract coverage for schema versions, naming, indexes, privacy, and predicate validation.

## Risk Assessment

✅ Low: The change is limited to empty, versioned schemas, contracts, and documentation with no runtime cutover, and the required bounds, privacy defaults, predicate registry, indexes, and forbidden-scope exclusions are source-verifiably satisfied.

## Testing

The focused schema and naming contracts passed, and a reviewer-visible runtime transcript demonstrates versioned canonical documents, separate collections, protected private/evidence/reviewer fields, ADMIN_ONLY sensitivity defaults, and fail-closed URL and predicate validation. No screenshot was captured because this is intentionally a backend-only schema change with no route or UI cutover.

<details>
<summary>Evidence: Canonical schema contract demonstration</summary>

```text
{
  "validCanonicalDocuments": {
    "researchPlan": null,
    "sourceDocument": null,
    "evidenceClaim": null,
    "reviewDecision": null
  },
  "collections": {
    "researchPlan": "research_plans",
    "sourceDocument": "source_documents",
    "evidenceClaim": "evidence_claims",
    "reviewDecision": "review_decisions"
  },
  "schemaVersions": {
    "researchPlan": 1,
    "sourceDocument": 1,
    "evidenceClaim": 1,
    "reviewDecision": 1
  },
  "failClosedDefaults": {
    "sourceDocumentSensitivity": "ADMIN_ONLY",
    "evidenceClaimSensitivity": "ADMIN_ONLY"
  },
  "protectedByDefault": {
    "researchPlan": [
      [
        "privateNotes",
        false
      ],
      [
        "checklist",
        false
      ],
      [
        "deadlines",
        false
      ]
    ],
    "sourceDocument": [
      [
        "metadata",
        false
      ],
      [
        "snapshotPointer",
        false
      ]
    ],
    "evidenceClaim": [
      [
        "value",
        false
      ],
      [
        "excerpt",
        false
      ]
    ],
    "reviewDecision": [
      [
        "reviewerAccountId",
        false
      ],
      [
        "internalNotes",
        false
      ]
    ]
  },
  "rejectedInputs": {
    "credentialBearingUrl": true,
    "unregisteredPredicate": true,
    "predicateSubjectMismatch": true
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `graphify query "How do the new ResearchPlan SourceDocument EvidenceClaim and ReviewDecision models relate to existing Source, StudentEngagementEvent, privacy boundaries, and runtime exports?"`
- <code>`gh-axi issue view 205 --full` to verify the exact required predicate vocabulary</code>
- <code>`yarn install --immutable` at the repository root and in `server/` to restore isolated-worktree dependencies</code>
- `yarn test src/models/__tests__/canonicalEvidenceModels.test.ts src/models/__tests__/mongoNamingConventions.test.ts`
- <code>Executed `canonical-evidence-demo.ts` to construct and validate all four canonical documents, inspect physical collections and protected fields, verify fail-closed sensitivity defaults, and demonstrate rejection of credential-bearing URLs, unregistered predicates, and predicate/subject mismatches</code>
- `Reviewed the target commit’s changed-file scope for forbidden routes, scraper writers, migrations, startup hooks, and search/Meilisearch changes`
- <code>Removed transient root and server `node_modules` directories and confirmed `git status --short` was clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
