### PR TITLE
feat(server): add private ResearchEntity search baseline

### DIFF
--- a/docs/research-model-refactor-phase0-hot-paths.md
+++ b/docs/research-model-refactor-phase0-hot-paths.md
@@ -188,6 +188,10 @@ The following evidence must be collected read-only in Development, Beta, and the
 Do not run these diagnostics against the primary Production database unless the operator runbook explicitly authorizes the environment and load window.
 Reports must contain aggregate plan statistics and redacted query labels, not user IDs, entity names, notes, contact details, or raw evidence.
 
+The private ResearchEntity search-baseline command is documented in the [Phase 0 runbook](./research-model-refactor-phase0.md#private-researchentity-search-baseline).
+It covers the representative ResearchEntity query suite, deployed Meilisearch settings fingerprint, end-to-end latency samples, degradation state, estimated totals, and pseudonymous ordered result fingerprints.
+It does not replace the MongoDB `executionStats` evidence below.
+
 ### Environment and index drift
 
 1. Record MongoDB server version, collection document counts, and `getIndexes()` output for every collection named in this audit.
@@ -218,6 +222,8 @@ For `/research/:slug`, separately retain per-collection returned counts so bound
 
 ## Phase 0 disposition
 
-Source inspection is complete for these five surfaces, but measured query cost and deployed index use remain open.
+Source inspection is complete for these five surfaces.
+The repeatable private ResearchEntity search-baseline tooling is implemented, but reviewed Development, Beta, and ProductionCopy artifacts are still required.
+Measured MongoDB query cost and deployed index use remain open.
 The highest-priority live checks are the full-scan `/research` fallbacks, missing scholarly-link and attribution indexes, account planning's concurrent mutation-capable reads, fellowship all-record matching, and admin access-review's pre-pagination lookups and unbounded detail.
 No later migration phase should remove compatibility fields or redirect these readers until the live evidence is reviewed and an owner accepts the resulting index and cutover work.

--- a/docs/research-model-refactor-phase0.md
+++ b/docs/research-model-refactor-phase0.md
@@ -165,6 +165,96 @@ Coverage `totalEntitiesScanned` is computed over all entities selected by the ag
 The row limit does not cap summary-only counts.
 Use the default detailed dry-run modes only inside an approved private review workflow.
 
+## Private ResearchEntity search baseline
+
+The search baseline is read-only and exercises the current public ResearchEntity search service.
+That means each case includes Meilisearch candidate retrieval, MongoDB visibility verification, and the current access and planning enrichment reads.
+The bounded suite covers blank browse, keyword search, a short alias, a semantic phrase, department and research-area filters, and a deep allowed page.
+
+The artifact contains query labels and inputs, deployed settings and salt fingerprints, safe settings field names, index document count, latency samples, degradation state, estimated totals, and ordered HMAC result fingerprints.
+It never contains entity IDs, names, slugs, URLs, contact data, or the HMAC salt.
+The artifact is still private operational evidence because counts and stable cross-run fingerprints can reveal internal state.
+Do not attach it to an issue or pull request.
+
+Use the same high-entropy salt for every environment that will be compared.
+Store the salt in the team secret manager and inject it through `PHASE0_SEARCH_BASELINE_SALT`.
+Never pass the salt as a command-line argument or write it into a worktree.
+Every output must be a new `.json` path under the system temporary directory.
+The writer creates the file with mode `0600`, refuses symlink outputs, and refuses overwrite.
+
+Load the exact target credentials from an approved operator secret store before each command.
+Set `YLABS_SKIP_LOCAL_DOTENV=true` so a checkout-local `server/.env` cannot replace an omitted target setting.
+The command verifies the configured and connected MongoDB database name before search.
+It rejects primary Production and a Production Meilisearch prefix.
+Beta requires `MEILISEARCH_INDEX_PREFIX=beta`.
+ProductionCopy requires a dedicated prefix such as `production-copy-july`; it must never point at `prod_researchentities`.
+
+Run the Development baseline from a clean Beta worktree with `MONGODBURL` targeting `Development` and local Meilisearch:
+
+```bash
+umask 077
+
+export YLABS_SKIP_LOCAL_DOTENV=true
+export PHASE0_SEARCH_BASELINE_SALT
+export MONGODBURL
+export MEILISEARCH_HOST=http://localhost:7700
+unset MEILISEARCH_INDEX_PREFIX
+
+yarn model-refactor:search-baseline \
+  --environment=development \
+  --iterations=3 \
+  --top-k=10 \
+  --strict \
+  --output=/tmp/ylabs-phase0-search-development.json
+```
+
+Run the Beta baseline from the same source commit with the read-only Beta MongoDB user and private Beta Meilisearch credentials:
+
+```bash
+umask 077
+
+export YLABS_SKIP_LOCAL_DOTENV=true
+export PHASE0_SEARCH_BASELINE_SALT
+export MONGODBURL
+export MEILISEARCH_HOST
+export MEILISEARCH_API_KEY
+export MEILISEARCH_INDEX_PREFIX=beta
+
+yarn model-refactor:search-baseline \
+  --environment=beta \
+  --iterations=3 \
+  --top-k=10 \
+  --strict \
+  --output=/tmp/ylabs-phase0-search-beta.json
+```
+
+Run ProductionCopy only after the approved MongoDB restore and a dedicated non-production Meilisearch index copy exist:
+
+```bash
+umask 077
+
+export YLABS_SKIP_LOCAL_DOTENV=true
+export PHASE0_SEARCH_BASELINE_SALT
+export MONGODBURL
+export MEILISEARCH_HOST
+export MEILISEARCH_API_KEY
+export MEILISEARCH_INDEX_PREFIX=production-copy-july
+
+yarn model-refactor:search-baseline \
+  --environment=production-copy \
+  --iterations=3 \
+  --top-k=10 \
+  --strict \
+  --output=/tmp/ylabs-phase0-search-production-copy.json
+```
+
+Unset the injected credentials and salt after each run.
+Preserve the source commit, salt fingerprint, query suite, iteration count, top-K, and settings fingerprint with the comparison.
+Compare estimated totals and ordered result fingerprints per case.
+Treat any degraded sample, unstable ordered result set, unexpected count change, or ranking change as review-required evidence rather than silently accepting it.
+`--strict` writes the artifact and then exits nonzero when a degraded or unstable sample requires review.
+Latency is diagnostic only unless the environments use comparable network and compute conditions.
+
 ## Export and rollback prerequisites
 
 No later phase may drop or overwrite a collection until these exist and are verified:

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "meili:health": "curl http://localhost:7700/health",
     "meili:seed": "yarn --cwd server meili:seed",
     "migrate:mongo-naming": "yarn --cwd server migrate:mongo-naming",
+    "model-refactor:search-baseline": "yarn --cwd server model-refactor:search-baseline",
     "model-refactor:validators": "yarn --cwd server model-refactor:validators",
     "scrape": "yarn --cwd server scrape",
     "scrape:seed-sources": "yarn --cwd server scrape:seed-sources",

--- a/server/package.json
+++ b/server/package.json
@@ -39,6 +39,7 @@
     "research-entity:audit-rename": "tsx src/scripts/auditResearchEntityRename.ts",
     "research-entity:coverage-audit": "tsx src/scripts/researchEntityCoverageAudit.ts",
     "model-refactor:inventory": "tsx src/scripts/researchModelInventory.ts",
+    "model-refactor:search-baseline": "tsx src/scripts/phase0ResearchSearchBaseline.ts",
     "model-refactor:validators": "tsx src/scripts/canonicalMongoValidators.ts",
     "accepted-inputs": "tsx src/scripts/acceptedInputs.ts",
     "beta:data-quality": "tsx src/scripts/betaDataQuality.ts",

--- a/server/src/scripts/__tests__/phase0ResearchSearchBaseline.test.ts
+++ b/server/src/scripts/__tests__/phase0ResearchSearchBaseline.test.ts
@@ -1,0 +1,65 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import { writePhase0ResearchSearchBaseline } from '../phase0ResearchSearchBaseline';
+import type { Phase0ResearchSearchBaselineReport } from '../phase0ResearchSearchBaselineCore';
+
+function fixtureReport(): Phase0ResearchSearchBaselineReport {
+  return {
+    schemaVersion: 1,
+    artifactType: 'phase0-research-search-baseline',
+    generatedAt: '2026-07-28T12:00:00.000Z',
+    sourceCommit: '5d4b09617ed96c963c1e28011075a941d1307b13',
+    environment: 'development',
+    databaseName: 'Development',
+    saltFingerprint: 'salt-fingerprint',
+    meilisearch: {
+      targetKind: 'local',
+      indexName: 'researchentities',
+      settingsFingerprint: 'settings-fingerprint',
+      searchableAttributes: ['name'],
+      filterableAttributes: ['archived'],
+      sortableAttributes: ['browseRankScore'],
+      embedderNames: ['default'],
+      numberOfDocuments: 1,
+      indexing: false,
+    },
+    suite: { iterations: 1, topK: 1, caseCount: 0 },
+    summary: { degradedSamples: 0, unstableCases: 0, reviewRequired: false },
+    cases: [],
+  };
+}
+
+describe('Phase 0 ResearchEntity search baseline artifact writer', () => {
+  it('writes a new mode-0600 artifact and refuses overwrite', () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'ylabs-phase0-search-baseline-'));
+    const output = path.join(directory, 'baseline.json');
+
+    const receipt = writePhase0ResearchSearchBaseline(fixtureReport(), output);
+
+    expect(receipt).toMatchObject({ output });
+    expect(receipt.sha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(receipt.bytes).toBeGreaterThan(0);
+    expect(fs.statSync(output).mode & 0o777).toBe(0o600);
+    expect(JSON.parse(fs.readFileSync(output, 'utf8'))).toMatchObject({
+      artifactType: 'phase0-research-search-baseline',
+      environment: 'development',
+    });
+    expect(() => writePhase0ResearchSearchBaseline(fixtureReport(), output)).toThrow(
+      /EEXIST|file already exists/i,
+    );
+  });
+
+  it('refuses a symlink output', () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'ylabs-phase0-search-symlink-'));
+    const target = path.join(directory, 'target.json');
+    const output = path.join(directory, 'baseline.json');
+    fs.writeFileSync(target, '{}\n', { mode: 0o600 });
+    fs.symlinkSync(target, output);
+
+    expect(() => writePhase0ResearchSearchBaseline(fixtureReport(), output)).toThrow(
+      /EEXIST|symbolic link/i,
+    );
+  });
+});

