### PR TITLE
feat(server): add privacy-safe Phase 0 audit summaries

### DIFF
--- a/docs/research-model-refactor-phase0.md
+++ b/docs/research-model-refactor-phase0.md
@@ -137,7 +137,6 @@ SCRAPER_ENV=development yarn --cwd server research-entity:duplicate-name-review 
 SCRAPER_ENV=development yarn --cwd server research-entity:coverage-audit \
   --summary-only \
   --environment=development \
-  --all \
   --output /tmp/ylabs-development-coverage-summary.json
 ```
 
@@ -148,7 +147,10 @@ The coverage audit rejects `--slug` because a slug-targeted report is record-spe
 User-identity collision limits apply per identity field, and duplicate-name limits apply to normalized-name clusters.
 Their summary reports include explicit possible-truncation indicators and label limit-reached counts as bounded lower-bound evidence rather than full coverage.
 The member-reference summary preserves full orphan and archived-entity-member totals, while its proposed repair classifications remain detail-limit bounded and carry a separate possible-plan-truncation indicator.
-Coverage totals and issue counts are computed over all entities selected by the aggregate filters; its row limit does not cap summary-only counts.
+Coverage `totalEntitiesScanned` is computed over all entities selected by the aggregate filters.
+`flaggedEntities` and `issueCounts` are computed from entities whose issue score meets `--min-score`.
+`--all` controls detailed row inclusion only and is unnecessary in summary-only mode.
+The row limit does not cap summary-only counts.
 Use the default detailed dry-run modes only inside an approved private review workflow.
 
 ## Export and rollback prerequisites

--- a/docs/research-model-refactor-phase0.md
+++ b/docs/research-model-refactor-phase0.md
@@ -107,6 +107,45 @@ Deeper collision and identity analysis already lives in dedicated scripts and sh
 - `yarn --cwd server research-entity:duplicate-name-review` for duplicate entity identities.
 - `yarn --cwd server research-entity:coverage-audit` for entity evidence coverage.
 
+### Aggregate-only Development evidence
+
+Run these commands from the repository root after confirming `server/.env` points to the `Development` database.
+They retain aggregate collision, repair, category, reference-impact, and coverage counts without emitting record-level rows, identifiers, names, contact identities, slugs, URLs, or samples.
+
+```bash
+umask 077
+
+SCRAPER_ENV=development yarn --cwd server users:dedupe-by-identity \
+  --summary-only \
+  --limit=10000 \
+  --output /tmp/ylabs-development-user-identity-summary.json
+
+SCRAPER_ENV=development yarn --cwd server research-entity-members:audit-user-refs \
+  --summary-only \
+  --limit=10000 \
+  --output /tmp/ylabs-development-member-reference-summary.json
+
+SCRAPER_ENV=development yarn --cwd server research-entity:duplicate-name-review \
+  --summary-only \
+  --limit=10000 \
+  --plan-limit=10000 \
+  --output /tmp/ylabs-development-duplicate-name-summary.json
+
+SCRAPER_ENV=development yarn --cwd server research-entity:coverage-audit \
+  --summary-only \
+  --all \
+  --output /tmp/ylabs-development-coverage-summary.json
+```
+
+`--summary-only` is incompatible with `--apply`.
+The duplicate-name audit also rejects accepted-decision and decision-template options in summary-only mode.
+The coverage audit rejects `--slug` because a slug-targeted report is record-specific.
+User-identity collision limits apply per identity field, and duplicate-name limits apply to normalized-name clusters.
+Their summary reports include explicit possible-truncation indicators and label limit-reached counts as bounded lower-bound evidence rather than full coverage.
+The member-reference summary preserves full orphan and archived-entity-member totals, while its proposed repair classifications remain detail-limit bounded and carry a separate possible-plan-truncation indicator.
+Coverage totals and issue counts are computed over all entities selected by the aggregate filters; its row limit does not cap summary-only counts.
+Use the default detailed dry-run modes only inside an approved private review workflow.
+
 ## Export and rollback prerequisites
 
 No later phase may drop or overwrite a collection until these exist and are verified:

--- a/docs/research-model-refactor-phase0.md
+++ b/docs/research-model-refactor-phase0.md
@@ -117,27 +117,32 @@ umask 077
 
 SCRAPER_ENV=development yarn --cwd server users:dedupe-by-identity \
   --summary-only \
+  --environment=development \
   --limit=10000 \
   --output /tmp/ylabs-development-user-identity-summary.json
 
 SCRAPER_ENV=development yarn --cwd server research-entity-members:audit-user-refs \
   --summary-only \
+  --environment=development \
   --limit=10000 \
   --output /tmp/ylabs-development-member-reference-summary.json
 
 SCRAPER_ENV=development yarn --cwd server research-entity:duplicate-name-review \
   --summary-only \
+  --environment=development \
   --limit=10000 \
   --plan-limit=10000 \
   --output /tmp/ylabs-development-duplicate-name-summary.json
 
 SCRAPER_ENV=development yarn --cwd server research-entity:coverage-audit \
   --summary-only \
+  --environment=development \
   --all \
   --output /tmp/ylabs-development-coverage-summary.json
 ```
 
 `--summary-only` is incompatible with `--apply`.
+It requires an explicit `--environment` of `development`, `beta`, or `production-copy`, rejects primary production, and verifies both the configured and connected database names before any audit query.
 The duplicate-name audit also rejects accepted-decision and decision-template options in summary-only mode.
 The coverage audit rejects `--slug` because a slug-targeted report is record-specific.
 User-identity collision limits apply per identity field, and duplicate-name limits apply to normalized-name clusters.

--- a/scripts/security-preflight.test.mjs
+++ b/scripts/security-preflight.test.mjs
@@ -3390,6 +3390,12 @@ test('Phase 0 complementary audits enforce fail-closed summary-only output', () 
       /--summary-only does not accept a value/,
       `${name} must reject assigned summary-only values`,
     );
+    assert.match(parserSource, /--environment/, `${name} must parse an explicit environment`);
+    assert.match(
+      parserSource,
+      /parsePhase0SummaryOnlyEnvironment/,
+      `${name} must use the shared summary environment parser`,
+    );
     assert.match(
       builderSource,
       new RegExp(`export function ${summaryBuilder}`),
@@ -3400,6 +3406,16 @@ test('Phase 0 complementary audits enforce fail-closed summary-only output', () 
       new RegExp(`summaryOnly[\\s\\S]{0,160}\\? ${summaryBuilder}\\(`),
       `${name} must select the aggregate serializer before stdout and file output`,
     );
+    assert.match(
+      wrapperSource,
+      /assertPhase0SummaryOnlyConfiguredTarget/,
+      `${name} must validate the configured database before connecting`,
+    );
+    assert.match(
+      wrapperSource,
+      /assertPhase0SummaryOnlyConnectedTarget/,
+      `${name} must validate the connected database before querying`,
+    );
   }
 
   const sharedSource = fs.readFileSync(
@@ -3408,6 +3424,10 @@ test('Phase 0 complementary audits enforce fail-closed summary-only output', () 
   );
   assert.match(sharedSource, /args\.summaryOnly && args\.apply/);
   assert.match(sharedSource, /--summary-only cannot be combined with --apply/);
+  assert.match(sharedSource, /databaseNameFromMongoUrl/);
+  assert.match(sharedSource, /assertOperatorEnvironmentMatchesDatabase/);
+  assert.match(sharedSource, /--summary-only requires --environment/);
+  assert.match(sharedSource, /--environment requires development, beta, or production-copy/);
 
   const duplicateSource = fs.readFileSync(
     new URL('../server/src/scripts/duplicateEntityNameReview.ts', import.meta.url),

--- a/scripts/security-preflight.test.mjs
+++ b/scripts/security-preflight.test.mjs
@@ -3348,6 +3348,82 @@ test('identity cleanup report outputs are constrained to safe JSON roots', () =>
   }
 });
 
+test('Phase 0 complementary audits enforce fail-closed summary-only output', () => {
+  const contracts = [
+    [
+      'user identity dedupe',
+      '../server/src/scripts/dedupeUsersByIdentityCore.ts',
+      '../server/src/scripts/dedupeUsersByIdentity.ts',
+      '../server/src/scripts/dedupeUsersByIdentity.ts',
+      'buildDedupeUsersByIdentitySummaryOnlyOutput',
+    ],
+    [
+      'member reference audit',
+      '../server/src/scripts/researchEntityMemberReferenceAuditCore.ts',
+      '../server/src/scripts/researchEntityMemberReferenceAudit.ts',
+      '../server/src/scripts/researchEntityMemberReferenceAuditCore.ts',
+      'buildResearchEntityMemberReferenceSummaryOnlyOutput',
+    ],
+    [
+      'duplicate entity name review',
+      '../server/src/scripts/duplicateEntityNameReview.ts',
+      '../server/src/scripts/duplicateEntityNameReview.ts',
+      '../server/src/scripts/duplicateEntityNameReview.ts',
+      'buildDuplicateEntityNameReviewSummaryOnlyOutput',
+    ],
+    [
+      'research entity coverage audit',
+      '../server/src/scripts/researchEntityCoverageAudit.ts',
+      '../server/src/scripts/researchEntityCoverageAudit.ts',
+      '../server/src/scripts/researchEntityCoverageAudit.ts',
+      'buildResearchEntityCoverageSummaryOnlyOutput',
+    ],
+  ];
+
+  for (const [name, parserFile, wrapperFile, builderFile, summaryBuilder] of contracts) {
+    const parserSource = fs.readFileSync(new URL(parserFile, import.meta.url), 'utf8');
+    const wrapperSource = fs.readFileSync(new URL(wrapperFile, import.meta.url), 'utf8');
+    const builderSource = fs.readFileSync(new URL(builderFile, import.meta.url), 'utf8');
+    assert.match(parserSource, /arg === '--summary-only'/, `${name} must parse --summary-only`);
+    assert.match(
+      parserSource,
+      /--summary-only does not accept a value/,
+      `${name} must reject assigned summary-only values`,
+    );
+    assert.match(
+      builderSource,
+      new RegExp(`export function ${summaryBuilder}`),
+      `${name} must expose an explicit aggregate-only serializer`,
+    );
+    assert.match(
+      wrapperSource,
+      new RegExp(`summaryOnly[\\s\\S]{0,160}\\? ${summaryBuilder}\\(`),
+      `${name} must select the aggregate serializer before stdout and file output`,
+    );
+  }
+
+  const sharedSource = fs.readFileSync(
+    new URL('../server/src/scripts/phase0SummaryOnlyAudit.ts', import.meta.url),
+    'utf8',
+  );
+  assert.match(sharedSource, /args\.summaryOnly && args\.apply/);
+  assert.match(sharedSource, /--summary-only cannot be combined with --apply/);
+
+  const duplicateSource = fs.readFileSync(
+    new URL('../server/src/scripts/duplicateEntityNameReview.ts', import.meta.url),
+    'utf8',
+  );
+  assert.match(duplicateSource, /args\.decisionTemplateOutput/);
+  assert.match(duplicateSource, /cannot be combined with decision input/);
+
+  const coverageSource = fs.readFileSync(
+    new URL('../server/src/scripts/researchEntityCoverageAudit.ts', import.meta.url),
+    'utf8',
+  );
+  assert.match(coverageSource, /options\.summaryOnly && options\.slug/);
+  assert.match(coverageSource, /--summary-only cannot be combined with --slug/);
+});
+
 test('Mongo sanitizer rejects operator-shaped requests and bounds recursive traversal', () => {
   const source = fs.readFileSync(
     new URL('../server/src/middleware/sanitizeMongo.ts', import.meta.url),

--- a/server/src/scripts/__tests__/dedupeUsersByIdentityCli.test.ts
+++ b/server/src/scripts/__tests__/dedupeUsersByIdentityCli.test.ts
@@ -142,15 +142,14 @@ describe('dedupeUsersByIdentity CLI wrapper', () => {
         collisionLimitPerIdentityField: 100,
         identityFieldsScanned: 5,
         possibleCollisionTruncation: false,
-        planLimit: null,
-        possiblePlanTruncation: false,
+        applyGroupLimit: null,
         countSemantics: 'complete-within-scanned-collisions',
       },
     });
     expect(JSON.stringify(payload)).not.toContain('private');
   });
 
