### PR TITLE
feat(server): add migration-safe canonical validator workflow

### DIFF
--- a/docs/canonical-mongodb-validator-runbook.md
+++ b/docs/canonical-mongodb-validator-runbook.md
@@ -1,0 +1,152 @@
+# Canonical MongoDB Validator Runbook
+
+This runbook covers the guarded operator workflow for canonical MongoDB collection validators.
+The command defaults to a read-only dry run and applies only the reviewed plan for the connected database state.
+
+## Scope and operating rules
+
+Run this command locally from the repository root.
+Do not add it to Render, application startup, scraper execution, scheduled jobs, or deployment hooks.
+It uses the native MongoDB client and the `MONGODBURL` loaded from `server/.env`.
+Before every run, verify that `MONGODBURL` names the intended database and does not contain a different environment's target.
+
+The required `--environment` value must match both the configured database name and the database name reported after connection.
+The primary environment mapping is `development` to `Development`, `beta` to `Beta`, and `production` to `Production`.
+The command also accepts `production-copy` for `ProductionCopy` and `test` for an explicit test database.
+It fails closed on a missing environment, a target mismatch, an invalid reviewed artifact, or database drift.
+
+The desired registry is limited to the canonical collections explicitly declared in [`canonicalMongoValidatorRegistry.ts`](../server/src/scripts/canonicalMongoValidatorRegistry.ts).
+Collections outside that registry are read only as part of MongoDB collection discovery and are never planned for modification.
+During migration, desired validators use `validationLevel: moderate` and `validationAction: error`.
+This protects new and modified conforming writes without claiming that legacy documents have been backfilled or that references are valid.
+
+## Required review and recovery
+
+Before any apply:
+
+1. Create a recoverable database export, current Atlas backup, or verified point-in-time restore point for the exact target database.
+2. Record the recovery artifact identifier, restore owner, and restore procedure in the change record.
+3. Generate a fresh dry-run artifact against the target database.
+4. Review the artifact's `environment`, `databaseName`, credential-free `target`, `desiredCollections`, `summary`, `plan`, `rollbackPlan`, and `planFingerprint`.
+5. Confirm that every `createCollection` and `collMod` command is expected.
+6. Preserve the reviewed dry-run artifact unchanged and use a different path for the apply report.
+
+The fingerprint binds the reviewed environment, database, credential-free target, desired collection registry, current collection options, forward plan, and rollback plan.
+Apply reconnects, reads the current database state, recomputes the fixed-registry commands, and refuses to write if the reviewed artifact was changed or the database state drifted.
+The command never executes command objects supplied by the artifact.
+
+## Development
+
+Point `server/.env` at the `Development` database, then generate and review the dry-run artifact:
+
+```bash
+yarn model-refactor:validators \
+  --environment development \
+  --output /tmp/ylabs-canonical-validators-development-dry-run.json
+```
+
+After the recovery and review steps are complete, apply the exact reviewed state:
+
+```bash
+yarn model-refactor:validators \
+  --environment development \
+  --apply \
+  --apply-from /tmp/ylabs-canonical-validators-development-dry-run.json \
+  --confirm-canonical-validator-apply development \
+  --output /tmp/ylabs-canonical-validators-development-apply.json
+```
+
+Review `postApplyPlan` in the apply report.
+Every item must be a `noop`.
+Run a new dry run and confirm that `summary.writesPlanned` is `0` before continuing to Beta.
+
+## Beta
+
+Point `server/.env` at the `Beta` database.
+Create or verify the Beta recovery artifact, then generate and review a new Beta-specific artifact:
+
+```bash
+yarn model-refactor:validators \
+  --environment beta \
+  --output /tmp/ylabs-canonical-validators-beta-dry-run.json
+```
+
+Apply only that reviewed Beta artifact:
+
+```bash
+yarn model-refactor:validators \
+  --environment beta \
+  --apply \
+  --apply-from /tmp/ylabs-canonical-validators-beta-dry-run.json \
+  --confirm-canonical-validator-apply beta \
+  --output /tmp/ylabs-canonical-validators-beta-apply.json
+```
+
+Review the apply report and rerun the Beta dry run.
+Do not proceed until the second dry run reports `summary.writesPlanned` as `0` and Beta application behavior remains healthy.
+
+## Production
+
+Point `server/.env` at the `Production` database.
+Create and record a fresh Production export, Atlas backup, or point-in-time restore point before generating the final plan.
+Generate and review a new Production-specific artifact:
+
+```bash
+yarn model-refactor:validators \
+  --environment production \
+  --output /tmp/ylabs-canonical-validators-production-dry-run.json
+```
+
+Production apply requires the reviewed artifact, an environment-bound confirmation, and the separate production environment gate:
+
+```bash
+CONFIRM_PROD_MONGO_VALIDATORS=true \
+yarn model-refactor:validators \
+  --environment production \
+  --apply \
+  --apply-from /tmp/ylabs-canonical-validators-production-dry-run.json \
+  --confirm-canonical-validator-apply production \
+  --output /tmp/ylabs-canonical-validators-production-apply.json
+```
+
+Set `CONFIRM_PROD_MONGO_VALIDATORS=true` only for the apply process.
+Do not leave the production gate enabled in a shared development environment.
+Review `postApplyPlan`, then run a fresh Production dry run and require `summary.writesPlanned` to be `0`.
+
+## Apply behavior and failure recovery
+
+MongoDB collection commands are applied sequentially in deterministic collection-name order.
+The multi-command apply is not transactional.
+The runner stops at the first failed command and reports the successfully applied collection names, the failed collection, and the unattempted collections.
+
+If apply stops partway:
+
+1. Do not rerun the stale apply command.
+2. Preserve the reviewed artifact and terminal output as the partial-apply record.
+3. Inspect the named successful and failed collections in MongoDB.
+4. Decide whether to roll back the successful commands or continue from the new state.
+5. Generate a fresh dry-run artifact against the current database state.
+6. Review the new plan before any retry.
+
+A retry is safe only through a fresh dry run because already-current collections become `noop` and remaining drift produces a new bounded plan.
+
+## Manual rollback
+
+Every dry-run artifact contains a `rollbackPlan` built from the collection options observed before apply.
+The operator command does not execute rollback automatically.
+Inspect the rollback commands with:
+
+```bash
+jq '.rollbackPlan' /tmp/ylabs-canonical-validators-beta-dry-run.json
+```
+
+For a rejected complete apply, execute the matching `rollbackPlan[].command` entries manually with `db.runCommand(...)` against the exact database, preferably in reverse apply order.
+For a partial apply, execute rollback commands only for collections confirmed in the runner's successfully applied list.
+Record every command and result in the change record, then generate a fresh dry run to verify the resulting state.
+
+A rollback entry for an existing collection restores its previously observed validator, validation level, and validation action.
+A rollback entry for a collection created by the apply only disables its validator with `collMod`.
+The workflow never automatically drops a created collection because it cannot prove that no later writer added data.
+If a created collection must be removed, stop writers, inspect its contents, and use the recorded recovery procedure or a separately reviewed manual cleanup.
+
+Use the recorded database export, Atlas backup, or point-in-time restore when validator rollback commands cannot safely recover a broad or uncertain failure.

--- a/docs/research-model.md
+++ b/docs/research-model.md
@@ -506,7 +506,8 @@ Moderate validation does not prove reference integrity, backfill missing version
 
 Validator plans must be deterministic, dry-run reviewable, and limited to an explicit desired collection registry.
 The pure planner in [`server/src/scripts/canonicalMongoValidatorsCore.ts`](../server/src/scripts/canonicalMongoValidatorsCore.ts) does not connect to MongoDB or apply commands.
-A later guarded operator command must compare current collection options, require explicit confirmation before writes, and never run during application startup.
+The guarded operator command compares current collection options, requires a reviewed dry-run artifact plus environment-bound confirmation before writes, and never runs during application startup.
+Use the exact environment workflow and rollback guidance in the [`Canonical MongoDB Validator Runbook`](./canonical-mongodb-validator-runbook.md).
 
 ### Phase 1 evidence and planning schema foundation
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "meili:health": "curl http://localhost:7700/health",
     "meili:seed": "yarn --cwd server meili:seed",
     "migrate:mongo-naming": "yarn --cwd server migrate:mongo-naming",
+    "model-refactor:validators": "yarn --cwd server model-refactor:validators",
     "scrape": "yarn --cwd server scrape",
     "scrape:seed-sources": "yarn --cwd server scrape:seed-sources",
     "playwright:run": "bash scripts/with-playwright-libs.sh npx playwright",

--- a/server/.env.example
+++ b/server/.env.example
@@ -8,3 +8,4 @@ OPENAI_API_KEY=<your-openai-key>
 MEILISEARCH_HOST=http://localhost:7700
 MEILISEARCH_API_KEY=local_development_master_key
 # MEILISEARCH_INDEX_PREFIX=  (leave unset for local dev; set to "beta" or "prod" on Render)
+CONFIRM_PROD_MONGO_VALIDATORS=false

--- a/server/package.json
+++ b/server/package.json
@@ -39,6 +39,7 @@
     "research-entity:audit-rename": "tsx src/scripts/auditResearchEntityRename.ts",
     "research-entity:coverage-audit": "tsx src/scripts/researchEntityCoverageAudit.ts",
     "model-refactor:inventory": "tsx src/scripts/researchModelInventory.ts",
+    "model-refactor:validators": "tsx src/scripts/canonicalMongoValidators.ts",
     "accepted-inputs": "tsx src/scripts/acceptedInputs.ts",
     "beta:data-quality": "tsx src/scripts/betaDataQuality.ts",
     "beta:seed-environment": "tsx src/scripts/betaSeedEnvironment.ts",

--- a/server/src/models/orgUnit.ts
+++ b/server/src/models/orgUnit.ts
@@ -23,7 +23,7 @@ export interface OrgUnitRecord {
   archived: boolean;
 }
 