--- a/server/src/scripts/__tests__/phase0ResearchSearchBaseline.test.ts
+++ b/server/src/scripts/__tests__/phase0ResearchSearchBaseline.test.ts
@@ -62,4 +62,21 @@ describe('Phase 0 ResearchEntity search baseline artifact writer', () => {
       /EEXIST|symbolic link/i,
     );
   });
+
+  it('refuses a symlink parent before creating descendants through it', () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'ylabs-phase0-search-parent-'));
+    const outside = fs.mkdtempSync(path.join(process.cwd(), 'phase0-search-outside-'));
+    const linkedParent = path.join(directory, 'linked');
+    const output = path.join(linkedParent, 'new', 'baseline.json');
+    fs.symlinkSync(outside, linkedParent);
+
+    try {
+      expect(() => writePhase0ResearchSearchBaseline(fixtureReport(), output)).toThrow(
+        /real directories/,
+      );
+      expect(fs.existsSync(path.join(outside, 'new'))).toBe(false);
+    } finally {
+      fs.rmSync(outside, { recursive: true });
+    }
+  });
 });

--- a/server/src/scripts/__tests__/phase0ResearchSearchBaselineCore.test.ts
+++ b/server/src/scripts/__tests__/phase0ResearchSearchBaselineCore.test.ts
@@ -112,7 +112,28 @@ describe('Phase 0 ResearchEntity search baseline core', () => {
         environment: 'development',
         host: 'https://search.example.test',
       }),