-  it('marks identity collision counts as a possible lower bound when the scan limit is reached', () => {
+  it('separates collision truncation from the optional apply group bound', () => {
     const payload = buildDedupeUsersByIdentitySummaryOnlyOutput(
       {
         mode: 'dry-run',
@@ -170,8 +169,7 @@ describe('dedupeUsersByIdentity CLI wrapper', () => {
       collisionLimitPerIdentityField: 25,
       identityFieldsScanned: 1,
       possibleCollisionTruncation: true,
-      planLimit: 10,
-      possiblePlanTruncation: true,
+      applyGroupLimit: 10,
       countSemantics: 'bounded-lower-bound',
     });
   });

--- a/server/src/scripts/__tests__/dedupeUsersByIdentityCli.test.ts
+++ b/server/src/scripts/__tests__/dedupeUsersByIdentityCli.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 import {
   assertDedupeUsersByIdentityApplyAllowed,
   buildDedupeUsersByIdentityOutput,
+  buildDedupeUsersByIdentitySummaryOnlyOutput,
   buildUserIdentityCollisionPipeline,
   writeDedupeUsersByIdentityOutput,
 } from '../dedupeUsersByIdentity';
@@ -83,15 +84,110 @@ describe('dedupeUsersByIdentity CLI wrapper', () => {
       candidateGroups: 2,
       environment: 'beta',
       db: 'Beta',
-        options: {
-          apply: false,
-          confirmUserIdentityDedupe: false,
-          limit: 100,
-          limitProvided: false,
-          sampleSize: 25,
-          output: '/tmp/ylabs-user-identity-dedupe.json',
+      options: {
+        apply: false,
+        confirmUserIdentityDedupe: false,
+        limit: 100,
+        limitProvided: false,
+        sampleSize: 25,
+        output: '/tmp/ylabs-user-identity-dedupe.json',
       },
     });
+  });
+
+  it('builds a fail-closed aggregate-only identity report', () => {
+    const payload = buildDedupeUsersByIdentitySummaryOnlyOutput(
+      {
+        mode: 'dry-run',
+        candidateGroups: 4,
+        plannedGroups: 2,
+        duplicateUsers: 3,
+        warningGroups: 1,
+        plan: [
+          {
+            identityField: 'email',
+            identityValue: 'private@example.test',
+            canonicalUserId: 'user-private',
+            duplicateUserIds: ['user-duplicate'],
+            normalizedName: 'private person',
+          },
+        ],
+        warnings: [
+          {
+            identityField: 'email',
+            identityValue: 'private@example.test',
+            reason: 'identity-shared-by-different-names',
+            normalizedNames: ['private person'],
+            userIds: ['user-private'],
+          },
+        ],
+        applied: [],
+      },
+      { environment: 'development', db: 'Development' },
+      { limit: 100 },
+    );
+
+    expect(payload).toEqual({
+      summaryOnly: true,
+      environment: 'development',
+      db: 'Development',
+      mode: 'dry-run',
+      applyBlocked: true,
+      candidateGroups: 4,
+      plannedGroups: 2,
+      duplicateUsers: 3,
+      warningGroups: 1,
+      appliedCount: 0,
+      scan: {
+        collisionLimitPerIdentityField: 100,
+        identityFieldsScanned: 5,
+        possibleCollisionTruncation: false,
+        planLimit: null,
+        possiblePlanTruncation: false,
+        countSemantics: 'complete-within-scanned-collisions',
+      },
+    });
+    expect(JSON.stringify(payload)).not.toContain('private');
+  });
+
+  it('marks identity collision counts as a possible lower bound when the scan limit is reached', () => {
+    const payload = buildDedupeUsersByIdentitySummaryOnlyOutput(
+      {
+        mode: 'dry-run',
+        candidateGroups: 25,
+        plannedGroups: 12,
+        duplicateUsers: 12,
+        warningGroups: 0,
+        plan: [],
+        warnings: [],
+        applied: [],
+      },
+      { environment: 'development', db: 'Development' },
+      { limit: 25, identityField: 'email', maxApplyGroups: 10 },
+    );
+
+    expect(payload.scan).toEqual({
+      collisionLimitPerIdentityField: 25,
+      identityFieldsScanned: 1,
+      possibleCollisionTruncation: true,
+      planLimit: 10,
+      possiblePlanTruncation: true,
+      countSemantics: 'bounded-lower-bound',
+    });
+  });
+
+  it('rejects summary-only apply before connecting', () => {
+    expect(() =>
+      assertDedupeUsersByIdentityApplyAllowed({
+        apply: true,
+        summaryOnly: true,
+        confirmUserIdentityDedupe: true,
+        limit: 100,
+        limitProvided: true,
+        sampleSize: 25,
+        maxApplyGroups: 1,
+      }),
+    ).toThrow(/--summary-only cannot be combined with --apply/);
   });
 
   it('tracks whether the scan limit was explicitly supplied', () => {

--- a/server/src/scripts/__tests__/dedupeUsersByIdentityCore.test.ts
+++ b/server/src/scripts/__tests__/dedupeUsersByIdentityCore.test.ts
@@ -59,6 +59,20 @@ describe('parseDedupeUsersByIdentityArgs', () => {
     });
   });
 
+  it('parses summary-only without changing default output options', () => {
+    expect(parseDedupeUsersByIdentityArgs(['--summary-only'])).toEqual({
+      apply: false,
+      summaryOnly: true,
+      confirmUserIdentityDedupe: false,
+      limit: 100,
+      limitProvided: false,
+      sampleSize: 25,
+    });
+    expect(() => parseDedupeUsersByIdentityArgs(['--summary-only=true'])).toThrow(
+      '--summary-only does not accept a value',
+    );
+  });
+
   it('rejects non-positive sample-size and max-apply-groups values', () => {
     expect(() => parseDedupeUsersByIdentityArgs(['--sample-size=0'])).toThrow(
       '--sample-size must be a positive integer',

--- a/server/src/scripts/__tests__/dedupeUsersByIdentityCore.test.ts
+++ b/server/src/scripts/__tests__/dedupeUsersByIdentityCore.test.ts
@@ -60,17 +60,23 @@ describe('parseDedupeUsersByIdentityArgs', () => {
   });
 
   it('parses summary-only without changing default output options', () => {
-    expect(parseDedupeUsersByIdentityArgs(['--summary-only'])).toEqual({
-      apply: false,
-      summaryOnly: true,
-      confirmUserIdentityDedupe: false,
-      limit: 100,
-      limitProvided: false,
-      sampleSize: 25,
-    });
+    expect(parseDedupeUsersByIdentityArgs(['--summary-only', '--environment=development'])).toEqual(
+      {
+        apply: false,
+        summaryOnly: true,
+        environment: 'development',
+        confirmUserIdentityDedupe: false,
+        limit: 100,
+        limitProvided: false,
+        sampleSize: 25,
+      },
+    );
     expect(() => parseDedupeUsersByIdentityArgs(['--summary-only=true'])).toThrow(
       '--summary-only does not accept a value',
     );
+    expect(() =>
+      parseDedupeUsersByIdentityArgs(['--summary-only', '--environment=production']),
+    ).toThrow('--environment requires development, beta, or production-copy');
   });
 
   it('rejects non-positive sample-size and max-apply-groups values', () => {

--- a/server/src/scripts/__tests__/dedupeUsersByIdentityCore.test.ts
+++ b/server/src/scripts/__tests__/dedupeUsersByIdentityCore.test.ts
@@ -534,6 +534,39 @@ describe('buildUserIdentityDedupeSummary', () => {
     expect(summary.duplicateUsers).toBe(1);
     expect(summary.plan).toHaveLength(1);
   });
+
+  it('does not apply the apply group bound to dry-run summaries', () => {
+    const plan = buildUserIdentityDedupePlan([
+      {
+        identityField: 'email',
+        identityValue: 'first.person@example.test',
+        users: [
+          { id: 'first-canonical', fname: 'First', lname: 'Person', userConfirmed: true },
+          { id: 'first-duplicate', fname: 'F.', lname: 'Person' },
+        ],
+      },
+      {
+        identityField: 'email',
+        identityValue: 'second.fixture@example.test',
+        users: [
+          { id: 'second-canonical', fname: 'Second', lname: 'Person', userConfirmed: true },
+          { id: 'second-duplicate', fname: 'S.', lname: 'Person' },
+        ],
+      },
+    ]);
+
+    const summary = buildUserIdentityDedupeSummary({
+      apply: false,
+      plan,
+      sampleSize: 25,
+      maxApplyGroups: 1,
+      applied: [],
+    });
+
+    expect(summary.plannedGroups).toBe(2);
+    expect(summary.duplicateUsers).toBe(2);
+    expect(summary.plan).toHaveLength(2);
+  });
 });
 
 describe('post-materialization identity warning classification', () => {

--- a/server/src/scripts/__tests__/dedupeUsersByIdentityCore.test.ts
+++ b/server/src/scripts/__tests__/dedupeUsersByIdentityCore.test.ts
@@ -509,15 +509,15 @@ describe('buildUserIdentityDedupeSummary', () => {
         identityValue: 'first.person@example.test',
         users: [
           { id: 'first-canonical', fname: 'First', lname: 'Person', userConfirmed: true },
-          { id: 'first-duplicate', fname: 'F.', lname: 'Person' },
+          { id: 'first-duplicate', fname: 'First', lname: 'Person' },
         ],
       },
       {
         identityField: 'email',
-        identityValue: 'second.fixture@example.test',
+        identityValue: 'second.person@example.test',
         users: [
           { id: 'second-canonical', fname: 'Second', lname: 'Person', userConfirmed: true },
-          { id: 'second-duplicate', fname: 'S.', lname: 'Person' },
+          { id: 'second-duplicate', fname: 'Second', lname: 'Person' },
         ],
       },
     ]);
@@ -542,15 +542,15 @@ describe('buildUserIdentityDedupeSummary', () => {
         identityValue: 'first.person@example.test',
         users: [
           { id: 'first-canonical', fname: 'First', lname: 'Person', userConfirmed: true },
-          { id: 'first-duplicate', fname: 'F.', lname: 'Person' },
+          { id: 'first-duplicate', fname: 'First', lname: 'Person' },
         ],
       },
       {
         identityField: 'email',
-        identityValue: 'second.fixture@example.test',
+        identityValue: 'second.person@example.test',
         users: [
           { id: 'second-canonical', fname: 'Second', lname: 'Person', userConfirmed: true },
-          { id: 'second-duplicate', fname: 'S.', lname: 'Person' },
+          { id: 'second-duplicate', fname: 'Second', lname: 'Person' },
         ],
       },
     ]);

--- a/server/src/scripts/__tests__/duplicateEntityNameReview.test.ts
+++ b/server/src/scripts/__tests__/duplicateEntityNameReview.test.ts
@@ -84,9 +84,12 @@ describe('duplicate entity name review CLI helpers', () => {
   });
 
   it('parses summary-only as a literal flag', () => {
-    expect(parseDuplicateEntityNameReviewArgs(['--summary-only'])).toEqual({
+    expect(
+      parseDuplicateEntityNameReviewArgs(['--summary-only', '--environment=development']),
+    ).toEqual({
       apply: false,
       summaryOnly: true,
+      environment: 'development',
       confirmDuplicateEntityNameReview: false,
       limit: 10000,
       limitProvided: false,
@@ -96,6 +99,9 @@ describe('duplicate entity name review CLI helpers', () => {
     expect(() => parseDuplicateEntityNameReviewArgs(['--summary-only=true'])).toThrow(
       '--summary-only does not accept a value',
     );
+    expect(() =>
+      parseDuplicateEntityNameReviewArgs(['--summary-only', '--environment=test']),
+    ).toThrow('--environment requires development, beta, or production-copy');
   });
 
   it('rejects summary-only write and decision artifact options before connecting', () => {

--- a/server/src/scripts/__tests__/duplicateEntityNameReview.test.ts
+++ b/server/src/scripts/__tests__/duplicateEntityNameReview.test.ts
@@ -5,10 +5,12 @@ import { describe, expect, it } from 'vitest';
 
 import {
   buildDuplicateEntityNameReviewOutput,
+  buildDuplicateEntityNameReviewSummaryOnlyOutput,
   buildDuplicateEntityNameReviewDecisionTemplate,
   buildDuplicateEntityNameReviewPlans,
   buildDuplicateEntityNameMergeGroups,
   assertDuplicateEntityNameReviewApplyAllowed,
+  assertDuplicateEntityNameReviewSummaryOnlyAllowed,
   normalizeDuplicateEntityNameReviewObjectId,
   parseDuplicateEntityNameReviewArgs,
   readDuplicateEntityNameReviewDecisions,
@@ -81,6 +83,37 @@ describe('duplicate entity name review CLI helpers', () => {
     });
   });
 
+  it('parses summary-only as a literal flag', () => {
+    expect(parseDuplicateEntityNameReviewArgs(['--summary-only'])).toEqual({
+      apply: false,
+      summaryOnly: true,
+      confirmDuplicateEntityNameReview: false,
+      limit: 10000,
+      limitProvided: false,
+      planLimit: 100,
+      maxApply: 10,
+    });
+    expect(() => parseDuplicateEntityNameReviewArgs(['--summary-only=true'])).toThrow(
+      '--summary-only does not accept a value',
+    );
+  });
+
+  it('rejects summary-only write and decision artifact options before connecting', () => {
+    expect(() =>
+      assertDuplicateEntityNameReviewSummaryOnlyAllowed(
+        parseDuplicateEntityNameReviewArgs(['--summary-only', '--apply']),
+      ),
+    ).toThrow(/--summary-only cannot be combined with --apply/);
+    expect(() =>
+      assertDuplicateEntityNameReviewSummaryOnlyAllowed(
+        parseDuplicateEntityNameReviewArgs([
+          '--summary-only',
+          '--decision-template-output=/tmp/decisions.json',
+        ]),
+      ),
+    ).toThrow(/cannot be combined with decision input/);
+  });
+
   it('requires explicit confirmation before duplicate-name review apply', () => {
     expect(
       parseDuplicateEntityNameReviewArgs([
@@ -112,24 +145,24 @@ describe('duplicate entity name review CLI helpers', () => {
     expect(() => parseDuplicateEntityNameReviewArgs(['--output', '--apply'])).toThrow(
       '--output requires a path',
     );
-    expect(() => parseDuplicateEntityNameReviewArgs(['--limit', '--category=same_label_disambiguation'])).toThrow(
-      '--limit requires a number',
-    );
+    expect(() =>
+      parseDuplicateEntityNameReviewArgs(['--limit', '--category=same_label_disambiguation']),
+    ).toThrow('--limit requires a number');
     expect(() => parseDuplicateEntityNameReviewArgs(['--category', '--plan-limit=5'])).toThrow(
       '--category requires a value',
     );
-    expect(() => parseDuplicateEntityNameReviewArgs(['--accepted-decisions', '--allow-empty-decisions'])).toThrow(
-      '--accepted-decisions requires a path',
-    );
-    expect(() => parseDuplicateEntityNameReviewArgs(['--decision-template-output=--apply'])).toThrow(
-      '--decision-template-output requires a path',
-    );
-    expect(() => parseDuplicateEntityNameReviewArgs(['--output=/var/tmp/duplicate-review.json'])).toThrow(
-      /--output must write under/,
-    );
-    expect(() => parseDuplicateEntityNameReviewArgs(['--output=/tmp/duplicate-review.txt'])).toThrow(
-      /--output must point to a \.json report file/,
-    );
+    expect(() =>
+      parseDuplicateEntityNameReviewArgs(['--accepted-decisions', '--allow-empty-decisions']),
+    ).toThrow('--accepted-decisions requires a path');
+    expect(() =>
+      parseDuplicateEntityNameReviewArgs(['--decision-template-output=--apply']),
+    ).toThrow('--decision-template-output requires a path');
+    expect(() =>
+      parseDuplicateEntityNameReviewArgs(['--output=/var/tmp/duplicate-review.json']),
+    ).toThrow(/--output must write under/);
+    expect(() =>
+      parseDuplicateEntityNameReviewArgs(['--output=/tmp/duplicate-review.txt']),
+    ).toThrow(/--output must point to a \.json report file/);
     expect(() =>
       parseDuplicateEntityNameReviewArgs([
         '--accepted-decisions=/var/tmp/duplicate-review-decisions.json',
@@ -316,11 +349,7 @@ describe('duplicate entity name review CLI helpers', () => {
       generatedAt: '2026-05-31T20:00:00.000Z',
       applyBlocked: false,
       applyStatus: DUPLICATE_NAME_APPLY_STATUS,
-      acceptedDecisionValues: [
-        'merge_into_canonical',
-        'mark_distinct_homes',
-        'defer_review',
-      ],
+      acceptedDecisionValues: ['merge_into_canonical', 'mark_distinct_homes', 'defer_review'],
       decisions: [
         {
           planId: 'duplicate-name:shared_website_merge_review:example-lab',
@@ -435,8 +464,7 @@ describe('duplicate entity name review CLI helpers', () => {
     expect(validation).toMatchObject({
       artifactPath: decisionsPath,
       applyBlocked: false,
-      applyStatus:
-        DUPLICATE_NAME_APPLY_STATUS,
+      applyStatus: DUPLICATE_NAME_APPLY_STATUS,
       totalDecisions: 3,
       validDecisionCount: 1,
       invalidDecisionCount: 2,
@@ -458,9 +486,7 @@ describe('duplicate entity name review CLI helpers', () => {
         {
           planId: 'duplicate-name:same_label_disambiguation:miller-lab',
           status: 'invalid',
-          errors: [
-            'merge_into_canonical requires merge_preflight_ready_for_review status.',
-          ],
+          errors: ['merge_into_canonical requires merge_preflight_ready_for_review status.'],
         },
         {
           planId: 'duplicate-name:shared_website_merge_review:missing-lab',
@@ -539,8 +565,7 @@ describe('duplicate entity name review CLI helpers', () => {
       manualDisambiguationRequired: 0,
     });
     expect(planSummary.plans[0]).toMatchObject({
-      planId:
-        'duplicate-name:cross_department_same_person_review:avery-fixture-faculty-research',
+      planId: 'duplicate-name:cross_department_same_person_review:avery-fixture-faculty-research',
       reviewPreflight: {
         status: 'merge_preflight_ready_for_review',
         referenceRewriteRequired: true,
@@ -787,8 +812,7 @@ describe('duplicate entity name review CLI helpers', () => {
             entities: [],
           },
         ],
-        nextAction:
-          'Review category-specific clusters before any merge or archive apply.',
+        nextAction: 'Review category-specific clusters before any merge or archive apply.',
       },
       {
         environment: 'beta',
@@ -812,6 +836,104 @@ describe('duplicate entity name review CLI helpers', () => {
     expect(() =>
       writeDuplicateEntityNameReviewOutput(payload, '/var/tmp/duplicate-review.json'),
     ).toThrow(/--output must write under/);
+  });
+
+  it('builds a fail-closed aggregate-only duplicate-name report', () => {
+    const payload = buildDuplicateEntityNameReviewSummaryOnlyOutput(
+      {
+        generatedAt: '2026-07-28T00:00:00.000Z',
+        mongoTarget: 'mongodb://private.example.test/Development',
+        mode: 'dry-run',
+        applyBlocked: false,
+        applyStatus: DUPLICATE_NAME_APPLY_STATUS,
+        clusterLimit: 500,
+        clusterCount: 1,
+        entityCountInClusters: 2,
+        reviewSummary: {
+          totalClusters: 1,
+          byCategory: [{ category: 'shared_website_merge_review', count: 1 }],
+        },
+        planSummary: {
+          planLimit: 100,
+          plannedClusterCount: 1,
+          plannedEntityCount: 2,
+          planTruncated: false,
+          preflightSummary: {
+            mergePreflightReadyForReview: 1,
+            manualDisambiguationRequired: 0,
+            withReferenceRewrite: 1,
+            totalReferencesImpacted: 3,
+            requiredReviewerDecisions: [{ decision: 'private decision text', count: 1 }],
+          },
+          plans: [
+            {
+              planId: 'private-plan',
+              normalizedName: 'private lab',
+              reviewCategory: 'shared_website_merge_review',
+              entityIds: ['private-entity'],
+              entitySlugs: ['private-lab'],
+              sharedWebsiteUrl: 'https://private.example.test',
+              proposedAction: 'review_for_merge_or_aliasing',
+              reviewPreflight: {
+                status: 'merge_preflight_ready_for_review',
+                referenceRewriteRequired: true,
+                totalReferencesImpacted: 3,
+                blockers: [],
+                requiredReviewerDecisions: [],
+              },
+              applyBlocked: false,
+              applyStatus: DUPLICATE_NAME_APPLY_STATUS,
+            },
+          ],
+        },
+        clusters: [
+          {
+            normalizedName: 'private lab',
+            count: 2,
+            reviewCategory: 'shared_website_merge_review',
+            entities: [
+              {
+                id: 'private-entity',
+                name: 'Private Lab',
+                slug: 'private-lab',
+                websiteUrl: 'https://private.example.test',
+              },
+            ],
+          },
+        ],
+        nextAction: 'Private action',
+      },
+      { environment: 'development', db: 'Development' },
+    );
+    const serialized = JSON.stringify(payload);
+
+    expect(payload).toMatchObject({
+      summaryOnly: true,
+      environment: 'development',
+      db: 'Development',
+      mode: 'dry-run',
+      applyBlocked: true,
+      clusterCount: 1,
+      entityCountInClusters: 2,
+      possibleClusterTruncation: false,
+      countSemantics: 'complete-within-normalized-name-scan',
+      reviewSummary: {
+        byCategory: [{ category: 'shared_website_merge_review', count: 1 }],
+      },
+      planSummary: {
+        plannedClusterCount: 1,
+        plannedEntityCount: 2,
+        preflightSummary: {
+          totalReferencesImpacted: 3,
+        },
+      },
+      appliedCount: 0,
+    });
+    expect(payload).not.toHaveProperty('clusters');
+    expect(payload.planSummary).not.toHaveProperty('plans');
+    expect(serialized).not.toContain('private-entity');
+    expect(serialized).not.toContain('private lab');
+    expect(serialized).not.toContain('private.example');
   });
 
   it('exposes the dry-run command in server package scripts', () => {

--- a/server/src/scripts/__tests__/phase0SummaryOnlyAuditContract.test.ts
+++ b/server/src/scripts/__tests__/phase0SummaryOnlyAuditContract.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from 'vitest';
+import { buildDedupeUsersByIdentitySummaryOnlyOutput } from '../dedupeUsersByIdentity';
+import { buildDuplicateEntityNameReviewSummaryOnlyOutput } from '../duplicateEntityNameReview';
+import { buildResearchEntityCoverageSummaryOnlyOutput } from '../researchEntityCoverageAudit';
+import {
+  buildResearchEntityMemberReferenceAuditSummary,
+  buildResearchEntityMemberReferenceSummaryOnlyOutput,
+} from '../researchEntityMemberReferenceAuditCore';
+
+const PRIVATE = 'PRIVATE_RECORD_VALUE';
+const FORBIDDEN_KEYS = new Set([
+  'applied',
+  'candidateusers',
+  'canonicalentityid',
+  'canonicaluserid',
+  'clusters',
+  'duplicateuserids',
+  'entities',
+  'entityids',
+  'entityslugs',
+  'identityvalue',
+  'inferrednames',
+  'memberid',
+  'mongoTarget'.toLowerCase(),
+  'name',
+  'normalizedname',
+  'plan',
+  'plans',
+  'replacementnetid',
+  'replacementuserid',
+  'rows',
+  'samples',
+  'sharedwebsiteurl',
+  'slug',
+  'sourceurl',
+  'url',
+  'userid',
+  'userids',
+  'warnings',
+]);
+
+function collectKeys(value: unknown, keys: string[] = []): string[] {
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectKeys(item, keys));
+    return keys;
+  }
+  if (!value || typeof value !== 'object') return keys;
+  for (const [key, nested] of Object.entries(value)) {
+    keys.push(key.toLowerCase());
+    collectKeys(nested, keys);
+  }
+  return keys;
+}
+
+function expectAggregateOnlyContract(output: unknown): void {
+  expect(JSON.stringify(output)).not.toContain(PRIVATE);
+  expect(collectKeys(output).filter((key) => FORBIDDEN_KEYS.has(key))).toEqual([]);
+  expect(output).toMatchObject({
+    summaryOnly: true,
+    environment: 'development',
+    db: 'Development',
+  });
+}
+
+describe('Phase 0 summary-only audit output security contract', () => {
+  it('recursively excludes sensitive keys and values from all four audit outputs', () => {
+    const userIdentity = buildDedupeUsersByIdentitySummaryOnlyOutput(
+      {
+        mode: 'dry-run',
+        candidateGroups: 1,
+        plannedGroups: 1,
+        duplicateUsers: 1,
+        warningGroups: 1,
+        plan: [
+          {
+            identityField: 'email',
+            identityValue: PRIVATE,
+            canonicalUserId: PRIVATE,
+            duplicateUserIds: [PRIVATE],
+            normalizedName: PRIVATE,
+          },
+        ],
+        warnings: [
+          {
+            identityField: 'email',
+            identityValue: PRIVATE,
+            reason: 'identity-shared-by-different-names',
+            normalizedNames: [PRIVATE],
+            userIds: [PRIVATE],
+          },
+        ],
+        applied: [{ private: PRIVATE }],
+      },
+      { environment: 'development', db: 'Development' },
+      { limit: 100 },
+    );
+
+    const memberSummary = buildResearchEntityMemberReferenceAuditSummary({
+      totalOrphanedRefs: 1,
+      rows: [
+        {
+          member: {
+            id: PRIVATE,
+            userId: PRIVATE,
+            researchEntityId: PRIVATE,
+            name: PRIVATE,
+            sourceUrl: PRIVATE,
+          },
+          entity: { id: PRIVATE, name: PRIVATE, slug: PRIVATE },
+          candidateUsers: [{ id: PRIVATE, netid: PRIVATE, name: PRIVATE }],
+        },
+      ],
+    });
+    const memberReference = buildResearchEntityMemberReferenceSummaryOnlyOutput(
+      memberSummary,
+      {
+        environment: 'development',
+        db: 'Development',
+      },
+      { limit: 1000 },
+    );
+
+    const duplicateEntity = buildDuplicateEntityNameReviewSummaryOnlyOutput(
+      {
+        generatedAt: '2026-07-28T00:00:00.000Z',
+        mongoTarget: PRIVATE,
+        mode: 'dry-run',
+        applyBlocked: false,
+        applyStatus: PRIVATE,
+        clusterLimit: 100,
+        clusterCount: 1,
+        entityCountInClusters: 2,
+        reviewSummary: {
+          totalClusters: 1,
+          byCategory: [
+            { category: 'shared_website_merge_review', count: 1 },
+            { category: PRIVATE as never, count: 99 },
+          ],
+        },
+        planSummary: {
+          planLimit: 10,
+          plannedClusterCount: 1,
+          plannedEntityCount: 2,
+          planTruncated: false,
+          preflightSummary: {
+            mergePreflightReadyForReview: 1,
+            manualDisambiguationRequired: 0,
+            withReferenceRewrite: 1,
+            totalReferencesImpacted: 3,
+            requiredReviewerDecisions: [{ decision: PRIVATE, count: 1 }],
+          },
+          plans: [
+            {
+              planId: PRIVATE,
+              normalizedName: PRIVATE,
+              reviewCategory: 'shared_website_merge_review',
+              entityIds: [PRIVATE],
+              entitySlugs: [PRIVATE],
+              sharedWebsiteUrl: PRIVATE,
+              proposedAction: 'review_for_merge_or_aliasing',
+              reviewPreflight: {
+                status: 'merge_preflight_ready_for_review',
+                referenceRewriteRequired: true,
+                totalReferencesImpacted: 3,
+                blockers: [PRIVATE],
+                requiredReviewerDecisions: [PRIVATE],
+              },
+              applyBlocked: false,
+              applyStatus: PRIVATE,
+            },
+          ],
+        },
+        clusters: [
+          {
+            normalizedName: PRIVATE,
+            count: 2,
+            reviewCategory: 'shared_website_merge_review',
+            entities: [{ id: PRIVATE, name: PRIVATE, slug: PRIVATE, websiteUrl: PRIVATE }],
+          },
+        ],
+        nextAction: PRIVATE,
+        applied: [{ private: PRIVATE }] as never,
+      },
+      { environment: 'development', db: 'Development' },
+    );
+
+    const coverage = buildResearchEntityCoverageSummaryOnlyOutput(
+      {
+        generatedAt: '2026-07-28T00:00:00.000Z',
+        scope: 'bulk',
+        totalEntitiesScanned: 10,
+        flaggedEntities: 2,
+        filters: {
+          includeArchived: false,
+          includeAll: true,
+          minScore: 0,
+        },
+        issueCounts: {
+          NO_MEMBERS: 2,
+          [PRIVATE]: 99,
+        },
+      },
+      { environment: 'development', db: 'Development' },
+    );
+
+    for (const output of [userIdentity, memberReference, duplicateEntity, coverage]) {
+      expectAggregateOnlyContract(output);
+    }
+  });
+});

--- a/server/src/scripts/__tests__/phase0SummaryOnlyAuditContract.test.ts
+++ b/server/src/scripts/__tests__/phase0SummaryOnlyAuditContract.test.ts
@@ -6,6 +6,11 @@ import {
   buildResearchEntityMemberReferenceAuditSummary,
   buildResearchEntityMemberReferenceSummaryOnlyOutput,
 } from '../researchEntityMemberReferenceAuditCore';
+import {
+  assertPhase0SummaryOnlyConfiguredTarget,
+  assertPhase0SummaryOnlyConnectedTarget,
+  parsePhase0SummaryOnlyEnvironment,
+} from '../phase0SummaryOnlyAudit';
 
 const PRIVATE = 'PRIVATE_RECORD_VALUE';
 const FORBIDDEN_KEYS = new Set([
@@ -63,6 +68,59 @@ function expectAggregateOnlyContract(output: unknown): void {
 }
 
 describe('Phase 0 summary-only audit output security contract', () => {
+  it('fails closed on missing, production, configured, and connected environment mismatches', () => {
+    expect(() =>
+      assertPhase0SummaryOnlyConfiguredTarget({
+        summaryOnly: true,
+        mongoUrl: 'mongodb://example.test/Development',
+        scriptName: 'test-audit',
+      }),
+    ).toThrow('--summary-only requires --environment');
+    expect(() =>
+      assertPhase0SummaryOnlyConfiguredTarget({
+        summaryOnly: false,
+        environment: 'development',
+        mongoUrl: 'mongodb://example.test/Development',
+        scriptName: 'test-audit',
+      }),
+    ).toThrow('--environment is only valid with --summary-only');
+    expect(() => parsePhase0SummaryOnlyEnvironment('production')).toThrow(
+      '--environment requires development, beta, or production-copy',
+    );
+    expect(() =>
+      assertPhase0SummaryOnlyConfiguredTarget({
+        summaryOnly: true,
+        environment: 'development',
+        mongoUrl: 'mongodb://example.test/Beta',
+        scriptName: 'test-audit',
+      }),
+    ).toThrow(/environment development does not match MongoDB database Beta/);
+    expect(() =>
+      assertPhase0SummaryOnlyConfiguredTarget({
+        summaryOnly: true,
+        environment: 'development',
+        mongoUrl: 'mongodb://example.test/Development',
+        scriptName: 'test-audit',
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertPhase0SummaryOnlyConnectedTarget({
+        summaryOnly: true,
+        environment: 'beta',
+        databaseName: 'ProductionCopy',
+        scriptName: 'test-audit',
+      }),
+    ).toThrow(/environment beta does not match MongoDB database ProductionCopy/);
+    expect(() =>
+      assertPhase0SummaryOnlyConnectedTarget({
+        summaryOnly: true,
+        environment: 'production-copy',
+        databaseName: 'ProductionCopy',
+        scriptName: 'test-audit',
+      }),
+    ).not.toThrow();
+  });
+
   it('recursively excludes sensitive keys and values from all four audit outputs', () => {
     const userIdentity = buildDedupeUsersByIdentitySummaryOnlyOutput(
       {

--- a/server/src/scripts/__tests__/researchEntityCoverageAudit.test.ts
+++ b/server/src/scripts/__tests__/researchEntityCoverageAudit.test.ts
@@ -180,9 +180,14 @@ describe('researchEntityCoverageAudit CLI helpers', () => {
   });
 
   it('parses summary-only and rejects slug targeting before connecting', () => {
-    const options = parseResearchEntityCoverageAuditArgs(['--summary-only', '--all']);
+    const options = parseResearchEntityCoverageAuditArgs([
+      '--summary-only',
+      '--environment=development',
+      '--all',
+    ]);
     expect(options).toEqual({
       summaryOnly: true,
+      environment: 'development',
       includeAll: true,
       includeArchived: false,
       limit: 50,
@@ -191,6 +196,9 @@ describe('researchEntityCoverageAudit CLI helpers', () => {
     expect(() => parseResearchEntityCoverageAuditArgs(['--summary-only=true'])).toThrow(
       '--summary-only does not accept a value',
     );
+    expect(() =>
+      parseResearchEntityCoverageAuditArgs(['--summary-only', '--environment=production']),
+    ).toThrow('--environment requires development, beta, or production-copy');
     expect(() =>
       assertResearchEntityCoverageSummaryOnlyAllowed(
         parseResearchEntityCoverageAuditArgs(['--summary-only', '--slug=private-entity-slug']),

--- a/server/src/scripts/__tests__/researchEntityCoverageAudit.test.ts
+++ b/server/src/scripts/__tests__/researchEntityCoverageAudit.test.ts
@@ -6,6 +6,7 @@ import {
   buildCoverageAuditRow,
   buildCoverageIssues,
   extractSuspiciousConstraintQuotes,
+  selectCoverageAuditRows,
   summarizeIssueCounts,
   type CoverageAuditFacts,
 } from '../researchEntityCoverageAuditCore';
@@ -127,6 +128,78 @@ describe('summarizeIssueCounts', () => {
 
     expect(summary.MISSING_DESCRIPTION).toBe(1);
     expect(summary.BLANK_DETAIL_RISK).toBe(1);
+  });
+});
+
+describe('selectCoverageAuditRows', () => {
+  const flaggedRow = buildCoverageAuditRow(baseFacts());
+  const belowThresholdRow = buildCoverageAuditRow({
+    ...baseFacts(),
+    slug: 'missing-website-only',
+    name: 'Missing Website Only',
+    websiteUrl: '',
+    description: 'Complete description.',
+    counts: {
+      ...baseFacts().counts,
+      researchAreas: 2,
+      members: 2,
+      pathways: 1,
+      publicContactRoutes: 1,
+      totalContactRoutes: 1,
+      accessSignals: 2,
+    },
+    observationFlags: {
+      hasMicrositeObservation: false,
+      hasInferredPiObservation: false,
+      suspiciousConstraintQuotes: [],
+    },
+  });
+  const cleanRow = buildCoverageAuditRow({
+    ...baseFacts(),
+    slug: 'complete-entity',
+    name: 'Complete Entity',
+    websiteUrl: 'https://example.test/',
+    description: 'Complete description.',
+    counts: {
+      ...baseFacts().counts,
+      researchAreas: 2,
+      members: 2,
+      pathways: 1,
+      publicContactRoutes: 1,
+      totalContactRoutes: 1,
+      accessSignals: 2,
+    },
+    observationFlags: {
+      hasMicrositeObservation: false,
+      hasInferredPiObservation: false,
+      suspiciousConstraintQuotes: [],
+    },
+  });
+
+  it('includes all bounded rows without changing threshold-based aggregates', () => {
+    const selection = selectCoverageAuditRows([cleanRow, belowThresholdRow, flaggedRow], {
+      includeAll: true,
+      minScore: 2,
+      limit: 10,
+    });
+
+    expect(selection.flaggedEntities).toBe(1);
+    expect(selection.rows).toHaveLength(3);
+    expect(selection.issueCounts.MISSING_DESCRIPTION).toBe(1);
+    expect(selection.issueCounts.MISSING_WEBSITE_URL).toBeUndefined();
+  });
+
+  it('includes only threshold-flagged rows when all-row inclusion is disabled', () => {
+    const selection = selectCoverageAuditRows([cleanRow, belowThresholdRow, flaggedRow], {
+      includeAll: false,
+      minScore: 2,
+      limit: 10,
+    });
+
+    expect(selection.flaggedEntities).toBe(1);
+    expect(selection.rows).toEqual([flaggedRow]);
+    expect(selection.issueCounts.MISSING_DESCRIPTION).toBe(1);
+    expect(selection.issueCounts.MISSING_WEBSITE_URL).toBeUndefined();
   });
 });
 

--- a/server/src/scripts/__tests__/researchEntityCoverageAudit.test.ts
+++ b/server/src/scripts/__tests__/researchEntityCoverageAudit.test.ts
@@ -10,7 +10,9 @@ import {
   type CoverageAuditFacts,
 } from '../researchEntityCoverageAuditCore';
 import {
+  assertResearchEntityCoverageSummaryOnlyAllowed,
   buildResearchEntityCoverageAuditOutput,
+  buildResearchEntityCoverageSummaryOnlyOutput,
   parseResearchEntityCoverageAuditArgs,
   writeResearchEntityCoverageAuditOutput,
 } from '../researchEntityCoverageAudit';
@@ -160,9 +162,9 @@ describe('researchEntityCoverageAudit CLI helpers', () => {
     expect(() => parseResearchEntityCoverageAuditArgs(['--min-score=bad'])).toThrow(
       /--min-score requires a non-negative integer/,
     );
-    expect(() =>
-      parseResearchEntityCoverageAuditArgs(['--min-score=9007199254740992']),
-    ).toThrow(/--min-score requires a non-negative integer/);
+    expect(() => parseResearchEntityCoverageAuditArgs(['--min-score=9007199254740992'])).toThrow(
+      /--min-score requires a non-negative integer/,
+    );
     expect(() => parseResearchEntityCoverageAuditArgs(['--output', '--all'])).toThrow(
       /--output requires a path/,
     );
@@ -175,6 +177,25 @@ describe('researchEntityCoverageAudit CLI helpers', () => {
     expect(() =>
       parseResearchEntityCoverageAuditArgs(['--output', '/tmp/research-entity-coverage.txt']),
     ).toThrow(/--output must point to a \.json report file/);
+  });
+
+  it('parses summary-only and rejects slug targeting before connecting', () => {
+    const options = parseResearchEntityCoverageAuditArgs(['--summary-only', '--all']);
+    expect(options).toEqual({
+      summaryOnly: true,
+      includeAll: true,
+      includeArchived: false,
+      limit: 50,
+      minScore: 1,
+    });
+    expect(() => parseResearchEntityCoverageAuditArgs(['--summary-only=true'])).toThrow(
+      '--summary-only does not accept a value',
+    );
+    expect(() =>
+      assertResearchEntityCoverageSummaryOnlyAllowed(
+        parseResearchEntityCoverageAuditArgs(['--summary-only', '--slug=private-entity-slug']),
+      ),
+    ).toThrow(/--summary-only cannot be combined with --slug/);
   });
 
   it('writes the coverage audit artifact when output is provided', () => {
@@ -236,5 +257,46 @@ describe('researchEntityCoverageAudit CLI helpers', () => {
         output: '/tmp/ylabs-research-entity-coverage.json',
       },
     });
+  });
+
+  it('builds a fail-closed aggregate-only coverage report', () => {
+    const payload = buildResearchEntityCoverageSummaryOnlyOutput(
+      {
+        generatedAt: '2026-07-28T00:00:00.000Z',
+        scope: 'bulk',
+        totalEntitiesScanned: 10,
+        flaggedEntities: 4,
+        filters: {
+          includeArchived: false,
+          includeAll: true,
+          minScore: 0,
+        },
+        issueCounts: {
+          NO_MEMBERS: 3,
+          'private-entity-slug': 999,
+        },
+      },
+      { environment: 'development', db: 'Development' },
+    );
+
+    expect(payload).toEqual({
+      summaryOnly: true,
+      environment: 'development',
+      db: 'Development',
+      generatedAt: '2026-07-28T00:00:00.000Z',
+      scope: 'bulk',
+      applyBlocked: true,
+      totalEntitiesScanned: 10,
+      flaggedEntities: 4,
+      filters: {
+        includeArchived: false,
+        includeAll: true,
+        minScore: 0,
+      },
+      issueCounts: {
+        NO_MEMBERS: 3,
+      },
+    });
+    expect(JSON.stringify(payload)).not.toContain('private');
   });
 });

--- a/server/src/scripts/__tests__/researchEntityMemberReferenceAudit.test.ts
+++ b/server/src/scripts/__tests__/researchEntityMemberReferenceAudit.test.ts
@@ -14,6 +14,7 @@ import {
   assertResearchEntityMemberReferenceTargetAllowed,
   buildResearchEntityMemberReferenceAuditOutput,
   buildResearchEntityMemberReferenceAuditSummary,
+  buildResearchEntityMemberReferenceSummaryOnlyOutput,
   inferMemberReferenceNames,
   parseResearchEntityMemberReferenceAuditArgs,
 } from '../researchEntityMemberReferenceAuditCore';
@@ -150,6 +151,35 @@ describe('research entity member reference audit core', () => {
     });
   });
 
+  it('keeps the full archived-entity member count when detail rows are limit-capped', () => {
+    const summary = buildResearchEntityMemberReferenceAuditSummary({
+      totalOrphanedRefs: 0,
+      totalCurrentMembersOnArchivedEntities: 7,
+      rows: [
+        {
+          member: {
+            id: 'member-1',
+            userId: 'user-1',
+            researchEntityId: 'archived-entity',
+          },
+          entity: {
+            id: 'archived-entity',
+            archived: true,
+            canonicalGroupId: 'canonical-entity',
+          },
+          candidateUsers: [],
+        },
+      ],
+    });
+
+    expect(summary).toMatchObject({
+      currentMembersOnArchivedEntities: 7,
+      plannedCanonicalEntityRelinks: 1,
+      plannedArchivedEntityMemberArchives: 0,
+    });
+    expect(summary.plan).toHaveLength(1);
+  });
+
   it('parses bounds, output, and guarded apply flags', () => {
     expect(
       parseResearchEntityMemberReferenceAuditArgs([
@@ -171,10 +201,24 @@ describe('research entity member reference audit core', () => {
     });
   });
 
+  it('parses summary-only as a literal flag', () => {
+    expect(parseResearchEntityMemberReferenceAuditArgs(['--summary-only'])).toEqual({
+      apply: false,
+      summaryOnly: true,
+      confirmExactRelink: false,
+      limit: 1000,
+      limitProvided: false,
+      maxApply: 10,
+    });
+    expect(() => parseResearchEntityMemberReferenceAuditArgs(['--summary-only=true'])).toThrow(
+      '--summary-only does not accept a value',
+    );
+  });
+
   it('rejects malformed paired CLI values before running the member reference audit', () => {
-    expect(() =>
-      parseResearchEntityMemberReferenceAuditArgs(['--output', '--apply']),
-    ).toThrow('--output requires a path');
+    expect(() => parseResearchEntityMemberReferenceAuditArgs(['--output', '--apply'])).toThrow(
+      '--output requires a path',
+    );
     expect(() =>
       parseResearchEntityMemberReferenceAuditArgs(['--output=/etc/members.json']),
     ).toThrow(/--output must write under/);
@@ -184,15 +228,15 @@ describe('research entity member reference audit core', () => {
     expect(() =>
       parseResearchEntityMemberReferenceAuditArgs(['--limit', '--confirm-exact-relink']),
     ).toThrow('--limit requires a number');
-    expect(() =>
-      parseResearchEntityMemberReferenceAuditArgs(['--limit=1e3']),
-    ).toThrow('--limit must be a positive integer');
-    expect(() =>
-      parseResearchEntityMemberReferenceAuditArgs(['--max-apply=bad']),
-    ).toThrow('--max-apply must be a positive integer');
-    expect(() =>
-      parseResearchEntityMemberReferenceAuditArgs(['--max-apply=1e3']),
-    ).toThrow('--max-apply must be a positive integer');
+    expect(() => parseResearchEntityMemberReferenceAuditArgs(['--limit=1e3'])).toThrow(
+      '--limit must be a positive integer',
+    );
+    expect(() => parseResearchEntityMemberReferenceAuditArgs(['--max-apply=bad'])).toThrow(
+      '--max-apply must be a positive integer',
+    );
+    expect(() => parseResearchEntityMemberReferenceAuditArgs(['--max-apply=1e3'])).toThrow(
+      '--max-apply must be a positive integer',
+    );
     expect(() => parseResearchEntityMemberReferenceAuditArgs(['prod'])).toThrow(
       'Unknown research-entity-members:audit-user-refs option: prod',
     );
@@ -260,11 +304,29 @@ describe('research entity member reference audit core', () => {
     ).not.toThrow();
   });
 
+  it('rejects summary-only apply before connecting', () => {
+    const summary = buildResearchEntityMemberReferenceAuditSummary({
+      totalOrphanedRefs: 0,
+      rows: [],
+    });
+
+    expect(() =>
+      assertResearchEntityMemberReferenceApplyAllowed(
+        {
+          apply: true,
+          summaryOnly: true,
+          confirmExactRelink: true,
+          limit: 1000,
+          limitProvided: true,
+          maxApply: 10,
+        },
+        summary,
+      ),
+    ).toThrow(/--summary-only cannot be combined with --apply/);
+  });
+
   it('requires an explicit limit before member-reference apply can run', () => {
-    const args = parseResearchEntityMemberReferenceAuditArgs([
-      '--apply',
-      '--confirm-exact-relink',
-    ]);
+    const args = parseResearchEntityMemberReferenceAuditArgs(['--apply', '--confirm-exact-relink']);
     const exactSummary = buildResearchEntityMemberReferenceAuditSummary({
       totalOrphanedRefs: 1,
       rows: [
@@ -282,9 +344,9 @@ describe('research entity member reference audit core', () => {
       limit: 1000,
       limitProvided: false,
     });
-    expect(() =>
-      assertResearchEntityMemberReferenceApplyAllowed(args, exactSummary),
-    ).toThrow(/--limit is required/);
+    expect(() => assertResearchEntityMemberReferenceApplyAllowed(args, exactSummary)).toThrow(
+      /--limit is required/,
+    );
   });
 
   it('blocks member-reference apply against production without confirmation', () => {
@@ -362,20 +424,18 @@ describe('research entity member reference audit core', () => {
       ],
     });
 
-    expect(summary).toMatchObject(
-      {
-        mode: 'apply',
-        applied: [
-          {
-            action: 'relink_user_id_to_exact_name_match',
-            memberId: 'member-1',
-            previousUserId: 'missing-user',
-            replacementUserId: 'user-1',
-            replacementNetid: 'nb653',
-          },
-        ],
-      },
-    );
+    expect(summary).toMatchObject({
+      mode: 'apply',
+      applied: [
+        {
+          action: 'relink_user_id_to_exact_name_match',
+          memberId: 'member-1',
+          previousUserId: 'missing-user',
+          replacementUserId: 'user-1',
+          replacementNetid: 'nb653',
+        },
+      ],
+    });
   });
 
   it('marks apply summaries with applied duplicate archives', () => {
@@ -475,9 +535,9 @@ describe('research entity member reference audit CLI wrapper', () => {
       orphanedMemberUserRefs: 0,
       plan: [],
     });
-    expect(() => writeResearchEntityMemberReferenceAuditOutput(payload, '/etc/summary.json')).toThrow(
-      /--output must write under/,
-    );
+    expect(() =>
+      writeResearchEntityMemberReferenceAuditOutput(payload, '/etc/summary.json'),
+    ).toThrow(/--output must write under/);
   });
 
   it('adds target metadata to member-reference audit artifacts', () => {
@@ -514,6 +574,65 @@ describe('research entity member reference audit CLI wrapper', () => {
         output: '/tmp/ylabs-member-reference-audit.json',
       },
     });
+  });
+
+  it('builds a fail-closed aggregate-only member-reference report', () => {
+    const summary = buildResearchEntityMemberReferenceAuditSummary({
+      totalOrphanedRefs: 1,
+      rows: [
+        {
+          member: {
+            id: 'private-member-id',
+            userId: 'private-user-id',
+            researchEntityId: 'private-entity-id',
+            name: 'Private Person',
+            sourceUrl: 'https://private.example.test',
+          },
+          entity: {
+            id: 'private-entity-id',
+            name: 'Private Lab',
+            slug: 'private-lab',
+          },
+          candidateUsers: [
+            {
+              id: 'candidate-user-id',
+              netid: 'private1',
+              name: 'Private Person',
+            },
+          ],
+        },
+      ],
+    });
+    const payload = buildResearchEntityMemberReferenceSummaryOnlyOutput(
+      summary,
+      {
+        environment: 'development',
+        db: 'Development',
+      },
+      { limit: 1000 },
+    );
+
+    expect(payload).toEqual({
+      summaryOnly: true,
+      environment: 'development',
+      db: 'Development',
+      mode: 'dry-run',
+      orphanedMemberUserRefs: 1,
+      plannedExactRelinks: 1,
+      plannedDuplicateArchives: 0,
+      currentMembersOnArchivedEntities: 0,
+      plannedCanonicalEntityRelinks: 0,
+      plannedArchivedEntityMemberArchives: 0,
+      manualReviewCount: 0,
+      applyBlocked: true,
+      appliedCount: 0,
+      scan: {
+        detailRowLimitPerCategory: 1000,
+        plannedRows: 1,
+        possiblePlanTruncation: false,
+      },
+    });
+    expect(JSON.stringify(payload)).not.toContain('private');
   });
 
   it('exposes the dry-run command in server package scripts', () => {

--- a/server/src/scripts/__tests__/researchEntityMemberReferenceAudit.test.ts
+++ b/server/src/scripts/__tests__/researchEntityMemberReferenceAudit.test.ts
@@ -202,9 +202,16 @@ describe('research entity member reference audit core', () => {
   });
 
   it('parses summary-only as a literal flag', () => {
-    expect(parseResearchEntityMemberReferenceAuditArgs(['--summary-only'])).toEqual({
+    expect(
+      parseResearchEntityMemberReferenceAuditArgs([
+        '--summary-only',
+        '--environment',
+        'development',
+      ]),
+    ).toEqual({
       apply: false,
       summaryOnly: true,
+      environment: 'development',
       confirmExactRelink: false,
       limit: 1000,
       limitProvided: false,
@@ -213,6 +220,9 @@ describe('research entity member reference audit core', () => {
     expect(() => parseResearchEntityMemberReferenceAuditArgs(['--summary-only=true'])).toThrow(
       '--summary-only does not accept a value',
     );
+    expect(() =>
+      parseResearchEntityMemberReferenceAuditArgs(['--summary-only', '--environment=production']),
+    ).toThrow('--environment requires development, beta, or production-copy');
   });
 
   it('rejects malformed paired CLI values before running the member reference audit', () => {

--- a/server/src/scripts/dedupeUsersByIdentity.ts
+++ b/server/src/scripts/dedupeUsersByIdentity.ts
@@ -19,6 +19,8 @@ import {
 } from './dedupeUsersByIdentityCore';
 import { assertScriptApplyAllowed, resolveSafeJsonReportOutputPath } from './scriptWriteGuards';
 import {
+  assertPhase0SummaryOnlyConfiguredTarget,
+  assertPhase0SummaryOnlyConnectedTarget,
   assertPhase0SummaryOnlyDryRun,
   buildPhase0SummaryOnlyOutput,
   type Phase0SummaryOnlyMetadata,
@@ -202,10 +204,7 @@ export function buildDedupeUsersByIdentitySummaryOnlyOutput(
         collisionLimitPerIdentityField: options.limit,
         identityFieldsScanned: options.identityField ? 1 : IDENTITY_FIELDS.length,
         possibleCollisionTruncation,
-        planLimit: options.maxApplyGroups ?? null,
-        possiblePlanTruncation: Boolean(
-          options.maxApplyGroups && summary.plannedGroups >= options.maxApplyGroups,
-        ),
+        applyGroupLimit: options.maxApplyGroups ?? null,
         countSemantics: possibleCollisionTruncation
           ? 'bounded-lower-bound'
           : 'complete-within-scanned-collisions',
@@ -730,10 +729,22 @@ function uniqueNonEmptyValues(value: unknown): unknown[] {
 async function main() {
   const args = parseDedupeUsersByIdentityArgs(process.argv.slice(2));
   const guard = assertDedupeUsersByIdentityApplyAllowed(args, process.env, process.env.MONGODBURL);
+  assertPhase0SummaryOnlyConfiguredTarget({
+    summaryOnly: Boolean(args.summaryOnly),
+    environment: args.environment,
+    mongoUrl: process.env.MONGODBURL,
+    scriptName: 'users:dedupe-by-identity',
+  });
   await initializeConnections();
+  assertPhase0SummaryOnlyConnectedTarget({
+    summaryOnly: Boolean(args.summaryOnly),
+    environment: args.environment,
+    databaseName: mongoose.connection.db?.databaseName,
+    scriptName: 'users:dedupe-by-identity',
+  });
   const summary = await runDedupeUsersByIdentity(args);
   const metadata = {
-    environment: guard.environment,
+    environment: args.summaryOnly ? args.environment : guard.environment,
     db: mongoose.connection.db?.databaseName || mongoose.connection.name || guard.dbLabel,
     options: args,
   };

--- a/server/src/scripts/dedupeUsersByIdentity.ts
+++ b/server/src/scripts/dedupeUsersByIdentity.ts
@@ -18,6 +18,11 @@ import {
   type UserIdentityField,
 } from './dedupeUsersByIdentityCore';
 import { assertScriptApplyAllowed, resolveSafeJsonReportOutputPath } from './scriptWriteGuards';
+import {
+  assertPhase0SummaryOnlyDryRun,
+  buildPhase0SummaryOnlyOutput,
+  type Phase0SummaryOnlyMetadata,
+} from './phase0SummaryOnlyAudit';
 import { serializedDocumentId } from '../utils/idSerialization';
 import { sanitizeLogValue } from '../utils/logSanitizer';
 
@@ -108,10 +113,7 @@ export function buildUserIdentityCollisionPipeline(
   ];
 }
 
-export function writeDedupeUsersByIdentityOutput(
-  summary: UserIdentityDedupeSummary,
-  output?: string,
-): void {
+export function writeDedupeUsersByIdentityOutput(summary: unknown, output?: string): void {
   if (!output) return;
   const safeOutput = resolveSafeJsonReportOutputPath(output);
   fs.mkdirSync(path.dirname(safeOutput), { recursive: true });
@@ -124,6 +126,11 @@ export function assertDedupeUsersByIdentityApplyAllowed(
   mongoUrl?: string,
   plannedGroups?: number,
 ) {
+  assertPhase0SummaryOnlyDryRun({
+    summaryOnly: Boolean(args.summaryOnly),
+    apply: args.apply,
+    scriptName: 'users:dedupe-by-identity',
+  });
   if (args.apply) {
     if (!args.confirmUserIdentityDedupe) {
       throw new Error(
@@ -174,6 +181,38 @@ export function buildDedupeUsersByIdentityOutput<T extends object>(
     ...(metadata.db ? { db: metadata.db } : {}),
     options: metadata.options,
   };
+}
+
+export function buildDedupeUsersByIdentitySummaryOnlyOutput(
+  summary: UserIdentityDedupeSummary,
+  metadata: Phase0SummaryOnlyMetadata,
+  options: Pick<DedupeUsersByIdentityArgs, 'limit' | 'identityField' | 'maxApplyGroups'>,
+) {
+  const possibleCollisionTruncation = summary.candidateGroups >= options.limit;
+  return buildPhase0SummaryOnlyOutput(
+    {
+      mode: summary.mode,
+      applyBlocked: true,
+      candidateGroups: summary.candidateGroups,
+      plannedGroups: summary.plannedGroups,
+      duplicateUsers: summary.duplicateUsers,
+      warningGroups: summary.warningGroups,
+      appliedCount: summary.applied.length,
+      scan: {
+        collisionLimitPerIdentityField: options.limit,
+        identityFieldsScanned: options.identityField ? 1 : IDENTITY_FIELDS.length,
+        possibleCollisionTruncation,
+        planLimit: options.maxApplyGroups ?? null,
+        possiblePlanTruncation: Boolean(
+          options.maxApplyGroups && summary.plannedGroups >= options.maxApplyGroups,
+        ),
+        countSemantics: possibleCollisionTruncation
+          ? 'bounded-lower-bound'
+          : 'complete-within-scanned-collisions',
+      },
+    },
+    metadata,
+  );
 }
 
 async function loadCollisions(args: DedupeUsersByIdentityArgs): Promise<UserIdentityCollision[]> {
@@ -320,7 +359,9 @@ async function applyUserIdentityDedupeGroups(
         },
       );
       if (archiveResult.modifiedCount !== 1) {
-        throw new Error(`Failed to archive duplicate user ${duplicateUserId}; row may have changed.`);
+        throw new Error(
+          `Failed to archive duplicate user ${duplicateUserId}; row may have changed.`,
+        );
       }
 
       applied.push({
@@ -461,7 +502,9 @@ async function rewriteResearchEntityMemberReferences(
         },
       );
       if (result.modifiedCount !== 1) {
-        throw new Error(`Failed to archive duplicate member ${serializedDocumentId(member._id) || ''}.`);
+        throw new Error(
+          `Failed to archive duplicate member ${serializedDocumentId(member._id) || ''}.`,
+        );
       }
       archivedDuplicateCount += 1;
       continue;
@@ -492,14 +535,22 @@ async function rewriteScalarObjectIdReferences(
   const rewrites: ReferenceRewriteCount[] = [];
   for (const { collection, field } of USER_SCALAR_OBJECT_ID_REFERENCE_FIELDS) {
     const filter: Record<string, unknown> = { [field]: duplicateObjectId };
-    if (collection === 'research_scholarly_links' || collection === 'research_scholarly_attributions') {
+    if (
+      collection === 'research_scholarly_links' ||
+      collection === 'research_scholarly_attributions'
+    ) {
       filter.archived = { $ne: true };
     }
     const result = await db
       .collection(collection)
       .updateMany(filter, { $set: { [field]: canonicalObjectId } });
     if (result.matchedCount > 0 || result.modifiedCount > 0) {
-      rewrites.push({ collection, field, matchedCount: result.matchedCount, modifiedCount: result.modifiedCount });
+      rewrites.push({
+        collection,
+        field,
+        matchedCount: result.matchedCount,
+        modifiedCount: result.modifiedCount,
+      });
     }
   }
   return rewrites;
@@ -540,7 +591,9 @@ async function archiveDuplicateUniqueUserReferences(
       },
     );
     if (result.modifiedCount !== 1) {
-      throw new Error(`Failed to archive duplicate scholarly link ${serializedDocumentId(row._id) || ''}.`);
+      throw new Error(
+        `Failed to archive duplicate scholarly link ${serializedDocumentId(row._id) || ''}.`,
+      );
     }
     archivedDuplicateCount += 1;
   }
@@ -569,7 +622,12 @@ async function rewriteScalarStringReferences(
       .collection(collection)
       .updateMany({ [field]: duplicateUserId }, { $set: { [field]: canonicalUserId } });
     if (result.matchedCount > 0 || result.modifiedCount > 0) {
-      rewrites.push({ collection, field, matchedCount: result.matchedCount, modifiedCount: result.modifiedCount });
+      rewrites.push({
+        collection,
+        field,
+        matchedCount: result.matchedCount,
+        modifiedCount: result.modifiedCount,
+      });
     }
   }
   return rewrites;
@@ -587,10 +645,7 @@ async function rewriteArrayObjectIdReferences(
       .updateMany({ [field]: duplicateObjectId }, { $addToSet: { [field]: canonicalObjectId } });
     const pullResult = await db
       .collection(collection)
-      .updateMany(
-        { [field]: duplicateObjectId },
-        { $pull: { [field]: duplicateObjectId } } as any,
-      );
+      .updateMany({ [field]: duplicateObjectId }, { $pull: { [field]: duplicateObjectId } } as any);
     if (addResult.matchedCount > 0 || addResult.modifiedCount > 0 || pullResult.modifiedCount > 0) {
       rewrites.push({
         collection,
@@ -615,10 +670,7 @@ async function rewriteArrayStringReferences(
       .updateMany({ [field]: duplicateUserId }, { $addToSet: { [field]: canonicalUserId } });
     const pullResult = await db
       .collection(collection)
-      .updateMany(
-        { [field]: duplicateUserId },
-        { $pull: { [field]: duplicateUserId } } as any,
-      );
+      .updateMany({ [field]: duplicateUserId }, { $pull: { [field]: duplicateUserId } } as any);
     if (addResult.matchedCount > 0 || addResult.modifiedCount > 0 || pullResult.modifiedCount > 0) {
       rewrites.push({
         collection,
@@ -680,11 +732,14 @@ async function main() {
   const guard = assertDedupeUsersByIdentityApplyAllowed(args, process.env, process.env.MONGODBURL);
   await initializeConnections();
   const summary = await runDedupeUsersByIdentity(args);
-  const output = buildDedupeUsersByIdentityOutput(summary, {
+  const metadata = {
     environment: guard.environment,
     db: mongoose.connection.db?.databaseName || mongoose.connection.name || guard.dbLabel,
     options: args,
-  });
+  };
+  const output = args.summaryOnly
+    ? buildDedupeUsersByIdentitySummaryOnlyOutput(summary, metadata, args)
+    : buildDedupeUsersByIdentityOutput(summary, metadata);
   console.log(JSON.stringify(output, null, 2));
   writeDedupeUsersByIdentityOutput(output, args.output);
 }

--- a/server/src/scripts/dedupeUsersByIdentityCore.ts
+++ b/server/src/scripts/dedupeUsersByIdentityCore.ts
@@ -1,4 +1,8 @@
 import type { DuplicatePersonGroup } from '../scrapers/integrityGate';
+import {
+  parsePhase0SummaryOnlyEnvironment,
+  type Phase0SummaryOnlyEnvironment,
+} from './phase0SummaryOnlyAudit';
 import { resolveSafeJsonReportOutputPath } from './scriptWriteGuards';
 
 export type UserIdentityField = DuplicatePersonGroup['identityField'];
@@ -6,6 +10,7 @@ export type UserIdentityField = DuplicatePersonGroup['identityField'];
 export interface DedupeUsersByIdentityArgs {
   apply: boolean;
   summaryOnly?: boolean;
+  environment?: Phase0SummaryOnlyEnvironment;
   confirmUserIdentityDedupe: boolean;
   limit: number;
   limitProvided: boolean;
@@ -104,6 +109,7 @@ function consumeValue(
 export function parseDedupeUsersByIdentityArgs(argv: string[]): DedupeUsersByIdentityArgs {
   let apply = false;
   let summaryOnly = false;
+  let environment: Phase0SummaryOnlyEnvironment | undefined;
   let confirmUserIdentityDedupe = false;
   let limit = 100;
   let limitProvided = false;
@@ -136,6 +142,12 @@ export function parseDedupeUsersByIdentityArgs(argv: string[]): DedupeUsersByIde
     }
     if (arg.startsWith('--summary-only=')) {
       throw new Error('--summary-only does not accept a value');
+    }
+    if (arg === '--environment' || arg.startsWith('--environment=')) {
+      const { value, nextIndex } = consumeValue(argv, index, '--environment');
+      environment = parsePhase0SummaryOnlyEnvironment(value);
+      index = nextIndex;
+      continue;
     }
     if (arg === '--confirm-user-identity-dedupe') {
       confirmUserIdentityDedupe = true;
@@ -198,6 +210,7 @@ export function parseDedupeUsersByIdentityArgs(argv: string[]): DedupeUsersByIde
   return {
     apply,
     ...(summaryOnly ? { summaryOnly: true } : {}),
+    ...(environment ? { environment } : {}),
     confirmUserIdentityDedupe,
     limit,
     limitProvided,

--- a/server/src/scripts/dedupeUsersByIdentityCore.ts
+++ b/server/src/scripts/dedupeUsersByIdentityCore.ts
@@ -506,7 +506,7 @@ export function buildUserIdentityDedupeSummary(input: {
   applied: Record<string, unknown>[];
 }): UserIdentityDedupeSummary {
   const uniqueGroups = uniquePlannedUserIdentityDedupeGroups(input.plan.groups);
-  const plannedGroups = input.maxApplyGroups
+  const plannedGroups = input.apply && input.maxApplyGroups
     ? uniqueGroups.slice(0, input.maxApplyGroups)
     : uniqueGroups;
   const warnings = [...input.plan.warningGroups].sort(compareWarningGroups);

--- a/server/src/scripts/dedupeUsersByIdentityCore.ts
+++ b/server/src/scripts/dedupeUsersByIdentityCore.ts
@@ -5,6 +5,7 @@ export type UserIdentityField = DuplicatePersonGroup['identityField'];
 
 export interface DedupeUsersByIdentityArgs {
   apply: boolean;
+  summaryOnly?: boolean;
   confirmUserIdentityDedupe: boolean;
   limit: number;
   limitProvided: boolean;
@@ -86,7 +87,11 @@ function valueAfterEquals(arg: string, flag: string): string | undefined {
   return arg.startsWith(`${flag}=`) ? arg.slice(flag.length + 1) : undefined;
 }
 
-function consumeValue(argv: string[], index: number, flag: string): { value: string; nextIndex: number } {
+function consumeValue(
+  argv: string[],
+  index: number,
+  flag: string,
+): { value: string; nextIndex: number } {
   const arg = argv[index];
   const inline = valueAfterEquals(arg, flag);
   const value = inline !== undefined ? inline : arg === flag ? argv[index + 1] : undefined;
@@ -98,6 +103,7 @@ function consumeValue(argv: string[], index: number, flag: string): { value: str
 
 export function parseDedupeUsersByIdentityArgs(argv: string[]): DedupeUsersByIdentityArgs {
   let apply = false;
+  let summaryOnly = false;
   let confirmUserIdentityDedupe = false;
   let limit = 100;
   let limitProvided = false;
@@ -123,6 +129,13 @@ export function parseDedupeUsersByIdentityArgs(argv: string[]): DedupeUsersByIde
     if (arg === '--apply') {
       apply = true;
       continue;
+    }
+    if (arg === '--summary-only') {
+      summaryOnly = true;
+      continue;
+    }
+    if (arg.startsWith('--summary-only=')) {
+      throw new Error('--summary-only does not accept a value');
     }
     if (arg === '--confirm-user-identity-dedupe') {
       confirmUserIdentityDedupe = true;
@@ -184,6 +197,7 @@ export function parseDedupeUsersByIdentityArgs(argv: string[]): DedupeUsersByIde
 
   return {
     apply,
+    ...(summaryOnly ? { summaryOnly: true } : {}),
     confirmUserIdentityDedupe,
     limit,
     limitProvided,
@@ -422,7 +436,10 @@ export function buildUserIdentityDedupePlan(
   return {
     candidateGroups: collisions.length,
     groups: plannedGroups,
-    duplicateUsers: plannedGroups.reduce((count, group) => count + group.duplicateUserIds.length, 0),
+    duplicateUsers: plannedGroups.reduce(
+      (count, group) => count + group.duplicateUserIds.length,
+      0,
+    ),
     warningGroups: sortedWarnings,
   };
 }
@@ -485,7 +502,10 @@ export function buildUserIdentityDedupeSummary(input: {
     mode: input.apply ? 'apply' : 'dry-run',
     candidateGroups: input.plan.candidateGroups,
     plannedGroups: plannedGroups.length,
-    duplicateUsers: plannedGroups.reduce((count, group) => count + group.duplicateUserIds.length, 0),
+    duplicateUsers: plannedGroups.reduce(
+      (count, group) => count + group.duplicateUserIds.length,
+      0,
+    ),
     warningGroups: warnings.length,
     plan: plannedGroups.slice(0, input.sampleSize),
     warnings: warnings.slice(0, input.sampleSize),

--- a/server/src/scripts/dedupeUsersByIdentityCore.ts
+++ b/server/src/scripts/dedupeUsersByIdentityCore.ts
@@ -506,9 +506,10 @@ export function buildUserIdentityDedupeSummary(input: {
   applied: Record<string, unknown>[];
 }): UserIdentityDedupeSummary {
   const uniqueGroups = uniquePlannedUserIdentityDedupeGroups(input.plan.groups);
-  const plannedGroups = input.apply && input.maxApplyGroups
-    ? uniqueGroups.slice(0, input.maxApplyGroups)
-    : uniqueGroups;
+  const plannedGroups =
+    input.apply && input.maxApplyGroups
+      ? uniqueGroups.slice(0, input.maxApplyGroups)
+      : uniqueGroups;
   const warnings = [...input.plan.warningGroups].sort(compareWarningGroups);
 
   return {

--- a/server/src/scripts/duplicateEntityNameReview.ts
+++ b/server/src/scripts/duplicateEntityNameReview.ts
@@ -18,6 +18,11 @@ import {
   type ResearchEntityDedupeMergeGroup,
 } from './dedupeResearchEntitiesByPi';
 import { assertScriptApplyAllowed, resolveSafeJsonReportOutputPath } from './scriptWriteGuards';
+import {
+  assertPhase0SummaryOnlyDryRun,
+  buildPhase0SummaryOnlyOutput,
+  type Phase0SummaryOnlyMetadata,
+} from './phase0SummaryOnlyAudit';
 import { serializedDocumentId } from '../utils/idSerialization';
 import { sanitizeLogValue } from '../utils/logSanitizer';
 
@@ -121,6 +126,7 @@ const REFERENCE_IMPACT_COLLECTIONS: Array<{
 
 export interface DuplicateEntityNameReviewArgs {
   apply: boolean;
+  summaryOnly?: boolean;
   confirmDuplicateEntityNameReview: boolean;
   limit: number;
   limitProvided: boolean;
@@ -301,11 +307,7 @@ function consumeValue(
   return { value, nextIndex: index + 1 };
 }
 
-function consumeInlineValue(
-  arg: string,
-  flag: string,
-  noun: 'number' | 'path' | 'value',
-): string {
+function consumeInlineValue(arg: string, flag: string, noun: 'number' | 'path' | 'value'): string {
   const value = arg.slice(`${flag}=`.length);
   if (value.trim() === '' || value.startsWith('--')) {
     throw new Error(`${flag} requires a ${noun}`);
@@ -313,9 +315,7 @@ function consumeInlineValue(
   return value;
 }
 
-export function parseDuplicateEntityNameReviewArgs(
-  argv: string[],
-): DuplicateEntityNameReviewArgs {
+export function parseDuplicateEntityNameReviewArgs(argv: string[]): DuplicateEntityNameReviewArgs {
   const args: DuplicateEntityNameReviewArgs = {
     apply: false,
     confirmDuplicateEntityNameReview: false,
@@ -331,6 +331,13 @@ export function parseDuplicateEntityNameReviewArgs(
       args.apply = true;
       continue;
     }
+    if (arg === '--summary-only') {
+      args.summaryOnly = true;
+      continue;
+    }
+    if (arg.startsWith('--summary-only=')) {
+      throw new Error('--summary-only does not accept a value');
+    }
     if (arg === '--confirm-duplicate-entity-name-review') {
       args.confirmDuplicateEntityNameReview = true;
       continue;
@@ -343,7 +350,10 @@ export function parseDuplicateEntityNameReviewArgs(
       continue;
     }
     if (arg.startsWith('--limit=')) {
-      args.limit = parsePositiveIntegerValue(consumeInlineValue(arg, '--limit', 'number'), '--limit');
+      args.limit = parsePositiveIntegerValue(
+        consumeInlineValue(arg, '--limit', 'number'),
+        '--limit',
+      );
       args.limitProvided = true;
       continue;
     }
@@ -420,12 +430,7 @@ export function parseDuplicateEntityNameReviewArgs(
       continue;
     }
     if (arg === '--decision-template-output') {
-      const { value, nextIndex } = consumeValue(
-        argv,
-        index,
-        '--decision-template-output',
-        'path',
-      );
+      const { value, nextIndex } = consumeValue(argv, index, '--decision-template-output', 'path');
       args.decisionTemplateOutput = resolveSafeJsonReportOutputPath(
         value,
         '--decision-template-output',
@@ -476,10 +481,7 @@ export function buildDuplicateEntityNameReviewPlans(
   };
 }
 
-export function writeDuplicateEntityNameReviewOutput(
-  report: DuplicateEntityNameReviewReport,
-  output?: string,
-): void {
+export function writeDuplicateEntityNameReviewOutput(report: unknown, output?: string): void {
   if (!output) return;
   const safeOutput = resolveSafeJsonReportOutputPath(output);
   fs.mkdirSync(path.dirname(safeOutput), { recursive: true });
@@ -504,6 +506,85 @@ export function buildDuplicateEntityNameReviewOutput(
     options: metadata.options,
     ...report,
   };
+}
+
+export function assertDuplicateEntityNameReviewSummaryOnlyAllowed(
+  args: DuplicateEntityNameReviewArgs,
+): void {
+  assertPhase0SummaryOnlyDryRun({
+    summaryOnly: Boolean(args.summaryOnly),
+    apply: args.apply,
+    scriptName: 'research-entity:duplicate-name-review',
+  });
+  if (!args.summaryOnly) return;
+  if (
+    args.acceptedDecisions ||
+    args.allowEmptyDecisions ||
+    args.decisionTemplateOutput ||
+    args.confirmDuplicateEntityNameReview
+  ) {
+    throw new Error(
+      'research-entity:duplicate-name-review --summary-only cannot be combined with decision input, decision-template output, allow-empty-decisions, or apply confirmation options.',
+    );
+  }
+}
+
+export function buildDuplicateEntityNameReviewSummaryOnlyOutput(
+  report: DuplicateEntityNameReviewReport,
+  metadata: Phase0SummaryOnlyMetadata,
+) {
+  const safeCategories = new Set<DuplicateEntityReviewCategory>([
+    'shared_website_merge_review',
+    'cross_department_same_person_review',
+    'same_label_disambiguation',
+    'manual_review',
+  ]);
+  return buildPhase0SummaryOnlyOutput(
+    {
+      generatedAt: report.generatedAt,
+      mode: report.mode,
+      applyBlocked: true,
+      clusterLimit: report.clusterLimit,
+      clusterCount: report.clusterCount,
+      entityCountInClusters: report.entityCountInClusters,
+      possibleClusterTruncation: report.clusterCount >= report.clusterLimit,
+      countSemantics:
+        report.clusterCount >= report.clusterLimit
+          ? 'bounded-lower-bound'
+          : 'complete-within-normalized-name-scan',
+      reviewSummary: {
+        totalClusters: report.reviewSummary.totalClusters,
+        byCategory: report.reviewSummary.byCategory
+          .filter(
+            ({ category, count }) =>
+              safeCategories.has(category) && Number.isSafeInteger(count) && count >= 0,
+          )
+          .map(({ category, count }) => ({ category, count })),
+      },
+      planSummary: {
+        planLimit: report.planSummary.planLimit,
+        plannedClusterCount: report.planSummary.plannedClusterCount,
+        plannedEntityCount: report.planSummary.plannedEntityCount,
+        planTruncated: report.planSummary.planTruncated,
+        preflightSummary: {
+          mergePreflightReadyForReview:
+            report.planSummary.preflightSummary.mergePreflightReadyForReview,
+          manualDisambiguationRequired:
+            report.planSummary.preflightSummary.manualDisambiguationRequired,
+          withReferenceRewrite: report.planSummary.preflightSummary.withReferenceRewrite,
+          totalReferencesImpacted: report.planSummary.preflightSummary.totalReferencesImpacted,
+          requiredReviewerDecisionCount:
+            report.planSummary.preflightSummary.requiredReviewerDecisions.reduce(
+              (total, { count }) =>
+                Number.isSafeInteger(count) && count >= 0 ? total + count : total,
+              0,
+            ),
+        },
+      },
+      appliedCount: report.applied?.length || 0,
+    },
+    metadata,
+  );
 }
 
 export function writeDuplicateEntityNameReviewDecisionTemplate(
@@ -630,14 +711,18 @@ export function selectDuplicateEntityNamePlansForAcceptedMergeApply(
   }
   const planById = new Map(plans.map((plan) => [plan.planId, plan]));
   return validation.decisions
-    .filter((decision) => decision.status === 'valid' && decision.decision === 'merge_into_canonical')
+    .filter(
+      (decision) => decision.status === 'valid' && decision.decision === 'merge_into_canonical',
+    )
     .map((decision) => {
       const plan = planById.get(decision.planId);
       if (!plan || !decision.canonicalEntityId) return undefined;
       return { plan, canonicalEntityId: decision.canonicalEntityId };
     })
     .filter(
-      (selection): selection is { plan: DuplicateEntityNameReviewPlan; canonicalEntityId: string } =>
+      (
+        selection,
+      ): selection is { plan: DuplicateEntityNameReviewPlan; canonicalEntityId: string } =>
         Boolean(selection),
     );
 }
@@ -656,9 +741,7 @@ export function buildDuplicateEntityNameMergeGroups(
       canonicalEntityId,
       duplicateEntityIds,
       mergedDepartments: uniqueStrings(entities.flatMap((entity) => entity?.departments || [])),
-      mergedResearchAreas: uniqueStrings(
-        entities.flatMap((entity) => entity?.researchAreas || []),
-      ),
+      mergedResearchAreas: uniqueStrings(entities.flatMap((entity) => entity?.researchAreas || [])),
       mergedSourceUrls: uniqueStrings(
         entities.flatMap((entity) => [
           ...(entity?.sourceUrls || []),
@@ -821,6 +904,7 @@ async function buildDuplicateEntityNameReviewReport(
 
 async function main(): Promise<void> {
   const args = parseDuplicateEntityNameReviewArgs(process.argv.slice(2));
+  assertDuplicateEntityNameReviewSummaryOnlyAllowed(args);
   assertDuplicateEntityNameReviewApplyAllowed({
     apply: args.apply,
     confirmDuplicateEntityNameReview: args.confirmDuplicateEntityNameReview,
@@ -836,17 +920,22 @@ async function main(): Promise<void> {
   });
   await initializeConnections();
   const report = await buildDuplicateEntityNameReviewReport(args);
-  const outputReport = buildDuplicateEntityNameReviewOutput(report, {
+  const metadata = {
     environment: guard.environment,
     db: guard.dbLabel,
     options: args,
-  });
+  };
+  const outputReport = args.summaryOnly
+    ? buildDuplicateEntityNameReviewSummaryOnlyOutput(report, metadata)
+    : buildDuplicateEntityNameReviewOutput(report, metadata);
   console.log(JSON.stringify(outputReport, null, 2));
   writeDuplicateEntityNameReviewOutput(outputReport, args.output);
-  writeDuplicateEntityNameReviewDecisionTemplate(
-    buildDuplicateEntityNameReviewDecisionTemplate(report.planSummary.plans, report.generatedAt),
-    args.decisionTemplateOutput,
-  );
+  if (!args.summaryOnly) {
+    writeDuplicateEntityNameReviewDecisionTemplate(
+      buildDuplicateEntityNameReviewDecisionTemplate(report.planSummary.plans, report.generatedAt),
+      args.decisionTemplateOutput,
+    );
+  }
 }
 
 function collection(name: string): Collection<Document> {
@@ -1100,9 +1189,7 @@ function validateDuplicateEntityNameReviewDecision(
     decision.decision !== 'mark_distinct_homes' &&
     decision.decision !== 'defer_review'
   ) {
-    errors.push(
-      'Decision must be merge_into_canonical, mark_distinct_homes, or defer_review.',
-    );
+    errors.push('Decision must be merge_into_canonical, mark_distinct_homes, or defer_review.');
   }
 
   if (decision.decision === 'merge_into_canonical') {
@@ -1176,10 +1263,7 @@ function buildReferenceImpactPipeline(
     [field]: { $in: objectIds },
   };
   if (!array) {
-    return [
-      { $match: match },
-      { $group: { _id: `$${field}`, count: { $sum: 1 } } },
-    ];
+    return [{ $match: match }, { $group: { _id: `$${field}`, count: { $sum: 1 } } }];
   }
 
   return [
@@ -1214,7 +1298,9 @@ function totalReferenceCount(counts: DuplicateEntityReferenceImpactCounts): numb
 
 function uniqueStrings(values: Array<string | undefined>): string[] {
   return Array.from(
-    new Set(values.map((value) => value?.trim()).filter((value): value is string => Boolean(value))),
+    new Set(
+      values.map((value) => value?.trim()).filter((value): value is string => Boolean(value)),
+    ),
   );
 }
 
@@ -1237,7 +1323,11 @@ function normalizedWebsiteKey(value?: string): string {
     const urlPath = parsed.pathname.replace(/\/+$/, '').toLowerCase();
     return `${host}${urlPath}`;
   } catch {
-    return value.trim().replace(/^https?:\/\//i, '').replace(/\/+$/, '').toLowerCase();
+    return value
+      .trim()
+      .replace(/^https?:\/\//i, '')
+      .replace(/\/+$/, '')
+      .toLowerCase();
   }
 }
 

--- a/server/src/scripts/duplicateEntityNameReview.ts
+++ b/server/src/scripts/duplicateEntityNameReview.ts
@@ -19,8 +19,12 @@ import {
 } from './dedupeResearchEntitiesByPi';
 import { assertScriptApplyAllowed, resolveSafeJsonReportOutputPath } from './scriptWriteGuards';
 import {
+  assertPhase0SummaryOnlyConfiguredTarget,
+  assertPhase0SummaryOnlyConnectedTarget,
   assertPhase0SummaryOnlyDryRun,
   buildPhase0SummaryOnlyOutput,
+  parsePhase0SummaryOnlyEnvironment,
+  type Phase0SummaryOnlyEnvironment,
   type Phase0SummaryOnlyMetadata,
 } from './phase0SummaryOnlyAudit';
 import { serializedDocumentId } from '../utils/idSerialization';
@@ -127,6 +131,7 @@ const REFERENCE_IMPACT_COLLECTIONS: Array<{
 export interface DuplicateEntityNameReviewArgs {
   apply: boolean;
   summaryOnly?: boolean;
+  environment?: Phase0SummaryOnlyEnvironment;
   confirmDuplicateEntityNameReview: boolean;
   limit: number;
   limitProvided: boolean;
@@ -337,6 +342,18 @@ export function parseDuplicateEntityNameReviewArgs(argv: string[]): DuplicateEnt
     }
     if (arg.startsWith('--summary-only=')) {
       throw new Error('--summary-only does not accept a value');
+    }
+    if (arg === '--environment') {
+      const { value, nextIndex } = consumeValue(argv, index, '--environment', 'value');
+      args.environment = parsePhase0SummaryOnlyEnvironment(value);
+      index = nextIndex;
+      continue;
+    }
+    if (arg.startsWith('--environment=')) {
+      args.environment = parsePhase0SummaryOnlyEnvironment(
+        consumeInlineValue(arg, '--environment', 'value'),
+      );
+      continue;
     }
     if (arg === '--confirm-duplicate-entity-name-review') {
       args.confirmDuplicateEntityNameReview = true;
@@ -918,16 +935,30 @@ async function main(): Promise<void> {
     scriptName: 'research-entity:duplicate-name-review',
     mongoUrl: process.env.MONGODBURL,
   });
+  assertPhase0SummaryOnlyConfiguredTarget({
+    summaryOnly: Boolean(args.summaryOnly),
+    environment: args.environment,
+    mongoUrl: process.env.MONGODBURL,
+    scriptName: 'research-entity:duplicate-name-review',
+  });
   await initializeConnections();
+  assertPhase0SummaryOnlyConnectedTarget({
+    summaryOnly: Boolean(args.summaryOnly),
+    environment: args.environment,
+    databaseName: mongoose.connection.db?.databaseName,
+    scriptName: 'research-entity:duplicate-name-review',
+  });
   const report = await buildDuplicateEntityNameReviewReport(args);
-  const metadata = {
-    environment: guard.environment,
-    db: guard.dbLabel,
-    options: args,
-  };
   const outputReport = args.summaryOnly
-    ? buildDuplicateEntityNameReviewSummaryOnlyOutput(report, metadata)
-    : buildDuplicateEntityNameReviewOutput(report, metadata);
+    ? buildDuplicateEntityNameReviewSummaryOnlyOutput(report, {
+        environment: args.environment,
+        db: mongoose.connection.db?.databaseName,
+      })
+    : buildDuplicateEntityNameReviewOutput(report, {
+        environment: guard.environment,
+        db: guard.dbLabel,
+        options: args,
+      });
   console.log(JSON.stringify(outputReport, null, 2));
   writeDuplicateEntityNameReviewOutput(outputReport, args.output);
   if (!args.summaryOnly) {

--- a/server/src/scripts/phase0SummaryOnlyAudit.ts
+++ b/server/src/scripts/phase0SummaryOnlyAudit.ts
@@ -1,6 +1,24 @@
+import {
+  assertOperatorEnvironmentMatchesDatabase,
+  databaseNameFromMongoUrl,
+  parseOperatorDatabaseEnvironment,
+} from './operatorDatabaseEnvironment';
+
+export type Phase0SummaryOnlyEnvironment = 'development' | 'beta' | 'production-copy';
+
 export interface Phase0SummaryOnlyMetadata {
   environment?: string;
   db?: string;
+}
+
+export function parsePhase0SummaryOnlyEnvironment(
+  value: string | undefined,
+): Phase0SummaryOnlyEnvironment {
+  const environment = parseOperatorDatabaseEnvironment(value);
+  if (environment === 'production' || environment === 'test') {
+    throw new Error('--environment requires development, beta, or production-copy');
+  }
+  return environment;
 }
 
 export function assertPhase0SummaryOnlyDryRun(args: {
@@ -10,6 +28,42 @@ export function assertPhase0SummaryOnlyDryRun(args: {
 }): void {
   if (args.summaryOnly && args.apply) {
     throw new Error(`${args.scriptName} --summary-only cannot be combined with --apply.`);
+  }
+}
+
+export function assertPhase0SummaryOnlyConfiguredTarget(args: {
+  summaryOnly: boolean;
+  environment?: Phase0SummaryOnlyEnvironment;
+  mongoUrl?: string;
+  scriptName: string;
+}): void {
+  assertPhase0SummaryOnlyEnvironmentOption(args);
+  if (!args.summaryOnly || !args.environment) return;
+  const databaseName = databaseNameFromMongoUrl(args.mongoUrl || '');
+  assertOperatorEnvironmentMatchesDatabase(args.environment, databaseName);
+}
+
+export function assertPhase0SummaryOnlyConnectedTarget(args: {
+  summaryOnly: boolean;
+  environment?: Phase0SummaryOnlyEnvironment;
+  databaseName?: string;
+  scriptName: string;
+}): void {
+  assertPhase0SummaryOnlyEnvironmentOption(args);
+  if (!args.summaryOnly || !args.environment) return;
+  assertOperatorEnvironmentMatchesDatabase(args.environment, args.databaseName || '');
+}
+
+function assertPhase0SummaryOnlyEnvironmentOption(args: {
+  summaryOnly: boolean;
+  environment?: Phase0SummaryOnlyEnvironment;
+  scriptName: string;
+}): void {
+  if (args.summaryOnly && !args.environment) {
+    throw new Error(`${args.scriptName} --summary-only requires --environment.`);
+  }
+  if (!args.summaryOnly && args.environment) {
+    throw new Error(`${args.scriptName} --environment is only valid with --summary-only.`);
   }
 }
 

--- a/server/src/scripts/phase0SummaryOnlyAudit.ts
+++ b/server/src/scripts/phase0SummaryOnlyAudit.ts
@@ -1,0 +1,30 @@
+export interface Phase0SummaryOnlyMetadata {
+  environment?: string;
+  db?: string;
+}
+
+export function assertPhase0SummaryOnlyDryRun(args: {
+  summaryOnly: boolean;
+  apply: boolean;
+  scriptName: string;
+}): void {
+  if (args.summaryOnly && args.apply) {
+    throw new Error(`${args.scriptName} --summary-only cannot be combined with --apply.`);
+  }
+}
+
+export function buildPhase0SummaryOnlyOutput<T extends object>(
+  summary: T,
+  metadata: Phase0SummaryOnlyMetadata,
+): T & {
+  summaryOnly: true;
+  environment?: string;
+  db?: string;
+} {
+  return {
+    ...summary,
+    summaryOnly: true,
+    ...(metadata.environment ? { environment: metadata.environment } : {}),
+    ...(metadata.db ? { db: metadata.db } : {}),
+  };
+}

--- a/server/src/scripts/researchEntityCoverageAudit.ts
+++ b/server/src/scripts/researchEntityCoverageAudit.ts
@@ -16,7 +16,7 @@ import { sourceCoverageRegistry } from '../scrapers/sourceCoverageRegistry';
 import {
   buildCoverageAuditRow,
   extractSuspiciousConstraintQuotes,
-  summarizeIssueCounts,
+  selectCoverageAuditRows,
   type CoverageAuditFacts,
   type CoverageObservationFlags,
 } from './researchEntityCoverageAuditCore';
@@ -349,51 +349,53 @@ async function buildBulkAudit(options: ResearchEntityCoverageAuditCliOptions) {
     observationsBySlug.set(slug, list);
   }
 
-  const rows = entities
-    .map((entity) => {
-      const entityId = stringId(entity._id);
-      const facts: CoverageAuditFacts = {
-        slug: entity.slug,
-        name: entity.name,
-        kind: entity.kind,
-        school: entity.school,
-        websiteUrl: entity.websiteUrl,
-        description: entity.description,
-        shortDescription: entity.shortDescription,
-        fullDescription: entity.fullDescription,
-        counts: {
-          researchAreas: Array.isArray(entity.researchAreas) ? entity.researchAreas.length : 0,
-          sourceUrls: Array.isArray(entity.sourceUrls) ? entity.sourceUrls.length : 0,
-          members: memberCounts.get(entityId) || 0,
-          pathways: pathwayCounts.get(entityId) || 0,
-          publicContactRoutes: publicRouteCounts.get(entityId) || 0,
-          totalContactRoutes: totalRouteCounts.get(entityId) || 0,
-          accessSignals: signalCounts.get(entityId) || 0,
-          postedOpportunities: opportunityCounts.get(entityId) || 0,
-          activeListings: listingCounts.get(entityId) || 0,
-        },
-        observationFlags: buildObservationFlags(observationsBySlug.get(entity.slug) || []),
-      };
-      return buildCoverageAuditRow(facts);
-    })
-    .filter((row) => (options.includeAll ? true : row.issueScore >= options.minScore))
-    .sort((a, b) => b.issueScore - a.issueScore || a.name.localeCompare(b.name));
+  const rows = entities.map((entity) => {
+    const entityId = stringId(entity._id);
+    const facts: CoverageAuditFacts = {
+      slug: entity.slug,
+      name: entity.name,
+      kind: entity.kind,
+      school: entity.school,
+      websiteUrl: entity.websiteUrl,
+      description: entity.description,
+      shortDescription: entity.shortDescription,
+      fullDescription: entity.fullDescription,
+      counts: {
+        researchAreas: Array.isArray(entity.researchAreas) ? entity.researchAreas.length : 0,
+        sourceUrls: Array.isArray(entity.sourceUrls) ? entity.sourceUrls.length : 0,
+        members: memberCounts.get(entityId) || 0,
+        pathways: pathwayCounts.get(entityId) || 0,
+        publicContactRoutes: publicRouteCounts.get(entityId) || 0,
+        totalContactRoutes: totalRouteCounts.get(entityId) || 0,
+        accessSignals: signalCounts.get(entityId) || 0,
+        postedOpportunities: opportunityCounts.get(entityId) || 0,
+        activeListings: listingCounts.get(entityId) || 0,
+      },
+      observationFlags: buildObservationFlags(observationsBySlug.get(entity.slug) || []),
+    };
+    return buildCoverageAuditRow(facts);
+  });
+  const rowLimit = options.slug ? rows.length : options.limit;
+  const selection = selectCoverageAuditRows(rows, {
+    includeAll: options.includeAll,
+    minScore: options.minScore,
+    limit: rowLimit,
+  });
 
-  const limitedRows = options.slug ? rows : rows.slice(0, options.limit);
   return {
     generatedAt: new Date().toISOString(),
     scope: options.slug ? 'detail-candidate' : 'bulk',
     totalEntitiesScanned: entities.length,
-    flaggedEntities: rows.length,
+    flaggedEntities: selection.flaggedEntities,
     filters: {
       slug: options.slug || null,
       includeArchived: options.includeArchived,
       includeAll: options.includeAll,
-      limit: options.slug ? rows.length : options.limit,
+      limit: rowLimit,
       minScore: options.minScore,
     },
-    issueCounts: summarizeIssueCounts(rows),
-    rows: limitedRows,
+    issueCounts: selection.issueCounts,
+    rows: selection.rows,
   };
 }
 

--- a/server/src/scripts/researchEntityCoverageAudit.ts
+++ b/server/src/scripts/researchEntityCoverageAudit.ts
@@ -22,7 +22,11 @@ import {
 } from './researchEntityCoverageAuditCore';
 import { assertScriptApplyAllowed, resolveSafeJsonReportOutputPath } from './scriptWriteGuards';
 import {
+  assertPhase0SummaryOnlyConfiguredTarget,
+  assertPhase0SummaryOnlyConnectedTarget,
   buildPhase0SummaryOnlyOutput,
+  parsePhase0SummaryOnlyEnvironment,
+  type Phase0SummaryOnlyEnvironment,
   type Phase0SummaryOnlyMetadata,
 } from './phase0SummaryOnlyAudit';
 import { sanitizeLogValue } from '../utils/logSanitizer';
@@ -34,6 +38,7 @@ dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 export interface ResearchEntityCoverageAuditCliOptions {
   slug?: string;
   summaryOnly?: boolean;
+  environment?: Phase0SummaryOnlyEnvironment;
   limit: number;
   minScore: number;
   includeArchived: boolean;
@@ -113,6 +118,19 @@ export function parseResearchEntityCoverageAuditArgs(
     }
     if (arg.startsWith('--summary-only=')) {
       throw new Error('--summary-only does not accept a value');
+    }
+    if (arg === '--environment') {
+      const value = argv[i + 1];
+      if (!value || value.startsWith('--')) {
+        throw new Error('--environment requires a value');
+      }
+      options.environment = parsePhase0SummaryOnlyEnvironment(value);
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith('--environment=')) {
+      options.environment = parsePhase0SummaryOnlyEnvironment(arg.slice('--environment='.length));
+      continue;
     }
     if (arg.startsWith('--slug=')) {
       const value = arg.slice('--slug='.length).trim();
@@ -552,12 +570,24 @@ async function main(): Promise<void> {
     scriptName: 'research-entity:coverage-audit',
     mongoUrl: process.env.MONGODBURL,
   });
+  assertPhase0SummaryOnlyConfiguredTarget({
+    summaryOnly: Boolean(options.summaryOnly),
+    environment: options.environment,
+    mongoUrl: process.env.MONGODBURL,
+    scriptName: 'research-entity:coverage-audit',
+  });
   await initializeConnections();
+  assertPhase0SummaryOnlyConnectedTarget({
+    summaryOnly: Boolean(options.summaryOnly),
+    environment: options.environment,
+    databaseName: mongoose.connection.db?.databaseName,
+    scriptName: 'research-entity:coverage-audit',
+  });
 
   const result = options.slug ? await buildSlugAudit(options.slug) : await buildBulkAudit(options);
 
   const metadata = {
-    environment: guard.environment,
+    environment: options.summaryOnly ? options.environment : guard.environment,
     db: mongoose.connection.db?.databaseName || mongoose.connection.name || guard.dbLabel,
     options,
   };

--- a/server/src/scripts/researchEntityCoverageAudit.ts
+++ b/server/src/scripts/researchEntityCoverageAudit.ts
@@ -21,6 +21,10 @@ import {
   type CoverageObservationFlags,
 } from './researchEntityCoverageAuditCore';
 import { assertScriptApplyAllowed, resolveSafeJsonReportOutputPath } from './scriptWriteGuards';
+import {
+  buildPhase0SummaryOnlyOutput,
+  type Phase0SummaryOnlyMetadata,
+} from './phase0SummaryOnlyAudit';
 import { sanitizeLogValue } from '../utils/logSanitizer';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -29,6 +33,7 @@ dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 
 export interface ResearchEntityCoverageAuditCliOptions {
   slug?: string;
+  summaryOnly?: boolean;
   limit: number;
   minScore: number;
   includeArchived: boolean;
@@ -65,6 +70,20 @@ interface ObservationHint {
   confidence?: number;
 }
 
+const SUMMARY_ONLY_COVERAGE_ISSUES = [
+  'BLANK_DETAIL_RISK',
+  'MICROSITE_OBSERVED_NO_ACTIONABLE_ARTIFACTS',
+  'INFERRED_PI_WITHOUT_MEMBERSHIP',
+  'NO_ACTIONABLE_ACCESS',
+  'MISSING_DESCRIPTION',
+  'NO_MEMBERS',
+  'NO_PATHWAYS',
+  'NO_PUBLIC_CONTACT_ROUTE',
+  'SUSPICIOUS_CONSTRAINT_QUOTE_UNCLASSIFIED',
+  'NO_RESEARCH_AREAS',
+  'MISSING_WEBSITE_URL',
+] as const;
+
 export function parseResearchEntityCoverageAuditArgs(
   argv: string[],
 ): ResearchEntityCoverageAuditCliOptions {
@@ -87,6 +106,13 @@ export function parseResearchEntityCoverageAuditArgs(
     if (arg === '--all') {
       options.includeAll = true;
       continue;
+    }
+    if (arg === '--summary-only') {
+      options.summaryOnly = true;
+      continue;
+    }
+    if (arg.startsWith('--summary-only=')) {
+      throw new Error('--summary-only does not accept a value');
     }
     if (arg.startsWith('--slug=')) {
       const value = arg.slice('--slug='.length).trim();
@@ -153,6 +179,16 @@ export function buildResearchEntityCoverageAuditOutput<T extends object>(
     ...(metadata.db ? { db: metadata.db } : {}),
     options: metadata.options,
   };
+}
+
+export function assertResearchEntityCoverageSummaryOnlyAllowed(
+  options: ResearchEntityCoverageAuditCliOptions,
+): void {
+  if (options.summaryOnly && options.slug) {
+    throw new Error(
+      'research-entity:coverage-audit --summary-only cannot be combined with --slug.',
+    );
+  }
 }
 
 function stringId(value: unknown): string {
@@ -343,6 +379,44 @@ async function buildBulkAudit(options: ResearchEntityCoverageAuditCliOptions) {
   };
 }
 
+export function buildResearchEntityCoverageSummaryOnlyOutput(
+  result: {
+    generatedAt: string;
+    scope: string;
+    totalEntitiesScanned: number;
+    flaggedEntities: number;
+    filters: {
+      includeArchived: boolean;
+      includeAll: boolean;
+      minScore: number;
+    };
+    issueCounts: Record<string, number>;
+  },
+  metadata: Phase0SummaryOnlyMetadata,
+) {
+  return buildPhase0SummaryOnlyOutput(
+    {
+      generatedAt: result.generatedAt,
+      scope: result.scope,
+      applyBlocked: true,
+      totalEntitiesScanned: result.totalEntitiesScanned,
+      flaggedEntities: result.flaggedEntities,
+      filters: {
+        includeArchived: result.filters.includeArchived,
+        includeAll: result.filters.includeAll,
+        minScore: result.filters.minScore,
+      },
+      issueCounts: Object.fromEntries(
+        SUMMARY_ONLY_COVERAGE_ISSUES.flatMap((issue) => {
+          const count = result.issueCounts[issue];
+          return Number.isSafeInteger(count) && count >= 0 ? [[issue, count]] : [];
+        }),
+      ),
+    },
+    metadata,
+  );
+}
+
 async function buildSlugAudit(slug: string) {
   const entity = (await ResearchEntity.findOne({ slug })
     .select(
@@ -358,44 +432,43 @@ async function buildSlugAudit(slug: string) {
   }
 
   const entityId = stringId(entity._id);
-  const [
-    members,
-    pathways,
-    signals,
-    routes,
-    opportunities,
-    listings,
-    observations,
-  ] = await Promise.all([
-    ResearchGroupMember.find({ researchEntityId: entity._id })
-      .select('userId role isCurrentMember sourceUrl confidence lastObservedAt')
-      .lean(),
-    EntryPathway.find({ researchEntityId: entity._id, archived: { $ne: true } })
-      .select('pathwayType status evidenceStrength studentFacingLabel bestNextStep sourceUrls confidence derivationKey')
-      .lean(),
-    AccessSignal.find({ researchEntityId: entity._id, archived: { $ne: true } })
-      .select('signalType confidence confidenceScore excerpt sourceName sourceUrl observedAt derivationKey')
-      .sort({ observedAt: -1 })
-      .lean(),
-    ContactRoute.find({ researchEntityId: entity._id, archived: { $ne: true } })
-      .select('routeType label name role url visibility contactPolicy rationale sourceName sourceUrl observedAt derivationKey')
-      .sort({ priority: 1, observedAt: -1 })
-      .lean(),
-    PostedOpportunity.find({ researchEntityId: entity._id, archived: { $ne: true } })
-      .select('title term status applicationUrl sourceUrls derivationKey')
-      .lean(),
-    Listing.find({ researchEntityId: entity._id, archived: { $ne: true } })
-      .select('title deadline website')
-      .lean(),
-    Observation.find({
-      entityType: { $in: ['researchEntity', 'researchGroup'] },
-      superseded: false,
-      $or: [{ entityId: entity._id }, { entityKey: slug }],
-    })
-      .select('field value sourceName sourceUrl confidence observedAt entityKey')
-      .sort({ observedAt: -1 })
-      .lean(),
-  ]);
+  const [members, pathways, signals, routes, opportunities, listings, observations] =
+    await Promise.all([
+      ResearchGroupMember.find({ researchEntityId: entity._id })
+        .select('userId role isCurrentMember sourceUrl confidence lastObservedAt')
+        .lean(),
+      EntryPathway.find({ researchEntityId: entity._id, archived: { $ne: true } })
+        .select(
+          'pathwayType status evidenceStrength studentFacingLabel bestNextStep sourceUrls confidence derivationKey',
+        )
+        .lean(),
+      AccessSignal.find({ researchEntityId: entity._id, archived: { $ne: true } })
+        .select(
+          'signalType confidence confidenceScore excerpt sourceName sourceUrl observedAt derivationKey',
+        )
+        .sort({ observedAt: -1 })
+        .lean(),
+      ContactRoute.find({ researchEntityId: entity._id, archived: { $ne: true } })
+        .select(
+          'routeType label name role url visibility contactPolicy rationale sourceName sourceUrl observedAt derivationKey',
+        )
+        .sort({ priority: 1, observedAt: -1 })
+        .lean(),
+      PostedOpportunity.find({ researchEntityId: entity._id, archived: { $ne: true } })
+        .select('title term status applicationUrl sourceUrls derivationKey')
+        .lean(),
+      Listing.find({ researchEntityId: entity._id, archived: { $ne: true } })
+        .select('title deadline website')
+        .lean(),
+      Observation.find({
+        entityType: { $in: ['researchEntity', 'researchGroup'] },
+        superseded: false,
+        $or: [{ entityId: entity._id }, { entityKey: slug }],
+      })
+        .select('field value sourceName sourceUrl confidence observedAt entityKey')
+        .sort({ observedAt: -1 })
+        .lean(),
+    ]);
 
   const observationHints = observations as ObservationHint[];
   const coverageFacts: CoverageAuditFacts = {
@@ -473,6 +546,7 @@ async function buildSlugAudit(slug: string) {
 
 async function main(): Promise<void> {
   const options = parseResearchEntityCoverageAuditArgs(process.argv.slice(2));
+  assertResearchEntityCoverageSummaryOnlyAllowed(options);
   const guard = assertScriptApplyAllowed({
     apply: false,
     scriptName: 'research-entity:coverage-audit',
@@ -480,15 +554,17 @@ async function main(): Promise<void> {
   });
   await initializeConnections();
 
-  const result = options.slug
-    ? await buildSlugAudit(options.slug)
-    : await buildBulkAudit(options);
+  const result = options.slug ? await buildSlugAudit(options.slug) : await buildBulkAudit(options);
 
-  const output = buildResearchEntityCoverageAuditOutput(result, {
+  const metadata = {
     environment: guard.environment,
     db: mongoose.connection.db?.databaseName || mongoose.connection.name || guard.dbLabel,
     options,
-  });
+  };
+  const output =
+    options.summaryOnly && 'totalEntitiesScanned' in result
+      ? buildResearchEntityCoverageSummaryOnlyOutput(result, metadata)
+      : buildResearchEntityCoverageAuditOutput(result, metadata);
   console.log(JSON.stringify(output, null, 2));
   writeResearchEntityCoverageAuditOutput(output, options.output);
 }

--- a/server/src/scripts/researchEntityCoverageAuditCore.ts
+++ b/server/src/scripts/researchEntityCoverageAuditCore.ts
@@ -44,6 +44,12 @@ export interface CoverageAuditRow {
   issueScore: number;
 }
 
+export interface CoverageAuditRowSelection {
+  flaggedEntities: number;
+  issueCounts: Record<string, number>;
+  rows: CoverageAuditRow[];
+}
+
 const ISSUE_SCORES: Record<string, number> = {
   BLANK_DETAIL_RISK: 5,
   MICROSITE_OBSERVED_NO_ACTIONABLE_ARTIFACTS: 4,
@@ -65,7 +71,9 @@ export function textLength(value: string | undefined | null): number {
   return typeof value === 'string' ? value.trim().length : 0;
 }
 
-export function extractSuspiciousConstraintQuotes(quotes: Array<string | undefined | null>): string[] {
+export function extractSuspiciousConstraintQuotes(
+  quotes: Array<string | undefined | null>,
+): string[] {
   return quotes
     .map((quote) => (typeof quote === 'string' ? quote.trim() : ''))
     .filter((quote) => quote.length > 0 && SUSPICIOUS_CONSTRAINT_RE.test(quote));
@@ -169,4 +177,25 @@ export function summarizeIssueCounts(rows: CoverageAuditRow[]): Record<string, n
     }
     return summary;
   }, {});
+}
+
+export function selectCoverageAuditRows(
+  rows: CoverageAuditRow[],
+  options: {
+    includeAll: boolean;
+    minScore: number;
+    limit: number;
+  },
+): CoverageAuditRowSelection {
+  const sortedRows = [...rows].sort(
+    (a, b) => b.issueScore - a.issueScore || a.name.localeCompare(b.name),
+  );
+  const flaggedRows = sortedRows.filter((row) => row.issueScore >= options.minScore);
+  const includedRows = options.includeAll ? sortedRows : flaggedRows;
+
+  return {
+    flaggedEntities: flaggedRows.length,
+    issueCounts: summarizeIssueCounts(flaggedRows),
+    rows: includedRows.slice(0, options.limit),
+  };
 }

--- a/server/src/scripts/researchEntityMemberReferenceAudit.ts
+++ b/server/src/scripts/researchEntityMemberReferenceAudit.ts
@@ -8,6 +8,10 @@ import { initializeConnections } from '../db/connections';
 import { ResearchGroupMember } from '../models/researchGroupMember';
 import { User } from '../models/user';
 import { resolveSafeJsonReportOutputPath } from './scriptWriteGuards';
+import {
+  assertPhase0SummaryOnlyConfiguredTarget,
+  assertPhase0SummaryOnlyConnectedTarget,
+} from './phase0SummaryOnlyAudit';
 import { serializedDocumentId } from '../utils/idSerialization';
 import { sanitizeLogValue } from '../utils/logSanitizer';
 import {
@@ -438,10 +442,22 @@ async function main() {
     process.env,
     process.env.MONGODBURL,
   );
+  assertPhase0SummaryOnlyConfiguredTarget({
+    summaryOnly: Boolean(args.summaryOnly),
+    environment: args.environment,
+    mongoUrl: process.env.MONGODBURL,
+    scriptName: 'research-entity-members:audit-user-refs',
+  });
   await initializeConnections();
+  assertPhase0SummaryOnlyConnectedTarget({
+    summaryOnly: Boolean(args.summaryOnly),
+    environment: args.environment,
+    databaseName: mongoose.connection.db?.databaseName,
+    scriptName: 'research-entity-members:audit-user-refs',
+  });
   const summary = await runResearchEntityMemberReferenceAudit(args);
   const metadata = {
-    environment: guard.environment,
+    environment: args.summaryOnly ? args.environment : guard.environment,
     db: mongoose.connection.db?.databaseName || mongoose.connection.name || guard.dbLabel,
     options: args,
   };

--- a/server/src/scripts/researchEntityMemberReferenceAudit.ts
+++ b/server/src/scripts/researchEntityMemberReferenceAudit.ts
@@ -7,9 +7,7 @@ import { fileURLToPath } from 'url';
 import { initializeConnections } from '../db/connections';
 import { ResearchGroupMember } from '../models/researchGroupMember';
 import { User } from '../models/user';
-import {
-  resolveSafeJsonReportOutputPath,
-} from './scriptWriteGuards';
+import { resolveSafeJsonReportOutputPath } from './scriptWriteGuards';
 import { serializedDocumentId } from '../utils/idSerialization';
 import { sanitizeLogValue } from '../utils/logSanitizer';
 import {
@@ -18,6 +16,7 @@ import {
   assertResearchEntityMemberReferenceTargetAllowed,
   buildResearchEntityMemberReferenceAuditOutput,
   buildResearchEntityMemberReferenceAuditSummary,
+  buildResearchEntityMemberReferenceSummaryOnlyOutput,
   inferMemberReferenceNames,
   parseResearchEntityMemberReferenceAuditArgs,
   type ExistingMemberMatch,
@@ -161,7 +160,7 @@ export function buildExistingMemberMatchQuery(
 }
 
 export function writeResearchEntityMemberReferenceAuditOutput(
-  summary: ResearchEntityMemberReferenceAuditSummary,
+  summary: unknown,
   output?: string,
 ): void {
   if (!output) return;
@@ -172,9 +171,10 @@ export function writeResearchEntityMemberReferenceAuditOutput(
 
 async function loadOrphanRows(args: ResearchEntityMemberReferenceAuditArgs): Promise<{
   totalOrphanedRefs: number;
+  totalCurrentMembersOnArchivedEntities: number;
   rows: MemberReferenceAuditRow[];
 }> {
-  const [countRows, rawRows, _archivedCountRows, archivedRows] = await Promise.all([
+  const [countRows, rawRows, archivedCountRows, archivedRows] = await Promise.all([
     ResearchGroupMember.aggregate<{ count: number }>([
       ...ORPHAN_USER_REF_STAGES,
       { $count: 'count' },
@@ -213,6 +213,7 @@ async function loadOrphanRows(args: ResearchEntityMemberReferenceAuditArgs): Pro
 
   return {
     totalOrphanedRefs: countRows[0]?.count || 0,
+    totalCurrentMembersOnArchivedEntities: archivedCountRows[0]?.count || 0,
     rows: [...rows, ...archivedEntityRows],
   };
 }
@@ -272,10 +273,7 @@ async function loadExistingCanonicalMemberMatches(
 ): Promise<ExistingMemberMatch[]> {
   const canonicalGroupId = normalizeMemberReferenceObjectId(row.entity?.canonicalGroupId);
   const userId = normalizeMemberReferenceObjectId(row.member.userId);
-  if (
-    !canonicalGroupId ||
-    !userId
-  ) {
+  if (!canonicalGroupId || !userId) {
     return [];
   }
   const query: Record<string, unknown> = {
@@ -302,8 +300,13 @@ async function loadExistingCanonicalMemberMatches(
 export async function runResearchEntityMemberReferenceAudit(
   args: ResearchEntityMemberReferenceAuditArgs,
 ): Promise<ResearchEntityMemberReferenceAuditSummary> {
-  const { totalOrphanedRefs, rows } = await loadOrphanRows(args);
-  const summary = buildResearchEntityMemberReferenceAuditSummary({ totalOrphanedRefs, rows });
+  const { totalOrphanedRefs, totalCurrentMembersOnArchivedEntities, rows } =
+    await loadOrphanRows(args);
+  const summary = buildResearchEntityMemberReferenceAuditSummary({
+    totalOrphanedRefs,
+    totalCurrentMembersOnArchivedEntities,
+    rows,
+  });
   assertResearchEntityMemberReferenceApplyAllowed(args, summary);
   if (!args.apply) {
     return summary;
@@ -437,11 +440,14 @@ async function main() {
   );
   await initializeConnections();
   const summary = await runResearchEntityMemberReferenceAudit(args);
-  const output = buildResearchEntityMemberReferenceAuditOutput(summary, {
+  const metadata = {
     environment: guard.environment,
     db: mongoose.connection.db?.databaseName || mongoose.connection.name || guard.dbLabel,
     options: args,
-  });
+  };
+  const output = args.summaryOnly
+    ? buildResearchEntityMemberReferenceSummaryOnlyOutput(summary, metadata, args)
+    : buildResearchEntityMemberReferenceAuditOutput(summary, metadata);
   console.log(JSON.stringify(output, null, 2));
   writeResearchEntityMemberReferenceAuditOutput(output, args.output);
 }

--- a/server/src/scripts/researchEntityMemberReferenceAuditCore.ts
+++ b/server/src/scripts/researchEntityMemberReferenceAuditCore.ts
@@ -2,12 +2,15 @@ import { assertScriptApplyAllowed, resolveSafeJsonReportOutputPath } from './scr
 import {
   assertPhase0SummaryOnlyDryRun,
   buildPhase0SummaryOnlyOutput,
+  parsePhase0SummaryOnlyEnvironment,
+  type Phase0SummaryOnlyEnvironment,
   type Phase0SummaryOnlyMetadata,
 } from './phase0SummaryOnlyAudit';
 
 export interface ResearchEntityMemberReferenceAuditArgs {
   apply: boolean;
   summaryOnly?: boolean;
+  environment?: Phase0SummaryOnlyEnvironment;
   confirmExactRelink: boolean;
   limit: number;
   limitProvided: boolean;
@@ -104,7 +107,7 @@ function consumeValue(
   argv: string[],
   index: number,
   flag: string,
-  noun: 'number' | 'path',
+  noun: 'number' | 'path' | 'value',
 ): { value: string; nextIndex: number } {
   const value = argv[index + 1];
   if (value === undefined || value.trim() === '' || value.startsWith('--')) {
@@ -113,7 +116,7 @@ function consumeValue(
   return { value, nextIndex: index + 1 };
 }
 
-function consumeInlineValue(arg: string, flag: string, noun: 'number' | 'path'): string {
+function consumeInlineValue(arg: string, flag: string, noun: 'number' | 'path' | 'value'): string {
   const value = arg.slice(`${flag}=`.length);
   if (value.trim() === '' || value.startsWith('--')) {
     throw new Error(`${flag} requires a ${noun}`);
@@ -144,6 +147,18 @@ export function parseResearchEntityMemberReferenceAuditArgs(
     }
     if (arg.startsWith('--summary-only=')) {
       throw new Error('--summary-only does not accept a value');
+    }
+    if (arg === '--environment') {
+      const { value, nextIndex } = consumeValue(argv, index, '--environment', 'value');
+      args.environment = parsePhase0SummaryOnlyEnvironment(value);
+      index = nextIndex;
+      continue;
+    }
+    if (arg.startsWith('--environment=')) {
+      args.environment = parsePhase0SummaryOnlyEnvironment(
+        consumeInlineValue(arg, '--environment', 'value'),
+      );
+      continue;
     }
     if (arg === '--confirm-exact-relink') {
       args.confirmExactRelink = true;

--- a/server/src/scripts/researchEntityMemberReferenceAuditCore.ts
+++ b/server/src/scripts/researchEntityMemberReferenceAuditCore.ts
@@ -1,7 +1,13 @@
 import { assertScriptApplyAllowed, resolveSafeJsonReportOutputPath } from './scriptWriteGuards';
+import {
+  assertPhase0SummaryOnlyDryRun,
+  buildPhase0SummaryOnlyOutput,
+  type Phase0SummaryOnlyMetadata,
+} from './phase0SummaryOnlyAudit';
 
 export interface ResearchEntityMemberReferenceAuditArgs {
   apply: boolean;
+  summaryOnly?: boolean;
   confirmExactRelink: boolean;
   limit: number;
   limitProvided: boolean;
@@ -132,12 +138,22 @@ export function parseResearchEntityMemberReferenceAuditArgs(
       args.apply = true;
       continue;
     }
+    if (arg === '--summary-only') {
+      args.summaryOnly = true;
+      continue;
+    }
+    if (arg.startsWith('--summary-only=')) {
+      throw new Error('--summary-only does not accept a value');
+    }
     if (arg === '--confirm-exact-relink') {
       args.confirmExactRelink = true;
       continue;
     }
     if (arg.startsWith('--limit=')) {
-      args.limit = parsePositiveIntegerValue(consumeInlineValue(arg, '--limit', 'number'), '--limit');
+      args.limit = parsePositiveIntegerValue(
+        consumeInlineValue(arg, '--limit', 'number'),
+        '--limit',
+      );
       args.limitProvided = true;
       continue;
     }
@@ -188,6 +204,7 @@ export function inferMemberReferenceNames(row: MemberReferenceAuditRow): string[
 export function buildResearchEntityMemberReferenceAuditSummary(input: {
   mode?: 'dry-run' | 'apply';
   totalOrphanedRefs: number;
+  totalCurrentMembersOnArchivedEntities?: number;
   rows: MemberReferenceAuditRow[];
   applied?: ResearchEntityMemberReferenceAuditSummary['applied'];
 }): ResearchEntityMemberReferenceAuditSummary {
@@ -212,7 +229,9 @@ export function buildResearchEntityMemberReferenceAuditSummary(input: {
         inferredNames: inferMemberReferenceNames(row),
         candidateUsers: row.candidateUsers,
         replacementResearchEntityId: row.entity.canonicalGroupId,
-        ...(existingCanonicalMemberMatch ? { existingMemberId: existingCanonicalMemberMatch.id } : {}),
+        ...(existingCanonicalMemberMatch
+          ? { existingMemberId: existingCanonicalMemberMatch.id }
+          : {}),
         reason: existingCanonicalMemberMatch
           ? 'Canonical entity already has this current member; archive the stale member row on the archived entity.'
           : 'Current member points at an archived entity; relink to canonicalGroupId.',
@@ -267,11 +286,13 @@ export function buildResearchEntityMemberReferenceAuditSummary(input: {
   const plannedDuplicateArchives = plan.filter(
     (item) => item.action === 'archive_orphan_duplicate_member',
   ).length;
-  const currentMembersOnArchivedEntities = plan.filter(
+  const plannedCurrentMembersOnArchivedEntities = plan.filter(
     (item) =>
       item.action === 'relink_member_to_canonical_entity' ||
       item.action === 'archive_current_member_on_archived_entity',
   ).length;
+  const currentMembersOnArchivedEntities =
+    input.totalCurrentMembersOnArchivedEntities ?? plannedCurrentMembersOnArchivedEntities;
   const plannedCanonicalEntityRelinks = plan.filter(
     (item) => item.action === 'relink_member_to_canonical_entity',
   ).length;
@@ -329,12 +350,19 @@ export function assertResearchEntityMemberReferenceApplyAllowed(
 export function assertResearchEntityMemberReferenceApplyPreflightAllowed(
   args: ResearchEntityMemberReferenceAuditArgs,
 ): void {
+  assertPhase0SummaryOnlyDryRun({
+    summaryOnly: Boolean(args.summaryOnly),
+    apply: args.apply,
+    scriptName: 'research-entity-members:audit-user-refs',
+  });
   if (!args.apply) return;
   if (!args.confirmExactRelink) {
     throw new Error('Apply requires --confirm-exact-relink.');
   }
   if (!args.limitProvided) {
-    throw new Error('--limit is required when --apply is set for research-entity-members:audit-user-refs.');
+    throw new Error(
+      '--limit is required when --apply is set for research-entity-members:audit-user-refs.',
+    );
   }
 }
 
@@ -369,6 +397,35 @@ export function buildResearchEntityMemberReferenceAuditOutput<T extends object>(
     ...(metadata.db ? { db: metadata.db } : {}),
     options: metadata.options,
   };
+}
+
+export function buildResearchEntityMemberReferenceSummaryOnlyOutput(
+  summary: ResearchEntityMemberReferenceAuditSummary,
+  metadata: Phase0SummaryOnlyMetadata,
+  options: Pick<ResearchEntityMemberReferenceAuditArgs, 'limit'>,
+) {
+  return buildPhase0SummaryOnlyOutput(
+    {
+      mode: summary.mode,
+      orphanedMemberUserRefs: summary.orphanedMemberUserRefs,
+      plannedExactRelinks: summary.plannedExactRelinks,
+      plannedDuplicateArchives: summary.plannedDuplicateArchives,
+      currentMembersOnArchivedEntities: summary.currentMembersOnArchivedEntities,
+      plannedCanonicalEntityRelinks: summary.plannedCanonicalEntityRelinks,
+      plannedArchivedEntityMemberArchives: summary.plannedArchivedEntityMemberArchives,
+      manualReviewCount: summary.manualReviewCount,
+      applyBlocked: true,
+      appliedCount: summary.applied.length,
+      scan: {
+        detailRowLimitPerCategory: options.limit,
+        plannedRows: summary.plan.length,
+        possiblePlanTruncation:
+          summary.orphanedMemberUserRefs + summary.currentMembersOnArchivedEntities >
+          summary.plan.length,
+      },
+    },
+    metadata,
+  );
 }
 
 function findExistingMemberMatch(


### PR DESCRIPTION
## Intent

Unblock GitHub issue #204 by adding a consistent fail-closed --summary-only mode to exactly the four Phase 0 complementary audit CLIs. Summary-only stdout and saved JSON must recursively exclude record rows, document IDs, names, emails or netids, identity values, slugs, URLs, candidates, plans, warnings, clusters, and samples while retaining useful aggregate counts. It must reject apply, record-targeted, and incompatible decision-artifact options before connecting, while preserving every existing default detailed dry-run behavior. Identity and duplicate-name limit-reached counts must be labeled as possibly truncated lower bounds. Member-reference totals must preserve full orphan and archived-entity-member counts even when repair detail rows are capped, with plan truncation reported separately. Document exact aggregate-only Development commands with private file permissions. Add focused parser, serializer, recursive privacy, regression, and security-preflight contracts. Do not run any live database audit in this implementation turn. Push a PR targeting beta linked to issue #204, but do not merge it.

## What Changed

- Add fail-closed `--summary-only` output to the four Phase 0 audit CLIs, retaining aggregate counts while excluding record-level identifiers and details.
- Reject apply, record-targeted, and incompatible decision-artifact options before database connection, while preserving existing detailed dry-run behavior and reporting truncation semantics explicitly.
- Document private aggregate-only Development commands and add parser, serialization, privacy, regression, and security-preflight contracts.

## Risk Assessment

✅ Low: The change is well-bounded and source inspection found no material correctness, privacy, preflight, regression, security, or intent-conformance defects in the four summary-only audit paths.

## Testing

After restoring the isolated worktree’s locked dependencies, all targeted parser, serializer, recursive privacy, regression, member-count, and security-preflight contracts passed; manual CLI checks produced a reviewer-visible transcript showing all incompatible requests fail before any live database audit.

<details>
<summary>Evidence: Summary-only fail-closed CLI transcript</summary>

```text
$ yarn --cwd server users:dedupe-by-identity --summary-only --apply
Error: users:dedupe-by-identity --summary-only cannot be combined with --apply.
Error: users:dedupe-by-identity --summary-only cannot be combined with --apply.
    at assertPhase0SummaryOnlyDryRun (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKBRHS2VY5DGDVYGZVJW0YN/server/src/scripts/phase0SummaryOnlyAudit.ts:12:11)
    at assertDedupeUsersByIdentityApplyAllowed (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKBRHS2VY5DGDVYGZVJW0YN/server/src/scripts/dedupeUsersByIdentity.ts:129:3)
    at main (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKBRHS2VY5DGDVYGZVJW0YN/server/src/scripts/dedupeUsersByIdentity.ts:732:17)
    at <anonymous> (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKBRHS2VY5DGDVYGZVJW0YN/server/src/scripts/dedupeUsersByIdentity.ts:752:3)
    at ModuleJob.run (node:internal/modules/esm/module_job:439:25)
    at async node:internal/modules/esm/loader:633:26
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)
exit_code=1

$ yarn --cwd server research-entity-members:audit-user-refs --summary-only --apply
Error: research-entity-members:audit-user-refs --summary-only cannot be combined with --apply.
Error: research-entity-members:audit-user-refs --summary-only cannot be combined with --apply.
    at assertPhase0SummaryOnlyDryRun (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKBRHS2VY5DGDVYGZVJW0YN/server/src/scripts/phase0SummaryOnlyAudit.ts:12:11)
    at assertResearchEntityMemberReferenceApplyPreflightAllowed (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKBRHS2VY5DGDVYGZVJW0YN/server/src/scripts/researchEntityMemberReferenceAuditCore.ts:353:3)
    at main (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKBRHS2VY5DGDVYGZVJW0YN/server/src/scripts/researchEntityMemberReferenceAudit.ts:435:3)
    at <anonymous> (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKBRHS2VY5DGDVYGZVJW0YN/server/src/scripts/researchEntityMemberReferenceAudit.ts:460:3)
    at ModuleJob.run (node:internal/modules/esm/module_job:439:25)
    at async node:internal/modules/esm/loader:633:26
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)
exit_code=1

$ yarn --cwd server research-entity:duplicate-name-review --summary-only --apply
Error: research-entity:duplicate-name-review --summary-only cannot be combined with --apply.
Error: research-entity:duplicate-name-review --summary-only cannot be combined with --apply.
    at assertPhase0SummaryOnlyDryRun (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKBRHS2VY5DGDVYGZVJW0YN/server/src/scripts/phase0SummaryOnlyAudit.ts:12:11)
    at assertDuplicateEntityNameReviewSummaryOnlyAllowed (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKBRHS2VY5DGDVYGZVJW0YN/server/src/scripts/duplicateEntityNameReview.ts:514:3)
    at main (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKBRHS2VY5DGDVYGZVJW0YN/server/src/scripts/duplicateEntityNameReview.ts:907:3)
    at <anonymous> (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKBRHS2VY5DGDVYGZVJW0YN/server/src/scripts/duplicateEntityNameReview.ts:1376:3)
    at ModuleJob.run (node:internal/modules/esm/module_job:439:25)
    at async node:internal/modules/esm/loader:633:26
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)
exit_code=1

$ yarn --cwd server research-entity:coverage-audit --summary-only --apply
Error: Unknown research entity coverage audit argument: --apply
Error: Unknown research entity coverage audit argument: --apply
    at parseResearchEntityCoverageAuditArgs (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKBRHS2VY5DGDVYGZVJW0YN/server/src/scripts/researchEntityCoverageAudit.ts:142:11)
    at main (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKBRHS2VY5DGDVYGZVJW0YN/server/src/scripts/researchEntityCoverageAudit.ts:548:19)
    at <anonymous> (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKBRHS2VY5DGDVYGZVJW0YN/server/src/scripts/researchEntityCoverageAudit.ts:573:3)
    at ModuleJob.run (node:internal/modules/esm/module_job:439:25)
    at async node:internal/modules/esm/loader:633:26
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)
exit_code=1

$ yarn --cwd server research-entity:coverage-audit --summary-only --slug=private-record
Error: research-entity:coverage-audit --summary-only cannot be combined with --slug.
Error: research-entity:coverage-audit --summary-only cannot be combined with --slug.
    at assertResearchEntityCoverageSummaryOnlyAllowed (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKBRHS2VY5DGDVYGZVJW0YN/server/src/scripts/researchEntityCoverageAudit.ts:188:11)
    at main (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKBRHS2VY5DGDVYGZVJW0YN/server/src/scripts/researchEntityCoverageAudit.ts:549:3)
    at <anonymous> (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKBRHS2VY5DGDVYGZVJW0YN/server/src/scripts/researchEntityCoverageAudit.ts:573:3)
    at ModuleJob.run (node:internal/modules/esm/module_job:439:25)
    at async node:internal/modules/esm/loader:633:26
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)
exit_code=1

$ yarn --cwd server research-entity:duplicate-name-review --summary-only --decision-template-output=/tmp/private.json
Error: research-entity:duplicate-name-review --summary-only cannot be combined with decision input, decision-template output, allow-empty-decisions, or apply confirmation options.
Error: research-entity:duplicate-name-review --summary-only cannot be combined with decision input, decision-template output, allow-empty-decisions, or apply confirmation options.
    at assertDuplicateEntityNameReviewSummaryOnlyAllowed (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKBRHS2VY5DGDVYGZVJW0YN/server/src/scripts/duplicateEntityNameReview.ts:526:11)
    at main (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKBRHS2VY5DGDVYGZVJW0YN/server/src/scripts/duplicateEntityNameReview.ts:907:3)
    at <anonymous> (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKBRHS2VY5DGDVYGZVJW0YN/server/src/scripts/duplicateEntityNameReview.ts:1376:3)
    at ModuleJob.run (node:internal/modules/esm/module_job:439:25)
    at async node:internal/modules/esm/loader:633:26
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)
exit_code=1
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`yarn install --immutable` and `yarn --cwd server install --immutable` to restore locked dependency state after the initial test command could not start</code>
- `yarn --cwd server test src/scripts/__tests__/phase0SummaryOnlyAuditContract.test.ts src/scripts/__tests__/dedupeUsersByIdentityCli.test.ts src/scripts/__tests__/dedupeUsersByIdentityCore.test.ts src/scripts/__tests__/duplicateEntityNameReview.test.ts src/scripts/__tests__/researchEntityCoverageAudit.test.ts src/scripts/__tests__/researchEntityMemberReferenceAudit.test.ts`
- `node --test --test-name-pattern='Phase 0 complementary audits enforce fail-closed summary-only output' scripts/security-preflight.test.mjs`
- <code>Invoked all four real CLIs with `--summary-only --apply` and confirmed nonzero pre-connection refusal; additionally checked coverage `--slug` and duplicate-name decision-template incompatibilities</code>
- <code>Reviewed the documented aggregate-only Development commands, `umask 077` permission setup, lower-bound labeling, and separate member-plan truncation guidance</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