-const MAX_ORG_UNIT_ALIASES = 20;
+export const MAX_ORG_UNIT_ALIASES = 20;
 
 function hasBoundedUniqueAliases(values: readonly string[]): boolean {
   const normalized = values.map((value) => value.trim().toLocaleLowerCase());

--- a/server/src/models/roleAssignment.ts
+++ b/server/src/models/roleAssignment.ts
@@ -48,7 +48,7 @@ export interface RoleAssignmentRecord {
   archived: boolean;
 }
 
-const MAX_EVIDENCE_CLAIMS_PER_ROLE = 100;
+export const MAX_EVIDENCE_CLAIMS_PER_ROLE = 100;
 
 function hasBoundedUniqueObjectIds(values: readonly mongoose.Types.ObjectId[]): boolean {
   return (

--- a/server/src/models/taxonomyTerm.ts
+++ b/server/src/models/taxonomyTerm.ts
@@ -27,7 +27,7 @@ export interface TaxonomyTermRecord {
   archived: boolean;
 }
 
-const MAX_TAXONOMY_ALIASES = 30;
+export const MAX_TAXONOMY_ALIASES = 30;
 
 export function normalizeTaxonomyLabel(value: string): string {
   return value.normalize('NFKC').trim().toLocaleLowerCase().replace(/\s+/g, ' ');

--- a/server/src/scripts/__tests__/canonicalMongoValidatorRegistry.test.ts
+++ b/server/src/scripts/__tests__/canonicalMongoValidatorRegistry.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EVIDENCE_CLAIM_SCHEMA_VERSION,
+  RESEARCH_PLAN_SCHEMA_VERSION,
+  REVIEW_DECISION_SCHEMA_VERSION,
+  SOURCE_DOCUMENT_SCHEMA_VERSION,
+  accountSchemaVersion,
+  orgUnitSchemaVersion,
+  personSchemaVersion,
+  roleAssignmentSchemaVersion,
+  taxonomyTermSchemaVersion,
+} from '../../models';
+import {
+  CANONICAL_MONGO_VALIDATORS,
+  CANONICAL_MONGO_VALIDATOR_COLLECTIONS,
+} from '../canonicalMongoValidatorRegistry';
+import { canonicalMongoValidatorFingerprint } from '../canonicalMongoValidatorsCore';
+
+const EXPECTED_COLLECTIONS = [
+  'accounts',
+  'evidence_claims',
+  'org_units',
+  'people',
+  'research_plans',
+  'review_decisions',
+  'role_assignments',
+  'source_documents',
+  'taxonomy_terms',
+];
+
+const VERSION_BY_COLLECTION = new Map([
+  ['accounts', accountSchemaVersion],
+  ['evidence_claims', EVIDENCE_CLAIM_SCHEMA_VERSION],
+  ['org_units', orgUnitSchemaVersion],
+  ['people', personSchemaVersion],
+  ['research_plans', RESEARCH_PLAN_SCHEMA_VERSION],
+  ['review_decisions', REVIEW_DECISION_SCHEMA_VERSION],
+  ['role_assignments', roleAssignmentSchemaVersion],
+  ['source_documents', SOURCE_DOCUMENT_SCHEMA_VERSION],
+  ['taxonomy_terms', taxonomyTermSchemaVersion],
+]);
+
+describe('canonical MongoDB validator registry', () => {
+  it('contains exactly the nine versioned Phase 1 collections in deterministic order', () => {
+    expect(CANONICAL_MONGO_VALIDATOR_COLLECTIONS).toEqual(EXPECTED_COLLECTIONS);
+    expect(CANONICAL_MONGO_VALIDATORS).toHaveLength(EXPECTED_COLLECTIONS.length);
+  });
+
+  it('links every desired validator to its model-owned schema-version contract', () => {
+    for (const desired of CANONICAL_MONGO_VALIDATORS) {
+      const contract = VERSION_BY_COLLECTION.get(desired.collectionName);
+      expect(contract).toBeDefined();
+      expect(desired.validator.$jsonSchema.required).toContain('schemaVersion');
+      expect(desired.validator.$jsonSchema.properties.schemaVersion).toEqual({
+        bsonType: 'int',
+        enum: contract?.supportedVersions,
+        description: `Canonical schema version. New documents use version ${contract?.currentVersion}.`,
+      });
+      expect(desired.validationLevel).toBe('moderate');
+      expect(desired.validationAction).toBe('error');
+    }
+  });
+
+  it('retains Mongoose structural contracts and important bounded-array safeguards', () => {
+    const byCollection = new Map(
+      CANONICAL_MONGO_VALIDATORS.map((desired) => [desired.collectionName, desired]),
+    );
+
+    expect(byCollection.get('people')?.validator.$jsonSchema.properties.profileLinks).toMatchObject(
+      {
+        bsonType: ['array', 'null'],
+        maxItems: 5,
+      },
+    );
+    expect(
+      byCollection.get('role_assignments')?.validator.$jsonSchema.properties.evidenceClaimIds,
+    ).toMatchObject({
+      bsonType: ['array', 'null'],
+      maxItems: 100,
+      uniqueItems: true,
+    });
+    expect(
+      byCollection.get('source_documents')?.validator.$jsonSchema.properties.redirectChain,
+    ).toMatchObject({
+      bsonType: ['array', 'null'],
+      maxItems: 10,
+    });
+    expect(
+      byCollection.get('review_decisions')?.validator.$jsonSchema.properties.evidenceClaimIds,
+    ).toMatchObject({
+      bsonType: ['array', 'null'],
+      maxItems: 50,
+      uniqueItems: true,
+    });
+  });
+
+  it('does not close schemas to migration-era fields or invent unrelated validators', () => {
+    expect(JSON.stringify(CANONICAL_MONGO_VALIDATORS)).not.toContain('additionalProperties');
+    expect(CANONICAL_MONGO_VALIDATOR_COLLECTIONS).not.toContain('sources');
+    expect(CANONICAL_MONGO_VALIDATOR_COLLECTIONS).not.toContain('student_engagement_events');
+    expect(CANONICAL_MONGO_VALIDATOR_COLLECTIONS).not.toContain('research_entity_relationships');
+    expect(CANONICAL_MONGO_VALIDATOR_COLLECTIONS).not.toContain('organizations');
+  });
+
+  it('requires an explicit review when generated validator contracts drift', () => {
+    expect(canonicalMongoValidatorFingerprint(CANONICAL_MONGO_VALIDATORS)).toBe(
+      '135ad7cd228ebbb8e986102747fc514392ad673ca4a3433eeb81aa1b9f1e5b21',
+    );
+  });
+});

--- a/server/src/scripts/__tests__/canonicalMongoValidators.test.ts
+++ b/server/src/scripts/__tests__/canonicalMongoValidators.test.ts
@@ -69,11 +69,14 @@ function fakeMongoHarness(
     listError?: Error;
     listFailureCall?: number;
     commandFailure?: (command: Record<string, unknown>, callIndex: number) => boolean;
+    closeError?: Error;
   } = {},
 ): FakeMongoHarness {
   const collectionInfos = (args.collectionInfos ?? []).map(cloneInfo);
   const connect = vi.fn(async () => undefined);
-  const close = vi.fn(async () => undefined);
+  const close = vi.fn(async () => {
+    if (args.closeError) throw args.closeError;
+  });
   let listReadCall = 0;
   const listCollections = vi.fn(() => ({
     toArray: vi.fn(async () => {
@@ -474,6 +477,37 @@ describe('runCanonicalMongoValidators', () => {
       CANONICAL_MONGO_VALIDATOR_COLLECTIONS.slice(1),
     );
     expect(rerun.postApplyPlan?.every(({ action }) => action === 'noop')).toBe(true);
+    expect(harness.close).toHaveBeenCalledOnce();
+  });
+
+  it('preserves partial progress when closing also fails', async () => {
+    const failingCollection = CANONICAL_MONGO_VALIDATOR_COLLECTIONS[1];
+    const harness = fakeMongoHarness({
+      commandFailure: (_command, callIndex) => callIndex === 1,
+    });
+    const dryRun = await reviewedDryRun(harness);
+    harness.close.mockRejectedValue(new Error('injected MongoDB close failure'));
+
+    let applyError: unknown;
+    try {
+      await runCanonicalMongoValidators(applyArgs(), 'mongodb://localhost/development', {
+        client: harness.client,
+        reviewedArtifact: dryRun,
+      });
+    } catch (error) {
+      applyError = error;
+    }
+
+    expect(applyError).toBeInstanceOf(CanonicalMongoValidatorApplyError);
+    expect(applyError).toMatchObject({
+      appliedCollections: [CANONICAL_MONGO_VALIDATOR_COLLECTIONS[0]],
+      failedCollection: failingCollection,
+      unattemptedCollections: CANONICAL_MONGO_VALIDATOR_COLLECTIONS.slice(2),
+    });
+    expect(applyError).toHaveProperty(
+      'message',
+      expect.stringContaining('MongoDB client cleanup also failed: injected MongoDB close failure'),
+    );
     expect(harness.close).toHaveBeenCalledOnce();
   });
 

--- a/server/src/scripts/__tests__/canonicalMongoValidators.test.ts
+++ b/server/src/scripts/__tests__/canonicalMongoValidators.test.ts
@@ -1,0 +1,557 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  assertCanonicalMongoValidatorApplyAllowed,
+  CanonicalMongoValidatorApplyError,
+  CanonicalMongoValidatorVerificationError,
+  parseCanonicalMongoValidatorArgs,
+  runCanonicalMongoValidators,
+  type CanonicalMongoValidatorArgs,
+  type CanonicalMongoValidatorReport,
+  type ValidatorMongoClient,
+} from '../canonicalMongoValidators';
+import {
+  CANONICAL_MONGO_VALIDATORS,
+  CANONICAL_MONGO_VALIDATOR_COLLECTIONS,
+} from '../canonicalMongoValidatorRegistry';
+
+interface FakeCollectionInfo {
+  name: string;
+  type?: string;
+  options?: {
+    validator?: unknown;
+    validationLevel?: unknown;
+    validationAction?: unknown;
+    timeseries?: unknown;
+  };
+}
+
+interface FakeMongoHarness {
+  client: ValidatorMongoClient;
+  connect: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  command: ReturnType<typeof vi.fn>;
+  listCollections: ReturnType<typeof vi.fn>;
+  collectionInfos: FakeCollectionInfo[];
+}
+
+const developmentArgs: CanonicalMongoValidatorArgs = {
+  environment: 'development',
+  apply: false,
+};
+
+function cloneInfo(info: FakeCollectionInfo): FakeCollectionInfo {
+  return structuredClone(info);
+}
+
+function desiredCollectionInfo(collectionName: string): FakeCollectionInfo {
+  const desired = CANONICAL_MONGO_VALIDATORS.find(
+    (candidate) => candidate.collectionName === collectionName,
+  );
+  if (!desired) {
+    throw new Error(`Missing desired validator fixture for ${collectionName}`);
+  }
+
+  return {
+    name: collectionName,
+    type: 'collection',
+    options: {
+      validator: structuredClone(desired.validator),
+      validationLevel: desired.validationLevel,
+      validationAction: desired.validationAction,
+    },
+  };
+}
+
+function fakeMongoHarness(
+  args: {
+    databaseName?: string;
+    collectionInfos?: FakeCollectionInfo[];
+    listError?: Error;
+    listFailureCall?: number;
+    commandFailure?: (command: Record<string, unknown>, callIndex: number) => boolean;
+  } = {},
+): FakeMongoHarness {
+  const collectionInfos = (args.collectionInfos ?? []).map(cloneInfo);
+  const connect = vi.fn(async () => undefined);
+  const close = vi.fn(async () => undefined);
+  let listReadCall = 0;
+  const listCollections = vi.fn(() => ({
+    toArray: vi.fn(async () => {
+      const callIndex = listReadCall;
+      listReadCall += 1;
+      if (
+        args.listError &&
+        (args.listFailureCall === undefined || args.listFailureCall === callIndex)
+      ) {
+        throw args.listError;
+      }
+      return collectionInfos.map(cloneInfo);
+    }),
+  }));
+  let commandCallIndex = 0;
+  const command = vi.fn(async (mongoCommand: Record<string, unknown>) => {
+    const callIndex = commandCallIndex;
+    commandCallIndex += 1;
+    if (args.commandFailure?.(mongoCommand, callIndex)) {
+      throw new Error('injected MongoDB command failure');
+    }
+
+    const create = typeof mongoCommand.create === 'string' ? mongoCommand.create : undefined;
+    const collMod = typeof mongoCommand.collMod === 'string' ? mongoCommand.collMod : undefined;
+    const collectionName = create ?? collMod;
+    if (!collectionName) {
+      throw new Error(`Unexpected MongoDB command: ${JSON.stringify(mongoCommand)}`);
+    }
+
+    const replacement: FakeCollectionInfo = {
+      name: collectionName,
+      type: 'collection',
+      options: {
+        validator: structuredClone(mongoCommand.validator),
+        validationLevel: mongoCommand.validationLevel,
+        validationAction: mongoCommand.validationAction,
+      },
+    };
+    const existingIndex = collectionInfos.findIndex((info) => info.name === collectionName);
+    if (existingIndex === -1) {
+      collectionInfos.push(replacement);
+    } else {
+      collectionInfos[existingIndex] = replacement;
+    }
+    return { ok: 1 };
+  });
+  const client: ValidatorMongoClient = {
+    connect,
+    db: () => ({
+      databaseName: args.databaseName ?? 'development',
+      listCollections,
+      command,
+    }),
+    close,
+  };
+
+  return {
+    client,
+    connect,
+    close,
+    command,
+    listCollections,
+    collectionInfos,
+  };
+}
+
+function applyArgs(
+  environment: CanonicalMongoValidatorArgs['environment'] = 'development',
+): CanonicalMongoValidatorArgs {
+  return {
+    environment,
+    apply: true,
+    confirmEnvironment: environment,
+    applyFrom: '/tmp/canonical-validator-dry-run.json',
+  };
+}
+
+async function reviewedDryRun(
+  harness: FakeMongoHarness,
+  mongoUrl = 'mongodb://localhost/development',
+): Promise<CanonicalMongoValidatorReport> {
+  return runCanonicalMongoValidators(developmentArgs, mongoUrl, {
+    client: harness.client,
+  });
+}
+
+describe('canonical MongoDB validator CLI arguments', () => {
+  it('requires an explicit supported environment', () => {
+    expect(() => parseCanonicalMongoValidatorArgs([])).toThrow('--environment is required');
+    expect(() => parseCanonicalMongoValidatorArgs(['--environment', 'staging'])).toThrow(
+      'requires development, beta, production-copy, production, or test',
+    );
+    expect(parseCanonicalMongoValidatorArgs(['--environment=beta'])).toEqual({
+      environment: 'beta',
+      apply: false,
+    });
+  });
+
+  it('parses apply review and confirmation flags in both accepted forms', () => {
+    expect(
+      parseCanonicalMongoValidatorArgs([
+        '--environment',
+        'beta',
+        '--apply',
+        '--confirm-canonical-validator-apply=beta',
+        '--apply-from',
+        '/tmp/reviewed.json',
+        '--output=/tmp/applied.json',
+      ]),
+    ).toEqual({
+      environment: 'beta',
+      apply: true,
+      confirmEnvironment: 'beta',
+      applyFrom: '/tmp/reviewed.json',
+      output: '/tmp/applied.json',
+    });
+  });
+
+  it('binds apply confirmation to the selected environment and reviewed artifact', () => {
+    expect(() =>
+      assertCanonicalMongoValidatorApplyAllowed({
+        environment: 'beta',
+        apply: true,
+        confirmEnvironment: 'development',
+        applyFrom: '/tmp/reviewed.json',
+      }),
+    ).toThrow('must match --environment beta');
+
+    expect(() =>
+      assertCanonicalMongoValidatorApplyAllowed({
+        environment: 'beta',
+        apply: true,
+        confirmEnvironment: 'beta',
+      }),
+    ).toThrow('--apply-from is required');
+
+    expect(() =>
+      assertCanonicalMongoValidatorApplyAllowed({
+        environment: 'beta',
+        apply: false,
+        confirmEnvironment: 'beta',
+      }),
+    ).toThrow('require --apply');
+  });
+
+  it('requires an additional production-only environment confirmation', () => {
+    const args = applyArgs('production');
+    expect(() => assertCanonicalMongoValidatorApplyAllowed(args, {})).toThrow(
+      'CONFIRM_PROD_MONGO_VALIDATORS=true',
+    );
+    expect(() =>
+      assertCanonicalMongoValidatorApplyAllowed(args, {
+        CONFIRM_PROD_MONGO_VALIDATORS: 'true',
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe('runCanonicalMongoValidators', () => {
+  it('rejects a missing or mismatched configured database before connecting', async () => {
+    const missingDatabase = fakeMongoHarness();
+    await expect(
+      runCanonicalMongoValidators(developmentArgs, 'mongodb://localhost', {
+        client: missingDatabase.client,
+      }),
+    ).rejects.toThrow('MONGODBURL must include an explicit database name');
+    expect(missingDatabase.connect).not.toHaveBeenCalled();
+    expect(missingDatabase.close).not.toHaveBeenCalled();
+
+    const invalidProtocol = fakeMongoHarness();
+    await expect(
+      runCanonicalMongoValidators(developmentArgs, 'https://localhost/development', {
+        client: invalidProtocol.client,
+      }),
+    ).rejects.toThrow('must use the mongodb or mongodb+srv protocol');
+    expect(invalidProtocol.connect).not.toHaveBeenCalled();
+    expect(invalidProtocol.close).not.toHaveBeenCalled();
+
+    const mismatchedDatabase = fakeMongoHarness();
+    await expect(
+      runCanonicalMongoValidators(developmentArgs, 'mongodb://localhost/beta', {
+        client: mismatchedDatabase.client,
+      }),
+    ).rejects.toThrow('environment development does not match MongoDB database beta');
+    expect(mismatchedDatabase.connect).not.toHaveBeenCalled();
+    expect(mismatchedDatabase.close).not.toHaveBeenCalled();
+  });
+
+  it('rejects a mismatched connected database and closes the client', async () => {
+    const harness = fakeMongoHarness({ databaseName: 'beta' });
+
+    await expect(
+      runCanonicalMongoValidators(developmentArgs, 'mongodb://localhost/development', {
+        client: harness.client,
+      }),
+    ).rejects.toThrow('environment development does not match MongoDB database beta');
+    expect(harness.connect).toHaveBeenCalledOnce();
+    expect(harness.listCollections).not.toHaveBeenCalled();
+    expect(harness.command).not.toHaveBeenCalled();
+    expect(harness.close).toHaveBeenCalledOnce();
+  });
+
+  it('keeps dry-run read-only and ignores unrelated collections', async () => {
+    const harness = fakeMongoHarness({
+      collectionInfos: [
+        { name: 'legacy_rows', type: 'collection', options: { validator: { ignored: true } } },
+        { name: 'system.views', type: 'collection' },
+      ],
+    });
+
+    const report = await reviewedDryRun(harness);
+
+    expect(report.mode).toBe('dry-run');
+    expect(report.desiredCollections).toEqual(CANONICAL_MONGO_VALIDATOR_COLLECTIONS);
+    expect(report.currentCollections).toHaveLength(CANONICAL_MONGO_VALIDATORS.length);
+    expect(report.currentCollections).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ collectionName: 'legacy_rows' }),
+        expect.objectContaining({ collectionName: 'system.views' }),
+      ]),
+    );
+    expect(report.plan.every(({ action }) => action === 'createCollection')).toBe(true);
+    expect(report.summary).toEqual({
+      desiredCollections: CANONICAL_MONGO_VALIDATORS.length,
+      createCollection: CANONICAL_MONGO_VALIDATORS.length,
+      collMod: 0,
+      noop: 0,
+      writesPlanned: CANONICAL_MONGO_VALIDATORS.length,
+    });
+    expect(harness.command).not.toHaveBeenCalled();
+    expect(harness.close).toHaveBeenCalledOnce();
+  });
+
+  it('produces a stable sorted plan and fingerprint across metadata and key ordering', async () => {
+    const orderedInfos = CANONICAL_MONGO_VALIDATOR_COLLECTIONS.map(desiredCollectionInfo);
+    const reverseObjectKeys = (value: unknown): unknown => {
+      if (Array.isArray(value)) return value.map(reverseObjectKeys);
+      if (!value || typeof value !== 'object') return value;
+      return Object.fromEntries(
+        Object.entries(value as Record<string, unknown>)
+          .reverse()
+          .map(([key, nested]) => [key, reverseObjectKeys(nested)]),
+      );
+    };
+    const reversedInfos = orderedInfos
+      .map((info) => reverseObjectKeys(info) as FakeCollectionInfo)
+      .reverse();
+    const firstHarness = fakeMongoHarness({ collectionInfos: orderedInfos });
+    const secondHarness = fakeMongoHarness({ collectionInfos: reversedInfos });
+
+    const first = await reviewedDryRun(firstHarness);
+    const second = await reviewedDryRun(secondHarness);
+
+    expect(first.plan.map(({ collectionName }) => collectionName)).toEqual(
+      [...CANONICAL_MONGO_VALIDATOR_COLLECTIONS].sort(),
+    );
+    expect(first.plan.every(({ action }) => action === 'noop')).toBe(true);
+    expect(second.plan).toEqual(first.plan);
+    expect(second.planFingerprint).toBe(first.planFingerprint);
+  });
+
+  it('rejects reviewed artifact drift before executing any command', async () => {
+    const harness = fakeMongoHarness();
+    const dryRun = await reviewedDryRun(harness);
+    harness.collectionInfos.push(desiredCollectionInfo(CANONICAL_MONGO_VALIDATOR_COLLECTIONS[0]));
+    harness.close.mockClear();
+
+    await expect(
+      runCanonicalMongoValidators(applyArgs(), 'mongodb://localhost/development', {
+        client: harness.client,
+        reviewedArtifact: dryRun,
+      }),
+    ).rejects.toThrow('validator state drifted after the reviewed dry-run');
+    expect(harness.command).not.toHaveBeenCalled();
+    expect(harness.close).toHaveBeenCalledOnce();
+  });
+
+  it('rejects a tampered reviewed artifact before executing any command', async () => {
+    const harness = fakeMongoHarness();
+    const dryRun = await reviewedDryRun(harness);
+    harness.close.mockClear();
+    const tampered = structuredClone(dryRun);
+    tampered.plan[0].reasons = ['already-current'];
+
+    await expect(
+      runCanonicalMongoValidators(applyArgs(), 'mongodb://localhost/development', {
+        client: harness.client,
+        reviewedArtifact: tampered,
+      }),
+    ).rejects.toThrow('artifact fingerprint is invalid');
+    expect(harness.command).not.toHaveBeenCalled();
+    expect(harness.close).toHaveBeenCalledOnce();
+  });
+
+  it('fingerprint-binds the human-reviewed plan summary', async () => {
+    const harness = fakeMongoHarness();
+    const dryRun = await reviewedDryRun(harness);
+    harness.close.mockClear();
+    const tampered = structuredClone(dryRun);
+    tampered.summary.writesPlanned = 0;
+
+    await expect(
+      runCanonicalMongoValidators(applyArgs(), 'mongodb://localhost/development', {
+        client: harness.client,
+        reviewedArtifact: tampered,
+      }),
+    ).rejects.toThrow('artifact fingerprint is invalid');
+    expect(harness.command).not.toHaveBeenCalled();
+    expect(harness.close).toHaveBeenCalledOnce();
+  });
+
+  it('applies only sorted write plans and verifies every validator is current', async () => {
+    const existingNoop = CANONICAL_MONGO_VALIDATOR_COLLECTIONS[2];
+    const harness = fakeMongoHarness({
+      collectionInfos: [desiredCollectionInfo(existingNoop)],
+    });
+    const dryRun = await reviewedDryRun(harness);
+    harness.close.mockClear();
+    harness.listCollections.mockClear();
+
+    const report = await runCanonicalMongoValidators(
+      applyArgs(),
+      'mongodb://localhost/development',
+      {
+        client: harness.client,
+        reviewedArtifact: dryRun,
+      },
+    );
+
+    const expectedWrites = CANONICAL_MONGO_VALIDATOR_COLLECTIONS.filter(
+      (collectionName) => collectionName !== existingNoop,
+    );
+    expect(
+      harness.command.mock.calls.map(([command]) => command.create ?? command.collMod),
+    ).toEqual(expectedWrites);
+    expect(harness.command.mock.calls).not.toEqual(
+      expect.arrayContaining([
+        [expect.objectContaining({ create: existingNoop })],
+        [expect.objectContaining({ collMod: existingNoop })],
+      ]),
+    );
+    expect(report.applied?.map(({ collectionName }) => collectionName)).toEqual(expectedWrites);
+    expect(report.postApplyPlan).toHaveLength(CANONICAL_MONGO_VALIDATORS.length);
+    expect(report.postApplyPlan?.every(({ action }) => action === 'noop')).toBe(true);
+    expect(harness.listCollections).toHaveBeenCalledTimes(2);
+    expect(harness.close).toHaveBeenCalledOnce();
+  });
+
+  it('reports partial progress, stops at the first failure, closes, and supports a fresh rerun', async () => {
+    const failingCollection = CANONICAL_MONGO_VALIDATOR_COLLECTIONS[1];
+    let failOnce = true;
+    const harness = fakeMongoHarness({
+      commandFailure: (command) => {
+        const collectionName = command.create ?? command.collMod;
+        if (collectionName === failingCollection && failOnce) {
+          failOnce = false;
+          return true;
+        }
+        return false;
+      },
+    });
+    const firstDryRun = await reviewedDryRun(harness);
+    harness.close.mockClear();
+
+    let applyError: unknown;
+    try {
+      await runCanonicalMongoValidators(applyArgs(), 'mongodb://localhost/development', {
+        client: harness.client,
+        reviewedArtifact: firstDryRun,
+      });
+    } catch (error) {
+      applyError = error;
+    }
+
+    expect(applyError).toBeInstanceOf(CanonicalMongoValidatorApplyError);
+    expect(applyError).toMatchObject({
+      appliedCollections: [CANONICAL_MONGO_VALIDATOR_COLLECTIONS[0]],
+      failedCollection: failingCollection,
+      unattemptedCollections: CANONICAL_MONGO_VALIDATOR_COLLECTIONS.slice(2),
+    });
+    expect(harness.command).toHaveBeenCalledTimes(2);
+    expect(harness.close).toHaveBeenCalledOnce();
+
+    harness.command.mockClear();
+    harness.close.mockClear();
+    const freshDryRun = await reviewedDryRun(harness);
+    harness.close.mockClear();
+    const rerun = await runCanonicalMongoValidators(
+      applyArgs(),
+      'mongodb://localhost/development',
+      {
+        client: harness.client,
+        reviewedArtifact: freshDryRun,
+      },
+    );
+
+    expect(rerun.applied?.map(({ collectionName }) => collectionName)).toEqual(
+      CANONICAL_MONGO_VALIDATOR_COLLECTIONS.slice(1),
+    );
+    expect(rerun.postApplyPlan?.every(({ action }) => action === 'noop')).toBe(true);
+    expect(harness.close).toHaveBeenCalledOnce();
+  });
+
+  it('propagates collection metadata failures without writes and closes the client', async () => {
+    const harness = fakeMongoHarness({
+      listError: new Error('listCollections unavailable'),
+    });
+
+    await expect(reviewedDryRun(harness)).rejects.toThrow('listCollections unavailable');
+    expect(harness.command).not.toHaveBeenCalled();
+    expect(harness.close).toHaveBeenCalledOnce();
+  });
+
+  it('reports applied collections when post-apply verification cannot read metadata', async () => {
+    const harness = fakeMongoHarness({
+      listError: new Error('post-apply listCollections unavailable'),
+      listFailureCall: 2,
+    });
+    const dryRun = await reviewedDryRun(harness);
+    harness.close.mockClear();
+
+    let verificationError: unknown;
+    try {
+      await runCanonicalMongoValidators(applyArgs(), 'mongodb://localhost/development', {
+        client: harness.client,
+        reviewedArtifact: dryRun,
+      });
+    } catch (error) {
+      verificationError = error;
+    }
+
+    expect(verificationError).toBeInstanceOf(CanonicalMongoValidatorVerificationError);
+    expect(verificationError).toMatchObject({
+      appliedCollections: CANONICAL_MONGO_VALIDATOR_COLLECTIONS,
+      remainingCollections: [],
+    });
+    expect(verificationError).toHaveProperty(
+      'message',
+      expect.stringContaining('post-apply listCollections unavailable'),
+    );
+    expect(harness.close).toHaveBeenCalledOnce();
+  });
+
+  it.each(['view', 'timeseries'])(
+    'rejects canonical targets reported as MongoDB type %s',
+    async (type) => {
+      const harness = fakeMongoHarness({
+        collectionInfos: [
+          {
+            name: CANONICAL_MONGO_VALIDATOR_COLLECTIONS[0],
+            type,
+          },
+        ],
+      });
+
+      await expect(reviewedDryRun(harness)).rejects.toThrow(
+        `is a ${type}, not a standard collection`,
+      );
+      expect(harness.command).not.toHaveBeenCalled();
+      expect(harness.close).toHaveBeenCalledOnce();
+    },
+  );
+
+  it('rejects a time-series target even when MongoDB reports its base type as collection', async () => {
+    const harness = fakeMongoHarness({
+      collectionInfos: [
+        {
+          name: CANONICAL_MONGO_VALIDATOR_COLLECTIONS[0],
+          type: 'collection',
+          options: { timeseries: { timeField: 'observedAt' } },
+        },
+      ],
+    });
+
+    await expect(reviewedDryRun(harness)).rejects.toThrow(
+      'is a time-series collection, not a standard collection',
+    );
+    expect(harness.command).not.toHaveBeenCalled();
+    expect(harness.close).toHaveBeenCalledOnce();
+  });
+});

--- a/server/src/scripts/__tests__/canonicalMongoValidators.test.ts
+++ b/server/src/scripts/__tests__/canonicalMongoValidators.test.ts
@@ -486,6 +486,7 @@ describe('runCanonicalMongoValidators', () => {
       commandFailure: (_command, callIndex) => callIndex === 1,
     });
     const dryRun = await reviewedDryRun(harness);
+    harness.close.mockClear();
     harness.close.mockRejectedValue(new Error('injected MongoDB close failure'));
 
     let applyError: unknown;

--- a/server/src/scripts/__tests__/canonicalMongoValidatorsCore.test.ts
+++ b/server/src/scripts/__tests__/canonicalMongoValidatorsCore.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { defineCanonicalSchemaVersion } from '../../models/canonicalSchemaVersion';
 import {
   buildCanonicalCollectionValidator,
+  buildCanonicalMongoValidatorRollbackPlan,
+  canonicalMongoValidatorFingerprint,
   planCanonicalMongoValidators,
 } from '../canonicalMongoValidatorsCore';
 
@@ -219,5 +221,93 @@ describe('canonical MongoDB validators', () => {
         ],
       ),
     ).toThrow('Duplicate current collection validation state');
+  });
+
+  it('fingerprints equivalent validator objects independently of key order', () => {
+    expect(
+      canonicalMongoValidatorFingerprint({
+        validator: {
+          properties: {
+            displayName: { maxLength: 240, bsonType: 'string' },
+          },
+          required: ['schemaVersion', 'displayName'],
+        },
+      }),
+    ).toBe(
+      canonicalMongoValidatorFingerprint({
+        validator: {
+          required: ['schemaVersion', 'displayName'],
+          properties: {
+            displayName: { bsonType: 'string', maxLength: 240 },
+          },
+        },
+      }),
+    );
+  });
+
+  it('captures exact existing validation options for collMod rollback', () => {
+    const current = [
+      {
+        collectionName: 'people',
+        exists: true,
+        validator: { $jsonSchema: { bsonType: 'object', required: ['legacyId'] } },
+        validationLevel: 'strict',
+        validationAction: 'warn',
+      },
+    ];
+    const plan = planCanonicalMongoValidators([peopleValidator], current);
+
+    expect(buildCanonicalMongoValidatorRollbackPlan(plan, current)).toEqual([
+      {
+        collectionName: 'people',
+        reason: 'restore-previous-validation',
+        command: {
+          collMod: 'people',
+          validator: current[0].validator,
+          validationLevel: 'strict',
+          validationAction: 'warn',
+        },
+      },
+    ]);
+  });
+
+  it('uses safe MongoDB defaults when prior validation options are absent', () => {
+    const current = [
+      {
+        collectionName: 'people',
+        exists: true,
+      },
+    ];
+    const plan = planCanonicalMongoValidators([peopleValidator], current);
+
+    expect(buildCanonicalMongoValidatorRollbackPlan(plan, current)).toEqual([
+      {
+        collectionName: 'people',
+        reason: 'restore-previous-validation',
+        command: {
+          collMod: 'people',
+          validator: {},
+          validationLevel: 'strict',
+          validationAction: 'error',
+        },
+      },
+    ]);
+  });
+
+  it('disables a validator instead of dropping a newly created collection during rollback', () => {
+    const plan = planCanonicalMongoValidators([peopleValidator], []);
+
+    expect(buildCanonicalMongoValidatorRollbackPlan(plan, [])).toEqual([
+      {
+        collectionName: 'people',
+        reason: 'disable-created-collection-validator',
+        command: {
+          collMod: 'people',
+          validator: {},
+          validationLevel: 'off',
+          validationAction: 'error',
+        },
+      },
+    ]);
   });
 });

--- a/server/src/scripts/canonicalMongoValidatorRegistry.ts
+++ b/server/src/scripts/canonicalMongoValidatorRegistry.ts
@@ -1,0 +1,237 @@
+import type mongoose from 'mongoose';
+import {
+  Account,
+  accountSchemaVersion,
+  EvidenceClaim,
+  EVIDENCE_CLAIM_SCHEMA_VERSION,
+  MAX_EVIDENCE_CLAIM_EXCERPT_LENGTH,
+  MAX_EVIDENCE_CLAIM_SUBJECT_KEY_LENGTH,
+  MAX_EVIDENCE_CLAIMS_PER_ROLE,
+  MAX_ORG_UNIT_ALIASES,
+  MAX_RESEARCH_PLAN_CHECKLIST_ITEMS,
+  MAX_RESEARCH_PLAN_DEADLINES,
+  MAX_RESEARCH_PLAN_NOTES_LENGTH,
+  RESEARCH_PLAN_SCHEMA_VERSION,
+  MAX_REVIEW_DECISION_EVIDENCE_CLAIMS,
+  MAX_REVIEW_DECISION_FIELD_PATHS,
+  MAX_REVIEW_DECISION_INTERNAL_NOTES_LENGTH,
+  MAX_REVIEW_DECISION_RATIONALE_LENGTH,
+  MAX_SOURCE_DOCUMENT_EXTERNAL_KEY_LENGTH,
+  MAX_SOURCE_DOCUMENT_KEY_LENGTH,
+  MAX_SOURCE_DOCUMENT_POINTER_LENGTH,
+  MAX_SOURCE_DOCUMENT_REDIRECTS,
+  MAX_SOURCE_DOCUMENT_URL_LENGTH,
+  MAX_TAXONOMY_ALIASES,
+  OrgUnit,
+  Person,
+  ResearchPlan,
+  REVIEW_DECISION_SCHEMA_VERSION,
+  ReviewDecision,
+  RoleAssignment,
+  SOURCE_DOCUMENT_SCHEMA_VERSION,
+  SourceDocument,
+  TaxonomyTerm,
+  orgUnitSchemaVersion,
+  personProfileLinkKinds,
+  personSchemaVersion,
+  roleAssignmentSchemaVersion,
+  taxonomyTermSchemaVersion,
+} from '../models';
+import type { CanonicalSchemaVersionContract } from '../models/canonicalSchemaVersion';
+import {
+  buildCanonicalCollectionValidator,
+  type CanonicalCollectionValidator,
+  type MongoJsonSchemaProperty,
+} from './canonicalMongoValidatorsCore';
+
+interface GeneratedMongoJsonSchema {
+  required?: string[];
+  properties?: Record<string, MongoJsonSchemaProperty>;
+}
+
+interface CanonicalModelValidatorContract {
+  model: mongoose.Model<any>;
+  schemaVersion: CanonicalSchemaVersionContract;
+  propertyOverrides?: Readonly<Record<string, MongoJsonSchemaProperty>>;
+}
+
+function numericOption(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (Array.isArray(value) && typeof value[0] === 'number' && Number.isFinite(value[0])) {
+    return value[0];
+  }
+  return undefined;
+}
+
+function topLevelMongooseConstraints(
+  model: mongoose.Model<any>,
+  field: string,
+): MongoJsonSchemaProperty {
+  const schemaType = model.schema.path(field);
+  if (!schemaType) return {};
+
+  const options = schemaType.options as Record<string, unknown>;
+  const minimum = numericOption(options.min);
+  const maximum = numericOption(options.max);
+  const minLength = numericOption(options.minlength);
+  const maxLength = numericOption(options.maxlength);
+  const match = Array.isArray(options.match) ? options.match[0] : options.match;
+  const pattern = match instanceof RegExp && match.flags === '' ? match.source : undefined;
+
+  return {
+    ...(minimum !== undefined ? { minimum } : {}),
+    ...(maximum !== undefined ? { maximum } : {}),
+    ...(minLength !== undefined ? { minLength } : {}),
+    ...(maxLength !== undefined ? { maxLength } : {}),
+    ...(pattern ? { pattern } : {}),
+  };
+}
+
+function buildCanonicalModelValidator(
+  contract: CanonicalModelValidatorContract,
+): CanonicalCollectionValidator {
+  const generated = contract.model.schema.toJSONSchema({
+    useBsonType: true,
+  }) as GeneratedMongoJsonSchema;
+  const generatedProperties = structuredClone(generated.properties ?? {});
+  delete generatedProperties.schemaVersion;
+
+  const properties = Object.fromEntries(
+    Object.entries(generatedProperties).map(([field, property]) => [
+      field,
+      {
+        ...property,
+        ...topLevelMongooseConstraints(contract.model, field),
+        ...(contract.propertyOverrides?.[field] ?? {}),
+      },
+    ]),
+  );
+
+  return buildCanonicalCollectionValidator({
+    collectionName: contract.model.collection.name,
+    schemaVersion: contract.schemaVersion,
+    requiredFields: (generated.required ?? []).filter((field) => field !== 'schemaVersion'),
+    properties,
+  });
+}
+
+function generatedModelProperty(
+  model: mongoose.Model<any>,
+  field: string,
+): MongoJsonSchemaProperty {
+  const generated = model.schema.toJSONSchema({
+    useBsonType: true,
+  }) as GeneratedMongoJsonSchema;
+  return structuredClone(generated.properties?.[field] ?? {});
+}
+
+const evidenceSubjectProperty = generatedModelProperty(EvidenceClaim, 'subject');
+const evidenceSubjectProperties =
+  (evidenceSubjectProperty.properties as Record<string, MongoJsonSchemaProperty> | undefined) ?? {};
+
+const canonicalModelValidatorContracts: readonly CanonicalModelValidatorContract[] = [
+  {
+    model: Account,
+    schemaVersion: accountSchemaVersion,
+  },
+  {
+    model: Person,
+    schemaVersion: personSchemaVersion,
+    propertyOverrides: {
+      profileLinks: { maxItems: personProfileLinkKinds.length },
+    },
+  },
+  {
+    model: RoleAssignment,
+    schemaVersion: roleAssignmentSchemaVersion,
+    propertyOverrides: {
+      evidenceClaimIds: {
+        maxItems: MAX_EVIDENCE_CLAIMS_PER_ROLE,
+        uniqueItems: true,
+      },
+    },
+  },
+  {
+    model: OrgUnit,
+    schemaVersion: orgUnitSchemaVersion,
+    propertyOverrides: {
+      aliases: {
+        maxItems: MAX_ORG_UNIT_ALIASES,
+        uniqueItems: true,
+      },
+    },
+  },
+  {
+    model: TaxonomyTerm,
+    schemaVersion: taxonomyTermSchemaVersion,
+    propertyOverrides: {
+      aliases: {
+        maxItems: MAX_TAXONOMY_ALIASES,
+        uniqueItems: true,
+      },
+    },
+  },
+  {
+    model: ResearchPlan,
+    schemaVersion: RESEARCH_PLAN_SCHEMA_VERSION,
+    propertyOverrides: {
+      privateNotes: { maxLength: MAX_RESEARCH_PLAN_NOTES_LENGTH },
+      checklist: { maxItems: MAX_RESEARCH_PLAN_CHECKLIST_ITEMS },
+      deadlines: { maxItems: MAX_RESEARCH_PLAN_DEADLINES },
+    },
+  },
+  {
+    model: SourceDocument,
+    schemaVersion: SOURCE_DOCUMENT_SCHEMA_VERSION,
+    propertyOverrides: {
+      documentKey: { maxLength: MAX_SOURCE_DOCUMENT_KEY_LENGTH },
+      canonicalUrl: { maxLength: MAX_SOURCE_DOCUMENT_URL_LENGTH },
+      externalResourceKey: { maxLength: MAX_SOURCE_DOCUMENT_EXTERNAL_KEY_LENGTH },
+      snapshotPointer: { maxLength: MAX_SOURCE_DOCUMENT_POINTER_LENGTH },
+      redirectChain: { maxItems: MAX_SOURCE_DOCUMENT_REDIRECTS },
+    },
+  },
+  {
+    model: EvidenceClaim,
+    schemaVersion: EVIDENCE_CLAIM_SCHEMA_VERSION,
+    propertyOverrides: {
+      subject: {
+        ...evidenceSubjectProperty,
+        properties: {
+          ...evidenceSubjectProperties,
+          key: {
+            bsonType: ['string', 'null'],
+            maxLength: MAX_EVIDENCE_CLAIM_SUBJECT_KEY_LENGTH,
+          },
+        },
+      },
+      excerpt: { maxLength: MAX_EVIDENCE_CLAIM_EXCERPT_LENGTH },
+    },
+  },
+  {
+    model: ReviewDecision,
+    schemaVersion: REVIEW_DECISION_SCHEMA_VERSION,
+    propertyOverrides: {
+      fieldPaths: {
+        maxItems: MAX_REVIEW_DECISION_FIELD_PATHS,
+        uniqueItems: true,
+      },
+      rationale: { maxLength: MAX_REVIEW_DECISION_RATIONALE_LENGTH },
+      internalNotes: { maxLength: MAX_REVIEW_DECISION_INTERNAL_NOTES_LENGTH },
+      evidenceClaimIds: {
+        maxItems: MAX_REVIEW_DECISION_EVIDENCE_CLAIMS,
+        uniqueItems: true,
+      },
+    },
+  },
+];
+
+export const CANONICAL_MONGO_VALIDATORS: readonly CanonicalCollectionValidator[] = Object.freeze(
+  canonicalModelValidatorContracts
+    .map(buildCanonicalModelValidator)
+    .sort((left, right) => left.collectionName.localeCompare(right.collectionName)),
+);
+
+export const CANONICAL_MONGO_VALIDATOR_COLLECTIONS: readonly string[] = Object.freeze(
+  CANONICAL_MONGO_VALIDATORS.map(({ collectionName }) => collectionName),
+);

--- a/server/src/scripts/canonicalMongoValidators.ts
+++ b/server/src/scripts/canonicalMongoValidators.ts
@@ -415,6 +415,8 @@ export async function runCanonicalMongoValidators(
   assertOperatorEnvironmentMatchesDatabase(args.environment, configuredDatabaseName);
 
   const client = options.client ?? (new MongoClient(mongoUrl) as unknown as ValidatorMongoClient);
+  let primaryError: unknown;
+  let failed = false;
   try {
     await client.connect();
     const db = client.db();
@@ -494,8 +496,28 @@ export async function runCanonicalMongoValidators(
       applied,
       postApplyPlan,
     };
+  } catch (error) {
+    failed = true;
+    primaryError = error;
+    throw error;
   } finally {
-    await client.close();
+    try {
+      await client.close();
+    } catch (closeError) {
+      if (!failed) throw closeError;
+
+      const closeFailureReason = sanitizeLogValue(
+        closeError instanceof Error ? closeError.message : closeError,
+      );
+      if (primaryError instanceof Error) {
+        primaryError.message = `${primaryError.message}. MongoDB client cleanup also failed: ${closeFailureReason}`;
+      } else {
+        throw new AggregateError(
+          [primaryError, closeError],
+          `Canonical MongoDB validator operation and client cleanup both failed: ${closeFailureReason}`,
+        );
+      }
+    }
   }
 }
 

--- a/server/src/scripts/canonicalMongoValidators.ts
+++ b/server/src/scripts/canonicalMongoValidators.ts
@@ -1,0 +1,563 @@
+/**
+ * Guarded operator workflow for canonical MongoDB validators.
+ *
+ * Dry-run is the default.
+ * Apply requires a reviewed dry-run artifact and an explicit confirmation flag.
+ */
+import dotenv from 'dotenv';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { MongoClient } from 'mongodb';
+import { summarizeMongoUrl } from '../scrapers/scraperEnvironment';
+import { sanitizeLogValue } from '../utils/logSanitizer';
+import {
+  buildCanonicalMongoValidatorRollbackPlan,
+  canonicalMongoValidatorFingerprint,
+  canonicalMongoValidatorValuesEqual,
+  planCanonicalMongoValidators,
+  type CanonicalMongoValidatorPlanItem,
+  type CanonicalMongoValidatorRollbackItem,
+  type CurrentMongoCollectionValidation,
+} from './canonicalMongoValidatorsCore';
+import {
+  CANONICAL_MONGO_VALIDATORS,
+  CANONICAL_MONGO_VALIDATOR_COLLECTIONS,
+} from './canonicalMongoValidatorRegistry';
+import {
+  assertOperatorEnvironmentMatchesDatabase,
+  databaseNameFromMongoUrl,
+  parseOperatorDatabaseEnvironment,
+  type OperatorDatabaseEnvironment,
+} from './operatorDatabaseEnvironment';
+import { resolveSafeJsonReportOutputPath } from './scriptWriteGuards';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+dotenv.config({ path: path.resolve(__dirname, '../../.env') });
+
+export const CANONICAL_MONGO_VALIDATOR_REPORT_VERSION = 1 as const;
+export const CONFIRM_CANONICAL_VALIDATOR_APPLY_FLAG =
+  '--confirm-canonical-validator-apply' as const;
+
+interface MongoCollectionInfo {
+  name: string;
+  type?: string;
+  options?: {
+    validator?: unknown;
+    validationLevel?: unknown;
+    validationAction?: unknown;
+    timeseries?: unknown;
+  };
+}
+
+interface ValidatorMongoDb {
+  databaseName: string;
+  listCollections(
+    filter?: Record<string, unknown>,
+    options?: { nameOnly?: boolean },
+  ): {
+    toArray(): Promise<MongoCollectionInfo[]>;
+  };
+  command(command: Record<string, unknown>): Promise<unknown>;
+}
+
+export interface ValidatorMongoClient {
+  connect(): Promise<unknown>;
+  db(): ValidatorMongoDb;
+  close(): Promise<void>;
+}
+
+export interface CanonicalMongoValidatorArgs {
+  environment: OperatorDatabaseEnvironment;
+  apply: boolean;
+  confirmEnvironment?: OperatorDatabaseEnvironment;
+  applyFrom?: string;
+  output?: string;
+}
+
+export interface CanonicalMongoValidatorSummary {
+  desiredCollections: number;
+  createCollection: number;
+  collMod: number;
+  noop: number;
+  writesPlanned: number;
+}
+
+export interface CanonicalMongoValidatorReport {
+  reportVersion: typeof CANONICAL_MONGO_VALIDATOR_REPORT_VERSION;
+  mode: 'dry-run' | 'apply';
+  environment: OperatorDatabaseEnvironment;
+  databaseName: string;
+  target: string;
+  desiredCollections: readonly string[];
+  summary: CanonicalMongoValidatorSummary;
+  currentCollections: CurrentMongoCollectionValidation[];
+  plan: CanonicalMongoValidatorPlanItem[];
+  rollbackPlan: CanonicalMongoValidatorRollbackItem[];
+  planFingerprint: string;
+  applied?: Array<{
+    collectionName: string;
+    action: Exclude<CanonicalMongoValidatorPlanItem['action'], 'noop'>;
+  }>;
+  postApplyPlan?: CanonicalMongoValidatorPlanItem[];
+}
+
+export class CanonicalMongoValidatorApplyError extends Error {
+  readonly appliedCollections: readonly string[];
+  readonly failedCollection: string;
+  readonly failureReason: string;
+  readonly unattemptedCollections: readonly string[];
+
+  constructor(args: {
+    appliedCollections: readonly string[];
+    failedCollection: string;
+    failureReason: string;
+    unattemptedCollections: readonly string[];
+  }) {
+    super(
+      `Canonical validator apply stopped at ${args.failedCollection}: ${args.failureReason}. Applied: ${
+        args.appliedCollections.join(', ') || '(none)'
+      }. Unattempted: ${args.unattemptedCollections.join(', ') || '(none)'}. Generate a fresh dry-run before retrying.`,
+    );
+    this.name = 'CanonicalMongoValidatorApplyError';
+    this.appliedCollections = [...args.appliedCollections];
+    this.failedCollection = args.failedCollection;
+    this.failureReason = args.failureReason;
+    this.unattemptedCollections = [...args.unattemptedCollections];
+  }
+}
+
+export class CanonicalMongoValidatorVerificationError extends Error {
+  readonly appliedCollections: readonly string[];
+  readonly remainingCollections: readonly string[];
+
+  constructor(args: {
+    appliedCollections: readonly string[];
+    failureReason: string;
+    remainingCollections?: readonly string[];
+  }) {
+    const remainingCollections = args.remainingCollections ?? [];
+    super(
+      `Canonical validator post-apply verification failed: ${args.failureReason}. Applied commands: ${
+        args.appliedCollections.join(', ') || '(none)'
+      }. Remaining drift: ${
+        remainingCollections.join(', ') || '(unknown)'
+      }. Inspect the connected database and generate a fresh dry-run before any retry.`,
+    );
+    this.name = 'CanonicalMongoValidatorVerificationError';
+    this.appliedCollections = [...args.appliedCollections];
+    this.remainingCollections = [...remainingCollections];
+  }
+}
+
+function requireFlagValue(argv: string[], index: number, flag: string): string {
+  const value = argv[index + 1]?.trim();
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+export function parseCanonicalMongoValidatorArgs(argv: string[]): CanonicalMongoValidatorArgs {
+  let environment: OperatorDatabaseEnvironment | undefined;
+  let apply = false;
+  let confirmEnvironment: OperatorDatabaseEnvironment | undefined;
+  let applyFrom: string | undefined;
+  let output: string | undefined;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--environment') {
+      environment = parseOperatorDatabaseEnvironment(
+        requireFlagValue(argv, index, '--environment'),
+      );
+      index += 1;
+    } else if (arg.startsWith('--environment=')) {
+      environment = parseOperatorDatabaseEnvironment(arg.slice('--environment='.length));
+    } else if (arg === '--apply') {
+      apply = true;
+    } else if (arg === CONFIRM_CANONICAL_VALIDATOR_APPLY_FLAG) {
+      confirmEnvironment = parseOperatorDatabaseEnvironment(
+        requireFlagValue(argv, index, CONFIRM_CANONICAL_VALIDATOR_APPLY_FLAG),
+        CONFIRM_CANONICAL_VALIDATOR_APPLY_FLAG,
+      );
+      index += 1;
+    } else if (arg.startsWith(`${CONFIRM_CANONICAL_VALIDATOR_APPLY_FLAG}=`)) {
+      confirmEnvironment = parseOperatorDatabaseEnvironment(
+        arg.slice(`${CONFIRM_CANONICAL_VALIDATOR_APPLY_FLAG}=`.length),
+        CONFIRM_CANONICAL_VALIDATOR_APPLY_FLAG,
+      );
+    } else if (arg === '--apply-from') {
+      applyFrom = requireFlagValue(argv, index, '--apply-from');
+      index += 1;
+    } else if (arg.startsWith('--apply-from=')) {
+      applyFrom = arg.slice('--apply-from='.length).trim();
+      if (!applyFrom) throw new Error('--apply-from requires a value');
+    } else if (arg === '--output') {
+      output = requireFlagValue(argv, index, '--output');
+      index += 1;
+    } else if (arg.startsWith('--output=')) {
+      output = arg.slice('--output='.length).trim();
+      if (!output) throw new Error('--output requires a value');
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!environment) {
+    throw new Error('--environment is required');
+  }
+
+  return {
+    environment,
+    apply,
+    ...(confirmEnvironment ? { confirmEnvironment } : {}),
+    ...(applyFrom ? { applyFrom } : {}),
+    ...(output ? { output } : {}),
+  };
+}
+
+export function assertCanonicalMongoValidatorApplyAllowed(
+  args: CanonicalMongoValidatorArgs,
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  if (!args.apply && (args.confirmEnvironment || args.applyFrom)) {
+    throw new Error(`${CONFIRM_CANONICAL_VALIDATOR_APPLY_FLAG} and --apply-from require --apply.`);
+  }
+  if (args.apply && !args.confirmEnvironment) {
+    throw new Error(`${CONFIRM_CANONICAL_VALIDATOR_APPLY_FLAG} is required when --apply is set.`);
+  }
+  if (args.apply && args.confirmEnvironment !== args.environment) {
+    throw new Error(
+      `${CONFIRM_CANONICAL_VALIDATOR_APPLY_FLAG} must match --environment ${args.environment}.`,
+    );
+  }
+  if (args.apply && !args.applyFrom) {
+    throw new Error('--apply-from is required when --apply is set.');
+  }
+  if (
+    args.apply &&
+    args.environment === 'production' &&
+    env.CONFIRM_PROD_MONGO_VALIDATORS !== 'true'
+  ) {
+    throw new Error(
+      'Production validator writes require CONFIRM_PROD_MONGO_VALIDATORS=true in the environment.',
+    );
+  }
+}
+
+export async function readCurrentCanonicalMongoValidators(
+  db: ValidatorMongoDb,
+): Promise<CurrentMongoCollectionValidation[]> {
+  const desiredNames = new Set(CANONICAL_MONGO_VALIDATOR_COLLECTIONS);
+  const infos = await db.listCollections({}, { nameOnly: false }).toArray();
+  const infosByName = new Map<string, MongoCollectionInfo>();
+
+  for (const info of infos) {
+    if (!desiredNames.has(info.name)) continue;
+    if (infosByName.has(info.name)) {
+      throw new Error(`MongoDB returned duplicate collection metadata for ${info.name}.`);
+    }
+    if (info.type !== 'collection' || info.options?.timeseries !== undefined) {
+      const collectionType =
+        info.options?.timeseries !== undefined
+          ? 'time-series collection'
+          : (info.type ?? 'unknown');
+      throw new Error(
+        `Canonical validator target ${info.name} is a ${collectionType}, not a standard collection.`,
+      );
+    }
+    infosByName.set(info.name, info);
+  }
+
+  return CANONICAL_MONGO_VALIDATOR_COLLECTIONS.map((collectionName) => {
+    const info = infosByName.get(collectionName);
+    if (!info) {
+      return { collectionName, exists: false };
+    }
+    const options = info.options ?? {};
+    return {
+      collectionName,
+      exists: true,
+      ...(Object.hasOwn(options, 'validator')
+        ? { validator: structuredClone(options.validator) }
+        : {}),
+      ...(Object.hasOwn(options, 'validationLevel')
+        ? { validationLevel: options.validationLevel }
+        : {}),
+      ...(Object.hasOwn(options, 'validationAction')
+        ? { validationAction: options.validationAction }
+        : {}),
+    };
+  });
+}
+
+function summarizePlan(
+  plan: readonly CanonicalMongoValidatorPlanItem[],
+): CanonicalMongoValidatorSummary {
+  const createCollection = plan.filter((item) => item.action === 'createCollection').length;
+  const collMod = plan.filter((item) => item.action === 'collMod').length;
+  const noop = plan.filter((item) => item.action === 'noop').length;
+  return {
+    desiredCollections: plan.length,
+    createCollection,
+    collMod,
+    noop,
+    writesPlanned: createCollection + collMod,
+  };
+}
+
+function fingerprintInput(report: {
+  reportVersion: number;
+  environment: OperatorDatabaseEnvironment;
+  databaseName: string;
+  target: string;
+  desiredCollections: readonly string[];
+  summary: unknown;
+  currentCollections: unknown;
+  plan: unknown;
+  rollbackPlan: unknown;
+}): object {
+  return {
+    reportVersion: report.reportVersion,
+    environment: report.environment,
+    databaseName: report.databaseName,
+    target: report.target,
+    desiredCollections: report.desiredCollections,
+    summary: report.summary,
+    currentCollections: report.currentCollections,
+    plan: report.plan,
+    rollbackPlan: report.rollbackPlan,
+  };
+}
+
+function buildReport(args: {
+  mode: CanonicalMongoValidatorReport['mode'];
+  environment: OperatorDatabaseEnvironment;
+  databaseName: string;
+  target: string;
+  currentCollections: CurrentMongoCollectionValidation[];
+}): CanonicalMongoValidatorReport {
+  const plan = planCanonicalMongoValidators(CANONICAL_MONGO_VALIDATORS, args.currentCollections);
+  const rollbackPlan = buildCanonicalMongoValidatorRollbackPlan(plan, args.currentCollections);
+  const reportWithoutFingerprint = {
+    reportVersion: CANONICAL_MONGO_VALIDATOR_REPORT_VERSION,
+    mode: args.mode,
+    environment: args.environment,
+    databaseName: args.databaseName,
+    target: args.target,
+    desiredCollections: CANONICAL_MONGO_VALIDATOR_COLLECTIONS,
+    summary: summarizePlan(plan),
+    currentCollections: args.currentCollections,
+    plan,
+    rollbackPlan,
+  };
+
+  return {
+    ...reportWithoutFingerprint,
+    planFingerprint: canonicalMongoValidatorFingerprint(fingerprintInput(reportWithoutFingerprint)),
+  };
+}
+
+export function assertReviewedCanonicalMongoValidatorPlan(
+  reviewed: unknown,
+  current: CanonicalMongoValidatorReport,
+): void {
+  if (!reviewed || typeof reviewed !== 'object' || Array.isArray(reviewed)) {
+    throw new Error('--apply-from must contain a canonical validator dry-run report.');
+  }
+  const artifact = reviewed as Partial<CanonicalMongoValidatorReport>;
+  if (artifact.mode !== 'dry-run') {
+    throw new Error('--apply-from must reference a dry-run report.');
+  }
+
+  const artifactFingerprint = canonicalMongoValidatorFingerprint(
+    fingerprintInput({
+      reportVersion: artifact.reportVersion ?? 0,
+      environment: artifact.environment ?? current.environment,
+      databaseName: artifact.databaseName ?? '',
+      target: artifact.target ?? '',
+      desiredCollections: artifact.desiredCollections ?? [],
+      summary: artifact.summary,
+      currentCollections: artifact.currentCollections,
+      plan: artifact.plan,
+      rollbackPlan: artifact.rollbackPlan,
+    }),
+  );
+  if (artifact.planFingerprint !== artifactFingerprint) {
+    throw new Error('The reviewed validator artifact fingerprint is invalid.');
+  }
+  if (
+    artifact.planFingerprint !== current.planFingerprint ||
+    !canonicalMongoValidatorValuesEqual(
+      fingerprintInput(artifact as CanonicalMongoValidatorReport),
+      fingerprintInput(current),
+    )
+  ) {
+    throw new Error(
+      'The connected database validator state drifted after the reviewed dry-run. Generate and review a new plan.',
+    );
+  }
+}
+
+export async function runCanonicalMongoValidators(
+  args: CanonicalMongoValidatorArgs,
+  mongoUrl: string,
+  options: {
+    client?: ValidatorMongoClient;
+    reviewedArtifact?: unknown;
+    env?: NodeJS.ProcessEnv;
+  } = {},
+): Promise<CanonicalMongoValidatorReport> {
+  assertCanonicalMongoValidatorApplyAllowed(args, options.env);
+  const configuredDatabaseName = databaseNameFromMongoUrl(mongoUrl);
+  assertOperatorEnvironmentMatchesDatabase(args.environment, configuredDatabaseName);
+
+  const client = options.client ?? (new MongoClient(mongoUrl) as unknown as ValidatorMongoClient);
+  try {
+    await client.connect();
+    const db = client.db();
+    assertOperatorEnvironmentMatchesDatabase(args.environment, db.databaseName);
+
+    const currentCollections = await readCurrentCanonicalMongoValidators(db);
+    const currentReport = buildReport({
+      mode: args.apply ? 'apply' : 'dry-run',
+      environment: args.environment,
+      databaseName: db.databaseName,
+      target: summarizeMongoUrl(mongoUrl),
+      currentCollections,
+    });
+
+    if (!args.apply) return currentReport;
+
+    assertReviewedCanonicalMongoValidatorPlan(options.reviewedArtifact, {
+      ...currentReport,
+      mode: 'dry-run',
+    });
+
+    const applied: NonNullable<CanonicalMongoValidatorReport['applied']> = [];
+    const writePlan = currentReport.plan.filter(
+      (
+        item,
+      ): item is CanonicalMongoValidatorPlanItem & {
+        action: 'createCollection' | 'collMod';
+      } => item.action !== 'noop',
+    );
+    for (const [index, item] of writePlan.entries()) {
+      if (!item.command) {
+        throw new Error(`Missing MongoDB command for ${item.collectionName}.`);
+      }
+      try {
+        await db.command(structuredClone(item.command));
+      } catch (error) {
+        throw new CanonicalMongoValidatorApplyError({
+          appliedCollections: applied.map(({ collectionName }) => collectionName),
+          failedCollection: item.collectionName,
+          failureReason: sanitizeLogValue(error instanceof Error ? error.message : error),
+          unattemptedCollections: writePlan
+            .slice(index + 1)
+            .map(({ collectionName }) => collectionName),
+        });
+      }
+      applied.push({
+        collectionName: item.collectionName,
+        action: item.action,
+      });
+    }
+
+    let postApplyCurrent: CurrentMongoCollectionValidation[];
+    try {
+      postApplyCurrent = await readCurrentCanonicalMongoValidators(db);
+    } catch (error) {
+      throw new CanonicalMongoValidatorVerificationError({
+        appliedCollections: applied.map(({ collectionName }) => collectionName),
+        failureReason: sanitizeLogValue(error instanceof Error ? error.message : error),
+      });
+    }
+    const postApplyPlan = planCanonicalMongoValidators(
+      CANONICAL_MONGO_VALIDATORS,
+      postApplyCurrent,
+    );
+    const remainingWrites = postApplyPlan.filter((item) => item.action !== 'noop');
+    if (remainingWrites.length > 0) {
+      throw new CanonicalMongoValidatorVerificationError({
+        appliedCollections: applied.map(({ collectionName }) => collectionName),
+        failureReason: `MongoDB still reports ${remainingWrites.length} validator write plan(s)`,
+        remainingCollections: remainingWrites.map(({ collectionName }) => collectionName),
+      });
+    }
+
+    return {
+      ...currentReport,
+      mode: 'apply',
+      applied,
+      postApplyPlan,
+    };
+  } finally {
+    await client.close();
+  }
+}
+
+export function readCanonicalMongoValidatorArtifact(target: string): unknown {
+  const safeTarget = resolveSafeJsonReportOutputPath(target, '--apply-from');
+  return JSON.parse(fs.readFileSync(safeTarget, 'utf8')) as unknown;
+}
+
+export function writeCanonicalMongoValidatorReport(
+  report: CanonicalMongoValidatorReport,
+  target: string | undefined,
+): void {
+  if (!target) return;
+  const safeTarget = resolveSafeJsonReportOutputPath(target);
+  fs.writeFileSync(safeTarget, `${JSON.stringify(report, null, 2)}\n`);
+}
+
+function pathsReferToSameFile(left: string, right: string): boolean {
+  const resolvedLeft = path.resolve(left);
+  const resolvedRight = path.resolve(right);
+  if (resolvedLeft === resolvedRight) return true;
+
+  try {
+    return fs.realpathSync(resolvedLeft) === fs.realpathSync(resolvedRight);
+  } catch {
+    return false;
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseCanonicalMongoValidatorArgs(process.argv.slice(2));
+  if (args.output) {
+    resolveSafeJsonReportOutputPath(args.output);
+  }
+  if (args.applyFrom) {
+    resolveSafeJsonReportOutputPath(args.applyFrom, '--apply-from');
+  }
+  if (args.applyFrom && args.output && pathsReferToSameFile(args.applyFrom, args.output)) {
+    throw new Error('--output must not overwrite the reviewed --apply-from artifact.');
+  }
+
+  const mongoUrl = process.env.MONGODBURL;
+  if (!mongoUrl) {
+    throw new Error('MONGODBURL is required');
+  }
+  const reviewedArtifact = args.applyFrom
+    ? readCanonicalMongoValidatorArtifact(args.applyFrom)
+    : undefined;
+  const report = await runCanonicalMongoValidators(args, mongoUrl, {
+    reviewedArtifact,
+  });
+  console.log(JSON.stringify(report, null, 2));
+  writeCanonicalMongoValidatorReport(report, args.output);
+}
+
+const isDirectRun = process.argv[1]
+  ? fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+  : false;
+
+if (isDirectRun) {
+  main().catch((error) => {
+    console.error(sanitizeLogValue(error));
+    process.exitCode = 1;
+  });
+}

--- a/server/src/scripts/canonicalMongoValidators.ts
+++ b/server/src/scripts/canonicalMongoValidators.ts
@@ -401,6 +401,30 @@ export function assertReviewedCanonicalMongoValidatorPlan(
   }
 }
 
+async function closeValidatorMongoClient(
+  client: ValidatorMongoClient,
+  failed: boolean,
+  primaryError: unknown,
+): Promise<void> {
+  try {
+    await client.close();
+  } catch (closeError) {
+    if (!failed) throw closeError;
+
+    const closeFailureReason = sanitizeLogValue(
+      closeError instanceof Error ? closeError.message : closeError,
+    );
+    if (primaryError instanceof Error) {
+      primaryError.message = `${primaryError.message}. MongoDB client cleanup also failed: ${closeFailureReason}`;
+      return;
+    }
+    throw new AggregateError(
+      [primaryError, closeError],
+      `Canonical MongoDB validator operation and client cleanup both failed: ${closeFailureReason}`,
+    );
+  }
+}
+
 export async function runCanonicalMongoValidators(
   args: CanonicalMongoValidatorArgs,
   mongoUrl: string,
@@ -501,23 +525,7 @@ export async function runCanonicalMongoValidators(
     primaryError = error;
     throw error;
   } finally {
-    try {
-      await client.close();
-    } catch (closeError) {
-      if (!failed) throw closeError;
-
-      const closeFailureReason = sanitizeLogValue(
-        closeError instanceof Error ? closeError.message : closeError,
-      );
-      if (primaryError instanceof Error) {
-        primaryError.message = `${primaryError.message}. MongoDB client cleanup also failed: ${closeFailureReason}`;
-      } else {
-        throw new AggregateError(
-          [primaryError, closeError],
-          `Canonical MongoDB validator operation and client cleanup both failed: ${closeFailureReason}`,
-        );
-      }
-    }
+    await closeValidatorMongoClient(client, failed, primaryError);
   }
 }
 

--- a/server/src/scripts/canonicalMongoValidatorsCore.ts
+++ b/server/src/scripts/canonicalMongoValidatorsCore.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import {
   canonicalSchemaVersionBsonProperty,
   defineCanonicalSchemaVersion,
@@ -51,6 +52,12 @@ export interface CanonicalMongoValidatorPlanItem {
   action: CanonicalMongoValidatorPlanAction;
   reasons: CanonicalMongoValidatorPlanReason[];
   command?: Record<string, unknown>;
+}
+
+export interface CanonicalMongoValidatorRollbackItem {
+  collectionName: string;
+  reason: 'restore-previous-validation' | 'disable-created-collection-validator';
+  command: Record<string, unknown>;
 }
 
 const MONGO_COLLECTION_NAME_PATTERN = /^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$/;
@@ -128,8 +135,14 @@ function stableValue(value: unknown): unknown {
   );
 }
 
-function valuesEqual(left: unknown, right: unknown): boolean {
+export function canonicalMongoValidatorValuesEqual(left: unknown, right: unknown): boolean {
   return JSON.stringify(stableValue(left)) === JSON.stringify(stableValue(right));
+}
+
+export function canonicalMongoValidatorFingerprint(value: unknown): string {
+  return createHash('sha256')
+    .update(JSON.stringify(stableValue(value)))
+    .digest('hex');
 }
 
 function indexCurrentCollections(
@@ -184,7 +197,7 @@ export function planCanonicalMongoValidators(
     }
 
     const reasons: CanonicalMongoValidatorPlanReason[] = [];
-    if (!valuesEqual(current.validator, desired.validator)) {
+    if (!canonicalMongoValidatorValuesEqual(current.validator, desired.validator)) {
       reasons.push('validator-drift');
     }
     if (current.validationLevel !== desired.validationLevel) {
@@ -213,5 +226,70 @@ export function planCanonicalMongoValidators(
         validationAction: desired.validationAction,
       },
     };
+  });
+}
+
+function previousValidationLevel(current: CurrentMongoCollectionValidation): string {
+  if (
+    current.validationLevel === 'strict' ||
+    current.validationLevel === 'moderate' ||
+    current.validationLevel === 'off'
+  ) {
+    return current.validationLevel;
+  }
+  return 'strict';
+}
+
+function previousValidationAction(current: CurrentMongoCollectionValidation): string {
+  return current.validationAction === 'warn' || current.validationAction === 'error'
+    ? current.validationAction
+    : 'error';
+}
+
+export function buildCanonicalMongoValidatorRollbackPlan(
+  plan: readonly CanonicalMongoValidatorPlanItem[],
+  currentCollections: readonly CurrentMongoCollectionValidation[],
+): CanonicalMongoValidatorRollbackItem[] {
+  const currentByName = new Map(
+    currentCollections.map((current) => [current.collectionName, current] as const),
+  );
+
+  return plan.flatMap((item): CanonicalMongoValidatorRollbackItem[] => {
+    if (item.action === 'noop') return [];
+
+    const current = currentByName.get(item.collectionName);
+    if (item.action === 'createCollection') {
+      return [
+        {
+          collectionName: item.collectionName,
+          reason: 'disable-created-collection-validator',
+          command: {
+            collMod: item.collectionName,
+            validator: {},
+            validationLevel: 'off',
+            validationAction: 'error',
+          },
+        },
+      ];
+    }
+
+    if (!current?.exists) {
+      throw new Error(
+        `Missing current validation state for collMod rollback: ${item.collectionName}`,
+      );
+    }
+
+    return [
+      {
+        collectionName: item.collectionName,
+        reason: 'restore-previous-validation',
+        command: {
+          collMod: item.collectionName,
+          validator: structuredClone(current.validator ?? {}),
+          validationLevel: previousValidationLevel(current),
+          validationAction: previousValidationAction(current),
+        },
+      },
+    ];
   });
 }

--- a/server/src/scripts/operatorDatabaseEnvironment.ts
+++ b/server/src/scripts/operatorDatabaseEnvironment.ts
@@ -1,0 +1,75 @@
+export type OperatorDatabaseEnvironment =
+  | 'development'
+  | 'beta'
+  | 'production-copy'
+  | 'production'
+  | 'test';
+
+const OPERATOR_DATABASE_NAMES: Record<
+  Exclude<OperatorDatabaseEnvironment, 'test'>,
+  ReadonlySet<string>
+> = {
+  development: new Set(['development']),
+  beta: new Set(['beta']),
+  'production-copy': new Set(['productioncopy']),
+  production: new Set(['production']),
+};
+
+export function parseOperatorDatabaseEnvironment(
+  value: string | undefined,
+  flag = '--environment',
+): OperatorDatabaseEnvironment {
+  if (
+    value === 'development' ||
+    value === 'beta' ||
+    value === 'production-copy' ||
+    value === 'production' ||
+    value === 'test'
+  ) {
+    return value;
+  }
+
+  throw new Error(`${flag} requires development, beta, production-copy, production, or test`);
+}
+
+export function databaseNameFromMongoUrl(mongoUrl: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(mongoUrl);
+  } catch {
+    throw new Error('MONGODBURL must be a valid MongoDB URL with an explicit database name.');
+  }
+
+  if (parsed.protocol !== 'mongodb:' && parsed.protocol !== 'mongodb+srv:') {
+    throw new Error('MONGODBURL must use the mongodb or mongodb+srv protocol.');
+  }
+
+  let databaseName: string;
+  try {
+    databaseName = decodeURIComponent(parsed.pathname.slice(1).split('/')[0] ?? '').trim();
+  } catch {
+    throw new Error('MONGODBURL contains an invalid encoded database name.');
+  }
+  if (!databaseName) {
+    throw new Error('MONGODBURL must include an explicit database name.');
+  }
+  return databaseName;
+}
+
+export function assertOperatorEnvironmentMatchesDatabase(
+  environment: OperatorDatabaseEnvironment,
+  databaseName: string,
+): void {
+  const lowerDatabaseName = databaseName.trim().toLowerCase();
+  const normalizedDatabaseName = lowerDatabaseName.replace(/[-_]/g, '');
+  const matches =
+    environment === 'test'
+      ? lowerDatabaseName === 'test' || /[-_]test$/.test(lowerDatabaseName)
+      : OPERATOR_DATABASE_NAMES[environment].has(normalizedDatabaseName);
+
+  if (!matches) {
+    throw new Error(
+      `Operator environment ${environment} does not match MongoDB database ${databaseName || '(missing)'}`,
+    );
+  }
+}

--- a/server/src/scripts/researchModelInventory.ts
+++ b/server/src/scripts/researchModelInventory.ts
@@ -18,6 +18,7 @@ import { MongoClient, ObjectId, type Db } from 'mongodb';
 import { summarizeMongoUrl } from '../scrapers/scraperEnvironment';
 import { resolveSafeJsonReportOutputPath } from './scriptWriteGuards';
 import { sanitizeLogValue } from '../utils/logSanitizer';
+import { databaseNameFromMongoUrl } from './operatorDatabaseEnvironment';
 import {
   INVENTORY_COLLECTIONS,
   REFERENCE_EDGES,
@@ -391,9 +392,7 @@ export async function runResearchModelInventory(
   mongoUrl: string,
   client: InventoryMongoClient = new MongoClient(mongoUrl),
 ): Promise<ReturnType<typeof buildResearchModelInventoryOutput>> {
-  const configuredDatabaseName = decodeURIComponent(
-    new URL(mongoUrl).pathname.slice(1).split('/')[0],
-  );
+  const configuredDatabaseName = databaseNameFromMongoUrl(mongoUrl);
   assertInventoryEnvironmentMatchesDatabase(args.environment, configuredDatabaseName);
 
   try {

--- a/server/src/scripts/researchModelInventoryCore.ts
+++ b/server/src/scripts/researchModelInventoryCore.ts
@@ -8,6 +8,10 @@
  * reference-integrity orphans. Keeping the shaping here means it can be unit
  * tested without a database, matching the other audit scripts in this folder.
  */
+import {
+  assertOperatorEnvironmentMatchesDatabase,
+  type OperatorDatabaseEnvironment,
+} from './operatorDatabaseEnvironment';
 
 export type InventoryGroup =
   | 'canonical-domain'
@@ -51,35 +55,15 @@ export interface ReferenceEdge {
   meaning: string;
 }
 
-export type InventoryEnvironment =
-  | 'development'
-  | 'beta'
-  | 'production-copy'
-  | 'production'
-  | 'test';
-
-const INVENTORY_DATABASE_NAMES: Record<
-  Exclude<InventoryEnvironment, 'test'>,
-  ReadonlySet<string>
-> = {
-  development: new Set(['development']),
-  beta: new Set(['beta']),
-  'production-copy': new Set(['productioncopy']),
-  production: new Set(['production']),
-};
+export type InventoryEnvironment = OperatorDatabaseEnvironment;
 
 export function assertInventoryEnvironmentMatchesDatabase(
   environment: InventoryEnvironment,
   databaseName: string,
 ): void {
-  const lowerDatabaseName = databaseName.trim().toLowerCase();
-  const normalizedDatabaseName = lowerDatabaseName.replace(/[-_]/g, '');
-  const matches =
-    environment === 'test'
-      ? lowerDatabaseName === 'test' || /[-_]test$/.test(lowerDatabaseName)
-      : INVENTORY_DATABASE_NAMES[environment].has(normalizedDatabaseName);
-
-  if (!matches) {
+  try {
+    assertOperatorEnvironmentMatchesDatabase(environment, databaseName);
+  } catch {
     throw new Error(
       `Inventory environment ${environment} does not match MongoDB database ${databaseName || '(missing)'}`,
     );


### PR DESCRIPTION
## Intent

Complete issue #216 by turning the pure canonical MongoDB validator planner into a migration-safe operator workflow. The command must use an explicit fixed registry derived from the nine Phase 1 canonical model contracts, default to a read-only deterministic dry run, validate both configured and connected environment targets, and require an environment-bound confirmation plus an unchanged reviewed artifact before applying any createCollection or collMod command. It must ignore unrelated collections, fail closed on views and time-series targets, use moderate/error during migration, apply sequentially with actionable partial-failure reporting, verify idempotency afterward, and provide exact rollback commands without automatically dropping collections. It must remain a local operator command only, never run in application startup, scraper execution, Render, deployment hooks, or schedules, and document the Development, Beta, and Production review, backup, apply, verification, and recovery workflow. Preserve the deliberate nontransactional, fixed-registry design and open a PR to Beta linked to issue #216.

## What Changed

- Add a fixed nine-collection validator registry and deterministic dry-run planning for canonical MongoDB models.
- Add a guarded operator workflow with environment validation, reviewed-artifact confirmation, sequential application, partial-failure reporting, post-apply verification, and non-dropping rollback commands.
- Document the Development, Beta, and Production review, backup, application, verification, and recovery procedures.

## Risk Assessment

✅ Low: The follow-up preserves the primary operator error and its partial-apply details when cleanup also fails, and the cumulative change satisfies the source-verifiable acceptance criteria without additional material issues.

## Testing

After installing locked worktree dependencies, all focused validator tests passed and an operator-level transcript demonstrated the complete dry-run, guarded sequential apply, partial-failure recovery, rollback-plan, and idempotency workflow. No visual artifact was captured because this is a local CLI-only change with no rendered UI.

<details>
<summary>Evidence: Canonical validator operator workflow evidence</summary>

```text
{
  "dryRun": {
    "mode": "dry-run",
    "target": "localhost/development",
    "desiredCollections": [
      "accounts",
      "evidence_claims",
      "org_units",
      "people",
      "research_plans",
      "review_decisions",
      "role_assignments",
      "source_documents",
      "taxonomy_terms"
    ],
    "summary": {
      "desiredCollections": 9,
      "createCollection": 9,
      "collMod": 0,
      "noop": 0,
      "writesPlanned": 9
    },
    "commandsExecuted": 0,
    "unrelatedCollectionPlanned": false,
    "validationModes": [
      "moderate/error"
    ],
    "rollbackCommands": [
      {
        "collMod": "accounts",
        "validator": {},
        "validationLevel": "off",
        "validationAction": "error"
      },
      {
        "collMod": "evidence_claims",
        "validator": {},
        "validationLevel": "off",
        "validationAction": "error"
      },
      {
        "collMod": "org_units",
        "validator": {},
        "validationLevel": "off",
        "validationAction": "error"
      },
      {
        "collMod": "people",
        "validator": {},
        "validationLevel": "off",
        "validationAction": "error"
      },
      {
        "collMod": "research_plans",
        "validator": {},
        "validationLevel": "off",
        "validationAction": "error"
      },
      {
        "collMod": "review_decisions",
        "validator": {},
        "validationLevel": "off",
        "validationAction": "error"
      },
      {
        "collMod": "role_assignments",
        "validator": {},
        "validationLevel": "off",
        "validationAction": "error"
      },
      {
        "collMod": "source_documents",
        "validator": {},
        "validationLevel": "off",
        "validationAction": "error"
      },
      {
        "collMod": "taxonomy_terms",
        "validator": {},
        "validationLevel": "off",
        "validationAction": "error"
      }
    ]
  },
  "partialFailure": {
    "message": "Canonical validator apply stopped at evidence_claims: simulated operator evidence failure. Applied: accounts. Unattempted: org_units, people, research_plans, review_decisions, role_assignments, source_documents, taxonomy_terms. Generate a fresh dry-run before retrying.",
    "appliedCollections": [
      "accounts"
    ],
    "failedCollection": "evidence_claims",
    "unattemptedCollections": [
      "org_units",
      "people",
      "research_plans",
      "review_decisions",
      "role_assignments",
      "source_documents",
      "taxonomy_terms"
    ]
  },
  "retryApply": {
    "applied": [
      {
        "collectionName": "evidence_claims",
        "action": "createCollection"
      },
      {
        "collectionName": "org_units",
        "action": "createCollection"
      },
      {
        "collectionName": "people",
        "action": "createCollection"
      },
      {
        "collectionName": "research_plans",
        "action": "createCollection"
      },
      {
        "collectionName": "review_decisions",
        "action": "createCollection"
      },
      {
        "collectionName": "role_assignments",
        "action": "createCollection"
      },
      {
        "collectionName": "source_documents",
        "action": "createCollection"
      },
      {
        "collectionName": "taxonomy_terms",
        "action": "createCollection"
      }
    ],
    "postApplyActions": [
      "noop"
    ]
  },
  "idempotency": {
    "desiredCollections": 9,
    "createCollection": 0,
    "collMod": 0,
    "noop": 9,
    "writesPlanned": 0
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `server/src/scripts/canonicalMongoValidators.ts:498` - The required &#34;apply sequentially with actionable partial-failure reporting&#34; guarantee is not durable here. If a command fails and `client.close()` also rejects, the `finally` rejection replaces `CanonicalMongoValidatorApplyError`, hiding the applied, failed, and unattempted collection lists. Preserve the primary apply or verification error and report any close failure secondarily.

🔧 Fix: Preserve validator errors when client cleanup fails
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `yarn --cwd server test src/scripts/__tests__/canonicalMongoValidatorRegistry.test.ts src/scripts/__tests__/canonicalMongoValidatorsCore.test.ts src/scripts/__tests__/canonicalMongoValidators.test.ts`
- `yarn --cwd server tsx /tmp/no-mistakes-evidence/01KYGMSZ4C5JSGCP8PG0ETHJ83/validator-workflow-evidence.ts`
- `Manually exercised a simulated operator sequence covering read-only dry run, the fixed nine-collection registry, unrelated-collection exclusion, credential-redacted target reporting, moderate/error commands, non-dropping rollback commands, actionable partial failure, fresh reviewed retry, post-apply verification, and zero-write idempotent rerun.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