-    ).toThrow(/unprefixed Development index/);
+    ).toThrow(/requires a local Meilisearch host/);
+    expect(() =>
+      assertPhase0ResearchSearchMeiliTarget({
+        environment: 'development',
+        host: 'https://search.example.test',
+        indexPrefix: 'development',
+      }),
+    ).toThrow(/requires a local Meilisearch host/);
+    expect(() =>
+      assertPhase0ResearchSearchMeiliTarget({
+        environment: 'beta',
+        host: 'http://localhost:7700',
+        indexPrefix: 'beta',
+      }),
+    ).toThrow(/requires a remote Meilisearch host/);
+    expect(() =>
+      assertPhase0ResearchSearchMeiliTarget({
+        environment: 'production-copy',
+        host: 'http://localhost:7700',
+        indexPrefix: 'production-copy-july',
+      }),
+    ).toThrow(/requires a remote Meilisearch host/);
     expect(() =>
       assertPhase0ResearchSearchMeiliTarget({
         environment: 'production-copy',

--- a/server/src/scripts/__tests__/phase0ResearchSearchBaselineCore.test.ts
+++ b/server/src/scripts/__tests__/phase0ResearchSearchBaselineCore.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PHASE0_RESEARCH_SEARCH_CASES,
+  assertPhase0ResearchSearchMeiliTarget,
+  buildPhase0ResearchSearchBaselineReport,
+  parsePhase0ResearchSearchBaselineArgs,
+  phase0ResearchSearchResultFingerprint,
+  phase0ResearchSearchSettingsFingerprint,
+  requirePhase0ResearchSearchSalt,
+  summarizePhase0ResearchSearchCase,
+} from '../phase0ResearchSearchBaselineCore';
+
+describe('Phase 0 ResearchEntity search baseline core', () => {
+  it('parses a bounded explicit evidence target', () => {
+    expect(
+      parsePhase0ResearchSearchBaselineArgs([
+        '--environment=beta',
+        '--iterations=5',
+        '--top-k=12',
+        '--strict',
+        '--output=/tmp/ylabs-phase0-search-beta.json',
+      ]),
+    ).toEqual({
+      environment: 'beta',
+      iterations: 5,
+      topK: 12,
+      strict: true,
+      output: '/tmp/ylabs-phase0-search-beta.json',
+    });
+
+    expect(() =>
+      parsePhase0ResearchSearchBaselineArgs([
+        '--environment=production',
+        '--output=/tmp/forbidden.json',
+      ]),
+    ).toThrow(/development, beta, or production-copy/);
+    expect(() =>
+      parsePhase0ResearchSearchBaselineArgs(['--output=/tmp/missing-environment.json']),
+    ).toThrow(/requires --environment/);
+    expect(() => parsePhase0ResearchSearchBaselineArgs(['--environment=beta'])).toThrow(
+      /requires --output/,
+    );
+    expect(() =>
+      parsePhase0ResearchSearchBaselineArgs([
+        '--environment=beta',
+        '--iterations=11',
+        '--output=/tmp/too-many.json',
+      ]),
+    ).toThrow(/--iterations must be at most 10/);
+    expect(() =>
+      parsePhase0ResearchSearchBaselineArgs([
+        '--environment=beta',
+        '--top-k=25',
+        '--output=/tmp/too-many-results.json',
+      ]),
+    ).toThrow(/--top-k must be at most 24/);
+    expect(() =>
+      parsePhase0ResearchSearchBaselineArgs([
+        '--environment=beta',
+        '--output=/var/tmp/not-approved.json',
+      ]),
+    ).toThrow(/--output must write under/);
+  });
+
+  it('fails closed on production and mismatched Meilisearch targets', () => {
+    expect(
+      assertPhase0ResearchSearchMeiliTarget({
+        environment: 'development',
+        host: 'http://localhost:7700',
+      }),
+    ).toEqual({
+      targetKind: 'local',
+      indexName: 'researchentities',
+    });
+    expect(
+      assertPhase0ResearchSearchMeiliTarget({
+        environment: 'beta',
+        host: 'https://search-beta.example.test',
+        indexPrefix: 'beta',
+      }),
+    ).toEqual({
+      targetKind: 'remote',
+      indexName: 'beta_researchentities',
+    });
+    expect(
+      assertPhase0ResearchSearchMeiliTarget({
+        environment: 'production-copy',
+        host: 'https://search-copy.example.test',
+        indexPrefix: 'production-copy-july',
+      }),
+    ).toEqual({
+      targetKind: 'remote',
+      indexName: 'production-copy-july_researchentities',
+    });
+
+    expect(() =>
+      assertPhase0ResearchSearchMeiliTarget({
+        environment: 'beta',
+        host: 'https://search-beta.example.test',
+        indexPrefix: 'prod',
+      }),
+    ).toThrow(/Primary Production/);
+    expect(() =>
+      assertPhase0ResearchSearchMeiliTarget({
+        environment: 'beta',
+        host: 'https://search-beta.example.test',
+        indexPrefix: 'development',
+      }),
+    ).toThrow(/requires MEILISEARCH_INDEX_PREFIX=beta/);
+    expect(() =>
+      assertPhase0ResearchSearchMeiliTarget({
+        environment: 'development',
+        host: 'https://search.example.test',
+      }),
+    ).toThrow(/unprefixed Development index/);
+    expect(() =>
+      assertPhase0ResearchSearchMeiliTarget({
+        environment: 'production-copy',
+        host: 'https://search-copy.example.test',
+        indexPrefix: 'beta',
+      }),
+    ).toThrow(/dedicated production-copy/);
+    expect(() =>
+      assertPhase0ResearchSearchMeiliTarget({
+        environment: 'beta',
+        host: 'ftp://search-beta.example.test',
+        indexPrefix: 'beta',
+      }),
+    ).toThrow(/http or https/);
+  });
+
+  it('requires a strong comparison salt and creates stable pseudonymous fingerprints', () => {
+    expect(() => requirePhase0ResearchSearchSalt(undefined)).toThrow(/PHASE0_SEARCH_BASELINE_SALT/);
+    expect(() =>
+      requirePhase0ResearchSearchSalt('replace-with-a-real-secret-value-123456'),
+    ).toThrow(/non-placeholder/);
+
+    const salt = requirePhase0ResearchSearchSalt(
+      '7decbd7cf96d4edca5e46dbe1d06f4a1b64b5846209f2bce',
+    );
+    const first = phase0ResearchSearchResultFingerprint('entity-private-1', salt);
+    const second = phase0ResearchSearchResultFingerprint('entity-private-1', salt);
+    const other = phase0ResearchSearchResultFingerprint('entity-private-2', salt);
+
+    expect(first).toBe(second);
+    expect(first).not.toBe(other);
+    expect(first).not.toContain('entity-private');
+  });
+
+  it('builds a bounded query suite and privacy-safe parity report', () => {
+    expect(PHASE0_RESEARCH_SEARCH_CASES.map((searchCase) => searchCase.queryClass)).toEqual([
+      'blank-browse',
+      'keyword',
+      'short-alias',
+      'semantic-phrase',
+      'department-filter',
+      'research-area-filter',
+      'deep-page',
+    ]);
+
+    const searchCase = PHASE0_RESEARCH_SEARCH_CASES[1];
+    const summarized = summarizePhase0ResearchSearchCase(searchCase, [
+      {
+        latencyMs: 9,
+        estimatedTotalHits: 20,
+        degraded: false,
+        topResultFingerprints: ['fingerprint-a', 'fingerprint-b'],
+      },
+      {
+        latencyMs: 5,
+        estimatedTotalHits: 20,
+        degraded: false,
+        topResultFingerprints: ['fingerprint-a', 'fingerprint-b'],
+      },
+      {
+        latencyMs: 18,
+        estimatedTotalHits: 20,
+        degraded: true,
+        topResultFingerprints: ['fingerprint-b', 'fingerprint-a'],
+      },
+    ]);
+    expect(summarized.latencyMs).toEqual({ min: 5, p50: 9, p95: 18, max: 18 });
+    expect(summarized.degradedSamples).toBe(1);
+    expect(summarized.distinctOrderedResultSets).toBe(2);
+
+    const privateId = '507f1f77bcf86cd799439011';
+    const privateName = 'PRIVATE PERSON';
+    const salt = '7decbd7cf96d4edca5e46dbe1d06f4a1b64b5846209f2bce';
+    const report = buildPhase0ResearchSearchBaselineReport({
+      generatedAt: '2026-07-28T12:00:00.000Z',
+      sourceCommit: '5d4b09617ed96c963c1e28011075a941d1307b13',
+      environment: 'beta',
+      databaseName: 'Beta',
+      salt,
+      meiliTarget: { targetKind: 'remote', indexName: 'beta_researchentities' },
+      meiliSettings: {
+        searchableAttributes: ['name', 'researchAreas'],
+        filterableAttributes: ['archived'],
+        sortableAttributes: ['browseRankScore'],
+        embedders: { default: { source: 'openAi', privateName } },
+      },
+      meiliStats: { numberOfDocuments: 200, isIndexing: false },
+      iterations: 3,
+      topK: 10,
+      cases: [
+        {
+          ...summarized,
+          samples: summarized.samples.map((sample) => ({
+            ...sample,
+            topResultFingerprints: [phase0ResearchSearchResultFingerprint(privateId, salt)],
+          })),
+        },
+      ],
+    });
+
+    expect(report.summary).toEqual({
+      degradedSamples: 1,
+      unstableCases: 1,
+      reviewRequired: true,
+    });
+    expect(report.meilisearch).toMatchObject({
+      targetKind: 'remote',
+      indexName: 'beta_researchentities',
+      searchableAttributes: ['name', 'researchAreas'],
+      embedderNames: ['default'],
+      numberOfDocuments: 200,
+      indexing: false,
+    });
+    expect(JSON.stringify(report)).not.toContain(privateId);
+    expect(JSON.stringify(report)).not.toContain(privateName);
+    expect(JSON.stringify(report)).not.toContain(salt);
+  });
+
+  it('fingerprints settings independent of object key order', () => {
+    expect(
+      phase0ResearchSearchSettingsFingerprint({
+        sortableAttributes: ['name'],
+        embedders: { default: { source: 'openAi' } },
+      }),
+    ).toBe(
+      phase0ResearchSearchSettingsFingerprint({
+        embedders: { default: { source: 'openAi' } },
+        sortableAttributes: ['name'],
+      }),
+    );
+  });
+});

--- a/server/src/scripts/phase0ResearchSearchBaseline.ts
+++ b/server/src/scripts/phase0ResearchSearchBaseline.ts
@@ -63,26 +63,49 @@ function sourceCommit(): string {
 
 function assertPrivateArtifactParent(output: string): void {
   const parent = path.dirname(output);
-  fs.mkdirSync(parent, { recursive: true, mode: 0o700 });
-  const parentStat = fs.lstatSync(parent);
-  if (!parentStat.isDirectory() || parentStat.isSymbolicLink()) {
-    throw new Error('--output parent must be a real directory.');
+  const systemTemp = path.resolve(os.tmpdir());
+  const projectTemp = path.resolve(process.cwd(), 'tmp');
+  const approvedRoot =
+    parent === systemTemp || parent.startsWith(`${systemTemp}${path.sep}`)
+      ? systemTemp
+      : parent === projectTemp || parent.startsWith(`${projectTemp}${path.sep}`)
+        ? projectTemp
+        : undefined;
+  if (!approvedRoot) {
+    throw new Error('--output parent is outside the approved temporary directory.');
   }
 
-  const resolvedParent = fs.realpathSync(parent);
-  const resolvedTemp = fs.realpathSync(path.resolve(os.tmpdir()));
-  const projectTemp = path.resolve(process.cwd(), 'tmp');
-  const insideSystemTemp =
-    resolvedParent === resolvedTemp || resolvedParent.startsWith(`${resolvedTemp}${path.sep}`);
-  let insideProjectTemp = false;
-  if (fs.existsSync(projectTemp)) {
-    const resolvedProjectTemp = fs.realpathSync(projectTemp);
-    insideProjectTemp =
-      resolvedParent === resolvedProjectTemp ||
-      resolvedParent.startsWith(`${resolvedProjectTemp}${path.sep}`);
+  const rootParent = path.dirname(approvedRoot);
+  const rootParentStat = fs.lstatSync(rootParent);
+  if (!rootParentStat.isDirectory() || rootParentStat.isSymbolicLink()) {
+    throw new Error('--output temporary root parent must be a real directory.');
   }
-  if (!insideSystemTemp && !insideProjectTemp) {
-    throw new Error('--output parent resolves outside the approved temporary directory.');
+  if (!fs.existsSync(approvedRoot)) {
+    fs.mkdirSync(approvedRoot, { mode: 0o700 });
+  }
+
+  const rootStat = fs.lstatSync(approvedRoot);
+  if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
+    throw new Error('--output temporary root must be a real directory.');
+  }
+  const resolvedRoot = fs.realpathSync(approvedRoot);
+  let current = approvedRoot;
+  for (const component of path.relative(approvedRoot, parent).split(path.sep).filter(Boolean)) {
+    current = path.join(current, component);
+    if (!fs.existsSync(current)) {
+      fs.mkdirSync(current, { mode: 0o700 });
+    }
+    const currentStat = fs.lstatSync(current);
+    if (!currentStat.isDirectory() || currentStat.isSymbolicLink()) {
+      throw new Error('--output parent must contain only real directories.');
+    }
+    const resolvedCurrent = fs.realpathSync(current);
+    if (
+      resolvedCurrent !== resolvedRoot &&
+      !resolvedCurrent.startsWith(`${resolvedRoot}${path.sep}`)
+    ) {
+      throw new Error('--output parent resolves outside the approved temporary directory.');
+    }
   }
 }
 

--- a/server/src/scripts/phase0ResearchSearchBaseline.ts
+++ b/server/src/scripts/phase0ResearchSearchBaseline.ts
@@ -1,0 +1,218 @@
+import { constants as fsConstants } from 'fs';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { performance } from 'perf_hooks';
+import { execFileSync } from 'child_process';
+import { createHash } from 'crypto';
+import { fileURLToPath } from 'url';
+import dotenv from 'dotenv';
+import mongoose from 'mongoose';
+import { initializeConnections } from '../db/connections';
+import { searchResearchGroupsViaMeili } from '../services/researchGroupService';
+import { getMeiliIndex } from '../utils/meiliClient';
+import { sanitizeLogValue } from '../utils/logSanitizer';
+import { serializedDocumentId } from '../utils/idSerialization';
+import {
+  assertPhase0SummaryOnlyConfiguredTarget,
+  assertPhase0SummaryOnlyConnectedTarget,
+} from './phase0SummaryOnlyAudit';
+import {
+  PHASE0_RESEARCH_SEARCH_CASES,
+  assertPhase0ResearchSearchMeiliTarget,
+  buildPhase0ResearchSearchBaselineReport,
+  parsePhase0ResearchSearchBaselineArgs,
+  phase0ResearchSearchResultFingerprint,
+  requirePhase0ResearchSearchSalt,
+  summarizePhase0ResearchSearchCase,
+  type Phase0ResearchSearchBaselineReport,
+  type Phase0ResearchSearchSample,
+} from './phase0ResearchSearchBaselineCore';
+import { resolveSafeJsonReportOutputPath } from './scriptWriteGuards';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+if (process.env.YLABS_SKIP_LOCAL_DOTENV !== 'true') {
+  dotenv.config({ path: path.resolve(__dirname, '../../.env') });
+}
+
+function roundedMilliseconds(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function sourceCommit(): string {
+  const declared =
+    process.env.SOURCE_COMMIT || process.env.RENDER_GIT_COMMIT || process.env.GIT_COMMIT;
+  if (declared && /^[a-f0-9]{7,64}$/i.test(declared.trim())) {
+    return declared.trim().toLowerCase();
+  }
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: path.resolve(__dirname, '../../..'),
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .trim()
+      .toLowerCase();
+  } catch {
+    throw new Error(
+      'Unable to resolve the source commit. Set SOURCE_COMMIT to the exact commit under audit.',
+    );
+  }
+}
+
+function assertPrivateArtifactParent(output: string): void {
+  const parent = path.dirname(output);
+  fs.mkdirSync(parent, { recursive: true, mode: 0o700 });
+  const parentStat = fs.lstatSync(parent);
+  if (!parentStat.isDirectory() || parentStat.isSymbolicLink()) {
+    throw new Error('--output parent must be a real directory.');
+  }
+
+  const resolvedParent = fs.realpathSync(parent);
+  const resolvedTemp = fs.realpathSync(path.resolve(os.tmpdir()));
+  const projectTemp = path.resolve(process.cwd(), 'tmp');
+  const insideSystemTemp =
+    resolvedParent === resolvedTemp || resolvedParent.startsWith(`${resolvedTemp}${path.sep}`);
+  let insideProjectTemp = false;
+  if (fs.existsSync(projectTemp)) {
+    const resolvedProjectTemp = fs.realpathSync(projectTemp);
+    insideProjectTemp =
+      resolvedParent === resolvedProjectTemp ||
+      resolvedParent.startsWith(`${resolvedProjectTemp}${path.sep}`);
+  }
+  if (!insideSystemTemp && !insideProjectTemp) {
+    throw new Error('--output parent resolves outside the approved temporary directory.');
+  }
+}
+
+export function writePhase0ResearchSearchBaseline(
+  report: Phase0ResearchSearchBaselineReport,
+  outputValue: string,
+): { output: string; sha256: string; bytes: number } {
+  const output = resolveSafeJsonReportOutputPath(outputValue);
+  assertPrivateArtifactParent(output);
+  const body = `${JSON.stringify(report, null, 2)}\n`;
+  const noFollow = fsConstants.O_NOFOLLOW || 0;
+  const fd = fs.openSync(
+    output,
+    fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | noFollow,
+    0o600,
+  );
+  try {
+    fs.writeFileSync(fd, body, { encoding: 'utf8' });
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
+  fs.chmodSync(output, 0o600);
+  return {
+    output,
+    sha256: createHash('sha256').update(body).digest('hex'),
+    bytes: Buffer.byteLength(body),
+  };
+}
+
+async function main(): Promise<void> {
+  const options = parsePhase0ResearchSearchBaselineArgs(process.argv.slice(2));
+  const salt = requirePhase0ResearchSearchSalt(process.env.PHASE0_SEARCH_BASELINE_SALT);
+  assertPhase0SummaryOnlyConfiguredTarget({
+    summaryOnly: true,
+    environment: options.environment,
+    mongoUrl: process.env.MONGODBURL,
+    scriptName: 'model-refactor:search-baseline',
+  });
+  const meiliTarget = assertPhase0ResearchSearchMeiliTarget({
+    environment: options.environment,
+    host: process.env.MEILISEARCH_HOST,
+    indexPrefix: process.env.MEILISEARCH_INDEX_PREFIX,
+  });
+
+  await initializeConnections();
+  const databaseName = mongoose.connection.db?.databaseName || mongoose.connection.name || '';
+  assertPhase0SummaryOnlyConnectedTarget({
+    summaryOnly: true,
+    environment: options.environment,
+    databaseName,
+    scriptName: 'model-refactor:search-baseline',
+  });
+
+  const index = await getMeiliIndex('researchentities');
+  const [meiliSettings, meiliStats] = await Promise.all([index.getSettings(), index.getStats()]);
+  const cases = [];
+  for (const searchCase of PHASE0_RESEARCH_SEARCH_CASES) {
+    const samples: Phase0ResearchSearchSample[] = [];
+    for (let iteration = 0; iteration < options.iterations; iteration += 1) {
+      const startedAt = performance.now();
+      const result = await searchResearchGroupsViaMeili(
+        searchCase.query,
+        searchCase.filters,
+        searchCase.page,
+        searchCase.pageSize,
+      );
+      const resultIds = result.researchEntities
+        .map((entity) => serializedDocumentId(entity._id))
+        .filter((id): id is string => Boolean(id))
+        .slice(0, options.topK);
+      samples.push({
+        latencyMs: roundedMilliseconds(performance.now() - startedAt),
+        estimatedTotalHits: Math.max(0, Math.floor(result.estimatedTotalHits || 0)),
+        degraded: result.degraded === true,
+        topResultFingerprints: resultIds.map((id) =>
+          phase0ResearchSearchResultFingerprint(id, salt),
+        ),
+      });
+    }
+    cases.push(summarizePhase0ResearchSearchCase(searchCase, samples));
+  }
+
+  const report = buildPhase0ResearchSearchBaselineReport({
+    generatedAt: new Date().toISOString(),
+    sourceCommit: sourceCommit(),
+    environment: options.environment,
+    databaseName,
+    salt,
+    meiliTarget,
+    meiliSettings,
+    meiliStats,
+    iterations: options.iterations,
+    topK: options.topK,
+    cases,
+  });
+  const receipt = writePhase0ResearchSearchBaseline(report, options.output);
+  console.log(
+    JSON.stringify(
+      {
+        artifactType: report.artifactType,
+        environment: report.environment,
+        databaseName: report.databaseName,
+        sourceCommit: report.sourceCommit,
+        output: receipt.output,
+        sha256: receipt.sha256,
+        bytes: receipt.bytes,
+        reviewRequired: report.summary.reviewRequired,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (options.strict && report.summary.reviewRequired) {
+    process.exitCode = 1;
+  }
+}
+
+const isDirectRun = process.argv[1]
+  ? fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+  : false;
+
+if (isDirectRun) {
+  main()
+    .catch((error) => {
+      console.error('Phase 0 ResearchEntity search baseline failed:', sanitizeLogValue(error));
+      process.exitCode = 1;
+    })
+    .finally(async () => {
+      await mongoose.disconnect();
+    });
+}

--- a/server/src/scripts/phase0ResearchSearchBaselineCore.ts
+++ b/server/src/scripts/phase0ResearchSearchBaselineCore.ts
@@ -1,0 +1,458 @@
+import { createHash, createHmac } from 'crypto';
+import {
+  parsePhase0SummaryOnlyEnvironment,
+  type Phase0SummaryOnlyEnvironment,
+} from './phase0SummaryOnlyAudit';
+import { resolveSafeJsonReportOutputPath } from './scriptWriteGuards';
+
+export interface Phase0ResearchSearchBaselineCliOptions {
+  environment: Phase0SummaryOnlyEnvironment;
+  iterations: number;
+  topK: number;
+  strict: boolean;
+  output: string;
+}
+
+export interface Phase0ResearchSearchCase {
+  label: string;
+  queryClass:
+    | 'blank-browse'
+    | 'keyword'
+    | 'short-alias'
+    | 'semantic-phrase'
+    | 'department-filter'
+    | 'research-area-filter'
+    | 'deep-page';
+  query: string;
+  filters: {
+    departments?: string[];
+    researchAreas?: string[];
+  };
+  page: number;
+  pageSize: number;
+}
+
+export interface Phase0ResearchSearchSample {
+  latencyMs: number;
+  estimatedTotalHits: number;
+  degraded: boolean;
+  topResultFingerprints: string[];
+}
+
+export interface Phase0ResearchSearchCaseResult {
+  label: string;
+  queryClass: Phase0ResearchSearchCase['queryClass'];
+  request: {
+    query: string;
+    filters: Phase0ResearchSearchCase['filters'];
+    page: number;
+    pageSize: number;
+  };
+  samples: Phase0ResearchSearchSample[];
+  latencyMs: {
+    min: number;
+    p50: number;
+    p95: number;
+    max: number;
+  };
+  degradedSamples: number;
+  distinctOrderedResultSets: number;
+}
+
+export interface Phase0ResearchSearchBaselineReport {
+  schemaVersion: 1;
+  artifactType: 'phase0-research-search-baseline';
+  generatedAt: string;
+  sourceCommit: string;
+  environment: Phase0SummaryOnlyEnvironment;
+  databaseName: string;
+  saltFingerprint: string;
+  meilisearch: {
+    targetKind: 'local' | 'remote';
+    indexName: string;
+    settingsFingerprint: string;
+    searchableAttributes: string[];
+    filterableAttributes: string[];
+    sortableAttributes: string[];
+    embedderNames: string[];
+    numberOfDocuments: number;
+    indexing: boolean;
+  };
+  suite: {
+    iterations: number;
+    topK: number;
+    caseCount: number;
+  };
+  summary: {
+    degradedSamples: number;
+    unstableCases: number;
+    reviewRequired: boolean;
+  };
+  cases: Phase0ResearchSearchCaseResult[];
+}
+
+export const PHASE0_RESEARCH_SEARCH_CASES: readonly Phase0ResearchSearchCase[] = [
+  {
+    label: 'blank-browse-first-page',
+    queryClass: 'blank-browse',
+    query: '',
+    filters: {},
+    page: 1,
+    pageSize: 24,
+  },
+  {
+    label: 'keyword-data-science',
+    queryClass: 'keyword',
+    query: 'data science',
+    filters: {},
+    page: 1,
+    pageSize: 24,
+  },
+  {
+    label: 'short-alias-ai',
+    queryClass: 'short-alias',
+    query: 'ai',
+    filters: {},
+    page: 1,
+    pageSize: 24,
+  },
+  {
+    label: 'semantic-beginner-brain-imaging',
+    queryClass: 'semantic-phrase',
+    query: 'beginner research using brain imaging',
+    filters: {},
+    page: 1,
+    pageSize: 24,
+  },
+  {
+    label: 'department-computer-science',
+    queryClass: 'department-filter',
+    query: '',
+    filters: { departments: ['Computer Science'] },
+    page: 1,
+    pageSize: 24,
+  },
+  {
+    label: 'research-area-neuroscience',
+    queryClass: 'research-area-filter',
+    query: '',
+    filters: { researchAreas: ['Neuroscience'] },
+    page: 1,
+    pageSize: 24,
+  },
+  {
+    label: 'blank-browse-deep-page',
+    queryClass: 'deep-page',
+    query: '',
+    filters: {},
+    page: 25,
+    pageSize: 24,
+  },
+] as const;
+
+const MAX_ITERATIONS = 10;
+const MAX_TOP_K = 24;
+const MIN_SALT_LENGTH = 32;
+const PLACEHOLDER_RE = /change|example|placeholder|replace|todo|your[-_ ]/i;
+const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
+const PRODUCTION_PREFIXES = new Set(['prod', 'production']);
+const PRODUCTION_COPY_PREFIX_RE = /^(?:production[-_]?copy|prod[-_]?copy)(?:[-_][a-z0-9-]+)?$/i;
+
+function requiredFlagValue(argv: string[], index: number, flag: string): string {
+  const value = argv[index + 1];
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function inlineFlagValue(arg: string, flag: string): string {
+  const value = arg.slice(`${flag}=`.length).trim();
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function boundedPositiveInteger(value: string, flag: string, maximum: number): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0 || String(parsed) !== value.trim()) {
+    throw new Error(`${flag} requires a positive integer`);
+  }
+  if (parsed > maximum) {
+    throw new Error(`${flag} must be at most ${maximum}`);
+  }
+  return parsed;
+}
+
+export function parsePhase0ResearchSearchBaselineArgs(
+  argv: string[],
+): Phase0ResearchSearchBaselineCliOptions {
+  let environment: Phase0SummaryOnlyEnvironment | undefined;
+  let output: string | undefined;
+  let iterations = 3;
+  let topK = 10;
+  let strict = false;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--strict') {
+      strict = true;
+      continue;
+    }
+    if (arg.startsWith('--strict=')) {
+      throw new Error('--strict does not accept a value');
+    }
+    if (arg === '--environment') {
+      environment = parsePhase0SummaryOnlyEnvironment(
+        requiredFlagValue(argv, index, '--environment'),
+      );
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith('--environment=')) {
+      environment = parsePhase0SummaryOnlyEnvironment(inlineFlagValue(arg, '--environment'));
+      continue;
+    }
+    if (arg === '--iterations') {
+      iterations = boundedPositiveInteger(
+        requiredFlagValue(argv, index, '--iterations'),
+        '--iterations',
+        MAX_ITERATIONS,
+      );
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith('--iterations=')) {
+      iterations = boundedPositiveInteger(
+        inlineFlagValue(arg, '--iterations'),
+        '--iterations',
+        MAX_ITERATIONS,
+      );
+      continue;
+    }
+    if (arg === '--top-k') {
+      topK = boundedPositiveInteger(
+        requiredFlagValue(argv, index, '--top-k'),
+        '--top-k',
+        MAX_TOP_K,
+      );
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith('--top-k=')) {
+      topK = boundedPositiveInteger(inlineFlagValue(arg, '--top-k'), '--top-k', MAX_TOP_K);
+      continue;
+    }
+    if (arg === '--output') {
+      output = resolveSafeJsonReportOutputPath(requiredFlagValue(argv, index, '--output'));
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith('--output=')) {
+      output = resolveSafeJsonReportOutputPath(inlineFlagValue(arg, '--output'));
+      continue;
+    }
+    throw new Error(`Unknown Phase 0 search baseline argument: ${arg}`);
+  }
+
+  if (!environment) {
+    throw new Error('model-refactor:search-baseline requires --environment');
+  }
+  if (!output) {
+    throw new Error('model-refactor:search-baseline requires --output');
+  }
+
+  return { environment, iterations, topK, strict, output };
+}
+
+export function assertPhase0ResearchSearchMeiliTarget(input: {
+  environment: Phase0SummaryOnlyEnvironment;
+  host?: string;
+  indexPrefix?: string;
+}): { targetKind: 'local' | 'remote'; indexName: string } {
+  let host: URL;
+  try {
+    host = new URL(input.host || '');
+  } catch {
+    throw new Error('MEILISEARCH_HOST must be an explicit http or https URL.');
+  }
+  if (host.protocol !== 'http:' && host.protocol !== 'https:') {
+    throw new Error('MEILISEARCH_HOST must use http or https.');
+  }
+  if (host.username || host.password) {
+    throw new Error('MEILISEARCH_HOST must not contain credentials.');
+  }
+
+  const targetKind = LOCAL_HOSTS.has(host.hostname.toLowerCase()) ? 'local' : 'remote';
+  const prefix = (input.indexPrefix || '').trim();
+  const lowerPrefix = prefix.toLowerCase();
+  if (PRODUCTION_PREFIXES.has(lowerPrefix)) {
+    throw new Error('Primary Production Meilisearch prefixes are forbidden.');
+  }
+
+  if (input.environment === 'development') {
+    if (prefix === '' && targetKind !== 'local') {
+      throw new Error(
+        'An unprefixed Development index is allowed only on a local Meilisearch host.',
+      );
+    }
+    if (prefix !== '' && !/^(?:dev|development)(?:[-_][a-z0-9-]+)?$/i.test(prefix)) {
+      throw new Error('Development requires an unprefixed local index or a development prefix.');
+    }
+  } else if (input.environment === 'beta') {
+    if (lowerPrefix !== 'beta') {
+      throw new Error('Beta search evidence requires MEILISEARCH_INDEX_PREFIX=beta.');
+    }
+  } else if (!PRODUCTION_COPY_PREFIX_RE.test(prefix)) {
+    throw new Error(
+      'ProductionCopy search evidence requires a dedicated production-copy Meilisearch prefix.',
+    );
+  }
+
+  return {
+    targetKind,
+    indexName: prefix ? `${prefix}_researchentities` : 'researchentities',
+  };
+}
+
+export function requirePhase0ResearchSearchSalt(value: string | undefined): string {
+  const salt = value?.trim() || '';
+  if (salt.length < MIN_SALT_LENGTH || PLACEHOLDER_RE.test(salt)) {
+    throw new Error(
+      `PHASE0_SEARCH_BASELINE_SALT must be a non-placeholder secret of at least ${MIN_SALT_LENGTH} characters.`,
+    );
+  }
+  return salt;
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalJson(item)).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, nested]) => `${JSON.stringify(key)}:${canonicalJson(nested)}`);
+    return `{${entries.join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function phase0ResearchSearchSettingsFingerprint(settings: unknown): string {
+  return createHash('sha256').update(canonicalJson(settings)).digest('hex');
+}
+
+export function phase0ResearchSearchSaltFingerprint(salt: string): string {
+  return createHash('sha256').update(`phase0-search-salt:v1:${salt}`).digest('hex');
+}
+
+export function phase0ResearchSearchResultFingerprint(id: string, salt: string): string {
+  return createHmac('sha256', salt).update(`research-entity:v1:${id}`).digest('hex');
+}
+
+function percentile(sortedValues: number[], fraction: number): number {
+  if (sortedValues.length === 0) return 0;
+  const index = Math.max(0, Math.ceil(sortedValues.length * fraction) - 1);
+  return sortedValues[index];
+}
+
+export function summarizePhase0ResearchSearchCase(
+  searchCase: Phase0ResearchSearchCase,
+  samples: Phase0ResearchSearchSample[],
+): Phase0ResearchSearchCaseResult {
+  const latencies = samples.map((sample) => sample.latencyMs).sort((left, right) => left - right);
+  const orderedResultSets = new Set(
+    samples.map((sample) =>
+      createHash('sha256').update(canonicalJson(sample.topResultFingerprints)).digest('hex'),
+    ),
+  );
+
+  return {
+    label: searchCase.label,
+    queryClass: searchCase.queryClass,
+    request: {
+      query: searchCase.query,
+      filters: searchCase.filters,
+      page: searchCase.page,
+      pageSize: searchCase.pageSize,
+    },
+    samples,
+    latencyMs: {
+      min: latencies[0] || 0,
+      p50: percentile(latencies, 0.5),
+      p95: percentile(latencies, 0.95),
+      max: latencies[latencies.length - 1] || 0,
+    },
+    degradedSamples: samples.filter((sample) => sample.degraded).length,
+    distinctOrderedResultSets: orderedResultSets.size,
+  };
+}
+
+function safeStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === 'string');
+}
+
+function safeNonNegativeInteger(value: unknown): number {
+  return Number.isSafeInteger(value) && Number(value) >= 0 ? Number(value) : 0;
+}
+
+export function buildPhase0ResearchSearchBaselineReport(input: {
+  generatedAt: string;
+  sourceCommit: string;
+  environment: Phase0SummaryOnlyEnvironment;
+  databaseName: string;
+  salt: string;
+  meiliTarget: { targetKind: 'local' | 'remote'; indexName: string };
+  meiliSettings: Record<string, unknown>;
+  meiliStats: Record<string, unknown>;
+  iterations: number;
+  topK: number;
+  cases: Phase0ResearchSearchCaseResult[];
+}): Phase0ResearchSearchBaselineReport {
+  const degradedSamples = input.cases.reduce(
+    (total, searchCase) => total + searchCase.degradedSamples,
+    0,
+  );
+  const unstableCases = input.cases.filter(
+    (searchCase) => searchCase.distinctOrderedResultSets > 1,
+  ).length;
+  const embedders =
+    input.meiliSettings.embedders &&
+    typeof input.meiliSettings.embedders === 'object' &&
+    !Array.isArray(input.meiliSettings.embedders)
+      ? Object.keys(input.meiliSettings.embedders as Record<string, unknown>).sort()
+      : [];
+
+  return {
+    schemaVersion: 1,
+    artifactType: 'phase0-research-search-baseline',
+    generatedAt: input.generatedAt,
+    sourceCommit: input.sourceCommit,
+    environment: input.environment,
+    databaseName: input.databaseName,
+    saltFingerprint: phase0ResearchSearchSaltFingerprint(input.salt),
+    meilisearch: {
+      ...input.meiliTarget,
+      settingsFingerprint: phase0ResearchSearchSettingsFingerprint(input.meiliSettings),
+      searchableAttributes: safeStringArray(input.meiliSettings.searchableAttributes),
+      filterableAttributes: safeStringArray(input.meiliSettings.filterableAttributes),
+      sortableAttributes: safeStringArray(input.meiliSettings.sortableAttributes),
+      embedderNames: embedders,
+      numberOfDocuments: safeNonNegativeInteger(input.meiliStats.numberOfDocuments),
+      indexing: input.meiliStats.isIndexing === true,
+    },
+    suite: {
+      iterations: input.iterations,
+      topK: input.topK,
+      caseCount: input.cases.length,
+    },
+    summary: {
+      degradedSamples,
+      unstableCases,
+      reviewRequired: degradedSamples > 0 || unstableCases > 0,
+    },
+    cases: input.cases,
+  };
+}

--- a/server/src/scripts/phase0ResearchSearchBaselineCore.ts
+++ b/server/src/scripts/phase0ResearchSearchBaselineCore.ts
@@ -292,6 +292,9 @@ export function assertPhase0ResearchSearchMeiliTarget(input: {
   }
 
   if (input.environment === 'development') {
+    if (targetKind !== 'local') {
+      throw new Error('Development search evidence requires a local Meilisearch host.');
+    }
     if (prefix === '' && targetKind !== 'local') {
       throw new Error(
         'An unprefixed Development index is allowed only on a local Meilisearch host.',
@@ -301,13 +304,21 @@ export function assertPhase0ResearchSearchMeiliTarget(input: {
       throw new Error('Development requires an unprefixed local index or a development prefix.');
     }
   } else if (input.environment === 'beta') {
+    if (targetKind !== 'remote') {
+      throw new Error('Beta search evidence requires a remote Meilisearch host.');
+    }
     if (lowerPrefix !== 'beta') {
       throw new Error('Beta search evidence requires MEILISEARCH_INDEX_PREFIX=beta.');
     }
-  } else if (!PRODUCTION_COPY_PREFIX_RE.test(prefix)) {
-    throw new Error(
-      'ProductionCopy search evidence requires a dedicated production-copy Meilisearch prefix.',
-    );
+  } else {
+    if (targetKind !== 'remote') {
+      throw new Error('ProductionCopy search evidence requires a remote Meilisearch host.');
+    }
+    if (!PRODUCTION_COPY_PREFIX_RE.test(prefix)) {
+      throw new Error(
+        'ProductionCopy search evidence requires a dedicated production-copy Meilisearch prefix.',
+      );
+    }
   }
 
   return {

--- a/server/src/services/__tests__/researchGroupService.test.ts
+++ b/server/src/services/__tests__/researchGroupService.test.ts
@@ -278,8 +278,26 @@ describe('searchResearchGroupsViaMeili', () => {
       estimatedTotalHits: 1,
       page: 1,
       pageSize: 1,
+      degraded: true,
       researchEntities: [{ _id: 'reilly-lab', slug: 'reilly-lab', name: 'Reilly Lab' }],
     });
+  });
+
+  it('marks browse results degraded when Meili cannot sort by browse rank', async () => {
+    mocks.search
+      .mockRejectedValueOnce({
+        code: 'invalid_search_sort',
+        message: 'Attribute `browseRankScore` is not sortable.',
+      })
+      .mockResolvedValueOnce({ hits: [], estimatedTotalHits: 0 });
+
+    const result = await searchResearchGroupsViaMeili('', {}, 1, 24);
+
+    expect(mocks.search).toHaveBeenCalledTimes(2);
+    expect(mocks.search.mock.calls[1][1]).toEqual(
+      expect.objectContaining({ sort: ['lastObservedAt:desc'] }),
+    );
+    expect(result.degraded).toBe(true);
   });
 
   it('expands AI and restricts short alias searches to topic fields', async () => {

--- a/server/src/services/researchGroupService.ts
+++ b/server/src/services/researchGroupService.ts
@@ -692,7 +692,10 @@ export async function searchResearchGroupsViaMeili(
   try {
     searchResult = await searchWithFallbacks();
   } catch (error) {
-    console.error('ResearchEntity Meilisearch failed; falling back to Mongo search:', error);
+    console.error(
+      'ResearchEntity Meilisearch failed; falling back to Mongo search:',
+      sanitizeLogValue(error),
+    );
     return searchResearchGroupsViaMongoFallback(
       normalizedQuery.raw,
       safeFilters,

--- a/server/src/services/researchGroupService.ts
+++ b/server/src/services/researchGroupService.ts
@@ -653,20 +653,28 @@ export async function searchResearchGroupsViaMeili(
   // the running index has not yet had it added to sortableAttributes. Each
   // degradation is applied at most once; anything else propagates.
   const searchWithFallbacks = async (): Promise<{
-    hits?: any[];
-    estimatedTotalHits?: number;
-    facetDistribution?: Record<string, Record<string, number>>;
+    result: {
+      hits?: any[];
+      estimatedTotalHits?: number;
+      facetDistribution?: Record<string, Record<string, number>>;
+    };
+    degraded: boolean;
   }> => {
     // Each attempt uses an immutable params object; degrading clones rather than
     // mutating, so already-issued calls keep the params they were sent.
     let params: Record<string, any> = searchParams;
+    let degraded = false;
     while (true) {
       try {
-        return await index.search(trimmedQuery, params);
+        return {
+          result: await index.search(trimmedQuery, params),
+          degraded,
+        };
       } catch (error) {
         if (params.hybrid && isMissingMeiliEmbedderError(error)) {
           params = { ...params };
           delete params.hybrid;
+          degraded = true;
           continue;
         }
         if (Array.isArray(params.sort) && isUnsortableAttributeError(error)) {
@@ -677,6 +685,7 @@ export async function searchResearchGroupsViaMeili(
             params = { ...params };
             if (filtered.length > 0) params.sort = filtered;
             else delete params.sort;
+            degraded = true;
             continue;
           }
         }
@@ -689,8 +698,11 @@ export async function searchResearchGroupsViaMeili(
     estimatedTotalHits?: number;
     facetDistribution?: Record<string, Record<string, number>>;
   };
+  let degraded = false;
   try {
-    searchResult = await searchWithFallbacks();
+    const outcome = await searchWithFallbacks();
+    searchResult = outcome.result;
+    degraded = outcome.degraded;
   } catch (error) {
     console.error(
       'ResearchEntity Meilisearch failed; falling back to Mongo search:',
@@ -763,6 +775,7 @@ export async function searchResearchGroupsViaMeili(
       page: safePage,
       pageSize: safePageSize,
       facetDistribution,
+      degraded,
     },
     { includeOperatorFields: safeOptions.includeNonPublic },
   );

--- a/server/src/utils/meiliClient.ts
+++ b/server/src/utils/meiliClient.ts
@@ -1,5 +1,7 @@
 import dotenv from 'dotenv';
-dotenv.config();
+if (process.env.YLABS_SKIP_LOCAL_DOTENV !== 'true') {
+  dotenv.config();
+}
 
 // Default to a common local meilisearch host if not provided
 const MEILISEARCH_HOST = process.env.MEILISEARCH_HOST || 'http://localhost:7700';


### PR DESCRIPTION
## Intent

Complete research-model refactor Phase 0 by adding a repeatable, bounded, read-only ResearchEntity search baseline for Development, Beta, and an approved ProductionCopy. Keep evidence private and pseudonymous, reject primary Production and mismatched MongoDB or Meilisearch targets, avoid local dotenv leakage for operator runs, prevent artifact overwrite, document exact operator commands, and open a Beta PR linked to #229 and parent #204. This slice must not overlap the #228 profile/recovery implementation or connect to live services during development.

## What Changed

- Add a bounded, read-only ResearchEntity search baseline command with pseudonymous result fingerprints, latency samples, settings metadata, and degradation reporting.
- Reject Production and mismatched MongoDB or Meilisearch targets, skip local dotenv loading for operator runs, and securely prevent artifact overwrite or path escape.
- Document Development, Beta, and ProductionCopy operator commands and add focused coverage for baseline collection, validation, and search fallback behavior.

## Risk Assessment

✅ Low: The corrective commit closes all three prior reachable paths, and the full source review found no remaining material violation of the bounded, read-only, private baseline requirements.

## Testing

Focused offline tests and end-user CLI checks passed, covering bounded pseudonymous reports, private non-overwriting artifacts, local dotenv bypass, degraded-search signaling, and fail-closed MongoDB and Meilisearch target validation without contacting live services; no screenshot was captured because this change exposes a CLI operator workflow rather than a rendered UI.

<details>
<summary>Evidence: Offline CLI safeguard transcript</summary>

```text
CASE: primary Production environment is rejected before connection
Phase 0 ResearchEntity search baseline failed: Error: --environment requires development, beta, or production-copy
Error: --environment requires development, beta, or production-copy
    at parsePhase0SummaryOnlyEnvironment (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKGJYG41QSAZN6DEW0TE9EH/server/src/scripts/phase0SummaryOnlyAudit.ts:19:11)
    at parsePhase0ResearchSearchBaselineArgs (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKGJYG41QSAZN6DEW0TE9EH/server/src/scripts/phase0ResearchSearchBaselineCore.ts:214:21)
    at main (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKGJYG41QSAZN6DEW0TE9EH/server/src/scripts/phase0ResearchSearchBaseline.ts:140:19)
    at <anonymous> (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKGJYG41QSAZN6DEW0TE9EH/server/src/scripts/phase0ResearchSearchBaseline.ts:233:3)
    at ModuleJob.run (node:internal/modules/esm/module_job:439:25)
    at async node:internal/modules/esm/loader:633:26
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)
EXIT_STATUS: 1

CASE: Beta rejects a Production MongoDB target before connection
Phase 0 ResearchEntity search baseline failed: Error: Operator environment beta does not match MongoDB database Production
Error: Operator environment beta does not match MongoDB database Production
    at assertOperatorEnvironmentMatchesDatabase (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKGJYG41QSAZN6DEW0TE9EH/server/src/scripts/operatorDatabaseEnvironment.ts:71:11)
    at assertPhase0SummaryOnlyConfiguredTarget (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKGJYG41QSAZN6DEW0TE9EH/server/src/scripts/phase0SummaryOnlyAudit.ts:43:3)
    at main (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKGJYG41QSAZN6DEW0TE9EH/server/src/scripts/phase0ResearchSearchBaseline.ts:142:3)
    at <anonymous> (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKGJYG41QSAZN6DEW0TE9EH/server/src/scripts/phase0ResearchSearchBaseline.ts:233:3)
    at ModuleJob.run (node:internal/modules/esm/module_job:439:25)
    at async node:internal/modules/esm/loader:633:26
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)
EXIT_STATUS: 1

CASE: Beta rejects a Production Meilisearch prefix before connection
Phase 0 ResearchEntity search baseline failed: Error: Primary Production Meilisearch prefixes are forbidden.
Error: Primary Production Meilisearch prefixes are forbidden.
    at assertPhase0ResearchSearchMeiliTarget (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKGJYG41QSAZN6DEW0TE9EH/server/src/scripts/phase0ResearchSearchBaselineCore.ts:291:11)
    at main (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKGJYG41QSAZN6DEW0TE9EH/server/src/scripts/phase0ResearchSearchBaseline.ts:148:23)
    at <anonymous> (/home/qunta/.no-mistakes/worktrees/5122e59873f3/01KYKGJYG41QSAZN6DEW0TE9EH/server/src/scripts/phase0ResearchSearchBaseline.ts:233:3)
    at ModuleJob.run (node:internal/modules/esm/module_job:439:25)
    at async node:internal/modules/esm/loader:633:26
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)
EXIT_STATUS: 1
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- 🚨 `server/src/scripts/phase0ResearchSearchBaseline.ts:160` - The required baseline&#39;s degradation state is incomplete. `result.degraded` becomes true only for the full MongoDB fallback, while `searchResearchGroupsViaMeili` silently retries without the semantic embedder or `browseRankScore` sort at lines 667-680 without marking the result degraded. A missing embedder or sortable attribute therefore produces `degraded: false`, and `--strict` can succeed despite measuring a different search mode. Propagate degradation from these shared fallback paths before recording the sample.
- 🚨 `server/src/scripts/phase0ResearchSearchBaselineCore.ts:294` - The intent requires rejecting mismatched Meilisearch targets, but validation matches only the prefix: Beta accepts a local host with prefix `beta`, ProductionCopy accepts a local host with a production-copy prefix, and Development accepts any remote host when it has a development prefix. These reachable combinations can collect evidence from the wrong service. Enforce the documented local-only Development and remote-only Beta/ProductionCopy target kinds, or add an equally strong approved-host identity check.
- ⚠️ `server/src/scripts/phase0ResearchSearchBaseline.ts:66` - The output guard creates the parent directory before resolving and approving it. For `/tmp/link/new/report.json` where `/tmp/link` is a symlink outside the approved roots, `mkdirSync` creates `new` outside those roots and only then rejects the resolved parent. Validate the nearest existing ancestor and securely create descendants within an approved real root before making any filesystem change.

🔧 Fix: Harden search baseline degradation and target validation
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `corepack yarn install --immutable && corepack yarn --cwd server install --immutable`
- `corepack yarn --cwd server vitest run src/scripts/__tests__/phase0ResearchSearchBaseline.test.ts src/scripts/__tests__/phase0ResearchSearchBaselineCore.test.ts src/services/__tests__/researchGroupService.test.ts`
- <code>Direct `yarn model-refactor:search-baseline` invocation rejecting `--environment=production` before connection</code>
- <code>Direct Beta invocation rejecting a `Production` MongoDB database before connection</code>
- <code>Direct Beta invocation rejecting `MEILISEARCH_INDEX_PREFIX=prod` before connection</code>
- `Verified rejected commands created no JSON artifacts and the git worktree remained clean`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
