### PR TITLE
feat(server): add bounded canonical readers and public projections

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -18,6 +18,9 @@ React (Vite) → Express (Passport.js) → MongoDB Atlas + Meilisearch
 
 The server follows: **Routes → Middleware → Controllers → Services → Models**
 
+Phase 1 canonical readers are isolated in `server/src/services/canonicalDomainLoaders.ts`, and their bounded public DTO contracts are in `server/src/services/canonicalPublicProjections.ts`.
+They intentionally do not power live REST routes or Meilisearch until the vertical cutover phases replace the corresponding legacy readers.
+
 ### Tech Stack
 
 | Layer           | Technology                                                                                       |

--- a/docs/research-model-refactor.md
+++ b/docs/research-model-refactor.md
@@ -208,7 +208,8 @@ They must not silently create new canonical taxonomy terms.
 #### Phase 1 identity and reference schema boundary
 
 The versioned `Account`, `Person`, `RoleAssignment`, `OrgUnit`, and `TaxonomyTerm` schemas are registered in `server/src/models/` with explicit `accounts`, `people`, `role_assignments`, `org_units`, and `taxonomy_terms` collection names.
-They currently coexist empty with legacy runtime collections and have no application readers, writers, routes, migrations, startup hooks, or Meilisearch projections.
+They currently coexist empty with legacy runtime collections and have no live route consumers, writers, migrations, startup hooks, or Meilisearch projections.
+The isolated Phase 1 readers and projections are documented in [`research-model.md`](./research-model.md#phase-1-bounded-canonical-read-contracts).
 
 `Account` contains CAS identity and lifecycle state but no person pointer or role array.
 `AdminGrant` remains the source of admin authority, research roles belong to `RoleAssignment`, and `Person.accountId` is the only optional account-person relationship.
@@ -262,13 +263,9 @@ type ResearchEntity = {
 
 The `discovery` object is a bounded computed projection for read-heavy research cards and search indexing.
 It is not a second source of truth.
-The reusable projection contract caps leads at eight records, text fields at 120 characters, active-opportunity counts at 9,999, and browse-rank scores to the supported numeric range.
 `accessState` remains bounded text in Phase 1 because the accepted target declares it as a string and no governed canonical access-summary vocabulary exists yet.
 The later vertical cutover must govern that vocabulary before it becomes a public filter or search facet instead of introducing a competing classification here.
-Every successful canonical materializer commit or moderated canonical write that changes a discovery input must recompute each affected entity after the authoritative records commit.
-A reconciliation pass must run at least every six hours as the missed-invalidation repair path, and a projection older than 24 hours is stale and must not be treated as current.
-Projection construction rejects future `computedAt` values, while readers still classify previously persisted future-dated summaries as invalid and requiring recomputation.
-Missing and stale projections also require recomputation.
+The authoritative bounds, invalidation triggers, reconciliation interval, and staleness behavior are documented in [`research-model.md`](./research-model.md#phase-1-bounded-canonical-read-contracts).
 Full roles, pathways, signals, routes, and evidence remain first-class records.
 
 Legacy fields such as `kind`, duplicate description fields, `acceptingUndergrads`, `openness`, `acceptanceConfidence`, embedded openness signals, and legacy research-group references must be retired after canonical reads cut over.
@@ -616,8 +613,7 @@ REST remains appropriate for the current bounded student experiences:
 
 Services should expose reusable domain loaders and projection functions so a future GraphQL layer could call the same logic.
 Public REST DTOs should remain purpose-built, bounded, contact-safe, and visibility-aware.
-The Phase 1 read contracts live in `canonicalDomainLoaders.ts` and `canonicalPublicProjections.ts`.
-They are not connected to current REST routes or Meilisearch during Phase 1.
+The Phase 1 implementation and cutover boundary are documented in [`research-model.md`](./research-model.md#phase-1-bounded-canonical-read-contracts).
 
 GraphQL should be reconsidered only if clients need materially different combinations of the graph or operator tools require frequent ad hoc traversal.
 A future GraphQL layer would require field-level authorization, query-cost limits, batching, persisted-query or caching policy, and strict protection against arbitrary evidence traversal.

--- a/docs/research-model-refactor.md
+++ b/docs/research-model-refactor.md
@@ -262,7 +262,13 @@ type ResearchEntity = {
 
 The `discovery` object is a bounded computed projection for read-heavy research cards and search indexing.
 It is not a second source of truth.
-Lead arrays and other embedded summaries must have explicit product bounds.
+The reusable projection contract caps leads at eight records, text fields at 120 characters, active-opportunity counts at 9,999, and browse-rank scores to the supported numeric range.
+`accessState` remains bounded text in Phase 1 because the accepted target declares it as a string and no governed canonical access-summary vocabulary exists yet.
+The later vertical cutover must govern that vocabulary before it becomes a public filter or search facet instead of introducing a competing classification here.
+Every successful canonical materializer commit or moderated canonical write that changes a discovery input must recompute each affected entity after the authoritative records commit.
+A reconciliation pass must run at least every six hours as the missed-invalidation repair path, and a projection older than 24 hours is stale and must not be treated as current.
+Projection construction rejects future `computedAt` values, while readers still classify previously persisted future-dated summaries as invalid and requiring recomputation.
+Missing and stale projections also require recomputation.
 Full roles, pathways, signals, routes, and evidence remain first-class records.
 
 Legacy fields such as `kind`, duplicate description fields, `acceptingUndergrads`, `openness`, `acceptanceConfidence`, embedded openness signals, and legacy research-group references must be retired after canonical reads cut over.
@@ -610,6 +616,8 @@ REST remains appropriate for the current bounded student experiences:
 
 Services should expose reusable domain loaders and projection functions so a future GraphQL layer could call the same logic.
 Public REST DTOs should remain purpose-built, bounded, contact-safe, and visibility-aware.
+The Phase 1 read contracts live in `canonicalDomainLoaders.ts` and `canonicalPublicProjections.ts`.
+They are not connected to current REST routes or Meilisearch during Phase 1.
 
 GraphQL should be reconsidered only if clients need materially different combinations of the graph or operator tools require frequent ad hoc traversal.
 A future GraphQL layer would require field-level authorization, query-cost limits, batching, persisted-query or caching policy, and strict protection against arbitrary evidence traversal.

--- a/docs/research-model.md
+++ b/docs/research-model.md
@@ -558,6 +558,27 @@ A later decision may point backward to one decision it supersedes, while the ori
 These collections may coexist empty with the current runtime.
 No current scraper or public read path should write or consume them until a later cutover phase adds reconciliation and explicit operational gates.
 
+### Phase 1 bounded canonical read contracts
+
+[`canonicalDomainLoaders.ts`](../server/src/services/canonicalDomainLoaders.ts) defines reusable, read-only loaders for public person identity, current approved roles, active organizations, approved taxonomy terms, public evidence metadata, and account-owned research plans.
+Every batch is capped at 100 identifiers or results, accepts only primitive or real `ObjectId` identifiers, selects an explicit field list, and preserves the owning account boundary for research plans.
+The default research-plan read excludes private notes, checklists, and deadlines, and selecting those fields requires an explicit owner-scoped request.
+
+[`canonicalPublicProjections.ts`](../server/src/services/canonicalPublicProjections.ts) defines the only Phase 1 public `Person` projection, bounded public evidence metadata, and the bounded `ResearchEntity.discovery` projection.
+The public person projection includes a selected reviewed primary profile and at most two reviewed researcher-profile links whose health is not known to be unavailable.
+It omits account links, identifiers without reviewed public links, direct contact data, mirrored profile fields, and unavailable or future-verified candidates.
+An `UNKNOWN` person requires a current approved role to render, while `DEPARTED` always fails closed even if a stale role remains current.
+Public evidence projection omits claim values, excerpts, source-document references, raw source documents, review notes, rejected claims, and diagnostics.
+
+`ResearchEntity.discovery` contains no more than eight deduplicated leads, 120-character summary fields, an active-opportunity count capped at 9,999, a bounded browse-rank score, a controlled visibility state, and `computedAt`.
+It is a rebuildable cache, not canonical evidence.
+`accessState` remains bounded text in Phase 1 because the accepted model has not established a governed access-summary vocabulary.
+The later runtime cutover must govern it before using it as a filter or facet.
+Every successful canonical materializer commit or moderated canonical write that changes an input must recompute affected entities after the authoritative write commits.
+A reconciliation pass must run at least every six hours to repair missed invalidations, projection construction rejects future timestamps, and readers require recomputation for missing, previously persisted future-dated, or more-than-24-hour-old projections.
+
+These loaders and projections are not wired to live REST routes, Meilisearch, materializer writes, or migration code in Phase 1.
+
 Current physical strategy: hard-pivot to physical `research_entities` and canonical dependent collections. Development has copied and dropped `research_groups`, `research_group_members`, `research_group_stats`, `paper_group_links`, and leftover `applications` after verified parity. Runtime paper activity now uses `research_scholarly_links` and `research_scholarly_attributions`; empty stats and paper-entity-link collections are not part of the launch copy set.
 
 The remaining end-to-end work is tracked in [`docs/tasks/priority-roadmap.md`](./tasks/priority-roadmap.md), including Beta seed, Pathway Meili relevance review, source blocker resolution, production scraper rollout, opportunity detail polish, data-quality operations, post-Beta legacy cleanup, and saved/advising workflow expansion.

--- a/server/src/services/__tests__/canonicalDomainLoaders.test.ts
+++ b/server/src/services/__tests__/canonicalDomainLoaders.test.ts
@@ -1,0 +1,274 @@
+import mongoose from 'mongoose';
+import { describe, expect, it } from 'vitest';
+import {
+  CANONICAL_ORG_UNIT_READ_FIELDS,
+  CANONICAL_PERSON_READ_FIELDS,
+  CANONICAL_PUBLIC_EVIDENCE_READ_FIELDS,
+  CANONICAL_RESEARCH_PLAN_READ_FIELDS,
+  CANONICAL_ROLE_READ_FIELDS,
+  CANONICAL_TAXONOMY_READ_FIELDS,
+  CanonicalReadAuthorizationError,
+  MAX_CANONICAL_LOADER_IDS,
+  createCanonicalDomainLoaders,
+  type CanonicalReadModel,
+  type CanonicalReadModels,
+} from '../canonicalDomainLoaders';
+
+interface QueryCall {
+  filter: Record<string, unknown>;
+  fields?: string;
+  sort?: Record<string, 1 | -1>;
+  limit?: number;
+}
+
+function fakeModel(rows: Record<string, unknown>[] = []): {
+  model: CanonicalReadModel;
+  calls: QueryCall[];
+} {
+  const calls: QueryCall[] = [];
+  const model: CanonicalReadModel = {
+    find(filter) {
+      const call: QueryCall = { filter };
+      calls.push(call);
+      const query = {
+        select(fields: string) {
+          call.fields = fields;
+          return query;
+        },
+        sort(sort: Record<string, 1 | -1>) {
+          call.sort = sort;
+          return query;
+        },
+        limit(limit: number) {
+          call.limit = limit;
+          return query;
+        },
+        lean() {
+          return query;
+        },
+        async exec() {
+          return rows;
+        },
+      };
+      return query;
+    },
+  };
+  return { model, calls };
+}
+
+function fixture() {
+  const EvidenceClaim = fakeModel([{ predicate: 'ENTITY_HAS_DESCRIPTION' }]);
+  const OrgUnit = fakeModel([{ name: 'Computer Science' }]);
+  const Person = fakeModel([{ displayName: 'Grace Hopper' }]);
+  const ResearchPlan = fakeModel([{ stage: 'SAVED' }]);
+  const RoleAssignment = fakeModel([{ role: 'PI' }]);
+  const TaxonomyTerm = fakeModel([{ label: 'Machine Learning' }]);
+  const models: CanonicalReadModels = {
+    EvidenceClaim: EvidenceClaim.model,
+    OrgUnit: OrgUnit.model,
+    Person: Person.model,
+    ResearchPlan: ResearchPlan.model,
+    RoleAssignment: RoleAssignment.model,
+    TaxonomyTerm: TaxonomyTerm.model,
+  };
+  return {
+    loaders: createCanonicalDomainLoaders(models),
+    EvidenceClaim,
+    OrgUnit,
+    Person,
+    ResearchPlan,
+    RoleAssignment,
+    TaxonomyTerm,
+  };
+}
+
+const ids = {
+  account: new mongoose.Types.ObjectId('507f191e810c19729de86001'),
+  otherAccount: new mongoose.Types.ObjectId('507f191e810c19729de86002'),
+  person: new mongoose.Types.ObjectId('507f191e810c19729de86003'),
+  entity: new mongoose.Types.ObjectId('507f191e810c19729de86004'),
+  orgUnit: new mongoose.Types.ObjectId('507f191e810c19729de86005'),
+  taxonomy: new mongoose.Types.ObjectId('507f191e810c19729de86006'),
+};
+
+describe('canonical domain loaders', () => {
+  it('loads only public person identity fields and rejects object-shaped id coercion', async () => {
+    const { loaders, Person } = fixture();
+
+    await expect(loaders.loadPublicPeopleByIds([ids.person.toHexString()])).resolves.toEqual([
+      { displayName: 'Grace Hopper' },
+    ]);
+    expect(Person.calls[0]).toMatchObject({
+      filter: {
+        _id: { $in: [ids.person] },
+        archived: false,
+        status: { $in: ['ACTIVE', 'UNKNOWN'] },
+      },
+      fields: CANONICAL_PERSON_READ_FIELDS,
+      limit: 1,
+    });
+    expect(Person.calls[0].fields).not.toMatch(/accountId|identifiers/);
+
+    await expect(
+      loaders.loadPublicPeopleByIds([
+        {
+          toString: () => ids.person.toHexString(),
+        } as unknown as string,
+      ]),
+    ).rejects.toThrow(/valid ObjectId/);
+  });
+
+  it('deduplicates ids and rejects loader fan-out above the explicit bound', async () => {
+    const { loaders, OrgUnit } = fixture();
+
+    await loaders.loadActiveOrgUnitsByIds([ids.orgUnit, ids.orgUnit.toHexString()]);
+    expect(OrgUnit.calls[0].limit).toBe(1);
+    expect((OrgUnit.calls[0].filter._id as { $in: unknown[] }).$in).toHaveLength(1);
+
+    await expect(
+      loaders.loadActiveOrgUnitsByIds(
+        Array.from({ length: MAX_CANONICAL_LOADER_IDS + 1 }, () => ids.orgUnit),
+      ),
+    ).rejects.toThrow(`at most ${MAX_CANONICAL_LOADER_IDS}`);
+  });
+
+  it('loads only approved current non-archived roles for explicit canonical targets', async () => {
+    const { loaders, RoleAssignment } = fixture();
+
+    await loaders.loadCurrentApprovedRolesForTargets([
+      { kind: 'RESEARCH_ENTITY', id: ids.entity },
+      { kind: 'RESEARCH_ENTITY', id: ids.entity.toHexString() },
+    ]);
+
+    expect(RoleAssignment.calls[0]).toMatchObject({
+      filter: {
+        $or: [
+          {
+            'target.kind': 'RESEARCH_ENTITY',
+            'target.id': ids.entity,
+          },
+        ],
+        state: 'CURRENT',
+        reviewStatus: 'APPROVED',
+        archived: false,
+        endedAt: { $exists: false },
+      },
+      fields: CANONICAL_ROLE_READ_FIELDS,
+    });
+    expect(RoleAssignment.calls[0].fields).not.toMatch(/evidenceClaimIds|confidence/);
+  });
+
+  it('loads active organizations and approved taxonomy terms with bounded reference aliases', async () => {
+    const { loaders, OrgUnit, TaxonomyTerm } = fixture();
+
+    await loaders.loadActiveOrgUnitsByIds([ids.orgUnit]);
+    await loaders.loadApprovedTaxonomyTermsByIds([ids.taxonomy]);
+
+    expect(OrgUnit.calls[0]).toMatchObject({
+      filter: {
+        _id: { $in: [ids.orgUnit] },
+        status: 'ACTIVE',
+        archived: false,
+      },
+      fields: CANONICAL_ORG_UNIT_READ_FIELDS,
+    });
+    expect(TaxonomyTerm.calls[0]).toMatchObject({
+      filter: {
+        _id: { $in: [ids.taxonomy] },
+        reviewStatus: 'APPROVED',
+        status: 'ACTIVE',
+        archived: false,
+      },
+      fields: CANONICAL_TAXONOMY_READ_FIELDS,
+    });
+    expect(OrgUnit.calls[0].fields).toContain('aliases');
+    expect(TaxonomyTerm.calls[0].fields).toContain('aliases');
+  });
+
+  it('loads only active public claim metadata without protected values or source documents', async () => {
+    const { loaders, EvidenceClaim } = fixture();
+    const before = new Date();
+
+    await loaders.loadPublicEvidenceForSubjects([{ kind: 'RESEARCH_ENTITY', id: ids.entity }]);
+
+    expect(EvidenceClaim.calls[0].filter).toMatchObject({
+      $or: [
+        {
+          'subject.kind': 'RESEARCH_ENTITY',
+          'subject.id': ids.entity,
+        },
+      ],
+      sensitivity: 'PUBLIC',
+      status: 'ACTIVE',
+    });
+    const observedAt = EvidenceClaim.calls[0].filter.observedAt as { $lte: Date };
+    expect(observedAt.$lte.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    expect(EvidenceClaim.calls[0]).toMatchObject({
+      fields: CANONICAL_PUBLIC_EVIDENCE_READ_FIELDS,
+      sort: { observedAt: -1, _id: 1 },
+    });
+    expect(EvidenceClaim.calls[0].fields).not.toMatch(
+      /value|excerpt|sourceDocumentId|supersededByClaimId/,
+    );
+  });
+
+  it('requires account ownership before any research-plan query', async () => {
+    const { loaders, ResearchPlan } = fixture();
+
+    await expect(
+      loaders.loadOwnedResearchPlans({
+        requesterAccountId: ids.account,
+        ownerAccountId: ids.otherAccount,
+      }),
+    ).rejects.toBeInstanceOf(CanonicalReadAuthorizationError);
+    expect(ResearchPlan.calls).toHaveLength(0);
+  });
+
+  it('scopes research plans to the owner and selects private fields only when explicit', async () => {
+    const { loaders, ResearchPlan } = fixture();
+
+    await loaders.loadOwnedResearchPlans({
+      requesterAccountId: ids.account,
+      ownerAccountId: ids.account.toHexString(),
+      target: {
+        kind: 'RESEARCH_ENTITY',
+        ids: [ids.entity],
+      },
+      limit: 25,
+    });
+    await loaders.loadOwnedResearchPlans({
+      requesterAccountId: ids.account,
+      ownerAccountId: ids.account,
+      includePrivateFields: true,
+    });
+
+    expect(ResearchPlan.calls[0]).toMatchObject({
+      filter: {
+        accountId: ids.account,
+        archived: false,
+        'target.kind': 'RESEARCH_ENTITY',
+        'target.id': { $in: [ids.entity] },
+      },
+      fields: CANONICAL_RESEARCH_PLAN_READ_FIELDS,
+      sort: { updatedAt: -1, _id: 1 },
+      limit: 25,
+    });
+    expect(ResearchPlan.calls[0].fields).not.toMatch(/privateNotes|checklist|deadlines/);
+    expect(ResearchPlan.calls[1].fields).toBe(
+      `${CANONICAL_RESEARCH_PLAN_READ_FIELDS} +privateNotes +checklist +deadlines`,
+    );
+  });
+
+  it('rejects unbounded plan requests before querying MongoDB', async () => {
+    const { loaders, ResearchPlan } = fixture();
+
+    await expect(
+      loaders.loadOwnedResearchPlans({
+        requesterAccountId: ids.account,
+        ownerAccountId: ids.account,
+        limit: 101,
+      }),
+    ).rejects.toThrow(/limit/);
+    expect(ResearchPlan.calls).toHaveLength(0);
+  });
+});

--- a/server/src/services/__tests__/canonicalPublicProjections.test.ts
+++ b/server/src/services/__tests__/canonicalPublicProjections.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   MAX_PUBLIC_DISCOVERY_LEADS,
   MAX_PUBLIC_DISCOVERY_OPPORTUNITY_COUNT,
+  MAX_PUBLIC_DISCOVERY_TEXT_LENGTH,
   MAX_PUBLIC_EVIDENCE_ITEMS,
   MAX_PUBLIC_PERSON_NAME_LENGTH,
   RESEARCH_ENTITY_DISCOVERY_RECONCILIATION_INTERVAL_MS,
@@ -202,7 +203,8 @@ describe('canonical public projections', () => {
       personId: new mongoose.Types.ObjectId(
         `507f191e810c19729de86${String(200 + index).slice(-3)}`,
       ),
-      displayName: `Lead ${index} lead${index}@yale.edu`,
+      displayName:
+        index === 1 ? `Lead ${index} ${'x'.repeat(200)}` : `Lead ${index} lead${index}@yale.edu`,
       role: 'PI',
       officialProfileUrl:
         index === 0
@@ -234,6 +236,7 @@ describe('canonical public projections', () => {
       officialProfileUrl: 'https://medicine.yale.edu/profile/lead-zero',
     });
     expect(discovery?.leads[1]).not.toHaveProperty('officialProfileUrl');
+    expect(discovery?.leads[1]?.displayName.length).toBe(MAX_PUBLIC_DISCOVERY_TEXT_LENGTH);
     expect(discovery?.leads[0]).not.toHaveProperty('accountId');
     expect(discovery?.leads[0]).not.toHaveProperty('reviewNotes');
     expect(discovery?.accessState).not.toContain('private@yale.edu');

--- a/server/src/services/__tests__/canonicalPublicProjections.test.ts
+++ b/server/src/services/__tests__/canonicalPublicProjections.test.ts
@@ -1,0 +1,330 @@
+import mongoose from 'mongoose';
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_PUBLIC_DISCOVERY_LEADS,
+  MAX_PUBLIC_DISCOVERY_OPPORTUNITY_COUNT,
+  MAX_PUBLIC_EVIDENCE_ITEMS,
+  MAX_PUBLIC_PERSON_NAME_LENGTH,
+  RESEARCH_ENTITY_DISCOVERY_RECONCILIATION_INTERVAL_MS,
+  RESEARCH_ENTITY_DISCOVERY_STALENESS_BOUND_MS,
+  buildResearchEntityDiscoveryProjection,
+  researchEntityDiscoveryFreshness,
+  researchEntityDiscoveryRecomputeTriggers,
+  shouldRecomputeResearchEntityDiscovery,
+  toPublicEvidenceClaimDtos,
+  toPublicPersonDto,
+} from '../canonicalPublicProjections';
+
+const now = new Date('2026-07-27T12:00:00.000Z');
+const personId = new mongoose.Types.ObjectId('507f191e810c19729de86101');
+
+function healthyProfileLink(kind: string, purpose: string, url: string): Record<string, unknown> {
+  return {
+    kind,
+    purpose,
+    url,
+    verifiedAt: new Date('2026-07-20T12:00:00.000Z'),
+    healthStatus: 'HEALTHY',
+  };
+}
+
+describe('canonical public projections', () => {
+  it('selects one primary profile and a bounded researcher-profile array by precedence', () => {
+    const dto = toPublicPersonDto(
+      {
+        _id: personId,
+        displayName: 'Grace Hopper',
+        status: 'ACTIVE',
+        archived: false,
+        accountId: new mongoose.Types.ObjectId(),
+        identifiers: { orcid: '9999-9999-9999-9994' },
+        email: 'private@yale.edu',
+        profileLinks: [
+          healthyProfileLink(
+            'LAB_ABOUT',
+            'PRIMARY_IDENTITY',
+            'https://example.edu/lab/people/grace',
+          ),
+          healthyProfileLink(
+            'YALE_OFFICIAL',
+            'PRIMARY_IDENTITY',
+            'https://engineering.yale.edu/profile/grace',
+          ),
+          healthyProfileLink('ORCID', 'SCHOLARLY', 'https://orcid.org/9999-9999-9999-9994/'),
+          healthyProfileLink(
+            'GOOGLE_SCHOLAR',
+            'SCHOLARLY',
+            'https://scholar.google.com/citations?hl=en&user=abcdefghijkl',
+          ),
+        ],
+      },
+      { now },
+    );
+
+    expect(dto).toEqual({
+      id: personId.toHexString(),
+      displayName: 'Grace Hopper',
+      primaryProfile: {
+        kind: 'YALE_OFFICIAL',
+        label: 'Yale profile',
+        url: 'https://engineering.yale.edu/profile/grace',
+      },
+      researchProfiles: [
+        {
+          kind: 'GOOGLE_SCHOLAR',
+          label: 'Google Scholar',
+          url: 'https://scholar.google.com/citations?user=abcdefghijkl',
+        },
+        {
+          kind: 'ORCID',
+          label: 'ORCID',
+          url: 'https://orcid.org/9999-9999-9999-9994',
+        },
+      ],
+    });
+    expect(dto).not.toHaveProperty('accountId');
+    expect(dto).not.toHaveProperty('identifiers');
+    expect(dto).not.toHaveProperty('email');
+  });
+
+  it('fails closed for departed people and corroborates unknown people with a current role', () => {
+    const unknown = {
+      _id: personId,
+      displayName: 'Unknown Status',
+      status: 'UNKNOWN',
+      archived: false,
+      profileLinks: [],
+    };
+
+    expect(toPublicPersonDto(unknown, { now })).toBeUndefined();
+    expect(toPublicPersonDto(unknown, { now, hasCurrentApprovedRole: true })).toMatchObject({
+      id: personId.toHexString(),
+      displayName: 'Unknown Status',
+    });
+    expect(
+      toPublicPersonDto({ ...unknown, status: 'DEPARTED' }, { now, hasCurrentApprovedRole: true }),
+    ).toBeUndefined();
+    expect(
+      toPublicPersonDto(
+        { ...unknown, status: 'ACTIVE', archived: true },
+        { now, hasCurrentApprovedRole: true },
+      ),
+    ).toBeUndefined();
+  });
+
+  it('omits unavailable, future-verified, malformed, and private-host profile links', () => {
+    const dto = toPublicPersonDto(
+      {
+        _id: personId,
+        displayName: 'Safe Person',
+        status: 'ACTIVE',
+        archived: false,
+        profileLinks: [
+          {
+            ...healthyProfileLink(
+              'YALE_OFFICIAL',
+              'PRIMARY_IDENTITY',
+              'https://medicine.yale.edu/profile/safe',
+            ),
+            healthStatus: 'UNAVAILABLE',
+          },
+          {
+            ...healthyProfileLink(
+              'GOOGLE_SCHOLAR',
+              'SCHOLARLY',
+              'https://scholar.google.com/citations?user=abcdefghijkl',
+            ),
+            verifiedAt: new Date('2026-08-01T00:00:00.000Z'),
+          },
+          healthyProfileLink('ORCID', 'SCHOLARLY', 'https://localhost/orcid'),
+        ],
+      },
+      { now },
+    );
+
+    expect(dto).toEqual({
+      id: personId.toHexString(),
+      displayName: 'Safe Person',
+      researchProfiles: [],
+    });
+  });
+
+  it('bounds and redacts public person text', () => {
+    const dto = toPublicPersonDto(
+      {
+        _id: personId,
+        displayName: `Reach me at private@yale.edu ${'x'.repeat(400)}`,
+        status: 'ACTIVE',
+        archived: false,
+        profileLinks: [],
+      },
+      { now },
+    );
+
+    expect(dto?.displayName).not.toContain('private@yale.edu');
+    expect(dto?.displayName.length).toBeLessThanOrEqual(MAX_PUBLIC_PERSON_NAME_LENGTH);
+  });
+
+  it('projects only active public evidence metadata within the item bound', () => {
+    const safeClaim = {
+      predicate: 'ENTITY_HAS_DESCRIPTION',
+      observedAt: new Date('2026-07-26T00:00:00.000Z'),
+      confidence: 0.9,
+      sensitivity: 'PUBLIC',
+      status: 'ACTIVE',
+      value: { private: 'raw claim value' },
+      excerpt: 'private@yale.edu',
+      sourceDocumentId: new mongoose.Types.ObjectId(),
+      diagnostics: { reviewNote: 'private' },
+    };
+    const claims = [
+      { ...safeClaim, sensitivity: 'ADMIN_ONLY' },
+      { ...safeClaim, status: 'REJECTED' },
+      ...Array.from({ length: MAX_PUBLIC_EVIDENCE_ITEMS + 5 }, () => ({ ...safeClaim })),
+    ];
+
+    const result = toPublicEvidenceClaimDtos(claims, now);
+
+    expect(result).toHaveLength(MAX_PUBLIC_EVIDENCE_ITEMS);
+    expect(result[0]).toEqual({
+      predicate: 'ENTITY_HAS_DESCRIPTION',
+      observedAt: '2026-07-26T00:00:00.000Z',
+      confidence: 0.9,
+    });
+    expect(result[0]).not.toHaveProperty('value');
+    expect(result[0]).not.toHaveProperty('excerpt');
+    expect(result[0]).not.toHaveProperty('sourceDocumentId');
+    expect(result[0]).not.toHaveProperty('diagnostics');
+  });
+
+  it('builds a bounded discovery projection and strips unsafe lead data', () => {
+    const leads = Array.from({ length: MAX_PUBLIC_DISCOVERY_LEADS + 4 }, (_, index) => ({
+      personId: new mongoose.Types.ObjectId(
+        `507f191e810c19729de86${String(200 + index).slice(-3)}`,
+      ),
+      displayName: `Lead ${index} lead${index}@yale.edu`,
+      role: 'PI',
+      officialProfileUrl:
+        index === 0
+          ? 'https://medicine.yale.edu/profile/lead-zero'
+          : 'https://example.org/not-an-official-yale-profile',
+      accountId: new mongoose.Types.ObjectId(),
+      reviewNotes: 'private',
+    }));
+    leads.push({ ...leads[0] });
+
+    const discovery = buildResearchEntityDiscoveryProjection(
+      {
+        leads,
+        accessState: `${'actionable '.repeat(30)}private@yale.edu`,
+        bestNextStepCategory: 'apply',
+        openOpportunityCount: Number.MAX_SAFE_INTEGER,
+        browseRankScore: Number.MAX_SAFE_INTEGER,
+        visibilityState: 'student_ready',
+        computedAt: now,
+      },
+      { now },
+    );
+
+    expect(discovery?.leads).toHaveLength(MAX_PUBLIC_DISCOVERY_LEADS);
+    expect(discovery?.leads[0]).toEqual({
+      personId: leads[0].personId.toHexString(),
+      displayName: 'Lead 0 [email redacted]',
+      role: 'PI',
+      officialProfileUrl: 'https://medicine.yale.edu/profile/lead-zero',
+    });
+    expect(discovery?.leads[1]).not.toHaveProperty('officialProfileUrl');
+    expect(discovery?.leads[0]).not.toHaveProperty('accountId');
+    expect(discovery?.leads[0]).not.toHaveProperty('reviewNotes');
+    expect(discovery?.accessState).not.toContain('private@yale.edu');
+    expect(discovery?.openOpportunityCount).toBe(MAX_PUBLIC_DISCOVERY_OPPORTUNITY_COUNT);
+    expect(discovery?.browseRankScore).toBe(1_000);
+  });
+
+  it('keeps accessState bounded text while rejecting invalid governed fields and dates', () => {
+    const base = {
+      leads: [],
+      accessState: 'NO_EVIDENCE',
+      openOpportunityCount: 0,
+      browseRankScore: 0,
+      visibilityState: 'student_ready',
+      computedAt: now,
+    };
+
+    expect(
+      buildResearchEntityDiscoveryProjection(
+        {
+          ...base,
+          bestNextStepCategory: 'email-the-professor',
+        },
+        { now },
+      ),
+    ).toBeUndefined();
+    expect(
+      buildResearchEntityDiscoveryProjection(
+        {
+          ...base,
+          visibilityState: 'PUBLIC',
+        },
+        { now },
+      ),
+    ).toBeUndefined();
+    expect(
+      buildResearchEntityDiscoveryProjection(
+        {
+          ...base,
+          computedAt: '2026-07-27T12:00:00.000Z',
+        },
+        { now },
+      ),
+    ).toBeUndefined();
+    expect(
+      buildResearchEntityDiscoveryProjection(
+        {
+          ...base,
+          computedAt: new Date(now.getTime() + 1),
+        },
+        { now },
+      ),
+    ).toBeUndefined();
+    expect(
+      buildResearchEntityDiscoveryProjection(
+        {
+          ...base,
+          accessState: 'SOURCE_BACKED_REVIEW_SUMMARY',
+        },
+        { now },
+      )?.accessState,
+    ).toBe('SOURCE_BACKED_REVIEW_SUMMARY');
+  });
+
+  it('marks discovery summaries stale exactly after the documented bound', () => {
+    const atBound = {
+      computedAt: new Date(now.getTime() - RESEARCH_ENTITY_DISCOVERY_STALENESS_BOUND_MS),
+    };
+    const overBound = {
+      computedAt: new Date(now.getTime() - RESEARCH_ENTITY_DISCOVERY_STALENESS_BOUND_MS - 1),
+    };
+    const future = {
+      computedAt: new Date(now.getTime() + 1),
+    };
+
+    expect(researchEntityDiscoveryFreshness(undefined, now)).toBe('missing');
+    expect(researchEntityDiscoveryFreshness(atBound, now)).toBe('fresh');
+    expect(researchEntityDiscoveryFreshness(overBound, now)).toBe('stale');
+    expect(researchEntityDiscoveryFreshness(future, now)).toBe('future');
+    expect(shouldRecomputeResearchEntityDiscovery(atBound, now)).toBe(false);
+    expect(shouldRecomputeResearchEntityDiscovery(overBound, now)).toBe(true);
+  });
+
+  it('defines direct invalidation plus a reconciliation interval below the stale bound', () => {
+    expect(researchEntityDiscoveryRecomputeTriggers).toEqual([
+      'CANONICAL_MATERIALIZER_COMMIT',
+      'MODERATED_CANONICAL_WRITE',
+      'SCHEDULED_RECONCILIATION',
+    ]);
+    expect(RESEARCH_ENTITY_DISCOVERY_RECONCILIATION_INTERVAL_MS).toBeLessThan(
+      RESEARCH_ENTITY_DISCOVERY_STALENESS_BOUND_MS,
+    );
+  });
+});

--- a/server/src/services/canonicalDomainLoaders.ts
+++ b/server/src/services/canonicalDomainLoaders.ts
@@ -1,0 +1,459 @@
+import mongoose from 'mongoose';
+import { EVIDENCE_CLAIM_SCHEMA_VERSION, EvidenceClaim } from '../models/evidenceClaim';
+import {
+  evidenceClaimSubjectKinds,
+  type EvidenceClaimPredicate,
+  type EvidenceClaimSubjectKind,
+} from '../models/evidencePredicateRegistry';
+import {
+  OrgUnit,
+  orgUnitSchemaVersion,
+  type OrgUnitKind,
+  type OrgUnitStatus,
+} from '../models/orgUnit';
+import {
+  Person,
+  personSchemaVersion,
+  type PersonProfileLink,
+  type PersonStatus,
+} from '../models/person';
+import {
+  RESEARCH_PLAN_SCHEMA_VERSION,
+  ResearchPlan,
+  type ResearchPlanStage,
+  type ResearchPlanTargetKind,
+} from '../models/researchPlan';
+import {
+  RoleAssignment,
+  roleAssignmentSchemaVersion,
+  roleAssignmentTargetKinds,
+  type RoleAssignmentReviewStatus,
+  type RoleAssignmentRole,
+  type RoleAssignmentState,
+  type RoleAssignmentTargetKind,
+} from '../models/roleAssignment';
+import {
+  TaxonomyTerm,
+  taxonomyTermSchemaVersion,
+  type TaxonomyTermKind,
+  type TaxonomyTermReviewStatus,
+  type TaxonomyTermStatus,
+} from '../models/taxonomyTerm';
+
+export const MAX_CANONICAL_LOADER_IDS = 100;
+export const MAX_CANONICAL_LOADER_RESULTS = 100;
+
+export const CANONICAL_PERSON_READ_FIELDS =
+  '_id schemaVersion displayName profileLinks status archived';
+export const CANONICAL_ROLE_READ_FIELDS =
+  '_id schemaVersion personId target role state reviewStatus archived';
+export const CANONICAL_ORG_UNIT_READ_FIELDS =
+  '_id schemaVersion slug name kind aliases parentOrgUnitId status archived';
+export const CANONICAL_TAXONOMY_READ_FIELDS =
+  '_id schemaVersion kind label aliases parentTermId reviewStatus status archived';
+export const CANONICAL_PUBLIC_EVIDENCE_READ_FIELDS =
+  '_id schemaVersion subject predicate observedAt confidence sensitivity status';
+export const CANONICAL_RESEARCH_PLAN_READ_FIELDS =
+  '_id schemaVersion accountId target stage exportPreferences archived createdAt updatedAt';
+
+type CanonicalObjectIdInput = string | mongoose.Types.ObjectId;
+type CanonicalRecord = Record<string, unknown>;
+
+export interface CanonicalPublicPersonRecord extends CanonicalRecord {
+  _id: mongoose.Types.ObjectId;
+  schemaVersion: number;
+  displayName: string;
+  profileLinks: PersonProfileLink[];
+  status: PersonStatus;
+  archived: false;
+}
+
+export interface CanonicalCurrentRoleRecord extends CanonicalRecord {
+  _id: mongoose.Types.ObjectId;
+  schemaVersion: number;
+  personId: mongoose.Types.ObjectId;
+  target: {
+    kind: RoleAssignmentTargetKind;
+    id: mongoose.Types.ObjectId;
+  };
+  role: RoleAssignmentRole;
+  state: RoleAssignmentState;
+  reviewStatus: RoleAssignmentReviewStatus;
+  archived: false;
+}
+
+export interface CanonicalOrgUnitReadRecord extends CanonicalRecord {
+  _id: mongoose.Types.ObjectId;
+  schemaVersion: number;
+  slug: string;
+  name: string;
+  kind: OrgUnitKind;
+  aliases: string[];
+  parentOrgUnitId?: mongoose.Types.ObjectId;
+  status: OrgUnitStatus;
+  archived: false;
+}
+
+export interface CanonicalTaxonomyReadRecord extends CanonicalRecord {
+  _id: mongoose.Types.ObjectId;
+  schemaVersion: number;
+  kind: TaxonomyTermKind;
+  label: string;
+  aliases: string[];
+  parentTermId?: mongoose.Types.ObjectId;
+  reviewStatus: TaxonomyTermReviewStatus;
+  status: TaxonomyTermStatus;
+  archived: false;
+}
+
+export interface CanonicalPublicEvidenceRecord extends CanonicalRecord {
+  _id: mongoose.Types.ObjectId;
+  schemaVersion: number;
+  subject: {
+    kind: EvidenceClaimSubjectKind;
+    id: mongoose.Types.ObjectId;
+  };
+  predicate: EvidenceClaimPredicate;
+  observedAt: Date;
+  confidence: number;
+  sensitivity: 'PUBLIC';
+  status: 'ACTIVE';
+}
+
+export interface CanonicalResearchPlanReadRecord extends CanonicalRecord {
+  _id: mongoose.Types.ObjectId;
+  schemaVersion: number;
+  accountId: mongoose.Types.ObjectId;
+  target: {
+    kind: ResearchPlanTargetKind;
+    id: mongoose.Types.ObjectId;
+  };
+  stage: ResearchPlanStage;
+  exportPreferences: {
+    includePrivateNotes: boolean;
+    includeChecklist: boolean;
+    includeDeadlines: boolean;
+  };
+  archived: false;
+  privateNotes?: string;
+  checklist?: unknown[];
+  deadlines?: unknown[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+interface CanonicalQuery {
+  select(fields: string): CanonicalQuery;
+  sort(sort: Record<string, 1 | -1>): CanonicalQuery;
+  limit(limit: number): CanonicalQuery;
+  lean(): CanonicalQuery;
+  exec(): Promise<CanonicalRecord[]>;
+}
+
+export interface CanonicalReadModel {
+  find(filter: Record<string, unknown>): CanonicalQuery;
+}
+
+export interface CanonicalReadModels {
+  EvidenceClaim: CanonicalReadModel;
+  OrgUnit: CanonicalReadModel;
+  Person: CanonicalReadModel;
+  ResearchPlan: CanonicalReadModel;
+  RoleAssignment: CanonicalReadModel;
+  TaxonomyTerm: CanonicalReadModel;
+}
+
+export interface CanonicalRoleTargetInput {
+  kind: RoleAssignmentTargetKind;
+  id: CanonicalObjectIdInput;
+}
+
+export interface CanonicalEvidenceSubjectInput {
+  kind: EvidenceClaimSubjectKind;
+  id: CanonicalObjectIdInput;
+}
+
+export interface OwnedResearchPlanLoadInput {
+  requesterAccountId: CanonicalObjectIdInput;
+  ownerAccountId: CanonicalObjectIdInput;
+  target?: {
+    kind: ResearchPlanTargetKind;
+    ids?: CanonicalObjectIdInput[];
+  };
+  includePrivateFields?: boolean;
+  limit?: number;
+}
+
+export class CanonicalReadAuthorizationError extends Error {
+  constructor(message = 'The canonical read is outside the requester boundary.') {
+    super(message);
+    this.name = 'CanonicalReadAuthorizationError';
+  }
+}
+
+const DEFAULT_MODELS: CanonicalReadModels = {
+  EvidenceClaim: EvidenceClaim as unknown as CanonicalReadModel,
+  OrgUnit: OrgUnit as unknown as CanonicalReadModel,
+  Person: Person as unknown as CanonicalReadModel,
+  ResearchPlan: ResearchPlan as unknown as CanonicalReadModel,
+  RoleAssignment: RoleAssignment as unknown as CanonicalReadModel,
+  TaxonomyTerm: TaxonomyTerm as unknown as CanonicalReadModel,
+};
+
+function canonicalObjectId(value: unknown, label: string): mongoose.Types.ObjectId {
+  if (value instanceof mongoose.Types.ObjectId) return value;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (mongoose.isObjectIdOrHexString(trimmed)) {
+      return new mongoose.Types.ObjectId(trimmed);
+    }
+  }
+  throw new TypeError(`${label} must be a valid ObjectId.`);
+}
+
+function boundedObjectIds(
+  values: readonly CanonicalObjectIdInput[],
+  label: string,
+): mongoose.Types.ObjectId[] {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+  if (values.length > MAX_CANONICAL_LOADER_IDS) {
+    throw new RangeError(`${label} must contain at most ${MAX_CANONICAL_LOADER_IDS} identifiers.`);
+  }
+
+  const ids = new Map<string, mongoose.Types.ObjectId>();
+  for (const value of values) {
+    const id = canonicalObjectId(value, label);
+    ids.set(id.toHexString(), id);
+  }
+  return [...ids.values()];
+}
+
+function boundedLimit(value: unknown): number {
+  if (value === undefined) return MAX_CANONICAL_LOADER_RESULTS;
+  if (
+    !Number.isInteger(value) ||
+    Number(value) < 1 ||
+    Number(value) > MAX_CANONICAL_LOADER_RESULTS
+  ) {
+    throw new RangeError(`limit must be an integer from 1 to ${MAX_CANONICAL_LOADER_RESULTS}.`);
+  }
+  return Number(value);
+}
+
+async function findRecords<T extends CanonicalRecord>({
+  model,
+  filter,
+  fields,
+  sort = { _id: 1 },
+  limit = MAX_CANONICAL_LOADER_RESULTS,
+}: {
+  model: CanonicalReadModel;
+  filter: Record<string, unknown>;
+  fields: string;
+  sort?: Record<string, 1 | -1>;
+  limit?: number;
+}): Promise<T[]> {
+  return model.find(filter).select(fields).sort(sort).limit(limit).lean().exec() as Promise<T[]>;
+}
+
+function assertRoleTargets(
+  values: readonly CanonicalRoleTargetInput[],
+): Array<{ kind: RoleAssignmentTargetKind; id: mongoose.Types.ObjectId }> {
+  if (!Array.isArray(values)) throw new TypeError('role targets must be an array.');
+  if (values.length > MAX_CANONICAL_LOADER_IDS) {
+    throw new RangeError(
+      `role targets must contain at most ${MAX_CANONICAL_LOADER_IDS} identifiers.`,
+    );
+  }
+
+  const targets = new Map<
+    string,
+    { kind: RoleAssignmentTargetKind; id: mongoose.Types.ObjectId }
+  >();
+  for (const value of values) {
+    if (!value || !roleAssignmentTargetKinds.includes(value.kind)) {
+      throw new TypeError('role target kind is invalid.');
+    }
+    const id = canonicalObjectId(value.id, 'role target id');
+    targets.set(`${value.kind}:${id.toHexString()}`, { kind: value.kind, id });
+  }
+  return [...targets.values()];
+}
+
+function assertEvidenceSubjects(
+  values: readonly CanonicalEvidenceSubjectInput[],
+): Array<{ kind: EvidenceClaimSubjectKind; id: mongoose.Types.ObjectId }> {
+  if (!Array.isArray(values)) throw new TypeError('evidence subjects must be an array.');
+  if (values.length > MAX_CANONICAL_LOADER_IDS) {
+    throw new RangeError(
+      `evidence subjects must contain at most ${MAX_CANONICAL_LOADER_IDS} identifiers.`,
+    );
+  }
+
+  const subjects = new Map<
+    string,
+    { kind: EvidenceClaimSubjectKind; id: mongoose.Types.ObjectId }
+  >();
+  for (const value of values) {
+    if (!value || !evidenceClaimSubjectKinds.includes(value.kind)) {
+      throw new TypeError('evidence subject kind is invalid.');
+    }
+    const id = canonicalObjectId(value.id, 'evidence subject id');
+    subjects.set(`${value.kind}:${id.toHexString()}`, { kind: value.kind, id });
+  }
+  return [...subjects.values()];
+}
+
+/**
+ * Creates bounded, read-only canonical loaders.
+ *
+ * The default models use MongoDB, while dependency injection keeps the query and
+ * authorization contracts directly testable.
+ */
+export function createCanonicalDomainLoaders(models: CanonicalReadModels = DEFAULT_MODELS) {
+  return {
+    async loadPublicPeopleByIds(
+      values: readonly CanonicalObjectIdInput[],
+    ): Promise<CanonicalPublicPersonRecord[]> {
+      const ids = boundedObjectIds(values, 'person ids');
+      if (ids.length === 0) return [];
+      return findRecords({
+        model: models.Person,
+        filter: {
+          _id: { $in: ids },
+          schemaVersion: { $in: personSchemaVersion.supportedVersions },
+          archived: false,
+          status: { $in: ['ACTIVE', 'UNKNOWN'] },
+        },
+        fields: CANONICAL_PERSON_READ_FIELDS,
+        limit: ids.length,
+      });
+    },
+
+    async loadCurrentApprovedRolesForTargets(
+      values: readonly CanonicalRoleTargetInput[],
+    ): Promise<CanonicalCurrentRoleRecord[]> {
+      const targets = assertRoleTargets(values);
+      if (targets.length === 0) return [];
+      return findRecords({
+        model: models.RoleAssignment,
+        filter: {
+          $or: targets.map((target) => ({
+            'target.kind': target.kind,
+            'target.id': target.id,
+          })),
+          schemaVersion: { $in: roleAssignmentSchemaVersion.supportedVersions },
+          state: 'CURRENT',
+          reviewStatus: 'APPROVED',
+          archived: false,
+          endedAt: { $exists: false },
+        },
+        fields: CANONICAL_ROLE_READ_FIELDS,
+      });
+    },
+
+    async loadActiveOrgUnitsByIds(
+      values: readonly CanonicalObjectIdInput[],
+    ): Promise<CanonicalOrgUnitReadRecord[]> {
+      const ids = boundedObjectIds(values, 'organization ids');
+      if (ids.length === 0) return [];
+      return findRecords({
+        model: models.OrgUnit,
+        filter: {
+          _id: { $in: ids },
+          schemaVersion: { $in: orgUnitSchemaVersion.supportedVersions },
+          status: 'ACTIVE',
+          archived: false,
+        },
+        fields: CANONICAL_ORG_UNIT_READ_FIELDS,
+        limit: ids.length,
+      });
+    },
+
+    async loadApprovedTaxonomyTermsByIds(
+      values: readonly CanonicalObjectIdInput[],
+    ): Promise<CanonicalTaxonomyReadRecord[]> {
+      const ids = boundedObjectIds(values, 'taxonomy term ids');
+      if (ids.length === 0) return [];
+      return findRecords({
+        model: models.TaxonomyTerm,
+        filter: {
+          _id: { $in: ids },
+          schemaVersion: { $in: taxonomyTermSchemaVersion.supportedVersions },
+          reviewStatus: 'APPROVED',
+          status: 'ACTIVE',
+          archived: false,
+        },
+        fields: CANONICAL_TAXONOMY_READ_FIELDS,
+        limit: ids.length,
+      });
+    },
+
+    async loadPublicEvidenceForSubjects(
+      values: readonly CanonicalEvidenceSubjectInput[],
+    ): Promise<CanonicalPublicEvidenceRecord[]> {
+      const subjects = assertEvidenceSubjects(values);
+      if (subjects.length === 0) return [];
+      return findRecords({
+        model: models.EvidenceClaim,
+        filter: {
+          $or: subjects.map((subject) => ({
+            'subject.kind': subject.kind,
+            'subject.id': subject.id,
+          })),
+          schemaVersion: { $in: EVIDENCE_CLAIM_SCHEMA_VERSION.supportedVersions },
+          sensitivity: 'PUBLIC',
+          status: 'ACTIVE',
+          observedAt: { $lte: new Date() },
+        },
+        fields: CANONICAL_PUBLIC_EVIDENCE_READ_FIELDS,
+        sort: { observedAt: -1, _id: 1 },
+      });
+    },
+
+    async loadOwnedResearchPlans(
+      input: OwnedResearchPlanLoadInput,
+    ): Promise<CanonicalResearchPlanReadRecord[]> {
+      const requesterAccountId = canonicalObjectId(
+        input.requesterAccountId,
+        'requester account id',
+      );
+      const ownerAccountId = canonicalObjectId(input.ownerAccountId, 'owner account id');
+      if (!requesterAccountId.equals(ownerAccountId)) {
+        throw new CanonicalReadAuthorizationError();
+      }
+
+      const filter: Record<string, unknown> = {
+        accountId: ownerAccountId,
+        schemaVersion: { $in: RESEARCH_PLAN_SCHEMA_VERSION.supportedVersions },
+        archived: false,
+      };
+      if (input.target) {
+        if (!['RESEARCH_ENTITY', 'PROGRAM'].includes(input.target.kind)) {
+          throw new TypeError('research plan target kind is invalid.');
+        }
+        filter['target.kind'] = input.target.kind;
+        if (input.target.ids !== undefined) {
+          const ids = boundedObjectIds(input.target.ids, 'research plan target ids');
+          if (ids.length === 0) return [];
+          filter['target.id'] = { $in: ids };
+        }
+      }
+
+      const privateFields = input.includePrivateFields
+        ? ' +privateNotes +checklist +deadlines'
+        : '';
+      return findRecords({
+        model: models.ResearchPlan,
+        filter,
+        fields: `${CANONICAL_RESEARCH_PLAN_READ_FIELDS}${privateFields}`,
+        sort: { updatedAt: -1, _id: 1 },
+        limit: boundedLimit(input.limit),
+      });
+    },
+  };
+}
+
+export type CanonicalDomainLoaders = ReturnType<typeof createCanonicalDomainLoaders>;

--- a/server/src/services/canonicalPublicProjections.ts
+++ b/server/src/services/canonicalPublicProjections.ts
@@ -301,7 +301,7 @@ function boundedBrowseRank(value: unknown): number {
 
 function discoveryLead(value: Record<string, unknown>): ResearchEntityDiscoveryLead | undefined {
   const personId = canonicalId(value.personId);
-  const displayName = boundedPublicText(value.displayName, MAX_PUBLIC_PERSON_NAME_LENGTH);
+  const displayName = boundedPublicText(value.displayName, MAX_PUBLIC_DISCOVERY_TEXT_LENGTH);
   if (
     !personId ||
     !displayName ||

--- a/server/src/services/canonicalPublicProjections.ts
+++ b/server/src/services/canonicalPublicProjections.ts
@@ -1,0 +1,387 @@
+import mongoose from 'mongoose';
+import {
+  isEvidenceClaimPredicate,
+  type EvidenceClaimPredicate,
+} from '../models/evidencePredicateRegistry';
+import {
+  isValidOrcid,
+  personProfileLinkKinds,
+  type PersonProfileLinkKind,
+  type PersonProfileLinkPurpose,
+} from '../models/person';
+import { roleAssignmentRoles, type RoleAssignmentRole } from '../models/roleAssignment';
+import { isStudentVisibilityTier, type StudentVisibilityTier } from '../models/studentVisibility';
+import { redactDirectContactInfo } from '../utils/contactRedaction';
+import { publicHttpUrl } from '../utils/urlSafety';
+import {
+  pathwayBestNextStepCategories,
+  type PathwayBestNextStepCategory,
+} from './pathwaySearchService';
+
+export const MAX_PUBLIC_PERSON_NAME_LENGTH = 240;
+export const MAX_PUBLIC_PERSON_RESEARCH_PROFILES = 2;
+export const MAX_PUBLIC_EVIDENCE_ITEMS = 12;
+export const MAX_PUBLIC_DISCOVERY_LEADS = 8;
+export const MAX_PUBLIC_DISCOVERY_TEXT_LENGTH = 120;
+export const MAX_PUBLIC_DISCOVERY_OPPORTUNITY_COUNT = 9_999;
+export const MIN_PUBLIC_DISCOVERY_BROWSE_RANK = -1_000;
+export const MAX_PUBLIC_DISCOVERY_BROWSE_RANK = 1_000;
+
+/**
+ * Discovery is recomputed for every affected entity after a successful
+ * canonical materializer or moderated canonical write.
+ * A scheduled reconciliation must repair missed invalidations before this
+ * 24-hour bound is exceeded.
+ */
+export const RESEARCH_ENTITY_DISCOVERY_STALENESS_BOUND_MS = 24 * 60 * 60 * 1_000;
+export const RESEARCH_ENTITY_DISCOVERY_RECONCILIATION_INTERVAL_MS = 6 * 60 * 60 * 1_000;
+export const researchEntityDiscoveryRecomputeTriggers = [
+  'CANONICAL_MATERIALIZER_COMMIT',
+  'MODERATED_CANONICAL_WRITE',
+  'SCHEDULED_RECONCILIATION',
+] as const;
+
+const PRIMARY_PROFILE_PRECEDENCE: readonly PersonProfileLinkKind[] = [
+  'YALE_OFFICIAL',
+  'LAB_ABOUT',
+  'PERSONAL_ACADEMIC',
+];
+const RESEARCH_PROFILE_PRECEDENCE: readonly PersonProfileLinkKind[] = ['GOOGLE_SCHOLAR', 'ORCID'];
+const PROFILE_LABELS: Record<PersonProfileLinkKind, string> = {
+  YALE_OFFICIAL: 'Yale profile',
+  LAB_ABOUT: 'Lab profile',
+  PERSONAL_ACADEMIC: 'Academic profile',
+  GOOGLE_SCHOLAR: 'Google Scholar',
+  ORCID: 'ORCID',
+};
+
+export interface PublicPersonProfileDto {
+  kind: PersonProfileLinkKind;
+  label: string;
+  url: string;
+}
+
+export interface PublicPersonDto {
+  id: string;
+  displayName: string;
+  primaryProfile?: PublicPersonProfileDto;
+  researchProfiles: PublicPersonProfileDto[];
+}
+
+export interface PublicPersonProjectionOptions {
+  hasCurrentApprovedRole?: boolean;
+  now?: Date;
+}
+
+export interface PublicEvidenceClaimDto {
+  predicate: EvidenceClaimPredicate;
+  observedAt: string;
+  confidence?: number;
+}
+
+export interface ResearchEntityDiscoveryLead {
+  personId: string;
+  displayName: string;
+  role: RoleAssignmentRole;
+  officialProfileUrl?: string;
+}
+
+export interface ResearchEntityDiscoveryProjection {
+  leads: ResearchEntityDiscoveryLead[];
+  accessState: string;
+  bestNextStepCategory?: PathwayBestNextStepCategory;
+  openOpportunityCount: number;
+  browseRankScore: number;
+  visibilityState: StudentVisibilityTier;
+  computedAt: Date;
+}
+
+export interface ResearchEntityDiscoveryInput {
+  leads?: readonly Record<string, unknown>[];
+  accessState: unknown;
+  bestNextStepCategory?: unknown;
+  openOpportunityCount: unknown;
+  browseRankScore: unknown;
+  visibilityState: unknown;
+  computedAt: unknown;
+}
+
+export interface ResearchEntityDiscoveryProjectionOptions {
+  now?: Date;
+}
+
+export type ResearchEntityDiscoveryFreshness = 'missing' | 'fresh' | 'stale' | 'future';
+
+function canonicalId(value: unknown): string | undefined {
+  if (value instanceof mongoose.Types.ObjectId) return value.toHexString();
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return mongoose.isObjectIdOrHexString(trimmed)
+    ? new mongoose.Types.ObjectId(trimmed).toHexString()
+    : undefined;
+}
+
+function boundedPublicText(value: unknown, maximum: number): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const text = redactDirectContactInfo(value.normalize('NFKC').replace(/\s+/g, ' ').trim()).slice(
+    0,
+    maximum,
+  );
+  return text || undefined;
+}
+
+function validDate(value: unknown, now?: Date): Date | undefined {
+  const date = value instanceof Date ? new Date(value.getTime()) : undefined;
+  if (!date || Number.isNaN(date.getTime())) return undefined;
+  if (now && date.getTime() > now.getTime()) return undefined;
+  return date;
+}
+
+function canonicalProfileUrl(kind: PersonProfileLinkKind, value: unknown): string | undefined {
+  const url = publicHttpUrl(value);
+  if (!url || !url.startsWith('https://')) return undefined;
+  const parsed = new URL(url);
+
+  if (kind === 'YALE_OFFICIAL') {
+    return parsed.hostname === 'yale.edu' || parsed.hostname.endsWith('.yale.edu')
+      ? url
+      : undefined;
+  }
+  if (kind === 'GOOGLE_SCHOLAR') {
+    const scholarId = parsed.searchParams.get('user');
+    return parsed.hostname === 'scholar.google.com' &&
+      parsed.pathname === '/citations' &&
+      typeof scholarId === 'string' &&
+      /^[A-Za-z0-9_-]+$/.test(scholarId)
+      ? `https://scholar.google.com/citations?user=${encodeURIComponent(scholarId)}`
+      : undefined;
+  }
+  if (kind === 'ORCID') {
+    const match = /^\/(\d{4}-\d{4}-\d{4}-\d{3}[\dX])\/?$/i.exec(parsed.pathname);
+    const orcid = match?.[1].toUpperCase();
+    return parsed.hostname === 'orcid.org' &&
+      orcid !== undefined &&
+      isValidOrcid(orcid) &&
+      !parsed.search &&
+      !parsed.hash
+      ? `https://orcid.org/${orcid}`
+      : undefined;
+  }
+  return url;
+}
+
+function publicProfileLink(
+  value: unknown,
+  expectedPurpose: PersonProfileLinkPurpose,
+  now: Date,
+): PublicPersonProfileDto | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const link = value as Record<string, unknown>;
+  if (
+    !personProfileLinkKinds.includes(link.kind as PersonProfileLinkKind) ||
+    link.purpose !== expectedPurpose ||
+    (link.healthStatus !== 'HEALTHY' && link.healthStatus !== 'UNKNOWN') ||
+    !validDate(link.verifiedAt, now)
+  ) {
+    return undefined;
+  }
+
+  const kind = link.kind as PersonProfileLinkKind;
+  const url = canonicalProfileUrl(kind, link.url);
+  if (!url) return undefined;
+  return {
+    kind,
+    label: PROFILE_LABELS[kind],
+    url,
+  };
+}
+
+/**
+ * Projects the only supported public Person shape.
+ *
+ * ACTIVE people may render directly.
+ * UNKNOWN people require a current approved role as corroboration.
+ * DEPARTED people always fail closed even if a stale role says CURRENT.
+ */
+export function toPublicPersonDto(
+  person: Record<string, unknown>,
+  options: PublicPersonProjectionOptions = {},
+): PublicPersonDto | undefined {
+  if (person.archived !== false || person.status === 'DEPARTED') return undefined;
+  if (
+    person.status !== 'ACTIVE' &&
+    !(person.status === 'UNKNOWN' && options.hasCurrentApprovedRole === true)
+  ) {
+    return undefined;
+  }
+
+  const id = canonicalId(person._id ?? person.id);
+  const displayName = boundedPublicText(person.displayName, MAX_PUBLIC_PERSON_NAME_LENGTH);
+  if (!id || !displayName) return undefined;
+
+  const now = options.now ?? new Date();
+  const links = Array.isArray(person.profileLinks)
+    ? person.profileLinks.slice(0, personProfileLinkKinds.length)
+    : [];
+  const primaryProfile = PRIMARY_PROFILE_PRECEDENCE.flatMap((kind) => {
+    const candidate = links.find(
+      (link) => link && typeof link === 'object' && (link as Record<string, unknown>).kind === kind,
+    );
+    const projected = publicProfileLink(candidate, 'PRIMARY_IDENTITY', now);
+    return projected ? [projected] : [];
+  })[0];
+  const researchProfiles = RESEARCH_PROFILE_PRECEDENCE.flatMap((kind) => {
+    const candidate = links.find(
+      (link) => link && typeof link === 'object' && (link as Record<string, unknown>).kind === kind,
+    );
+    const projected = publicProfileLink(candidate, 'SCHOLARLY', now);
+    return projected ? [projected] : [];
+  }).slice(0, MAX_PUBLIC_PERSON_RESEARCH_PROFILES);
+
+  return {
+    id,
+    displayName,
+    ...(primaryProfile ? { primaryProfile } : {}),
+    researchProfiles,
+  };
+}
+
+/**
+ * Projects public claim metadata only.
+ *
+ * Claim values, excerpts, source-document identifiers, raw source documents,
+ * review notes, and diagnostics are deliberately not accepted into the DTO.
+ */
+export function toPublicEvidenceClaimDtos(
+  claims: readonly Record<string, unknown>[],
+  now = new Date(),
+): PublicEvidenceClaimDto[] {
+  if (!Array.isArray(claims)) return [];
+  return claims
+    .flatMap((claim) => {
+      if (
+        claim.sensitivity !== 'PUBLIC' ||
+        claim.status !== 'ACTIVE' ||
+        !isEvidenceClaimPredicate(claim.predicate)
+      ) {
+        return [];
+      }
+      const observedAt = validDate(claim.observedAt, now);
+      if (!observedAt) return [];
+      const confidence =
+        typeof claim.confidence === 'number' &&
+        Number.isFinite(claim.confidence) &&
+        claim.confidence >= 0 &&
+        claim.confidence <= 1
+          ? claim.confidence
+          : undefined;
+      return [
+        {
+          predicate: claim.predicate,
+          observedAt: observedAt.toISOString(),
+          ...(confidence === undefined ? {} : { confidence }),
+        },
+      ];
+    })
+    .slice(0, MAX_PUBLIC_EVIDENCE_ITEMS);
+}
+
+function boundedDiscoveryCount(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return 0;
+  return Math.min(Math.floor(value), MAX_PUBLIC_DISCOVERY_OPPORTUNITY_COUNT);
+}
+
+function boundedBrowseRank(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 0;
+  return Math.max(
+    MIN_PUBLIC_DISCOVERY_BROWSE_RANK,
+    Math.min(value, MAX_PUBLIC_DISCOVERY_BROWSE_RANK),
+  );
+}
+
+function discoveryLead(value: Record<string, unknown>): ResearchEntityDiscoveryLead | undefined {
+  const personId = canonicalId(value.personId);
+  const displayName = boundedPublicText(value.displayName, MAX_PUBLIC_PERSON_NAME_LENGTH);
+  if (
+    !personId ||
+    !displayName ||
+    !roleAssignmentRoles.includes(value.role as RoleAssignmentRole)
+  ) {
+    return undefined;
+  }
+  const role = value.role as RoleAssignmentRole;
+  const officialProfileUrl = canonicalProfileUrl('YALE_OFFICIAL', value.officialProfileUrl);
+  return {
+    personId,
+    displayName,
+    role,
+    ...(officialProfileUrl ? { officialProfileUrl } : {}),
+  };
+}
+
+/**
+ * Builds the bounded ResearchEntity.discovery cache shape.
+ *
+ * It does not read or write MongoDB.
+ * Callers must persist it only after the canonical transaction or materializer
+ * inputs commit successfully.
+ */
+export function buildResearchEntityDiscoveryProjection(
+  input: ResearchEntityDiscoveryInput,
+  options: ResearchEntityDiscoveryProjectionOptions = {},
+): ResearchEntityDiscoveryProjection | undefined {
+  const accessState = boundedPublicText(input.accessState, MAX_PUBLIC_DISCOVERY_TEXT_LENGTH);
+  const computedAt = validDate(input.computedAt, options.now ?? new Date());
+  if (
+    !accessState ||
+    !computedAt ||
+    !isStudentVisibilityTier(input.visibilityState) ||
+    (input.bestNextStepCategory !== undefined &&
+      !pathwayBestNextStepCategories.includes(
+        input.bestNextStepCategory as PathwayBestNextStepCategory,
+      ))
+  ) {
+    return undefined;
+  }
+
+  const leads: ResearchEntityDiscoveryLead[] = [];
+  const seenPersonIds = new Set<string>();
+  for (const value of Array.isArray(input.leads) ? input.leads : []) {
+    const lead = discoveryLead(value);
+    if (!lead || seenPersonIds.has(lead.personId)) continue;
+    seenPersonIds.add(lead.personId);
+    leads.push(lead);
+    if (leads.length === MAX_PUBLIC_DISCOVERY_LEADS) break;
+  }
+
+  return {
+    leads,
+    accessState,
+    ...(input.bestNextStepCategory === undefined
+      ? {}
+      : { bestNextStepCategory: input.bestNextStepCategory as PathwayBestNextStepCategory }),
+    openOpportunityCount: boundedDiscoveryCount(input.openOpportunityCount),
+    browseRankScore: boundedBrowseRank(input.browseRankScore),
+    visibilityState: input.visibilityState,
+    computedAt,
+  };
+}
+
+export function researchEntityDiscoveryFreshness(
+  discovery: Pick<ResearchEntityDiscoveryProjection, 'computedAt'> | undefined,
+  now = new Date(),
+): ResearchEntityDiscoveryFreshness {
+  if (!discovery) return 'missing';
+  const computedAt = validDate(discovery.computedAt);
+  if (!computedAt) return 'missing';
+  const age = now.getTime() - computedAt.getTime();
+  if (age < 0) return 'future';
+  return age <= RESEARCH_ENTITY_DISCOVERY_STALENESS_BOUND_MS ? 'fresh' : 'stale';
+}
+
+export function shouldRecomputeResearchEntityDiscovery(
+  discovery: Pick<ResearchEntityDiscoveryProjection, 'computedAt'> | undefined,
+  now = new Date(),
+): boolean {
+  return researchEntityDiscoveryFreshness(discovery, now) !== 'fresh';
+}


### PR DESCRIPTION
## Intent

Implement GitHub issue #217 completely as the final read-only part of the Phase 1 canonical model foundation. Add bounded reusable loaders for public person identity, current approved role assignments, active organizations, approved taxonomy, public evidence metadata, and account-owned research plans. Define exactly one fail-closed public Person DTO with a selected reviewed primary profile and at most two canonical Google Scholar or ORCID links, plus a bounded ResearchEntity.discovery projection with explicit array, text, count, timestamp, invalidation, reconciliation, and staleness contracts. Keep private plans, account links, raw evidence values, source documents, review notes, rejected candidates, diagnostics, direct contact data, and unsafe URLs outside public projections. Do not wire these readers into current REST routes, GraphQL, Meilisearch, materializer writes, migrations, or legacy-field removal. Preserve accessState as bounded text because the accepted design has no governed vocabulary yet, and require the later cutover to govern it before filter or facet use. Target beta, link issue #217, validate automatically, and do not merge.

## What Changed

- Add bounded, read-only canonical loaders for public identities, approved roles and reference data, public evidence metadata, and account-owned research plans.
- Define fail-closed public Person and evidence DTOs plus a bounded `ResearchEntity.discovery` projection with explicit freshness, invalidation, and reconciliation contracts.
- Add focused loader and projection coverage and document the Phase 1 read contracts and intentionally unwired cutover boundary.

## Risk Assessment

✅ Low: The follow-up correctly applies the documented 120-character discovery text bound to lead names, and the complete branch remains bounded, fail-closed, read-only, and consistent with the stated acceptance criteria.

## Testing

After restoring locked dependencies, the two focused canonical-reader test files passed, a runtime JSON artifact demonstrated the intended bounded and fail-closed public behavior, forbidden runtime wiring was absent, and the worktree remained clean. No screenshot was captured because this change is an intentionally unwired backend read-contract library with no rendered UI surface.

<details>
<summary>Evidence: Public projection runtime JSON</summary>

```text
{
  "publicPerson": {
    "id": "507f191e810c19729de86101",
    "displayName": "Grace Hopper [email redacted]",
    "primaryProfile": {
      "kind": "YALE_OFFICIAL",
      "label": "Yale profile",
      "url": "https://engineering.yale.edu/profile/grace"
    },
    "researchProfiles": [
      {
        "kind": "GOOGLE_SCHOLAR",
        "label": "Google Scholar",
        "url": "https://scholar.google.com/citations?user=abcdefghijkl"
      },
      {
        "kind": "ORCID",
        "label": "ORCID",
        "url": "https://orcid.org/9999-9999-9999-9994"
      }
    ]
  },
  "publicEvidence": [
    {
      "predicate": "ENTITY_HAS_DESCRIPTION",
      "observedAt": "2026-07-26T00:00:00.000Z",
      "confidence": 0.9
    }
  ],
  "discovery": {
    "leads": [
      {
        "personId": "507f191e810c19729de86101",
        "displayName": "Grace Hopper [email redacted]",
        "role": "PI",
        "officialProfileUrl": "https://engineering.yale.edu/profile/grace"
      }
    ],
    "accessState": "SOURCE_BACKED_REVIEW_SUMMARY",
    "openOpportunityCount": 9999,
    "browseRankScore": 1000,
    "visibilityState": "student_ready",
    "computedAt": "2026-07-27T12:00:00.000Z"
  },
  "privacyChecks": {
    "personHasAccountId": false,
    "personHasEmail": false,
    "evidenceHasRawValue": false,
    "evidenceHasSourceDocumentId": false,
    "leadHasReviewNotes": false
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `server/src/services/canonicalPublicProjections.ts:304` - The required bounded discovery text contract is violated: the intent requires an explicit text bound, and the accompanying documentation says discovery text fields are capped at 120 characters, but lead display names use `MAX_PUBLIC_PERSON_NAME_LENGTH` (240). Use `MAX_PUBLIC_DISCOVERY_TEXT_LENGTH` here or explicitly approve and document a separate 240-character discovery-lead limit.

🔧 Fix: Bound discovery lead names to projection text limit
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`yarn install --immutable` and `yarn --cwd server install --immutable` to restore the isolated worktree&#39;s locked dependency state</code>
- `yarn --cwd server vitest run src/services/__tests__/canonicalDomainLoaders.test.ts src/services/__tests__/canonicalPublicProjections.test.ts`
- <code>Runtime `tsx` exercise of `toPublicPersonDto`, `toPublicEvidenceClaimDtos`, and `buildResearchEntityDiscoveryProjection`, saved as the JSON evidence artifact</code>
- <code>`rg -n &#34;canonicalDomainLoaders|canonicalPublicProjections&#34; server/src --glob &#39;!services/__tests__/**&#39; --glob &#39;!services/canonicalDomainLoaders.ts&#39; --glob &#39;!services/canonicalPublicProjections.ts&#39;` to verify the Phase 1 readers remain unwired</code>
- <code>`git status --short` to confirm testing left no working-tree changes</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
